### PR TITLE
docs(GNPS FileIO trio): add class-level Doxygen for the FBMN/IIMN writers

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/GNPSMGFFile.h
+++ b/src/openms/include/OpenMS/FORMAT/GNPSMGFFile.h
@@ -14,31 +14,62 @@
 
 namespace OpenMS
 {
-  class OPENMS_DLLAPI GNPSMGFFile : 
+  /**
+    @brief Writer for the consensus-spectrum MGF file consumed by GNPS Feature-Based / Ion-Identity Molecular Networking.
+
+    For each consensus feature in a @ref ConsensusMap, the GNPS workflow expects one
+    representative MS2 spectrum. This class reads the spectrum references stored on
+    each consensus element, resolves them to the original mzML files, optionally merges
+    multiple MS2 scans per feature into a single binned consensus spectrum, and writes
+    the result as an MGF file ready to be uploaded to GNPS.
+
+    Configurable behaviour is exposed through @ref DefaultParamHandler — see the defaults
+    installed by the constructor for the supported keys (@c output_type — @c "most_intense"
+    or @c "merged_spectra"; @c peptide_cutoff — how many top-intensity peptides to consider
+    per consensus element; @c ms2_bin_size — bin width when merging fragment ions;
+    @c merged_spectra:cos_similarity — cosine threshold for merging).
+
+    Used by the @ref TOPP_GNPSExport tool. See its page for the recommended OpenMS
+    metabolomics workflow producing the consensusXML input.
+
+    @ingroup FileIO
+  */
+  class OPENMS_DLLAPI GNPSMGFFile :
     public DefaultParamHandler,
     public ProgressLogger
   {
     public:
-      // default c'tor
+      /// Default constructor; installs the export parameters (see class docs)
       GNPSMGFFile();
 
-      // see GNPSExport tool documentation
       /**
-      * @brief Create file for GNPS molecular networking.
-      * @param[in] consensus_file_path path to consensusXML with spectrum references
-      * @param[in] mzml_file_paths path to mzML files referenced in consensusXML. Used to extract spectra as MGF.
-      * @param[in] out MGF file with MS2 peak data for molecular networking.
+        @brief Write the consensus-spectrum MGF for GNPS molecular networking.
+
+        The consensusXML at @p consensus_file_path must reference MS2 spectra in
+        @p mzml_file_paths (typically the same mzMLs that fed the feature finder).
+        Per consensus feature, the referenced MS2 scans are optionally merged into a
+        single representative spectrum (per the cosine-similarity / bin-width / peak-cutoff
+        parameters) and appended to the output MGF.
+
+        @param[in] consensus_file_path Path to a consensusXML file with spectrum references
+                                       on each consensus element.
+        @param[in] mzml_file_paths     Paths to the mzML files referenced by the consensusXML.
+        @param[in] out                 Output MGF path; one spectrum block per consensus feature.
       */
       void store(const String& consensus_file_path, const StringList& mzml_file_paths, const String& out) const;
 
     private:
+      /// Default cosine-similarity threshold used when merging multiple MS2 scans into one representative spectrum
       static constexpr double DEF_COSINE_SIMILARITY = 0.9;
+      /// Default m/z bin width for the binned-spectrum representation used during merging (high-res default)
       static constexpr double DEF_MERGE_BIN_SIZE = static_cast<double>(BinnedSpectrum::DEFAULT_BIN_WIDTH_HIRES);
 
 //      static constexpr double DEF_PREC_MASS_TOL = 0.5;
 //      static constexpr bool DEF_PREC_MASS_TOL_ISPPM = false;
 
+      /// Default value of the @c peptide_cutoff parameter — how many top-intensity peptides per consensus element to consider when @c output_type is @c merged_spectra (-1 = all)
       static constexpr int DEF_PEPT_CUTOFF = 5;
+      /// Declared default but currently not wired to any parameter — kept for source compatibility with earlier versions of the writer
       static constexpr int DEF_MSMAP_CACHE = 50;
   };
 }

--- a/src/openms/include/OpenMS/FORMAT/GNPSMetaValueFile.h
+++ b/src/openms/include/OpenMS/FORMAT/GNPSMetaValueFile.h
@@ -11,10 +11,37 @@
 
 namespace OpenMS
 {
+  /**
+    @brief Writer for the meta-value (.TSV) table consumed by GNPS Feature-Based Molecular Networking.
+
+    GNPS FBMN can pick up per-sample metadata so the web platform can group / colour
+    network nodes by sample attribute. The writer here produces the minimal seed of
+    such a table: one row per mzML file used to build the input @ref ConsensusMap,
+    populated with that file's basename and a sequential @c MAP&lt;i&gt; identifier. Users
+    typically extend the file with additional attribute columns before uploading to
+    GNPS (see https://ccms-ucsd.github.io/GNPSDocumentation/metadata/).
+
+    The file is optional for FBMN — supplying it lets users group/colour by attribute
+    on the GNPS side. Produced by the @ref TOPP_GNPSExport tool.
+
+    @ingroup FileIO
+  */
   class OPENMS_DLLAPI GNPSMetaValueFile
   {
     public:
-      /// Generate a meta value table (tsv file) for GNPS FBMN with information on the input mzML files extracted from ConsensusMap.
+      /**
+        @brief Write the FBMN meta-value TSV seed.
+
+        Pulls the primary mzML run paths from @p consensus_map via
+        @c ConsensusMap::getPrimaryMSRunPath and emits one row per path. The file
+        starts with a header row @c "\\tfilename\\tATTRIBUTE_MAPID" (the first
+        column header is empty); each data row is
+        @c "&lt;index&gt;\\t&lt;basename(path)&gt;\\tMAP&lt;index&gt;" with @c index
+        running from 0.
+
+        @param[in] consensus_map Consensus map whose primary MS-run paths provide the file list.
+        @param[in] output_file   Destination path for the TSV file (overwritten if it exists).
+      */
       static void store(const ConsensusMap& consensus_map, const String& output_file);
   };
 }

--- a/src/openms/include/OpenMS/FORMAT/GNPSQuantificationFile.h
+++ b/src/openms/include/OpenMS/FORMAT/GNPSQuantificationFile.h
@@ -11,13 +11,43 @@
 
 namespace OpenMS
 {
+  /**
+    @brief Writer for the feature-quantification (.TXT) table required by GNPS Feature-Based Molecular Networking.
+
+    For each consensus feature in a @ref ConsensusMap, this writer emits one row giving
+    the consensus-level @c rt_cf, @c mz_cf, @c intensity_cf, @c charge_cf, @c width_cf,
+    @c quality_cf (in that order), optionally followed by IIMN columns if
+    @c Constants::UserParam::IIMN_ROW_ID is set on the first feature, followed by per-map
+    sub-feature columns. The file starts with @c \#MAP and @c \#CONSENSUS header lines and
+    one @c MAP row per @c ConsensusMap::getColumnHeaders entry (id, filename, label, size).
+    The format matches the schema at
+    https://ccms-ucsd.github.io/GNPSDocumentation/featurebasedmolecularnetworking/#feature-quantification-table.
+
+    The file is **required** for FBMN (in contrast to the optional meta-value table).
+    Produced by the @ref TOPP_GNPSExport tool.
+
+    @ingroup FileIO
+  */
   class OPENMS_DLLAPI GNPSQuantificationFile
   {
     public:
-      /// Write feature quantification table (txt file) from a consensusXML file. Required for GNPS FBMN.
-      /// The table contains map information on the featureXML files from which the consensusXML file was generated as well as
-      /// a row for every consensus feature with information on rt, mz, intensity, width and quality. The same information is
-      /// added for each original feature in the consensus feature.
+      /**
+        @brief Write the FBMN feature-quantification table.
+
+        Output structure (tab-separated, written via @ref SVOutStream):
+          - @c "#MAP\\tid\\tfilename\\tlabel\\tsize" header.
+          - @c "#CONSENSUS\\trt_cf\\tmz_cf\\tintensity_cf\\tcharge_cf\\twidth_cf\\tquality_cf"
+            header, followed by IIMN columns (@c IIMN_ROW_ID, @c IIMN_BEST_ION,
+            @c IIMN_ADDUCT_PARTNERS, @c IIMN_ANNOTATION_NETWORK_NUMBER) iff the first
+            consensus feature carries @c IIMN_ROW_ID, then per-map sub-feature columns
+            @c "rt_&lt;i&gt;\\tmz_&lt;i&gt;\\tintensity_&lt;i&gt;\\tcharge_&lt;i&gt;\\twidth_&lt;i&gt;".
+          - One @c MAP row per @p consensus_map.getColumnHeaders entry.
+          - One @c CONSENSUS row per consensus feature; missing per-map sub-features
+            are filled with empty strings.
+
+        @param[in] consensus_map Consensus map whose column headers and features drive the rows.
+        @param[in] output_file   Destination path for the TXT file (overwritten if it exists).
+      */
       static void store(const ConsensusMap& consensus_map, const String& output_file);
   };
 }


### PR DESCRIPTION
## Summary

Documents the three FORMAT classes consumed by the `GNPSExport` tool. All three previously had only one-line `///` briefs (and `GNPSMGFFile` even just an inline "see GNPSExport tool documentation" pointer), with **no `@ingroup`**, so they did not appear under the File IO module page in Doxygen output.

Per class:

- **`GNPSMGFFile`** — writes the consensus-spectrum MGF (one representative MS2 per consensus feature, with optional cosine-similarity-based merging). Class-level `@brief` covers the per-consensus-feature one-MS2-per-row contract, where merging parameters come from, and the link to the GNPSExport workflow. Each `DEF_*` constant picks up an inline brief explaining what it controls.
- **`GNPSMetaValueFile`** — writes the optional per-sample metadata `.TSV`. Class-level `@brief` describes the schema link, that it's *optional* (used for grouping/colouring on the GNPS side), and that one row corresponds to one input mzML in the consensus map's column headers.
- **`GNPSQuantificationFile`** — writes the **required** FBMN feature-quantification `.TXT`. Class-level `@brief` describes the consensus-row + per-map sub-feature layout, the header recording input featureXML names, and the link to the GNPS schema.

`@ingroup FileIO` on all three (matches the convention in OpenMS/FORMAT).

`store()` methods on each class also pick up structured `@brief` + `@param[in]` tags.

Comments only — no behavioural change.

## Test plan

- [x] `cmake --build OpenMS-build --target OpenMS` succeeds locally.
- [ ] `Doxygen_Warning_test` is clean on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded user-facing documentation for GNPS exporters: clarified how to generate consensus-feature MGF files, FBMN meta-value TSVs, and feature-quantification tables, including expected inputs, output column structures, merge/scan behavior, and usage notes for downstream GNPS workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9298)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->