### PR TITLE
docs(IonIdentityMolecularNetworking): add class-level Doxygen and per-method docs

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/IonIdentityMolecularNetworking.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IonIdentityMolecularNetworking.h
@@ -12,19 +12,82 @@
 
 namespace OpenMS
 {
+  /**
+    @brief Helpers for the Ion Identity Molecular Networking (IIMN) workflow on GNPS.
+
+    IIMN extends GNPS Feature-Based Molecular Networking by grouping consensus features
+    that represent the same compound seen as different adducts (e.g. [M+H]+ and [M+Na]+).
+    The grouping information is usually produced upstream by an adduct decharger (e.g.
+    @ref TOPP_MetaboliteAdductDecharger), which records a set of adduct-group IDs in the
+    @c Constants::UserParam::IIMN_LINKED_GROUPS meta value on each consensus feature.
+
+    Two stages live in this class:
+
+      -# annotateConsensusMap() consumes @c IIMN_LINKED_GROUPS, builds a bipartite graph
+         (consensus feature ↔ adduct group), runs Boost connected-components on it, and
+         writes back three IIMN meta values: a 1-based row id, the network number, and
+         the list of partner-feature row ids. The @c IIMN_LINKED_GROUPS meta value is
+         consumed and removed.
+      -# writeSupplementaryPairTable() turns those annotations into the CSV file required
+         by GNPS IIMN as the "supplementary pairs" upload.
+
+    Output of stage 1 is also a precondition for the meta-value / quantification tables
+    written by @ref GNPSMetaValueFile and @ref GNPSQuantificationFile, and is invoked
+    by the @ref TOPP_GNPSExport tool.
+
+    @ingroup Analysis_ID
+  */
   class OPENMS_DLLAPI IonIdentityMolecularNetworking
   {
     public:
-      /// Annotate ConsensusMap for ion identity molecular networking (IIMN) workflow by GNPS.
-      /// Adds meta values Constants::UserParams::IIMN_ROW_ID (unique index for each feature), Constants::UserParams::IIMN_ADDUCT_PARTNERS (related features row IDs)
-      /// and Constants::UserParams::IIMN_ANNOTATION_NETWORK_NUMBER (all related features with different adduct states) get the same network number).
-      /// This method requires the features annotated with the Constants::UserParams::IIMN_LINKED_GROUPS meta value.
-      ///  If at least one of the features has an annotation for Constants::UserParam::IIMN_LINKED_GROUPS, annotate ConsensusMap for IIMN.
+      /**
+        @brief Populate the IIMN meta values on @p consensus_map in-place.
+
+        Reads @c Constants::UserParam::IIMN_LINKED_GROUPS (a list of adduct-group ids,
+        typically from @ref TOPP_MetaboliteAdductDecharger), constructs a bipartite graph
+        whose nodes are either consensus features or adduct groups, computes its
+        connected components, and writes three meta values per feature:
+
+          - @c IIMN_ROW_ID — 1-based index of the feature in @p consensus_map (assigned
+            to every feature, including those with no group annotation).
+          - @c IIMN_ANNOTATION_NETWORK_NUMBER — 1-based connected-component id;
+            features that are direct or transitive adduct partners share this id.
+            Set only on features that carried @c IIMN_LINKED_GROUPS.
+          - @c IIMN_ADDUCT_PARTNERS — semicolon-separated list of partner @c IIMN_ROW_ID
+            values; set only on features that share at least one adduct group.
+
+        The @c IIMN_LINKED_GROUPS meta value is consumed and removed from every feature
+        when the routine returns.
+
+        @param[in,out] consensus_map Map to annotate. Features that lack @c IIMN_LINKED_GROUPS
+                                     receive only @c IIMN_ROW_ID.
+      */
       static void annotateConsensusMap(ConsensusMap& consensus_map);
 
-      /// Write supplementary pair table (csv file) from a consensusXML file with edge annotations for connected features. Required for GNPS IIMN.
-      /// The table contains the columns "ID 1" (row ID of first feature), "ID 2" (row ID of second feature), "EdgeType" (MS1/2 annotation),
-      /// "Score" (the number of direct partners from both connected features) and "Annotation" (adducts and delta m/z between two connected features).
+      /**
+        @brief Write the IIMN supplementary pairs CSV consumed by GNPS.
+
+        Emits one row per pair of features that share at least one adduct group, with
+        columns:
+
+          - @c ID1, @c ID2 — @c IIMN_ROW_ID of the two features (from @ref annotateConsensusMap).
+          - @c EdgeType   — fixed string "MS1 annotation".
+          - @c Score      — number of direct partners across both sides of the pair
+                            (sum of each side's partner counts, minus 2 to remove the
+                            self-counts).
+          - @c Annotation — best-ion adduct string for each side (defaulting to "default"
+                            if no @c IIMN_BEST_ION was set) plus the absolute delta m/z
+                            between the two precursors.
+
+        Reverse edges are deduplicated as the file is written (only one row per unordered
+        pair). The schema matches https://ccms-ucsd.github.io/GNPSDocumentation/fbmn-iin/#supplementary-pairs.
+
+        @note Returns silently if the first feature has no @c IIMN_ROW_ID (i.e.
+              @ref annotateConsensusMap has not been run on @p consensus_map).
+
+        @param[in] consensus_map Annotated consensus map (call @ref annotateConsensusMap first).
+        @param[in] output_file   Destination CSV path (overwritten if it exists).
+      */
       static void writeSupplementaryPairTable(const ConsensusMap& consensus_map, const String& output_file);
   };
 } // closing namespace OpenMS


### PR DESCRIPTION
## Summary

Documents `IonIdentityMolecularNetworking`, the analysis class that produces the IIMN annotations and the supplementary pairs CSV consumed by GNPS. Previous docs were paragraph-each on the two methods but lacked `@brief`/`@param` structure, a class-level overview, and an explanation of how the two methods chain together (and depend on upstream adduct deconvolution).

Adds:

- **Class-level `@brief`** tying the class to the IIMN workflow on GNPS:
  - Names the upstream meta value (`IIMN_LINKED_GROUPS`) and the typical producer (`MetaboliteAdductDecharger`).
  - Explains the two-stage pipeline (annotate first, then write pairs).
  - Cross-references the sister classes `GNPSMetaValueFile` / `GNPSQuantificationFile` and the `GNPSExport` TOPP tool.
  - `@ingroup Analysis_ID`.

- **`annotateConsensusMap()`**: `@param[in,out]` direction tag; documents the three meta values written:
  - `IIMN_ROW_ID` — 1-based row index assigned to *every* feature.
  - `IIMN_ANNOTATION_NETWORK_NUMBER` — connected-component id; set only on features that carried `IIMN_LINKED_GROUPS`.
  - `IIMN_ADDUCT_PARTNERS` — semicolon-separated partner row ids; set only on features that share at least one adduct group.
  - And that `IIMN_LINKED_GROUPS` is consumed and removed after use.

- **`writeSupplementaryPairTable()`**: `@brief`, per-column meaning of the CSV (including the "sum of partners minus 2" Score formula and the `"default"` fallback for `IIMN_BEST_ION`), the silent no-op when run before `annotateConsensusMap()`, and the GNPS schema reference.

Comments only — no behavioural change. Complements #9298 (the GNPS FORMAT trio) by documenting the analysis half of the same workflow.

## Test plan

- [x] `cmake --build OpenMS-build --target OpenMS` succeeds locally.
- [ ] `Doxygen_Warning_test` is clean on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced user-facing docs for the Ion Identity Molecular Networking feature: clearer descriptions of the two-stage workflow, the types of metadata produced/consumed, and a more detailed explanation of the supplementary‑pairs CSV format and behavior to aid interpretation and downstream use.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9299)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->