### PR TITLE
docs(ChromatogramProcessor): add class-level Doxygen and per-method docs

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/TARGETED/ChromatogramProcessor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/TARGETED/ChromatogramProcessor.h
@@ -17,15 +17,47 @@ namespace OpenSwath { struct LightTargetedExperiment; }
 namespace OpenMS
 {
 
-  /// Small helper to encapsulate feature finding / scoring on chromatogram inputs.
-  /// This isolates MRMFeatureFinderScoring setup used in RT normalization and elsewhere.
+  /**
+    @brief Thin wrapper around MRMFeatureFinderScoring::pickExperiment for already-extracted chromatograms.
+
+    The class exists so callers that already hold a list of MS chromatograms (i.e. XICs that
+    have been extracted upstream) can drive feature picking / scoring without having to
+    construct an empty SWATH-map / transformation stack themselves. It is typically used
+    inside RT-normalisation flows in the OpenSwath workflow, where iRT chromatograms have
+    been extracted before the analytical-transition scoring runs.
+
+    All work is delegated to @ref MRMFeatureFinderScoring; see its documentation for the
+    semantics of the parameter set passed in through @p feature_finder_param.
+
+    @ingroup TargetedQuantitation
+  */
   class OPENMS_DLLAPI ChromatogramProcessor
   {
   public:
+    /// Default constructor (the class is stateless; the API is a single static method)
     ChromatogramProcessor() = default;
+
+    /// Destructor
     ~ChromatogramProcessor() = default;
 
-    /// Run pickExperiment on the provided chromatograms and fill featureFile and transition_group_map
+    /**
+      @brief Score the supplied chromatograms against the transition list and emit features + transition groups.
+
+      Wraps @p chromatograms in a @ref PeakMap and a @ref SpectrumAccessOpenMS accessor,
+      constructs an @ref MRMFeatureFinderScoring instance parameterised with
+      @p feature_finder_param (and with @c setStrictFlag(false) so the call does not abort
+      on transitions that have no matching chromatogram), then calls @c pickExperiment()
+      with an empty SWATH-map vector and an identity @ref TransformationDescription.
+
+      Both outputs are populated in place: @p featureFile gets one feature per scored
+      precursor, and @p transition_group_map gets one entry per transition group.
+
+      @param[in]  chromatograms         Already-extracted XICs to score (one per transition).
+      @param[in]  transition_exp        Transition list to align the chromatograms to.
+      @param[in]  feature_finder_param  Parameter set forwarded to @ref MRMFeatureFinderScoring.
+      @param[out] featureFile           Receives the scored features (one per precursor); not cleared first.
+      @param[out] transition_group_map  Receives the per-transition-group scoring state.
+    */
     static void pickExperiment(
       const std::vector<MSChromatogram> & chromatograms,
       const OpenSwath::LightTargetedExperiment & transition_exp,

--- a/src/openms/include/OpenMS/ANALYSIS/TARGETED/ChromatogramProcessor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/TARGETED/ChromatogramProcessor.h
@@ -18,16 +18,19 @@ namespace OpenMS
 {
 
   /**
-    @brief Thin wrapper around MRMFeatureFinderScoring::pickExperiment for already-extracted chromatograms.
+    @brief Convenience entry point that runs @ref MRMFeatureFinderScoring on
+           a list of already-extracted chromatograms.
 
-    The class exists so callers that already hold a list of MS chromatograms (i.e. XICs that
-    have been extracted upstream) can drive feature picking / scoring without having to
-    construct an empty SWATH-map / transformation stack themselves. It is typically used
-    inside RT-normalisation flows in the OpenSwath workflow, where iRT chromatograms have
-    been extracted before the analytical-transition scoring runs.
+    Intended for callers that already hold a list of MS chromatograms (XICs
+    extracted upstream) and only need the feature-finding / scoring step
+    without setting up a full SWATH-map / RT-transformation stack. Typical
+    use is inside RT-normalisation flows in the OpenSwath workflow, where
+    iRT chromatograms are extracted before the analytical-transition scoring
+    runs.
 
-    All work is delegated to @ref MRMFeatureFinderScoring; see its documentation for the
-    semantics of the parameter set passed in through @p feature_finder_param.
+    All scoring semantics come from @ref MRMFeatureFinderScoring; see its
+    documentation for the parameter set passed in via
+    @p feature_finder_param.
 
     @ingroup TargetedQuantitation
   */
@@ -41,16 +44,18 @@ namespace OpenMS
     ~ChromatogramProcessor() = default;
 
     /**
-      @brief Score the supplied chromatograms against the transition list and emit features + transition groups.
+      @brief Score the supplied chromatograms against the transition list
+             and emit features + transition groups.
 
-      Wraps @p chromatograms in a @ref PeakMap and a @ref SpectrumAccessOpenMS accessor,
-      constructs an @ref MRMFeatureFinderScoring instance parameterised with
-      @p feature_finder_param (and with @c setStrictFlag(false) so the call does not abort
-      on transitions that have no matching chromatogram), then calls @c pickExperiment()
-      with an empty SWATH-map vector and an identity @ref TransformationDescription.
+      Tolerates transitions that have no matching chromatogram (they are
+      simply skipped rather than reported as an error). Scoring is performed
+      with no SWATH map and no RT transformation, so this overload is intended
+      for callers that have already extracted the chromatograms upstream and
+      only need the feature-finding step.
 
-      Both outputs are populated in place: @p featureFile gets one feature per scored
-      precursor, and @p transition_group_map gets one entry per transition group.
+      Both outputs are populated in place: @p featureFile gets one feature
+      per scored precursor, and @p transition_group_map gets one entry per
+      transition group.
 
       @param[in]  chromatograms         Already-extracted XICs to score (one per transition).
       @param[in]  transition_exp        Transition list to align the chromatograms to.


### PR DESCRIPTION
## Summary

Documents `ChromatogramProcessor`, a thin wrapper around `MRMFeatureFinderScoring::pickExperiment` used by RT-normalisation paths in `OpenSwathWorkflow` when chromatograms are already extracted. The previous one-line briefs didn't explain:

- the internal wrapping pipeline (XICs → `PeakMap` → `SpectrumAccessOpenMS`)
- the implicit `setStrictFlag(false)` (call doesn't abort if a transition has no matching chromatogram)
- the empty-SwathMap / identity-`TransformationDescription` defaults
- that both output arguments are populated *in place* and not cleared first

Adds class-level `@brief` covering the wrapper rationale and the typical RT-normalisation use case (`@ingroup TargetedQuantitation`), plus a proper `@brief` / `@param[in]` / `@param[out]` block on `pickExperiment()`.

Comments only — no behavioural change.

## Test plan

- [x] `cmake --build OpenMS-build --target OpenMS` succeeds locally.
- [ ] `Doxygen_Warning_test` is clean on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation for chromatogram scoring: clarifies this entry point is a convenience wrapper, documents that unmatched transitions are skipped (not errored), notes no SWATH-map/RT transformation in this overload, and explicitly describes what each output receives and how inputs/parameters are forwarded to the scorer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9300)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->