### PR TITLE
docs(MetaboliteSpectralMatching): add class-level Doxygen and field-level docs

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/MetaboliteSpectralMatching.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/MetaboliteSpectralMatching.h
@@ -23,6 +23,7 @@
 namespace OpenMS
 {
 
+  /// Strict-weak ordering on @ref MSSpectrum by the first precursor's m/z (ascending). Convenient as a sort predicate when building a precursor-m/z-indexed spectral library.
   struct OPENMS_DLLAPI PrecursorMassComparator
   {
     bool operator() (const MSSpectrum& a, const MSSpectrum& b)
@@ -32,10 +33,24 @@ namespace OpenMS
 
   } PrecursorMZLess;
 
+  /**
+    @brief One library-search match record: the observed spectrum, the matching DB spectrum, the score, and the metabolite metadata copied from the hit.
+
+    Used by @ref MetaboliteSpectralMatching to accumulate all candidate matches before the
+    top-N export step. The fields fall into three groups:
+      - Observed-side: the index / native id of the experimental MS2 spectrum and its
+        precursor mass / RT.
+      - DB-side: the index of the matching DB spectrum, the DB precursor mass / charge,
+        and the hyperscore (see @ref MetaboliteSpectralMatching::computeHyperScore).
+      - Metabolite metadata copied from the DB spectrum: primary/secondary identifier,
+        common name, sum formula, InChI, SMILES, and the precursor adduct.
+
+    @ingroup Analysis_ID
+  */
   class OPENMS_DLLAPI SpectralMatch
   {
   public:
-    /// Default constructor
+    /// Default constructor (zero-initialised numeric fields, empty strings)
     SpectralMatch();
 
     /// Default destructor
@@ -47,73 +62,104 @@ namespace OpenMS
     /// Assignment operator
     SpectralMatch& operator=(const SpectralMatch&);
 
+    /// Precursor mass (Da) of the experimental MS2 spectrum being matched
     double getObservedPrecursorMass() const;
+    /// Setter for the observed-side precursor mass (Da)
     void setObservedPrecursorMass(const double&);
 
+    /// Retention time (seconds) at which the observed MS2 spectrum was acquired
     double getObservedPrecursorRT() const;
+    /// Setter for the observed-side precursor RT (seconds)
     void setObservedPrecursorRT(const double&);
 
+    /// Precursor mass (Da) recorded on the DB-side spectrum that matched
     double getFoundPrecursorMass() const;
+    /// Setter for the DB-side precursor mass (Da)
     void setFoundPrecursorMass(const double&);
 
+    /// Precursor charge recorded on the DB-side spectrum
     Int getFoundPrecursorCharge() const;
+    /// Setter for the DB-side precursor charge
     void setFoundPrecursorCharge(const Int&);
 
+    /// Hyperscore (higher is better; 0 if fewer than three peaks matched — see @ref MetaboliteSpectralMatching::computeHyperScore)
     double getMatchingScore() const;
+    /// Setter for the hyperscore
     void setMatchingScore(const double&);
 
+    /// Index of the observed MS2 spectrum in the input @ref PeakMap passed to @ref MetaboliteSpectralMatching::run
     Size getObservedSpectrumIndex() const;
+    /// Setter for the observed-spectrum index
     void setObservedSpectrumIndex(const Size&);
 
+    /// Index of the matching DB spectrum in the spectral-library @ref PeakMap
     Size getMatchingSpectrumIndex() const;
+    /// Setter for the DB-spectrum index
     void setMatchingSpectrumIndex(const Size&);
 
+    /// Native id (vendor-specific id) of the observed MS2 spectrum
     String getObservedSpectrumNativeID() const;
+    /// Setter for the observed-spectrum native id
     void setObservedSpectrumNativeID(const String&);
 
+    /// Primary identifier of the matched metabolite (e.g. HMDB / KEGG id; database-defined)
     String getPrimaryIdentifier() const;
+    /// Setter for the primary metabolite identifier
     void setPrimaryIdentifier(const String&);
 
+    /// Secondary identifier of the matched metabolite (e.g. alternate database accession)
     String getSecondaryIdentifier() const;
+    /// Setter for the secondary metabolite identifier
     void setSecondaryIdentifier(const String&);
 
+    /// Common (trivial) name of the matched metabolite
     String getCommonName() const;
+    /// Setter for the common name
     void setCommonName(const String&);
 
+    /// Chemical sum formula of the matched metabolite (neutral)
     String getSumFormula() const;
+    /// Setter for the sum formula
     void setSumFormula(const String&);
 
+    /// InChI string of the matched metabolite
     String getInchiString() const;
+    /// Setter for the InChI string
     void setInchiString(const String&);
 
+    /// SMILES string of the matched metabolite
     String getSMILESString() const;
+    /// Setter for the SMILES string
     void setSMILESString(const String&);
 
+    /// Adduct annotation recorded on the DB-side precursor (e.g. "[M+H]+")
     String getPrecursorAdduct() const;
+    /// Setter for the precursor adduct
     void setPrecursorAdduct(const String&);
 
 
   private:
-    double observed_precursor_mass_;
-    double observed_precursor_rt_;
-    double found_precursor_mass_;
-    Int found_precursor_charge_;
-    double matching_score_;
-    Size observed_spectrum_idx_;
-    Size matching_spectrum_idx_;
-    String observed_spectrum_native_id_;
+    double observed_precursor_mass_;   ///< Observed-side precursor mass (Da)
+    double observed_precursor_rt_;     ///< Observed-side precursor RT (seconds)
+    double found_precursor_mass_;      ///< DB-side precursor mass (Da)
+    Int found_precursor_charge_;       ///< DB-side precursor charge
+    double matching_score_;            ///< Hyperscore (see @ref MetaboliteSpectralMatching::computeHyperScore)
+    Size observed_spectrum_idx_;       ///< Index of the observed spectrum in the input PeakMap
+    Size matching_spectrum_idx_;       ///< Index of the DB spectrum in the spectral-library PeakMap
+    String observed_spectrum_native_id_; ///< Native id (vendor-specific) of the observed spectrum
 
     // further meta information
-    String primary_id_;
-    String secondary_id_;
-    String common_name_;
-    String sum_formula_;
-    String inchi_string_;
-    String smiles_string_;
-    String precursor_adduct_;
+    String primary_id_;     ///< Primary metabolite identifier
+    String secondary_id_;   ///< Secondary metabolite identifier
+    String common_name_;    ///< Trivial / common name
+    String sum_formula_;    ///< Neutral chemical sum formula
+    String inchi_string_;   ///< InChI string
+    String smiles_string_;  ///< SMILES string
+    String precursor_adduct_; ///< DB-side precursor adduct annotation
 
   };
 
+  /// Strict-weak ordering on @ref SpectralMatch by hyperscore (descending — top-scoring match comes first when sorted)
   struct OPENMS_DLLAPI SpectralMatchScoreComparator
   {
     bool operator() (const SpectralMatch& a, const SpectralMatch& b)
@@ -123,18 +169,57 @@ namespace OpenMS
 
   } SpectralMatchScoreGreater;
 
+  /**
+    @brief Metabolomics spectral-library search by hyperscore.
+
+    Matches the MS2 spectra in an experimental @ref PeakMap against the MS2 spectra of a
+    spectral library (e.g. exported from MoNA / MassBank / HMDB / GNPS) and emits the
+    top-scoring metabolite identifications as an @ref MzTab table.
+
+    Pipeline:
+      -# Sort the library by precursor m/z (using @ref PrecursorMassComparator) for fast lookup.
+      -# Apply @ref WindowMower noise reduction to each experimental MS2 spectrum.
+      -# For each experimental MS2 spectrum, select DB spectra whose precursor is within the
+         configured precursor m/z tolerance and ion-mode filter.
+      -# Score each candidate via @ref computeHyperScore (X!Tandem-style:
+         @c log(dot_product) + @c log(factorial(matched_ions))). Matches with fewer than three
+         matched ions are scored 0.
+      -# Sort matches per spectrum by score (using @ref SpectralMatchScoreComparator), keep
+         the top-N (parameter @c report_mode_), and export to MzTab.
+
+    Configuration is exposed through @ref DefaultParamHandler (precursor/fragment tolerances
+    and units, ion mode, top-N report mode, spectrum-merging toggle).
+
+    @ingroup Analysis_ID
+  */
   class OPENMS_DLLAPI MetaboliteSpectralMatching :
   public DefaultParamHandler,
   public ProgressLogger
   {
   public:
-    /// Default constructor
+    /// Default constructor; installs the search parameters (see class docs)
     MetaboliteSpectralMatching();
 
     /// Default destructor
     ~MetaboliteSpectralMatching() override;
 
-    /// hyperscore computation
+    /**
+      @brief Compute the X!Tandem-style hyperscore for one experimental vs. DB spectrum pair.
+
+      Formula: @c log(dot_product) + @c log(factorial(matched_ions)). The dot product
+      sums @c (db_intensity * exp_intensity) over peak pairs where the experimental peak
+      is within @p fragment_mass_error of a DB peak (ppm or Th per @p fragment_mass_tolerance_unit_ppm).
+      Matches that find fewer than three matched ions return 0; matched-ion counts above
+      @c boost::math::max_factorial saturate at the maximum factorial. Negative hyperscores
+      are clamped to 0.
+
+      @param[in] fragment_mass_error           Fragment-ion tolerance (value).
+      @param[in] fragment_mass_tolerance_unit_ppm If @c true, @p fragment_mass_error is in ppm; otherwise Th.
+      @param[in] exp_spectrum                  Experimental MS2 spectrum (sorted by m/z).
+      @param[in] db_spectrum                   DB MS2 spectrum (sorted by m/z).
+      @param[in] mz_lower_bound                Minimum m/z to consider; peaks below this are ignored. Default 0.0.
+      @return Hyperscore (>= 0; 0 if fewer than three matched peaks).
+    */
     static double computeHyperScore(
       double fragment_mass_error,
       bool fragment_mass_tolerance_unit_ppm,
@@ -142,7 +227,21 @@ namespace OpenMS
       const MSSpectrum& db_spectrum,
       double mz_lower_bound = 0.0);
 
-    /// hyperscore computation (with output of peak annotations)
+    /**
+      @brief Same as the other overload, but also fills @p annotations with per-peak match metadata.
+
+      Annotations are produced only when the DB spectrum carries a @ref MSSpectrum::StringDataArray
+      (annotation string) and a @ref MSSpectrum::IntegerDataArray (charge) — otherwise this
+      overload behaves like the no-annotation form.
+
+      @param[in]  fragment_mass_error           Fragment-ion tolerance (value).
+      @param[in]  fragment_mass_tolerance_unit_ppm If @c true, @p fragment_mass_error is in ppm; otherwise Th.
+      @param[in]  exp_spectrum                  Experimental MS2 spectrum (sorted by m/z).
+      @param[in]  db_spectrum                   DB MS2 spectrum (sorted by m/z).
+      @param[out] annotations                   Per-matched-peak annotations (annotation string, charge, m/z, intensity); appended to.
+      @param[in]  mz_lower_bound                Minimum m/z to consider; peaks below this are ignored.
+      @return Hyperscore (>= 0; 0 if fewer than three matched peaks).
+    */
     static double computeHyperScore(
       double fragment_mass_error,
       bool fragment_mass_tolerance_unit_ppm,
@@ -151,14 +250,24 @@ namespace OpenMS
       std::vector<PeptideHit::PeakAnnotation>& annotations,
       double mz_lower_bound = 0.0);
 
-    /// main method of MetaboliteSpectralMatching
-    void run(PeakMap &, PeakMap &, MzTab &, String &);
+    /**
+      @brief Run the metabolomics spectral-library search and populate the MzTab output.
+
+      Implements the pipeline described in the class brief: sort the DB by precursor m/z,
+      noise-reduce each experimental MS2 via @ref WindowMower, score candidate library
+      spectra, keep the top-N per query, and export to MzTab.
+
+      @param[in,out] msexp       Experimental MS2 spectra. Modified in place by the noise-reduction step.
+      @param[in,out] spec_db     Spectral library; will be sorted by precursor m/z.
+      @param[out]    mztab_out   MzTab result table populated with the top matches.
+      @param[in]     out_spectra If non-empty, the (noise-reduced) experimental spectra are also written to this mzML path.
+    */
+    void run(PeakMap & msexp, PeakMap & spec_db, MzTab & mztab_out, String & out_spectra);
 
   protected:
     void updateMembers_() override;
 
-    // we have to use a pointer for "annotations" because mutable
-    // references can't have temporary default values:
+    /// Shared implementation behind the two public computeHyperScore() overloads; uses a pointer for @p annotations because mutable references cannot carry a temporary default value.
     static double computeHyperScore_(
       double fragment_mass_error,
       bool fragment_mass_tolerance_unit_ppm,
@@ -168,17 +277,17 @@ namespace OpenMS
       double mz_lower_bound = 0.0);
 
   private:
-    /// private member functions
+    /// Convert the accumulated @ref SpectralMatch records into an MzTab table.
     void exportMzTab_(const std::vector<SpectralMatch>&, MzTab&);
 
-    double precursor_mz_error_;
-    double fragment_mz_error_;
-    String mz_error_unit_;
-    String ion_mode_;
+    double precursor_mz_error_;     ///< Precursor m/z tolerance (value); unit per @c mz_error_unit_
+    double fragment_mz_error_;      ///< Fragment m/z tolerance (value); unit per @c mz_error_unit_
+    String mz_error_unit_;          ///< "ppm" or "Da"
+    String ion_mode_;               ///< "positive" or "negative"; pre-filters DB spectra by polarity
 
-    String report_mode_;
+    String report_mode_;            ///< "all" / "top3" / "best" — controls how many matches per spectrum reach MzTab
 
-    bool merge_spectra_;
+    bool merge_spectra_;            ///< If true, merge same-precursor MS2 spectra before searching
   };
 
 }


### PR DESCRIPTION
## Summary

Documents `MetaboliteSpectralMatching` (hyperscore-based metabolomics spectral-library search) and its companion record class `SpectralMatch`, plus the two helper comparator structs. None of the four entities carried a class-level `@brief` or `@ingroup`, all `SpectralMatch` accessors were undocumented, the comparators had no docs at all, and the public `run()` method had **four anonymous parameters** in the header with no `@param` tags.

Adds:

- **`SpectralMatch`**: class-level `@brief` grouping the fields (observed-side / DB-side / metabolite metadata); per-accessor briefs with units (Da, seconds) and score semantics (0 if `<3` matched ions); per-private-field briefs.
- **`PrecursorMassComparator` / `SpectralMatchScoreComparator`**: one-line briefs spelling out sort direction (ascending precursor m/z / descending hyperscore) and intended use.
- **`MetaboliteSpectralMatching`**: class-level `@brief` outlining the five-stage pipeline (sort DB → `WindowMower` noise reduction → precursor-window candidate filter → hyperscore → top-N → MzTab) and naming the configuration keys; `@ingroup Analysis_ID`.
- **`computeHyperScore`** (both overloads): explains the formula `log(dot_product) + log(factorial(matched_ions))`, the `<3 matches → 0` rule, the boost-factorial saturation, the negative-score clamp, and (for the annotations overload) the dependency on the DB spectrum carrying `String`/`IntegerDataArrays`.
- **`run()`**: parameters are now named (`msexp`, `spec_db`, `mztab_out`, `out_spectra`) with correct `@param[in,out]`/`[out]`/`[in]` directions — `msexp` is modified in place by noise reduction, `spec_db` is sorted in place, `out_spectra` is a path the experimental spectra are written to if non-empty.
- All member fields: briefs with unit semantics and the enum-string domains (`"ppm"`/`"Da"`, `"positive"`/`"negative"`, `"all"`/`"top3"`/`"best"`).

Comments only — no behavioural change.

## Test plan

- [x] `cmake --build OpenMS-build --target OpenMS` succeeds locally.
- [ ] `Doxygen_Warning_test` is clean on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. This update includes internal documentation and comments for developer reference, with no impact to functionality or user experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9305)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->