### PR TITLE
docs(ILPDCWrapper): add class-level Doxygen and per-method docs

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/DECHARGING/ILPDCWrapper.h
+++ b/src/openms/include/OpenMS/ANALYSIS/DECHARGING/ILPDCWrapper.h
@@ -22,47 +22,79 @@ namespace OpenMS
   class FeatureMap;
   class ChargePair;
 
+  /**
+    @brief ILP-based decharging: pick the maximum-log-score subset of charge-pair edges that yields a consistent per-feature charge assignment.
+
+    Wraps the integer-linear-programming step shared by @ref FeatureDeconvolution (peptides)
+    and @ref MetaboliteFeatureDeconvolution (metabolites). Given a @ref FeatureMap and a
+    pre-computed list of putative @ref ChargePair edges between its features (each edge
+    captures one consistent charge-state hypothesis for a pair of features that are also
+    adduct/mass-shift compatible), the solver returns the maximum-log-score subset of edges
+    that respects per-feature consistency constraints (at most one realised
+    charge-assignment per feature). The realised edges are marked active in @p pairs.
+
+    The implementation first partitions the input edge set into connected components and
+    solves one ILP per component (so a single big input doesn't translate into a single
+    intractable LP) — this slicing is handled internally and is transparent to callers.
+
+    LP-solver choice (GLPK vs. CoinOR) is hidden behind @ref LPWrapper.
+
+    @ingroup Quantitation
+  */
   class OPENMS_DLLAPI ILPDCWrapper
   {
 
 public:
+    /// Container of putative charge-pair edges between features
     typedef std::vector<ChargePair> PairsType;
+    /// Index type into @ref PairsType, used for slicing
     typedef PairsType::size_type PairsIndex;
 
-    ///Constructor
+    /// Default constructor; the class is stateless and only exposes compute()
     ILPDCWrapper();
 
-    ///Destructor
+    /// Destructor
     virtual ~ILPDCWrapper();
 
-    /// Compute optimal solution and return value of objective function
-    /// If the input feature map is empty, a warning is issued and -1 is returned.
-    /// @return value of objective function
-    /// and @p pairs will have all realized edges set to "active"
+    /**
+      @brief Solve the ILP on @p pairs to find the max-log-score subset of consistent charge-pair edges.
+
+      Partitions the input edge graph into connected components, solves one ILP per
+      component (per @ref LPWrapper), accumulates the objective values, and marks every
+      realised edge active in @p pairs. The @ref FeatureMap is read-only here — features
+      themselves are not modified; the caller is expected to apply the chosen charge
+      assignments to @p fm separately.
+
+      @param[in]     fm            Feature map providing per-feature mass / intensity for log-score evaluation.
+      @param[in,out] pairs         Putative charge-pair edges to filter; realised edges are flagged active in place.
+      @param[in]     verbose_level Verbosity for the LP solver (0 = silent; higher = more solver chatter).
+      @return Sum of per-component objective values, or @c -1 if @p fm is empty (a warning is logged in that case).
+    */
     double compute(const FeatureMap& fm, PairsType& pairs, Size verbose_level) const;
 
 private:
 
-    /// slicing the problem into subproblems
+    /// Solve one slice of the edge graph (the new clique-based solver) — see compute() for the externally visible contract
     double computeSlice_(const FeatureMap& fm,
                          PairsType& pairs,
                          const PairsIndex margin_left,
                          const PairsIndex margin_right,
                          const Size verbose_level) const;
 
-    /// slicing the problem into subproblems
+    /// Legacy slice solver kept for comparison / regression testing — kept in lock-step with @ref computeSlice_
     double computeSliceOld_(const FeatureMap& fm,
                             PairsType& pairs,
                             const PairsIndex margin_left,
                             const PairsIndex margin_right,
                             const Size verbose_level) const;
 
-    /// calculate a score for the i_th edge
+    /// Log-score of one putative charge-pair edge given the underlying feature intensities and the recorded mass-shift probability
     double getLogScore_(const PairsType::value_type& pair, const FeatureMap& fm) const;
 
+    /// Internal lookup: feature id (as @ref String) -> set of compatible charge-annotation variant indices encountered for that feature so far
     typedef std::map<String, std::set<Size> > FeatureType_;
 
-    // add another charge annotation variant for a feature
+    /// Record one more charge-annotation variant @p v for the feature whose rotated id is @p rota_l in @p f_set
     void updateFeatureVariant_(FeatureType_& f_set, const String& rota_l, const Size& v) const;
 
 


### PR DESCRIPTION
## Summary

Documents `ILPDCWrapper`, the ILP-based decharging step shared by `FeatureDeconvolution` (peptides) and `MetaboliteFeatureDeconvolution` (metabolites). The class had **no class-level `@brief`**, no `@ingroup`, and `compute()` had only inline `///` comments that missed several user-relevant details.

Previously under-documented:

- **ILP objective**: pick the maximum-log-score subset of charge-pair edges that respects per-feature consistency constraints (at most one realised charge assignment per feature).
- **Both consumers** named: `FeatureDeconvolution` and `MetaboliteFeatureDeconvolution`.
- **Connected-components slicing**: the implementation partitions the edge graph and solves one ILP per component, so callers don't need to slice before calling.
- **No feature mutation**: the read-only `FeatureMap` is not modified — caller must apply chosen charge assignments separately. The function only flags edges active in the `pairs` argument.
- **LP-solver abstraction**: GLPK vs. CoinOR choice hidden behind `LPWrapper`.
- **The `-1` return**: signals empty input, not "no solution".

Adds:

- Class-level `@brief` covering all of the above with `@ingroup Quantitation`.
- Structured `@brief` / `@param[in,out]` / `@return` on `compute()`.
- Tightened briefs on the private helpers including a note that `computeSliceOld_` is kept for regression testing.

Comments only — no behavioural change.

## Test plan

- [x] `cmake --build OpenMS-build --target OpenMS` succeeds locally.
- [ ] `Doxygen_Warning_test` is clean on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced code documentation with expanded comments for the decharging analysis module, providing clearer descriptions of functionality and behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9307)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->