### PR TITLE
docs(OPXLDataStructs): add outer-class @brief, @ingroup, and enum-value briefs

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLDataStructs.h
+++ b/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLDataStructs.h
@@ -20,20 +20,52 @@
 
 namespace OpenMS
 {
+  /**
+    @brief Namespace-style container holding the data types shared across the OpenPepXL cross-linking pipeline.
+
+    OpenPepXL identifies cross-linked peptide pairs from MS/MS spectra. The pipeline needs a small set
+    of plain-data types to carry information between stages: candidate generation, precursor-mass filtering,
+    spectrum matching, scoring, and result aggregation. This class collects those types as nested
+    structs/enums so that callers can refer to them via @c OPXLDataStructs::CrossLinkSpectrumMatch etc.,
+    keeping the global namespace clean.
+
+    Type overview:
+
+      - @c ProteinProteinCrossLinkType / @c PeptidePosition — small classification enums.
+      - @c ProteinProteinCrossLink — one fully-specified cross-link candidate (alpha + beta peptide,
+        link positions, linker name/mass/term-specificity).
+      - @c XLPrecursor / @c XLPrecursorComparator — compact precursor-mass-only view used during
+        the (squared-complexity) peptide-pair enumeration; mass-comparable to plain doubles for binary
+        search.
+      - @c AASeqWithMass / @c AASeqWithMassComparator — digested peptide plus pre-computed mass, the
+        building block of the candidate enumeration.
+      - @c CrossLinkSpectrumMatch / @c CLSMScoreComparator — one PSM record carrying both the
+        underlying @c ProteinProteinCrossLink and the full score/annotation vector used for the
+        xQuest-style output.
+      - @c PreprocessedPairSpectra — the result of light/heavy label-pair denoising on an mzML run.
+
+    @ingroup Analysis_ID
+  */
   class OPENMS_DLLAPI OPXLDataStructs
   {
 
     public:
 
       /**
-       * @brief The ProteinProteinCrossLinkType enum enumerates possible types of Protein-Protein cross-linking reaction results. Cross-link, Mono-link or Loop-link.
-       */
+        @brief Kind of cross-linking reaction product.
+
+        A cross-link reagent can react in three observable ways at the MS2 level:
+        the canonical inter-peptide cross-link, a mono-link (reagent quenched on one
+        side and attached to only one residue), or a loop-link (reagent bridging two
+        residues within the same peptide). @c ProteinProteinCrossLink::getType
+        derives this value from the link layout.
+      */
       enum ProteinProteinCrossLinkType
       {
-        CROSS = 0,
-        MONO = 1,
-        LOOP = 2,
-        NUMBER_OF_CROSS_LINK_TYPES
+        CROSS = 0,                   ///< Inter-peptide cross-link (alpha and beta non-empty)
+        MONO = 1,                    ///< Mono-link (reagent attached to one peptide only; beta empty, @c cross_link_position.second == -1)
+        LOOP = 2,                    ///< Loop-link (reagent bridges two residues within the same peptide; beta empty, both positions valid)
+        NUMBER_OF_CROSS_LINK_TYPES   ///< Sentinel; total number of cross-link types (use to size arrays)
       };
 
       /**
@@ -190,11 +222,11 @@ namespace OpenMS
        */
       struct XLPrecursor
       {
-        float precursor_mass{};
-        unsigned int alpha_index = 0;
-        unsigned int beta_index = 0;
-        String alpha_seq;
-        String beta_seq;
+        float precursor_mass{};         ///< Mass of (alpha + beta + cross-linker), in Da; the key used to filter candidates against an experimental precursor
+        unsigned int alpha_index = 0;   ///< Index of the alpha peptide in the digested-protein-DB vector (the "longer" peptide by convention)
+        unsigned int beta_index = 0;    ///< Index of the beta peptide in the digested-protein-DB vector (empty/unused for mono- or loop-links)
+        String alpha_seq;               ///< Sequence string of the alpha peptide (cached to avoid re-lookup during scoring)
+        String beta_seq;                ///< Sequence string of the beta peptide (empty for mono- or loop-links)
       };
 
       // comparator for sorting XLPrecursor vectors and using upper_bound and lower_bound using only a precursor mass
@@ -220,15 +252,17 @@ namespace OpenMS
       };
 
       /**
-       * @brief The PeptidePosition enum
+        @brief Where the peptide came from in its parent protein after in-silico digestion.
 
-          Used to record the positions of peptides in proteins after in silico digestion determine whether protein terminal modifications are possible on a peptide.
-       */
+        Used to gate whether protein-terminal modifications can apply to a peptide:
+        only peptides that contain the protein's N- or C-terminus can carry the
+        corresponding protein-terminal modification.
+      */
       enum PeptidePosition
       {
-        INTERNAL = 0,
-        C_TERM = 1,
-        N_TERM = 2
+        INTERNAL = 0, ///< Peptide is internal to its parent protein (neither end is a protein terminus)
+        C_TERM = 1,   ///< Peptide ends at the parent protein's C-terminus (can carry protein-C-term modifications)
+        N_TERM = 2    ///< Peptide starts at the parent protein's N-terminus (can carry protein-N-term modifications)
       };
 
       /**
@@ -243,10 +277,10 @@ namespace OpenMS
        */
       struct AASeqWithMass
       {
-        double peptide_mass = 0;
-        AASequence peptide_seq;
-        PeptidePosition position = PeptidePosition::INTERNAL;
-        String unmodified_seq;
+        double peptide_mass = 0;                                    ///< Pre-computed monoisotopic mass of @c peptide_seq (Da); used as the sort/search key during pair enumeration
+        AASequence peptide_seq;                                     ///< The peptide itself, including any modifications carried over from the digest
+        PeptidePosition position = PeptidePosition::INTERNAL;       ///< Where the peptide sits in its parent protein (gates protein-terminal modifications)
+        String unmodified_seq;                                      ///< Plain-string view of the peptide without modifications (cached for fast comparison / lookup)
       };
 
       /**


### PR DESCRIPTION
## Summary

Documents the outer `OPXLDataStructs` namespace-style container (the wrapper class that gathers all OpenPepXL data types). The class itself had **no class-level `@brief`** and **no `@ingroup`**, so the type collection didn't surface on any Doxygen module page. Several fields and enum values were also undocumented.

Adds:

- **Class-level `@brief`** explaining the namespace-in-a-class rationale, plus a bullet-list type overview (classification enums / cross-link candidate / precursor-mass view / digested-peptide view / PSM record / preprocessed-pair-spectra). `@ingroup Analysis_ID`.
- **Per-enum-value briefs** on:
  - `ProteinProteinCrossLinkType` — `CROSS` / `MONO` / `LOOP` / `NUMBER_OF_CROSS_LINK_TYPES` with the precise predicate `ProteinProteinCrossLink::getType` derives each from.
  - `PeptidePosition` — `INTERNAL` / `C_TERM` / `N_TERM` with the protein-terminal-modification gating semantics.
- **Per-field briefs** on `XLPrecursor` and `AASeqWithMass` (the two structs whose members were bare).

Uses `@c` (monospace) instead of `@ref` for inner-type references in the class brief, since the brief sits before the class declaration and Doxygen cannot auto-resolve unqualified member refs there (same trap from #9309).

Comments only — no behavioural change.

## Test plan

- [x] `cmake --build OpenMS-build --target OpenMS` succeeds locally.
- [ ] `Doxygen_Warning_test` is clean on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Significantly expanded documentation for cross-linking mass spectrometry data structures. Updated descriptions include detailed information on nested data types, field semantics, and relationships between components.

* **Refactor**
  * Enhanced member initialization declarations with explicit default values to improve data structure reliability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9310)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->