### PR TITLE
docs(audit): ground three merged doc PRs' claims against the implementation

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/DECHARGING/ILPDCWrapper.h
+++ b/src/openms/include/OpenMS/ANALYSIS/DECHARGING/ILPDCWrapper.h
@@ -37,7 +37,8 @@ namespace OpenMS
     solves one ILP per component (so a single big input doesn't translate into a single
     intractable LP) — this slicing is handled internally and is transparent to callers.
 
-    LP-solver choice (GLPK vs. CoinOR) is hidden behind @ref LPWrapper.
+    LP-solver choice (GLPK, COIN-OR, or HiGHS — selected at build time via the
+    @c LP_SOLVER CMake variable) is hidden behind @ref LPWrapper.
 
     @ingroup Quantitation
   */

--- a/src/openms/include/OpenMS/ANALYSIS/ID/AccurateMassSearchEngine.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AccurateMassSearchEngine.h
@@ -51,8 +51,11 @@ namespace OpenMS
       - @c observed_mz       : observed @em m/z of the feature.
       - @c observed_rt       : retention time of the feature.
       - @c observed_intensity: intensity of the feature.
-      - @c individual_intensities : per-sample intensities for consensus
-                                    features (empty for single-map input).
+      - @c individual_intensities : per-FeatureHandle intensities, populated
+                                    only on the @c ConsensusMap overload of
+                                    @ref AccurateMassSearchEngine::run; stays
+                                    empty when the engine is invoked on a plain
+                                    @ref FeatureMap.
       - @c mass_trace_intensities : per-isotopologue intensities of the
                                     underlying mass traces (used for the
                                     isotope-pattern similarity score).

--- a/src/openms/include/OpenMS/ANALYSIS/ID/MetaboliteSpectralMatching.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/MetaboliteSpectralMatching.h
@@ -102,12 +102,12 @@ namespace OpenMS
     /// Setter for the observed-spectrum native id
     void setObservedSpectrumNativeID(const String&);
 
-    /// Primary identifier of the matched metabolite (e.g. HMDB / KEGG id; database-defined)
+    /// Primary identifier of the matched metabolite. The .cpp populates this via the first available of: @c GNPS_Spectrum_ID, @c Massbank_Accession_ID, the metabolite-name meta value, or — as a last fallback — the DB spectrum's native id.
     String getPrimaryIdentifier() const;
     /// Setter for the primary metabolite identifier
     void setPrimaryIdentifier(const String&);
 
-    /// Secondary identifier of the matched metabolite (e.g. alternate database accession)
+    /// Secondary identifier of the matched metabolite. The .cpp populates this from the @c HMDB_ID meta value on the DB-side spectrum.
     String getSecondaryIdentifier() const;
     /// Setter for the secondary metabolite identifier
     void setSecondaryIdentifier(const String&);
@@ -173,22 +173,28 @@ namespace OpenMS
     @brief Metabolomics spectral-library search by hyperscore.
 
     Matches the MS2 spectra in an experimental @ref PeakMap against the MS2 spectra of a
-    spectral library (e.g. exported from MoNA / MassBank / HMDB / GNPS) and emits the
-    top-scoring metabolite identifications as an @ref MzTab table.
+    spectral library (the .cpp recognises GNPS- and MassBank-style metadata on the DB-side
+    spectrum — see @ref SpectralMatch::getPrimaryIdentifier for the actual lookup chain)
+    and emits the matching results as an @ref MzTab table.
 
     Pipeline:
       -# Sort the library by precursor m/z (using @ref PrecursorMassComparator) for fast lookup.
       -# Apply @ref WindowMower noise reduction to each experimental MS2 spectrum.
       -# For each experimental MS2 spectrum, select DB spectra whose precursor is within the
-         configured precursor m/z tolerance and ion-mode filter.
-      -# Score each candidate via @ref computeHyperScore (X!Tandem-style:
-         @c log(dot_product) + @c log(factorial(matched_ions))). Matches with fewer than three
-         matched ions are scored 0.
-      -# Sort matches per spectrum by score (using @ref SpectralMatchScoreComparator), keep
-         the top-N (parameter @c report_mode_), and export to MzTab.
+         configured precursor m/z tolerance and ion-mode filter (parameter
+         @c "ionization_mode", values @c "positive" or @c "negative").
+      -# Score each candidate via @ref computeHyperScore — the hyperscore formula popularised
+         by X!Tandem, @c log(dot_product) + @c log(factorial(matched_ions)). Matches with
+         fewer than three matched ions are scored 0.
+      -# Sort matches per spectrum by score (using the @ref SpectralMatchScoreComparator
+         instance @c SpectralMatchScoreGreater) and emit either the top three or only the
+         single best match per spectrum according to parameter @c "report_mode" (only
+         @c "top3" or @c "best" are valid values) to MzTab.
 
-    Configuration is exposed through @ref DefaultParamHandler (precursor/fragment tolerances
-    and units, ion mode, top-N report mode, spectrum-merging toggle).
+    Configuration is exposed through @ref DefaultParamHandler — see the defaults installed
+    by the constructor for the supported keys (@c "prec_mass_error_value",
+    @c "frag_mass_error_value", @c "mass_error_unit", @c "ionization_mode", @c "report_mode",
+    @c "merge_spectra").
 
     @ingroup Analysis_ID
   */
@@ -283,9 +289,9 @@ namespace OpenMS
     double precursor_mz_error_;     ///< Precursor m/z tolerance (value); unit per @c mz_error_unit_
     double fragment_mz_error_;      ///< Fragment m/z tolerance (value); unit per @c mz_error_unit_
     String mz_error_unit_;          ///< "ppm" or "Da"
-    String ion_mode_;               ///< "positive" or "negative"; pre-filters DB spectra by polarity
+    String ion_mode_;               ///< Cached value of parameter @c "ionization_mode"; @c "positive" or @c "negative"; pre-filters DB spectra by precursor-charge sign
 
-    String report_mode_;            ///< "all" / "top3" / "best" — controls how many matches per spectrum reach MzTab
+    String report_mode_;            ///< Cached value of parameter @c "report_mode"; only @c "top3" or @c "best" are valid — controls whether the top 3 or only the single best match per spectrum is exported to MzTab
 
     bool merge_spectra_;            ///< If true, merge same-precursor MS2 spectra before searching
   };


### PR DESCRIPTION
## Summary

Retroactive audit of the doc PRs merged yesterday (#9288–#9307 batch) against the corresponding `.cpp` / cross-referenced files turned up three factually wrong claims that slipped through. This PR corrects them in-tree on `develop`.

### MetaboliteSpectralMatching (originally #9305)

- **Class brief** listed *"MoNA / MassBank / HMDB / GNPS"* as the supported spectral libraries. The .cpp (`MetaboliteSpectralMatching.cpp:545,552`) only recognises **GNPS- and MassBank-style** metadata on the DB-side spectrum. Tightened to that pair plus a pointer to the actual lookup chain.
- **Class brief** said *"keep the top-N (parameter `report_mode_`)"*. The valid strings for `report_mode` are only `{"top3","best"}` (`MetaboliteSpectralMatching.cpp:269`) — there is no numeric N. Rewrote to spell out the two enum values.
- **`SpectralMatch::getPrimaryIdentifier`** doc gave *"HMDB / KEGG id"* as examples; the .cpp (`MetaboliteSpectralMatching.cpp:568-585`) actually populates it from the first available of `GNPS_Spectrum_ID` → `Massbank_Accession_ID` → metabolite-name meta value → native id. Replaced examples with the actual fallback chain.
- **`SpectralMatch::getSecondaryIdentifier`** doc said *"alternate database accession"*; the .cpp (`MetaboliteSpectralMatching.cpp:586`) sources it from `HMDB_ID` specifically. Updated.
- **`report_mode_` member** field doc listed `"all"` as a valid value; not in the .cpp's valid-strings set. Fixed.
- **`ion_mode_` member** field doc now names the underlying parameter key (`"ionization_mode"`) — the field name and the param key differ.

### ILPDCWrapper (originally #9307)

- Class brief said *"LP-solver choice (GLPK vs. CoinOR) is hidden behind LPWrapper"*. The LP layer (`LPWrapper.h:169-174`) actually supports **three** solvers — GLPK, COIN-OR, and HiGHS — selected at build time via the `LP_SOLVER` CMake variable. Updated.

### AccurateMassSearchResult (originally #9290)

- Field-semantics line for `individual_intensities` said *"empty for single-map input"*. The actual gate is which `run()` overload was used: only the `ConsensusMap` overload (`AccurateMassSearchEngine.cpp:519`) populates the field; the `FeatureMap` overload leaves it empty. "Single-map" is the wrong axis. Tightened wording.

Comments only — no behavioural change.

## Test plan

- [x] `cmake --build OpenMS-build --target OpenMS` succeeds locally.
- [ ] `Doxygen_Warning_test` is clean on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated LP-solver abstraction documentation, now explicitly supporting GLPK, COIN-OR, and HiGHS as build-time selectable options.
  * Clarified accurate mass search results documentation regarding per-feature intensity handling, particularly for consensus feature maps.
  * Enhanced metabolite spectral matching documentation with more specific parameter descriptions and updated pipeline configuration details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9311)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->