### PR TITLE
docs(OpenPepXLAlgorithm): add @ingroup + ground enum / member docs against the .cpp

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/XLMS/OpenPepXLAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/XLMS/OpenPepXLAlgorithm.h
@@ -83,6 +83,7 @@ namespace OpenMS
     </table>
   </CENTER>
 
+  @ingroup Analysis_ID
 */
 
   class OPENMS_DLLAPI OpenPepXLAlgorithm :
@@ -90,13 +91,16 @@ namespace OpenMS
   {
 public:
 
-    /// Exit codes
+    /**
+      @brief Outcome of @ref run, distinguishing successful execution from configuration / input
+      problems detected before the search is attempted.
+    */
     enum class ExitCodes
     {
-      EXECUTION_OK,
-      ILLEGAL_PARAMETERS,
-      UNEXPECTED_RESULT,
-      INCOMPATIBLE_INPUT_DATA
+      EXECUTION_OK,            ///< Search ran to completion; the output arguments contain the results.
+      ILLEGAL_PARAMETERS,      ///< Parameter set is inconsistent — e.g. duplicate entries in @c modifications:fixed or @c modifications:variable (see .cpp lines 182, 189).
+      UNEXPECTED_RESULT,       ///< Reserved sentinel; not returned by the current implementation.
+      INCOMPATIBLE_INPUT_DATA  ///< Input is unusable — the spectrum container is empty (only chromatograms), or one of its spectra is not sorted by m/z (see .cpp lines 200, 209).
     };
 
     /// Default constructor
@@ -123,44 +127,63 @@ public:
 private:
     void updateMembers_() override;
 
+    /**
+      @brief Split labelled spectrum pairs into linear- and cross-link-bearing peak lists.
+
+      For every (@p spectrum_pairs[i].first, @p spectrum_pairs[i].second) pair (light/heavy
+      spectrum) the function aligns the two spectra and uses @p cross_link_mass_iso_shift to
+      tell which peaks are common to both (linear ions, no cross-linker attached) and which
+      are present at the expected shifted m/z (peaks that carry the cross-linker). The
+      result has three parallel @ref PeakMap members (linear / xlink / all) sized to
+      @c spectrum_pairs.size(). The outer loop is OpenMP-parallel.
+
+      @param[in] spectra                        Source spectrum container (light and heavy MS2 stored together).
+      @param[in] spectrum_pairs                 Indices into @p spectra giving (light, heavy) pairs.
+      @param[in] cross_link_mass_iso_shift      Mass difference (Da) between heavy and light cross-linker; controls the shift used for matching.
+      @param[in] fragment_mass_tolerance        Tolerance for matching linear (un-shifted) fragment ions.
+      @param[in] fragment_mass_tolerance_xlinks Tolerance for matching cross-link-bearing fragment ions.
+      @param[in] fragment_mass_tolerance_unit_ppm  If @c true, both tolerances are in ppm; otherwise Th.
+      @param[in] deisotope                      If @c true, the cross-link peak list keeps a parallel @c "iso_peak_count" IntegerDataArray.
+      @return A @ref OPXLDataStructs::PreprocessedPairSpectra with one entry per input pair in @c spectra_linear_peaks / @c spectra_xlink_peaks / @c spectra_all_peaks.
+    */
     static OPXLDataStructs::PreprocessedPairSpectra preprocessPairs_(const PeakMap& spectra, const std::vector< std::pair<Size, Size> >& spectrum_pairs, const double cross_link_mass_iso_shift, double fragment_mass_tolerance, double fragment_mass_tolerance_xlinks, bool fragment_mass_tolerance_unit_ppm, bool deisotope);
 
-    String decoy_string_;
-    bool decoy_prefix_;
+    String decoy_string_;   ///< Cached value of parameter @c "decoy_string"; substring marking decoy entries in the FASTA accessions
+    bool decoy_prefix_;     ///< Cached value of parameter @c "decoy_prefix"; if true the decoy string is matched as a prefix, otherwise as a suffix
 
-    Int min_precursor_charge_;
-    Int max_precursor_charge_;
-    double precursor_mass_tolerance_;
-    bool precursor_mass_tolerance_unit_ppm_;
-    IntList precursor_correction_steps_;
+    Int min_precursor_charge_;             ///< Cached value of parameter @c "precursor:min_charge"
+    Int max_precursor_charge_;             ///< Cached value of parameter @c "precursor:max_charge"
+    double precursor_mass_tolerance_;      ///< Cached value of parameter @c "precursor:mass_tolerance" (unit per @c precursor_mass_tolerance_unit_ppm_)
+    bool precursor_mass_tolerance_unit_ppm_; ///< Cached value of parameter @c "precursor:mass_tolerance_unit" == @c "ppm"
+    IntList precursor_correction_steps_;   ///< Cached value of parameter @c "precursor:corrections" — monoisotopic-peak-misassignment offsets to try
 
-    double fragment_mass_tolerance_;
-    double fragment_mass_tolerance_xlinks_;
-    bool fragment_mass_tolerance_unit_ppm_;
+    double fragment_mass_tolerance_;         ///< Cached value of parameter @c "fragment:mass_tolerance" (linear fragment ions)
+    double fragment_mass_tolerance_xlinks_;  ///< Cached value of parameter @c "fragment:mass_tolerance_xlinks" (cross-link-bearing fragment ions)
+    bool fragment_mass_tolerance_unit_ppm_;  ///< Cached value of parameter @c "fragment:mass_tolerance_unit" == @c "ppm"
 
-    StringList cross_link_residue1_;
-    StringList cross_link_residue2_;
-    double cross_link_mass_light_;
-    double cross_link_mass_iso_shift_;
-    DoubleList cross_link_mass_mono_link_;
-    String cross_link_name_;
+    StringList cross_link_residue1_;          ///< Cached value of parameter @c "cross_linker:residue1" — residues the first end of the linker reacts with
+    StringList cross_link_residue2_;          ///< Cached value of parameter @c "cross_linker:residue2" — residues the second end of the linker reacts with
+    double cross_link_mass_light_;            ///< Cached value of parameter @c "cross_linker:mass_light" — mass added by the light cross-linker
+    double cross_link_mass_iso_shift_;        ///< Cached value of parameter @c "cross_linker:mass_iso_shift" — mass difference heavy minus light
+    DoubleList cross_link_mass_mono_link_;    ///< Cached value of parameter @c "cross_linker:mass_mono_link" — possible mono-link masses
+    String cross_link_name_;                  ///< Cached value of parameter @c "cross_linker:name" — used to disambiguate mass-equivalent linkers
 
-    StringList fixedModNames_;
-    StringList varModNames_;
-    Size max_variable_mods_per_peptide_;
-    Size peptide_min_size_;
-    Size missed_cleavages_;
-    String enzyme_name_;
+    StringList fixedModNames_;                ///< Cached value of parameter @c "modifications:fixed" (UniMod names); duplicates trigger @ref ExitCodes::ILLEGAL_PARAMETERS
+    StringList varModNames_;                  ///< Cached value of parameter @c "modifications:variable" (UniMod names); duplicates trigger @ref ExitCodes::ILLEGAL_PARAMETERS
+    Size max_variable_mods_per_peptide_;      ///< Cached value of parameter @c "modifications:variable_max_per_peptide"
+    Size peptide_min_size_;                   ///< Cached value of parameter @c "peptide:min_size"
+    Size missed_cleavages_;                   ///< Cached value of parameter @c "peptide:missed_cleavages"
+    String enzyme_name_;                      ///< Cached value of parameter @c "peptide:enzyme"
 
-    Int number_top_hits_;
-    String deisotope_mode_;
+    Int number_top_hits_;                     ///< Cached value of parameter @c "algorithm:number_top_hits"
+    String deisotope_mode_;                   ///< Cached value of parameter @c "algorithm:deisotope" (@c "true" / @c "false" / @c "auto")
 
-    String add_y_ions_;
-    String add_b_ions_;
-    String add_x_ions_;
-    String add_a_ions_;
-    String add_c_ions_;
-    String add_z_ions_;
-    String add_losses_;
+    String add_y_ions_;   ///< Cached value of parameter @c "ions:y_ions"
+    String add_b_ions_;   ///< Cached value of parameter @c "ions:b_ions"
+    String add_x_ions_;   ///< Cached value of parameter @c "ions:x_ions"
+    String add_a_ions_;   ///< Cached value of parameter @c "ions:a_ions"
+    String add_c_ions_;   ///< Cached value of parameter @c "ions:c_ions"
+    String add_z_ions_;   ///< Cached value of parameter @c "ions:z_ions"
+    String add_losses_;   ///< Cached value of parameter @c "ions:neutral_losses"
   };
 }


### PR DESCRIPTION
## Summary

Extends the existing class-level docs of `OpenPepXLAlgorithm` (the cross-link search algorithm behind `TOPP_OpenPepXL`) with grounded per-enum-value, per-field, and per-private-method details verified against `OpenPepXLAlgorithm.cpp`.

Additions:

- **`@ingroup Analysis_ID`** so the class surfaces on the Identification module page.
- **Per-enum-value briefs on `ExitCodes`** with the precise `.cpp` triggers:
  - `ILLEGAL_PARAMETERS` → duplicate fixed / variable modifications (.cpp:182, 189).
  - `INCOMPATIBLE_INPUT_DATA` → empty peak data or unsorted spectra (.cpp:200, 209).
  - `UNEXPECTED_RESULT` → **declared but never returned** in the current `.cpp`. Documented as a reserved sentinel rather than inventing a meaning.
- **Doxygen block on `preprocessPairs_`** describing what it actually does (light/heavy alignment using `cross_link_mass_iso_shift` to split linear- vs cross-link-bearing fragment peaks, OpenMP-parallel outer loop, produces three parallel `PeakMap` results sized to `spectrum_pairs.size()`).
- **Per-field briefs on every cached member**, each naming the underlying `Param` key (`"decoy_string"`, `"precursor:mass_tolerance"`, `"cross_linker:residue1"`, `"modifications:variable_max_per_peptide"`, etc.) so callers can map between member-variable names and the actual `Param` keys used by `updateMembers_`.

Comments only — no behavioural change.

## Test plan

- [x] `cmake --build OpenMS-build --target OpenMS` succeeds locally.
- [ ] `Doxygen_Warning_test` is clean on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved API documentation with clearer descriptions of error codes and parameter definitions for the cross-linking analysis algorithm.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9314)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->