### PR TITLE
docs(TransitionParquetFile): add @ingroup + ground method docs against the .cpp

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TransitionParquetFile.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TransitionParquetFile.h
@@ -92,20 +92,50 @@ namespace OpenMS
       Optional columns:
       - traml_id (string)
       - annotation (string)
+
+      @ingroup FileIO
   */
   class OPENMS_DLLAPI TransitionParquetFile
   {
   public:
-    /// Default constructor
+    /// Default constructor (the class is stateless; API consists of the two convert* methods)
     TransitionParquetFile() = default;
 
     /// Default destructor
     ~TransitionParquetFile() = default;
 
-    /// Read a .oswpq library directory and populate a LightTargetedExperiment
+    /**
+      @brief Read a @c .oswpq library and populate a @ref OpenSwath::LightTargetedExperiment.
+
+      Opens @c library/precursors.parquet and @c library/transitions.parquet from @p oswpq_dir
+      (zip archive or extracted directory), validates each table against the
+      @ref OSWPrecursorSchema / @ref OSWTransitionSchema in subset mode (extra columns are
+      tolerated), and materialises the rows into @p targeted_exp.
+
+      @p targeted_exp is **reset** to an empty @ref OpenSwath::LightTargetedExperiment at the
+      start of the call — pre-existing contents are discarded rather than appended to.
+
+      @param[in]  oswpq_dir    Path to a @c .oswpq archive or to an already-extracted directory containing @c library/.
+      @param[out] targeted_exp Populated targeted experiment; cleared before being filled.
+      @throws Exception::MissingInformation If a required parquet entry (precursors / transitions) cannot be located inside @p oswpq_dir.
+      @throws Exception::InvalidValue If a loaded parquet table fails schema validation against the precursor / transition schema, or if any other required row-level field is missing during materialisation.
+    */
     void convertParquetToTargetedExperiment(const String& oswpq_dir, OpenSwath::LightTargetedExperiment& targeted_exp) const;
 
-    /// Write a LightTargetedExperiment to a .oswpq library (zip file or directory)
+    /**
+      @brief Write a @ref OpenSwath::LightTargetedExperiment to a @c .oswpq library.
+
+      Output target depends on @p oswpq_path: if it points at an existing directory, the
+      parquet files are written directly under @c \<oswpq_path\>/library/. Otherwise the writer
+      stages the layout in a temporary directory, then assembles a zip archive at
+      @p oswpq_path via a @c .tmp staging archive that is renamed into place once complete.
+
+      @param[in] oswpq_path  Destination — existing directory or zip-file path.
+      @param[in] targeted_exp Library to serialise.
+      @throws Exception::FileNotWritable If a generated file inside the staging area cannot be written.
+      @throws Exception::MissingInformation If required per-row data (e.g. a transition lacking a peptide ref) is missing from @p targeted_exp.
+      @throws Exception::InvalidValue If row-level invariants are violated (e.g. duplicate precursor ids, schema-incompatible values).
+    */
     void convertLightTargetedExperimentToParquet(const String& oswpq_path, const OpenSwath::LightTargetedExperiment& targeted_exp) const;
   };
 


### PR DESCRIPTION
## Summary

Extends the docs on `TransitionParquetFile` (the reader/writer for the OpenSwath `.oswpq` parquet-backed transition library). The class brief already documented the container layout, `metadata.json` schema, and the required/optional parquet columns. What was missing was `@ingroup` and proper per-method `@brief`/`@param`/`@throws` blocks.

Every prose claim added by this PR is verified against `TransitionParquetFile.cpp`.

Additions:

- **`@ingroup FileIO`**.
- **`convertParquetToTargetedExperiment()`** — Doxygen block with:
  - Note that `targeted_exp` is **reset** at entry (line 209: `targeted_exp = OpenSwath::LightTargetedExperiment{};`). Caller-supplied state is discarded, not appended to.
  - Schema validation done in subset mode (lines 237, 243).
  - `@throws Exception::MissingInformation` when a required parquet entry is missing (line 227).
  - `@throws Exception::InvalidValue` on schema-validation failure (lines 240, 246).
- **`convertLightTargetedExperimentToParquet()`** — Doxygen block with:
  - Output target depends on whether `oswpq_path` is an existing directory (writes directly under `<oswpq_path>/library/`) or a target zip path (stages in a TempDir then zips, via a `.tmp` staging archive; cpp lines 395-403, 695-716).
  - `@throws Exception::FileNotWritable` on metadata write failure (line 120).
  - `@throws Exception::MissingInformation` / `InvalidValue` on per-row data problems (lines 524, 579, 605, 678).

Comments only — no behavioural change.

## Test plan

- [x] `cmake --build OpenMS-build --target OpenMS` succeeds locally.
- [ ] `Doxygen_Warning_test` is clean on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Parquet conversion docs: clarified that the converter is stateless and exposes two conversion operations; detailed expected directory/table layout and schema validation modes; clarified that target data is reset at start, parameter meanings, output-path/staging behavior, and explicit error conditions for missing or invalid data and unwritable staging outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9316)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->