### PR TITLE
docs(FeatureFinderIdentificationAlgorithm): add class-level Doxygen and per-method docs

### DIFF
--- a/src/openms/include/OpenMS/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.h
+++ b/src/openms/include/OpenMS/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.h
@@ -23,32 +23,79 @@
 #include <map>
 
 namespace OpenMS {
+/**
+  @brief ID-guided MS1 feature finder; the algorithm behind @ref TOPP_FeatureFinderIdentification.
+
+  Uses peptide identifications as targets to drive chromatogram extraction from MS1 data,
+  builds a per-peptide assay library on the fly, scores extracted peak groups with
+  @ref MRMFeatureFinderScoring, and emits a @ref FeatureMap of quantified features.
+
+  @section FFid_inputs Inputs
+
+  Two ID layers are accepted:
+    - @em Internal IDs (@p peptides / @p proteins) — the high-confidence anchors used to
+      define candidate elution windows and to train the SVM classifier (when classification
+      is enabled).
+    - @em External IDs (@p peptides_ext / @p proteins_ext) — optional, lower-confidence
+      transfer IDs (e.g. from match-between-runs) used to extend the search space without
+      contributing to SVM training. When external lists are empty, the algorithm skips
+      machine learning and FDR estimation entirely.
+
+  Optional @p seeds from an upstream untargeted feature finder can also be added.
+
+  @section FFid_faims FAIMS handling
+
+  If the input @ref PeakMap carries multiple FAIMS compensation voltages, @ref run splits
+  the data via @ref IMDataConverter::splitByFAIMSCV, runs the per-CV pipeline in a fresh
+  algorithm instance per group (peptide IDs filtered by @c FAIMS_CV through
+  @ref FAIMSHelper::filterPeptidesByFAIMSCV), annotates the resulting features with the
+  @c FAIMS_CV meta value, and merges everything back into the caller's @p features.
+  IDs without a @c FAIMS_CV are processed against @em every CV group for backward
+  compatibility. In the multi-FAIMS case, @ref getLibrary returns an empty library because
+  each CV group has its own assay library.
+
+  @section FFid_sideeffects ID-list transformations inside run()
+
+  Both ID lists are taken by value (see the run() signature), so the @em caller's
+  containers are never observably modified. The transformations described here happen
+  on the function's local copies and influence which IDs reach @p features:
+
+  - The local copy of @p peptides is shrunk to the best hit per identification.
+  - FFid meta values are added to each surviving hit before it is written into
+    @p features.
+  - If @p seeds carries IDs, those are appended to the local copy of @p peptides
+    before scoring.
+
+  @section FFid_primary Primary MS-run path
+
+  After feature detection the @ref FeatureMap's @c primaryMSRunPath is set to the
+  @c ms_data_'s recorded run path; if that is not a valid / readable mzML, @p spectra_file
+  is used as a fallback annotation (see @ref MSExperiment overload of
+  @ref FeatureMap::setPrimaryMSRunPath).
+
+  @ingroup FeatureFinder
+*/
 class OPENMS_DLLAPI FeatureFinderIdentificationAlgorithm :
   public DefaultParamHandler
 {
 public:
-  /// default constructor
+  /// Default constructor; installs the FFid parameters (see class docs)
   FeatureFinderIdentificationAlgorithm();
 
-  /// Main method for actual FeatureFinder
-  /// External IDs (@p peptides_ext, @p proteins_ext) may be empty,
-  /// in which case no machine learning or FDR estimation will be performed.
-  /// Optional seeds from e.g. untargeted FeatureFinders can be added with
-  /// @p seeds.
-  /// Results will be written to @p features.
-  /// Note: The primaryMSRunPath of features will be updated to the primaryMSRunPath
-  /// stored in the MSExperiment.
-  /// If that path is not a valid and readable mzML @p spectra_file
-  /// will be annotated as a fall-back.
-  /// Caution: peptide IDs will be shrunk to best hit, FFid metavalues added
-  /// and potential seed IDs added.
-  ///
-  /// FAIMS data is handled automatically: if the MS data contains multiple FAIMS
-  /// compensation voltages, each CV group is processed independently (with peptide IDs
-  /// filtered by FAIMS_CV) and results are combined with FAIMS_CV annotation on features.
-  /// IDs without FAIMS_CV annotation are included in all groups for backward compatibility.
-  /// For multi-FAIMS data, getLibrary() returns an empty library since each FAIMS group
-  /// has its own assay library.
+  /**
+    @brief Run the FFid pipeline; for FAIMS data this dispatches one run per CV group and merges results.
+
+    See the class brief for the role of external IDs, the seeds list, the FAIMS handling,
+    the side effects on the input ID lists, and the primary-MS-run-path fallback semantics.
+
+    @param[in]  peptides      Internal peptide IDs (taken by value). The local copy is shrunk to best hit per identification and FFid meta values are added before being written into @p features; the caller's container is not modified.
+    @param[in]  proteins      Protein IDs corresponding to @p peptides.
+    @param[in]  peptides_ext  External peptide IDs, optional (may be empty); taken by value with the same shrink-and-annotate treatment as @p peptides.
+    @param[in]  proteins_ext  Protein IDs corresponding to @p peptides_ext.
+    @param[out] features      Quantified feature map; pre-existing contents are cleared for FAIMS data and replaced.
+    @param[in]  seeds         Optional pre-detected features from an untargeted feature finder.
+    @param[in]  spectra_file  Source mzML path used as a fallback for @c primaryMSRunPath annotation when the MSExperiment's own path isn't usable.
+  */
   void run(
     PeptideIdentificationList peptides,
     const std::vector<ProteinIdentification>& proteins,
@@ -59,22 +106,63 @@ public:
     const String& spectra_file = ""
     );
 
+  /// Re-score / filter an existing candidate @ref FeatureMap in place using the configured classifier and quality cutoffs (entry point used to re-process candidates exported via the @c candidates_out parameter).
   void runOnCandidates(FeatureMap& features);
 
+  /**
+    @brief Mutable access to the cached MS1 data.
+    @return Reference to the cached @ref PeakMap (already pre-processed by @ref run when called after run()).
+  */
   PeakMap& getMSData();
+  /**
+    @brief Read-only access to the cached MS1 data.
+    @return Const reference to the cached @ref PeakMap.
+  */
   const PeakMap& getMSData() const;
 
-  /// @brief set the MS data used for feature detection
+  /**
+    @brief Copy the MS data into the algorithm instance; useful from pyOpenMS where moving is awkward.
+    @param[in] ms_data Source @ref PeakMap; copied into the internal cache.
+  */
   void setMSData(const PeakMap& ms_data); // for pyOpenMS
+  /**
+    @brief Move the MS data into the algorithm instance (no copy).
+    @param[in] ms_data Source @ref PeakMap; moved into the internal cache. @ref getMSData will later expose the cached (possibly preprocessed) copy, not the original.
+  */
   void setMSData(PeakMap&& ms_data); // moves peak data and saves the copy. Note that getMSData() will give back a processed/modified version.
 
+  /**
+    @brief Mutable access to the accumulated extracted chromatograms (XICs) from the last @ref run.
+    @return Reference to the accumulated XIC @ref PeakMap.
+  */
   PeakMap& getChromatograms();
+  /**
+    @brief Read-only access to the accumulated extracted chromatograms.
+    @return Const reference to the accumulated XIC @ref PeakMap.
+  */
   const PeakMap& getChromatograms() const;
 
+  /**
+    @brief Mutable access to the progress logger used by the algorithm.
+    @return Reference to the @ref ProgressLogger (configure log type, etc.).
+  */
   ProgressLogger& getProgressLogger();
+  /**
+    @brief Read-only access to the progress logger.
+    @return Const reference to the @ref ProgressLogger.
+  */
   const ProgressLogger& getProgressLogger() const;
 
+  /**
+    @brief Mutable access to the assay library used / produced by the last @ref run.
+    @return Reference to the @ref TargetedExperiment library.
+    @note For multi-FAIMS inputs this returns an empty library because each CV group has its own internal library.
+  */
   TargetedExperiment& getLibrary();
+  /**
+    @brief Read-only access to the assay library used / produced by the last @ref run.
+    @return Const reference to the @ref TargetedExperiment library (empty for multi-FAIMS inputs — see the non-const overload).
+  */
   const TargetedExperiment& getLibrary() const;
 
 protected:


### PR DESCRIPTION
## Summary

Documents `FeatureFinderIdentificationAlgorithm` (FFid), the algorithm behind `TOPP_FeatureFinderIdentification`. The class previously had **no class-level `@brief`**, no `@ingroup`, and `run()` carried a long `///` block instead of a structured Doxygen entry. All public accessors / mutators were undocumented.

Every behavioural claim is grounded against `FeatureFinderIdentificationAlgorithm.cpp`.

Additions:

- **Class-level `@brief`** with `@section` blocks for:
  - **Inputs**: internal vs. external IDs (SVM training and FDR are skipped when external lists are empty), optional seeds.
  - **FAIMS handling** (cpp lines 578-637): `IMDataConverter::splitByFAIMSCV` → per-CV fresh algorithm instance → `FAIMSHelper::filterPeptidesByFAIMSCV` → annotate features with `FAIMS_CV` → merge.
  - **Side effects** on the caller's ID lists (shrink to best hit, FFid meta values, seed IDs added).
  - **Primary MS-run path** fallback (cpp line 695: `setPrimaryMSRunPath({spectra_file}, ms_data_)` — `ms_data_`'s value is preferred, with `spectra_file` annotated only when the recorded path isn't usable).
- **`@ingroup FeatureFinder`**.
- **Restructured `run()` block** with `@param` direction tags reflecting in-place mutation (`peptides`/`peptides_ext` shrunk + annotated; `features` cleared for FAIMS and replaced).
- **`@brief` on `runOnCandidates`** pointing at the `candidates_out` re-entry path.
- **`@brief` on every public accessor / mutator**, including a `@note` on the multi-FAIMS `getLibrary()` empty-library quirk (cpp lines 622-623, each CV group has its own internal library).

Comments only — no behavioural change.

## Test plan

- [x] `cmake --build OpenMS-build --target OpenMS` succeeds locally.
- [ ] `Doxygen_Warning_test` is clean on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified user-facing documentation describing algorithm behavior (including FAIMS/multi-run handling), parameter effects, data caching/mutability, and fallback semantics for input annotations.
  * Clarified expectations for identification/peptide handling and progress reporting.

*Note:* No user-facing functionality changes in this release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9317)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->