### PR TITLE
docs(OSWData): promote /// briefs to @brief, add @ingroup + enum/field briefs

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/OSWData.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/OSWData.h
@@ -17,34 +17,49 @@ namespace OpenMS
 {
     class MSExperiment;
 
-    /// hierarchy levels of the OSWData tree
+    /**
+      @brief Hierarchy levels of the @ref OSWData tree.
+
+      Captures the four-level tree (Protein → Peptide → Feature → Transition) used by every
+      @c OSWData accessor that needs to talk about "which depth is being addressed",
+      together with a stable string table @c LevelName[] for log / UI output.
+
+      @ingroup TargetedQuantitation
+    */
     struct OPENMS_DLLAPI OSWHierarchy
     {
-      /// the actual levels
+      /// Tree levels in top-down order.
       enum Level
       {
-        PROTEIN,
-        PEPTIDE,
-        FEATURE,
-        TRANSITION,
-        SIZE_OF_VALUES
+        PROTEIN,         ///< Top-level protein record (@ref OSWProtein).
+        PEPTIDE,         ///< Charged peptide precursor under a protein (@ref OSWPeptidePrecursor).
+        FEATURE,         ///< One candidate peak group (chromatographic feature) under a peptide (@ref OSWPeakGroup).
+        TRANSITION,      ///< One fragment-ion transition under a feature (@ref OSWTransition).
+        SIZE_OF_VALUES   ///< Sentinel; total number of levels (also used by @ref OSWIndexTrace::lowest to mean "not set").
       };
-      /// strings matching 'Level'
+      /// Display strings parallel to @ref Level (indexed by enum value).
       static const char* LevelName[SIZE_OF_VALUES];
     };
 
-    /// Describes a node in the OSWData model tree. 
-    /// If a lower level, e.g. feature, is set, the upper levels need to be set as well.
-    /// The lowest level which is set, must be indicated by setting @p lowest.
+    /**
+      @brief Index path into the @ref OSWData tree from the root down to a specific node.
+
+      If a lower level is set (e.g. @c idx_feat), every level above it must also be set
+      (the indices form a path through the tree, not arbitrary points). The deepest level
+      whose index is meaningful is recorded in @c lowest; @c lowest == @c SIZE_OF_VALUES is
+      the default-constructed "not pointing anywhere" state.
+
+      @ingroup TargetedQuantitation
+    */
     struct OPENMS_DLLAPI OSWIndexTrace
     {
-      int idx_prot = -1;
-      int idx_pep = -1;
-      int idx_feat = -1;
-      int idx_trans = -1;
-      OSWHierarchy::Level lowest = OSWHierarchy::Level::SIZE_OF_VALUES;
+      int idx_prot  = -1;   ///< Index into @ref OSWData::getProteins, or -1 if not set
+      int idx_pep   = -1;   ///< Index into the parent protein's @c getPeptidePrecursors, or -1 if not set
+      int idx_feat  = -1;   ///< Index into the parent precursor's @c getFeatures, or -1 if not set
+      int idx_trans = -1;   ///< Index into the parent feature's @c getTransitionIDs, or -1 if not set
+      OSWHierarchy::Level lowest = OSWHierarchy::Level::SIZE_OF_VALUES;  ///< Deepest level whose index is meaningful; @c SIZE_OF_VALUES marks an unset trace
 
-      /// is the trace default constructed (=false), or does it point somewhere (=true)?
+      /// @c true if the trace points somewhere (@c lowest != @c SIZE_OF_VALUES); @c false if it is default-constructed.
       bool isSet() const
       {
         return lowest != OSWHierarchy::Level::SIZE_OF_VALUES;
@@ -52,7 +67,16 @@ namespace OpenMS
 
     };
 
-    /// high-level meta data of a transition
+    /**
+      @brief High-level meta-data of one fragment-ion transition referenced by an @ref OSWPeakGroup.
+
+      Immutable after construction (the only mutating ops are the defaulted move / copy
+      assignment overloads). The @c id field doubles as the chromatogram-native-id used to
+      resolve back into an sqMass chromatogram via @ref OSWData::fromNativeID after
+      @ref OSWData::buildNativeIDResolver has been called.
+
+      @ingroup TargetedQuantitation
+    */
     struct OPENMS_DLLAPI OSWTransition
     {
       public:
@@ -101,8 +125,12 @@ namespace OpenMS
     };
 
     /**
-      A peak group (also called feature) is defined on a small RT range (leftWidth to rightWidth) in a group of extracted transitions (chromatograms).
-      The same transitions can be used to defined multiple (usually non-overlapping in RT) peak groups, of which usually only one is correct (lowest q-value).
+      @brief A peak group (also called feature) is defined on a small RT range (leftWidth to rightWidth) in a group of extracted transitions (chromatograms).
+
+      The same transitions can be used to define multiple (usually non-overlapping in RT) peak
+      groups, of which usually only one is correct (lowest q-value).
+
+      @ingroup TargetedQuantitation
     */
     class OPENMS_DLLAPI OSWPeakGroup
     {
@@ -169,12 +197,14 @@ namespace OpenMS
     };
 
     /**
-      @brief A peptide with a charge state
+      @brief A peptide with a charge state.
 
-      An OSWProtein has one or more OSWPeptidePrecursors.
+      An @ref OSWProtein has one or more @c OSWPeptidePrecursors.
 
-      The OSWPeptidePrecursor contains multiple candidate features (peak groups) of type OSWPeakGroup, only one of which is usually true.
+      The @c OSWPeptidePrecursor contains multiple candidate features (peak groups) of type
+      @ref OSWPeakGroup, only one of which is usually true.
 
+      @ingroup TargetedQuantitation
     */
     class OPENMS_DLLAPI OSWPeptidePrecursor
     {
@@ -229,6 +259,7 @@ namespace OpenMS
     /**
       @brief A Protein is the highest entity and contains one or more peptides which were found/traced.
 
+      @ingroup TargetedQuantitation
     */
     class OPENMS_DLLAPI OSWProtein
     {
@@ -246,16 +277,19 @@ namespace OpenMS
         /// move assignment operator
         OSWProtein& operator=(OSWProtein&& rhs) = default;
 
+        /// Protein accession (UniProt-style identifier supplied at construction).
         const String& getAccession() const
         {
           return accession_;
         }
 
+        /// Protein ID as recorded by the OSW file (the @c PROTEIN_ID column in the sqlite schema).
         Size getID() const
         {
           return id_;
         }
 
+        /// Charged peptide precursors that map to this protein.
         const std::vector<OSWPeptidePrecursor>& getPeptidePrecursors() const
         {
           return peptides_;
@@ -269,11 +303,13 @@ namespace OpenMS
 
 
     /**
-      @brief Holds all or partial information from an OSW file
+      @brief Holds all or partial information from an OSW file.
 
-      First, fill in all transitions and only then add proteins (which reference transitions via their transition-ids deep down).
-      References will be checked and enforced (exception otherwise -- see addProtein()).
+      First, fill in all transitions and only then add proteins (which reference transitions
+      via their transition-ids deep down). References will be checked and enforced
+      (exception otherwise -- see @ref addProtein).
 
+      @ingroup TargetedQuantitation
     */
     class OPENMS_DLLAPI OSWData
     {


### PR DESCRIPTION
## Summary

The `OSWData.h` header had a mixed-style class-brief situation: the lower types (`OSWPeakGroup`, `OSWPeptidePrecursor`, `OSWProtein`, `OSWData`) carried proper `@brief` blocks but the three outer container types (`OSWHierarchy`, `OSWIndexTrace`, `OSWTransition`) had only `///` briefs with no `@brief` tag, no field docs, and no `@ingroup`. Doxygen output was inconsistent as a result.

Additions (all comments only — no behavioural change):

- **`@ingroup TargetedQuantitation`** on all 7 classes/structs in the file (`OSWHierarchy`, `OSWIndexTrace`, `OSWTransition`, `OSWPeakGroup`, `OSWPeptidePrecursor`, `OSWProtein`, `OSWData`).
- **`OSWHierarchy`**: `@brief` block describing the four-level tree (`PROTEIN`/`PEPTIDE`/`FEATURE`/`TRANSITION`) and the `LevelName[]` string table; per-enum-value briefs naming the wrapping type at each level (`OSWProtein` → `OSWPeptidePrecursor` → `OSWPeakGroup` → `OSWTransition`).
- **`OSWIndexTrace`**: `@brief` explaining the "indices form a path through the tree" invariant and the `SIZE_OF_VALUES` sentinel; per-field briefs (`idx_prot`/`idx_pep`/`idx_feat`/`idx_trans`/`lowest`).
- **`OSWTransition`**: `@brief` notes that the `id` field doubles as the sqMass chromatogram nativeID used by `OSWData::buildNativeIDResolver` / `fromNativeID` (verified against `OSWData.cpp:36, 63, 74`).
- **`OSWProtein` accessor briefs** on `getAccession()` / `getID()` / `getPeptidePrecursors()`.

## Test plan

- [x] `cmake --build OpenMS-build --target OpenMS` succeeds locally.
- [ ] `Doxygen_Warning_test` is clean on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved internal documentation for quantitation data model structures to better describe initialization order and validation expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9320)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->