### PR TITLE
[DOC] Document MapConversion (KERNEL/ConversionHelper) and ground side effects

### DIFF
--- a/src/openms/include/OpenMS/KERNEL/ConversionHelper.h
+++ b/src/openms/include/OpenMS/KERNEL/ConversionHelper.h
@@ -21,8 +21,9 @@ namespace OpenMS
            types (@c PeakMap, @c FeatureMap, @c ConsensusMap).
 
     Each overload replaces the contents of the destination, gives it a
-    container-level unique id, and leaves its cached ranges consistent with
-    the new data so range queries are valid immediately after the call.
+    container-level unique id, and leaves it in a state where the standard
+    range queries reflect the new contents without further bookkeeping by
+    the caller.
 
     The conversions are not symmetric: which fields are preserved
     (container / element unique ids, protein and unassigned peptide
@@ -49,8 +50,9 @@ public:
 
       @param[in]     input_map_index Index assigned to the input map in the
                                      resulting @c ConsensusMap column headers.
-      @param[in,out] input_map       Source peaks; its cached ranges are
-                                     refreshed as a side effect.
+      @param[in,out] input_map       Source peaks; its range queries are
+                                     left consistent with its contents as a
+                                     side effect.
       @param[out]    output_map      Resulting @c ConsensusMap; previous
                                      contents are replaced.
       @param[in]     n               Maximum number of peaks to copy. The

--- a/src/openms/include/OpenMS/KERNEL/ConversionHelper.h
+++ b/src/openms/include/OpenMS/KERNEL/ConversionHelper.h
@@ -16,22 +16,47 @@
 namespace OpenMS
 {
 
+  /**
+    @brief Static helpers that convert between the three OpenMS container types
+           (@c PeakMap, @c FeatureMap, @c ConsensusMap).
+
+    Every overload clears the destination container before writing, sets a
+    unique id on the output, and calls @c updateRanges() on the output so
+    range queries return the expected values immediately after the conversion.
+
+    The conversions are not symmetric: which fields are preserved (unique ids,
+    protein / unassigned peptide identifications) depends on the source and
+    target container -- see each overload for the exact behaviour.
+
+    @ingroup Kernel
+  */
   class OPENMS_DLLAPI MapConversion
   {
 public:
 
     /**
-      @brief Similar to @p convert for FeatureMaps.
+      @brief Copy the @p n most intense peaks of a @c PeakMap into a
+             @c ConsensusMap.
 
-      Only the @p n most intense elements are copied.
+      The output is cleared and assigned a fresh unique id (@c PeakMap has no
+      container-level unique id, so one is generated). The input's ranges are
+      updated (the underlying 2D peak data is then materialized via
+      @c get2DData) and the result is partial-sorted by intensity in descending
+      order so the top @p n peaks are kept. Each surviving peak is appended as
+      a @c ConsensusFeature carrying @p input_map_index, the peak, and its
+      rank in the sorted list. The column header @c size for
+      @p input_map_index is set to @p n, and the output's ranges are updated.
 
-      Currently PeakMap does not have a unique id but ConsensusMap has
-      one, so we assign a new one here.
-
-      @param[in] input_map_index The index of the input map.
-      @param[in,out] input_map The input map to be converted.
-      @param[out] output_map The resulting ConsensusMap.
-      @param[in] n The maximum number of elements to be copied.
+      @param[in]     input_map_index Index assigned to the input map in the
+                                     resulting @c ConsensusMap column headers.
+      @param[in,out] input_map       Source peaks; @c updateRanges() is called
+                                     on it as a side effect.
+      @param[out]    output_map      Resulting @c ConsensusMap; previous
+                                     contents are cleared.
+      @param[in]     n               Maximum number of peaks to copy. The
+                                     default (@c Size(-1)) is clamped to
+                                     @c input_map.getSize(), i.e. all peaks
+                                     are copied.
     */
     static void convert(UInt64 const input_map_index,
                         PeakMap& input_map,
@@ -39,37 +64,55 @@ public:
                         Size n = -1);
 
     /**
-      @brief Convert a ConsensusMap to a FeatureMap (of any feature type).
+      @brief Convert a @c ConsensusMap to a @c FeatureMap.
 
-      The previous content of output_map is cleared. UID's of the elements and
-      the container is copied if the @p keep_uids flag is set.
+      The output is cleared and resized to @c input_map.size(). The input's
+      @c DocumentIdentifier is copied to the output, then either the
+      container-level unique id is copied as well (when @p keep_uids is
+      @c true) or a new one is generated (when @c false). Protein
+      identifications and unassigned peptide identifications are copied
+      verbatim from input to output. For each element, the @c BaseFeature
+      portion of the @c ConsensusFeature is copied into the corresponding
+      @c Feature; when @p keep_uids is @c false the per-feature unique id is
+      regenerated. Finally @c updateRanges() is called on the output.
 
-      @param[in] input_map The container to be converted.
-      @param[in] keep_uids Shall the UID's of the elements and the container be kept or created anew
-      @param[out] output_map The resulting ConsensusMap.
+      @param[in]  input_map  Source @c ConsensusMap.
+      @param[in]  keep_uids  If @c true, preserve the container-level and
+                             per-element unique ids from @p input_map;
+                             otherwise mint new ones.
+      @param[out] output_map Resulting @c FeatureMap; previous contents are
+                             cleared.
     */
     static void convert(ConsensusMap const& input_map,
                         const bool keep_uids,
                         FeatureMap& output_map);
 
     /**
-      @brief Convert a FeatureMap (of any feature type) to a ConsensusMap.
+      @brief Convert a @c FeatureMap to a @c ConsensusMap.
 
-      Each ConsensusFeature contains a map index, so this has to be given as
-      well. The previous content of @p output_map is cleared. An arguable
-      design decision is that the unique id of the FeatureMap is copied (!) to
-      the ConsensusMap, because that is the way it is meant to be used in the
-      algorithms.
+      The output is cleared, its container-level unique id is overwritten with
+      the @c FeatureMap's unique id (an intentional design choice -- callers
+      that need a fresh id must overwrite it afterwards), and the first @p n
+      features (in input order; no sorting is performed) are appended as
+      @c ConsensusFeature entries tagged with @p input_map_index. Protein and
+      unassigned peptide identifications are copied verbatim from input to
+      output. The column header @c size for @p input_map_index is set to
+      @c input_map.size() (i.e. the full input size, even when @p n truncates
+      the copy), and @c updateRanges() is called on the output.
 
-      Only the first (!) @p n elements are copied. (This parameter exists
-      mainly for compatibility with @p convert for MSExperiments. To use it in
-      a meaningful way, apply one of the sorting methods to @p input_map
-      beforehand.)
+      @note Because elements are taken in input order, @p n is mainly useful
+            after pre-sorting @p input_map (e.g. by intensity); it exists for
+            symmetry with the @c PeakMap overload above.
 
-      @param[in] input_map_index The index of the input map.
-      @param[in] input_map The container to be converted.
-      @param[out] output_map The resulting ConsensusMap.
-      @param[in] n The maximum number of elements to be copied.
+      @param[in]  input_map_index Index assigned to the input map in the
+                                  resulting @c ConsensusMap column headers.
+      @param[in]  input_map       Source @c FeatureMap.
+      @param[out] output_map      Resulting @c ConsensusMap; previous contents
+                                  are cleared.
+      @param[in]  n               Maximum number of features to copy. The
+                                  default (@c Size(-1)) is clamped to
+                                  @c input_map.size(), i.e. all features are
+                                  copied.
     */
     static void convert(UInt64 const input_map_index,
                         FeatureMap const& input_map,

--- a/src/openms/include/OpenMS/KERNEL/ConversionHelper.h
+++ b/src/openms/include/OpenMS/KERNEL/ConversionHelper.h
@@ -17,16 +17,17 @@ namespace OpenMS
 {
 
   /**
-    @brief Static helpers that convert between the three OpenMS container types
-           (@c PeakMap, @c FeatureMap, @c ConsensusMap).
+    @brief Static helpers that convert between the three OpenMS container
+           types (@c PeakMap, @c FeatureMap, @c ConsensusMap).
 
-    Every overload clears the destination container before writing, sets a
-    unique id on the output, and calls @c updateRanges() on the output so
-    range queries return the expected values immediately after the conversion.
+    Each overload replaces the contents of the destination, gives it a
+    container-level unique id, and leaves its cached ranges consistent with
+    the new data so range queries are valid immediately after the call.
 
-    The conversions are not symmetric: which fields are preserved (unique ids,
-    protein / unassigned peptide identifications) depends on the source and
-    target container -- see each overload for the exact behaviour.
+    The conversions are not symmetric: which fields are preserved
+    (container / element unique ids, protein and unassigned peptide
+    identifications) depends on the source and target container, so see
+    each overload for the exact contract.
 
     @ingroup Kernel
   */
@@ -35,28 +36,25 @@ namespace OpenMS
 public:
 
     /**
-      @brief Copy the @p n most intense peaks of a @c PeakMap into a
+      @brief Copy the most intense peaks of a @c PeakMap into a
              @c ConsensusMap.
 
-      The output is cleared and assigned a fresh unique id (@c PeakMap has no
-      container-level unique id, so one is generated). The input's ranges are
-      updated (the underlying 2D peak data is then materialized via
-      @c get2DData) and the result is partial-sorted by intensity in descending
-      order so the top @p n peaks are kept. Each surviving peak is appended as
-      a @c ConsensusFeature carrying @p input_map_index, the peak, and its
-      rank in the sorted list. The column header @c size for
-      @p input_map_index is set to @p n, and the output's ranges are updated.
+      The output's previous contents are dropped and it is given a fresh
+      container unique id (@c PeakMap has no container-level unique id, so
+      one is generated). The @p n peaks with the highest intensity are
+      written to the output as @c ConsensusFeature entries tagged with
+      @p input_map_index; their order in the output is by descending
+      intensity. The column header @c size for @p input_map_index reflects
+      the number of peaks written.
 
       @param[in]     input_map_index Index assigned to the input map in the
                                      resulting @c ConsensusMap column headers.
-      @param[in,out] input_map       Source peaks; @c updateRanges() is called
-                                     on it as a side effect.
+      @param[in,out] input_map       Source peaks; its cached ranges are
+                                     refreshed as a side effect.
       @param[out]    output_map      Resulting @c ConsensusMap; previous
-                                     contents are cleared.
+                                     contents are replaced.
       @param[in]     n               Maximum number of peaks to copy. The
-                                     default (@c Size(-1)) is clamped to
-                                     @c input_map.getSize(), i.e. all peaks
-                                     are copied.
+                                     default (@c Size(-1)) keeps all peaks.
     */
     static void convert(UInt64 const input_map_index,
                         PeakMap& input_map,
@@ -66,22 +64,18 @@ public:
     /**
       @brief Convert a @c ConsensusMap to a @c FeatureMap.
 
-      The output is cleared and resized to @c input_map.size(). The input's
-      @c DocumentIdentifier is copied to the output, then either the
-      container-level unique id is copied as well (when @p keep_uids is
-      @c true) or a new one is generated (when @c false). Protein
-      identifications and unassigned peptide identifications are copied
-      verbatim from input to output. For each element, the @c BaseFeature
-      portion of the @c ConsensusFeature is copied into the corresponding
-      @c Feature; when @p keep_uids is @c false the per-feature unique id is
-      regenerated. Finally @c updateRanges() is called on the output.
+      Every element of @p input_map is converted to a @c Feature in
+      @p output_map (the @c BaseFeature portion is copied; positional and
+      meta data are preserved). The document identifier and the protein /
+      unassigned peptide identifications are preserved on the output.
 
       @param[in]  input_map  Source @c ConsensusMap.
-      @param[in]  keep_uids  If @c true, preserve the container-level and
-                             per-element unique ids from @p input_map;
-                             otherwise mint new ones.
+      @param[in]  keep_uids  If @c true, the container unique id and every
+                             element's unique id are preserved from
+                             @p input_map; otherwise they are replaced with
+                             fresh ones.
       @param[out] output_map Resulting @c FeatureMap; previous contents are
-                             cleared.
+                             replaced.
     */
     static void convert(ConsensusMap const& input_map,
                         const bool keep_uids,
@@ -90,29 +84,29 @@ public:
     /**
       @brief Convert a @c FeatureMap to a @c ConsensusMap.
 
-      The output is cleared, its container-level unique id is overwritten with
-      the @c FeatureMap's unique id (an intentional design choice -- callers
-      that need a fresh id must overwrite it afterwards), and the first @p n
-      features (in input order; no sorting is performed) are appended as
-      @c ConsensusFeature entries tagged with @p input_map_index. Protein and
-      unassigned peptide identifications are copied verbatim from input to
-      output. The column header @c size for @p input_map_index is set to
-      @c input_map.size() (i.e. the full input size, even when @p n truncates
-      the copy), and @c updateRanges() is called on the output.
+      The first @p n features of @p input_map (in input order; no sorting
+      is performed) are written to @p output_map as @c ConsensusFeature
+      entries tagged with @p input_map_index. The output's container unique
+      id is taken from @p input_map (an intentional design choice -- callers
+      that need a fresh id must overwrite it afterwards). The protein and
+      unassigned peptide identifications are preserved on the output.
 
-      @note Because elements are taken in input order, @p n is mainly useful
+      @note Because features are taken in input order, @p n is mainly useful
             after pre-sorting @p input_map (e.g. by intensity); it exists for
             symmetry with the @c PeakMap overload above.
+
+      @note The column header @c size for @p input_map_index is set to
+            @c input_map.size() -- the full input size -- even when @p n
+            truncates the actual copy. Inspect the output container's size
+            for the number of features that were actually written.
 
       @param[in]  input_map_index Index assigned to the input map in the
                                   resulting @c ConsensusMap column headers.
       @param[in]  input_map       Source @c FeatureMap.
-      @param[out] output_map      Resulting @c ConsensusMap; previous contents
-                                  are cleared.
+      @param[out] output_map      Resulting @c ConsensusMap; previous
+                                  contents are replaced.
       @param[in]  n               Maximum number of features to copy. The
-                                  default (@c Size(-1)) is clamped to
-                                  @c input_map.size(), i.e. all features are
-                                  copied.
+                                  default (@c Size(-1)) keeps all features.
     */
     static void convert(UInt64 const input_map_index,
                         FeatureMap const& input_map,


### PR DESCRIPTION
## Summary
- Add a class-level Doxygen brief and `@ingroup Kernel` to `MapConversion` (it currently has none, so it doesn't surface in the generated docs).
- Fix the wrong `@param[out] output_map The resulting ConsensusMap` on the `ConsensusMap -> FeatureMap` overload (the actual type is `FeatureMap`).
- Document the default `n = Size(-1)` semantics (clamped to input size = all elements) in the two `n`-bounded overloads.
- Document the side effects that the header didn't surface, all grounded against `ConversionHelper.cpp:13-108`:
  - `PeakMap -> ConsensusMap`: `updateRanges()` is called on the **input** as a side effect; partial-sort is descending by intensity; column header `size` is set to `n`.
  - `ConsensusMap -> FeatureMap`: `DocumentIdentifier` and the protein / unassigned-peptide identifications are copied; per-feature UIDs are regenerated when `keep_uids` is `false`.
  - `FeatureMap -> ConsensusMap`: the input map's container unique id is **overwritten** on the output (intentional design choice); column header `size` is set to the *full* input size, even when `n` truncates the copy -- this is a real quirk worth calling out.

No behaviour change; documentation only.

## Test plan
- [x] `cmake --build OpenMS-build --target OpenMS` builds cleanly.
- [ ] CI Doxygen warning check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified conversion behavior: destination containers are replaced and unique IDs are assigned or propagated so outputs are immediately queryable. Peak→consensus now copies the top‑n peaks by intensity (output ordered by descending intensity) and tags entries with input indices; consensus→feature and feature→consensus conversions document which UIDs and identifications are preserved and how input sizing/tagging is handled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9324)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->