### PR TITLE
[DOC] NetworkGetRequest: lifecycle and grounded error contract

### DIFF
--- a/src/openms/include/OpenMS/SYSTEM/NetworkGetRequest.h
+++ b/src/openms/include/OpenMS/SYSTEM/NetworkGetRequest.h
@@ -39,10 +39,22 @@ namespace OpenMS
     NetworkGetRequest();
     ~NetworkGetRequest();
 
-    /// Set the URL to request. The URL is consumed by the next @ref run call; no validation is performed here.
+    /**
+      @brief Set the URL to request.
+
+      The URL is consumed by the next @ref run call; no validation is performed here.
+
+      @param[in] url URL to request on the next @ref run call.
+    */
     void setUrl(const std::string& url);
 
-    /// Set the request timeout in seconds. The default of @c 0 leaves the timeout unset (request blocks until the server responds or libcurl gives up on its own).
+    /**
+      @brief Set the request timeout in seconds.
+
+      @param[in] seconds Timeout in seconds. @c 0 (the default) leaves the
+                         timeout unset, so the request blocks until the server
+                         responds or libcurl gives up on its own.
+    */
     void setTimeout(int seconds);
 
     /**
@@ -60,22 +72,39 @@ namespace OpenMS
         - a transport-level libcurl error occurred (error string from
           @c curl_easy_strerror), or
         - the server responded with HTTP status @c >= @c 400 (error
-          string @c "HTTP error <code>").
+          string @c "HTTP error N", where @c N is the status code).
 
       No exception is thrown for any of these.
     */
     void run();
 
-    /// Response body as a string (copy of @ref getResponseBinary).
+    /**
+      @brief Response body as a string.
+
+      @return A copy of @ref getResponseBinary materialised as @c std::string.
+    */
     std::string getResponse() const;
 
-    /// Raw response body. Reference is valid until the next @ref run call or destruction.
+    /**
+      @brief Raw response body.
+
+      @return Reference to the byte buffer; valid until the next @ref run call or destruction.
+    */
     const std::vector<char>& getResponseBinary() const;
 
-    /// @c true if the last @ref run call did not produce a usable response (see @ref run for the conditions).
+    /**
+      @brief Whether the last @ref run produced an error.
+
+      @return @c true if the last @ref run call did not produce a usable
+              response (see @ref run for the conditions).
+    */
     bool hasError() const;
 
-    /// Human-readable error message; empty when @ref hasError is @c false.
+    /**
+      @brief Human-readable description of the last error.
+
+      @return Error message; empty when @ref hasError is @c false.
+    */
     std::string getErrorString() const;
 
   private:

--- a/src/openms/include/OpenMS/SYSTEM/NetworkGetRequest.h
+++ b/src/openms/include/OpenMS/SYSTEM/NetworkGetRequest.h
@@ -15,32 +15,67 @@
 
 namespace OpenMS
 {
-  /// Synchronous HTTP GET request using libcurl.
+  /**
+    @brief Synchronous HTTP GET request backed by libcurl.
+
+    Typical lifecycle: set the URL via @ref setUrl, optionally set a
+    timeout via @ref setTimeout, call @ref run to perform the request,
+    then read the result via @ref getResponse / @ref getResponseBinary
+    or check @ref hasError / @ref getErrorString. The instance can be
+    reused for further requests; each call to @ref run replaces the
+    previously observed state. Redirects are followed automatically.
+
+    Failures (libcurl initialisation, transport errors, HTTP status
+    @c >= @c 400) are reported through @ref hasError and
+    @ref getErrorString; @ref run does not throw on those conditions.
+
+    Instances are not copyable.
+
+    @ingroup System
+  */
   class OPENMS_DLLAPI NetworkGetRequest
   {
   public:
     NetworkGetRequest();
     ~NetworkGetRequest();
 
-    /// set the URL to request
+    /// Set the URL to request. The URL is consumed by the next @ref run call; no validation is performed here.
     void setUrl(const std::string& url);
 
-    /// set the timeout in seconds (0 = no timeout)
+    /// Set the request timeout in seconds. The default of @c 0 leaves the timeout unset (request blocks until the server responds or libcurl gives up on its own).
     void setTimeout(int seconds);
 
-    /// execute the GET request (blocks until complete or timeout)
+    /**
+      @brief Execute the GET request synchronously.
+
+      Performs the request configured by the last @ref setUrl /
+      @ref setTimeout call, blocking the caller until the response is
+      complete or libcurl reports a timeout / error. Redirects are
+      followed. The previous response and error state are cleared at
+      the start of the call.
+
+      The call sets @ref hasError to @c true when:
+        - libcurl could not be initialised (error string
+          @c "Failed to initialize libcurl"),
+        - a transport-level libcurl error occurred (error string from
+          @c curl_easy_strerror), or
+        - the server responded with HTTP status @c >= @c 400 (error
+          string @c "HTTP error <code>").
+
+      No exception is thrown for any of these.
+    */
     void run();
 
-    /// returns the response as a string
+    /// Response body as a string (copy of @ref getResponseBinary).
     std::string getResponse() const;
 
-    /// returns the raw response bytes
+    /// Raw response body. Reference is valid until the next @ref run call or destruction.
     const std::vector<char>& getResponseBinary() const;
 
-    /// returns true if an error occurred during the query
+    /// @c true if the last @ref run call did not produce a usable response (see @ref run for the conditions).
     bool hasError() const;
 
-    /// returns the error message
+    /// Human-readable error message; empty when @ref hasError is @c false.
     std::string getErrorString() const;
 
   private:


### PR DESCRIPTION
## Summary

- Add `@ingroup System` so the class surfaces in the generated docs.
- Class brief now describes the lifecycle (`setUrl` / `setTimeout` -> `run` -> read), reuseability, automatic redirect following, and that errors surface via `hasError()` / `getErrorString()` rather than exceptions.
- `run()` documents the three error conditions that flip `hasError()` to `true` and their exact error strings, grounded in `NetworkGetRequest.cpp:42-86`:
  - libcurl init failure -> `"Failed to initialize libcurl"`
  - libcurl transport error -> the string from `curl_easy_strerror`
  - HTTP status `>= 400` -> `"HTTP error <code>"`
- Note that `setTimeout(0)` is the default and leaves the timeout unset.
- Note that `getResponseBinary()` returns a reference valid until the next `run()` call or destruction.

No behaviour change; documentation only.

## Test plan
- [x] `cmake --build OpenMS-build --target OpenMS` builds cleanly.
- [ ] CI Doxygen warning check passes (Linux; Windows runner has the pre-existing `@dot`/`HAVE_DOT` infra issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified API docs for network requests: request lifecycle and state-reset across runs, automatic redirect handling, explicit descriptions of error conditions and how errors are reported, and clearer notes for URL, timeout and response behaviors.

---

Note: Documentation-only changes; no functional or public API signature changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9326)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->