### PR TITLE
[DOC] AbsoluteQuantitationStandards: ground match rules, fix findComponentFeature_ target claim

### DIFF
--- a/src/openms/include/OpenMS/METADATA/AbsoluteQuantitationStandards.h
+++ b/src/openms/include/OpenMS/METADATA/AbsoluteQuantitationStandards.h
@@ -58,8 +58,8 @@ public:
     };
 
     /**
-      @brief One target component matched to the @ref FeatureMap-side feature
-             plus its known concentration.
+      @brief One target component matched to a feature in the corresponding
+             @ref FeatureMap, paired with its known concentration.
 
       Produced by @ref mapComponentsToConcentrations and
       @ref getComponentFeatureConcentrations.

--- a/src/openms/include/OpenMS/METADATA/AbsoluteQuantitationStandards.h
+++ b/src/openms/include/OpenMS/METADATA/AbsoluteQuantitationStandards.h
@@ -15,54 +15,94 @@ namespace OpenMS
 {
 
   /**
-    @brief AbsoluteQuantitationStandards is a class to handle the relationship between
-    runs, components, and their actual concentrations.
+    @brief Bridges sample-level concentration tables with the @ref FeatureMap
+           output of a feature finder, for building calibration curves used in
+           absolute quantitation.
 
-    A mapping between a run, the components in the run, and the actual concentration
-    of the components in the run are required to build a calibration curve that is
-    required for absolute quantitation.
+    The user supplies a list of @ref runConcentration entries -- one per
+    (sample, target component, internal-standard) triple with the known
+    concentrations -- together with the @ref FeatureMap instances produced
+    for each sample. The class then locates each component (and its
+    internal standard, when given) in the matching @ref FeatureMap and
+    pairs it with the entry's concentration, yielding @ref featureConcentration
+    records that downstream calibration code can consume.
+
+    @ingroup Quantitation
   */
   class OPENMS_DLLAPI AbsoluteQuantitationStandards
   {
 
 public:
-    /// Constructor
+    /// Default constructor.
     AbsoluteQuantitationStandards() = default;
 
-    /// Destructor
+    /// Destructor.
     ~AbsoluteQuantitationStandards() = default;
 
-    /// Structure to map runs to components to known concentrations.
+    /**
+      @brief One (sample, target, internal-standard, concentration) entry as
+             provided by the user.
+
+      Typically populated from a calibration-table file before the standards
+      are mapped to feature data.
+    */
     struct runConcentration
     {
-      String sample_name;
-      String component_name;
-      String IS_component_name;
-      double actual_concentration;
-      double IS_actual_concentration;
-      String concentration_units;
-      double dilution_factor;
-    };
-
-    /// Structure to hold a single component and its corresponding known concentration.
-    struct featureConcentration
-    {
-      Feature feature;
-      Feature IS_feature;
-      double actual_concentration;
-      double IS_actual_concentration;
-      String concentration_units;
-      double dilution_factor;
+      String sample_name;              ///< Sample identifier; matched against @ref FeatureMap::getPrimaryMSRunPath after stripping a @c .mzML or @c .txt suffix.
+      String component_name;           ///< Identifier of the target component (matched against subordinate-feature meta value @c "native_id").
+      String IS_component_name;        ///< Identifier of the paired internal standard, or empty if there is none.
+      double actual_concentration;     ///< Known concentration of the target component in this sample.
+      double IS_actual_concentration;  ///< Known concentration of the internal standard in this sample.
+      String concentration_units;      ///< Units the concentration values are expressed in.
+      double dilution_factor;          ///< Sample dilution factor.
     };
 
     /**
-      @brief Method to map runs to components to known concentrations.
+      @brief One target component matched to the @ref FeatureMap-side feature
+             plus its known concentration.
 
-      @warning The method checks for the FeatureMaps' sample names with FeatureMap::getPrimaryMSRunPath()
+      Produced by @ref mapComponentsToConcentrations and
+      @ref getComponentFeatureConcentrations.
+    */
+    struct featureConcentration
+    {
+      Feature feature;                 ///< Subordinate feature found in the matching @ref FeatureMap (see @ref mapComponentsToConcentrations for the match rule).
+      Feature IS_feature;              ///< Subordinate feature for the internal standard. Default-constructed when @ref runConcentration::IS_component_name was empty or no IS subordinate was found.
+      double actual_concentration;     ///< Copied from @ref runConcentration::actual_concentration.
+      double IS_actual_concentration;  ///< Copied from @ref runConcentration::IS_actual_concentration.
+      String concentration_units;      ///< Copied from @ref runConcentration::concentration_units.
+      double dilution_factor;          ///< Copied from @ref runConcentration::dilution_factor.
+    };
 
-      @param[in] run_concentrations A list of runConcentration structs (e.g., from file upload).
-      @param[in] feature_maps The method maps to these features.
-      @param[out] components_to_concentrations A map that links run data to feature data.
+    /**
+      @brief Match each @ref runConcentration to a feature in @p feature_maps and
+             produce one @ref featureConcentration record per match, keyed by
+             component name.
+
+      For every entry in @p run_concentrations:
+        - Entries with an empty @c sample_name or @c component_name are
+          skipped.
+        - A @ref FeatureMap from @p feature_maps is considered a candidate
+          when its first @ref FeatureMap::getPrimaryMSRunPath entry, with a
+          trailing @c .mzML or @c .txt suffix removed, equals the entry's
+          @c sample_name. When the primary-run-path list is empty the
+          candidate is accepted unconditionally.
+        - Within the chosen @ref FeatureMap, the target component is located
+          as a subordinate feature whose @c "native_id" meta value equals
+          @c component_name. If no such subordinate exists, the entry is
+          skipped.
+        - When @c IS_component_name is non-empty, the same subordinate
+          lookup is performed for the internal standard, but the entry is
+          kept even when the IS lookup fails (the resulting
+          @ref featureConcentration::IS_feature is then default-constructed).
+        - At most one @ref FeatureMap is matched per entry; matching stops
+          at the first hit.
+
+      @param[in]  run_concentrations           Calibration entries to consider.
+      @param[in]  feature_maps                 Feature maps to search.
+      @param[out] components_to_concentrations Result, keyed by
+                                               @c component_name. Cleared at
+                                               the start of the call.
     */
     void mapComponentsToConcentrations(
       const std::vector<AbsoluteQuantitationStandards::runConcentration>& run_concentrations,
@@ -71,17 +111,20 @@ public:
     ) const;
 
     /**
-      @brief Get the feature concentrations from a single component.
+      @brief Return the @ref featureConcentration records for a single
+             component name.
 
-      This method internally calls `mapComponentsToConcentrations()`, but takes in consideration only those
-      elements of `run_concentrations` that have the passed `component_name`.
+      Equivalent to filtering @p run_concentrations down to entries whose
+      @c component_name matches @p component_name and running
+      @ref mapComponentsToConcentrations on the result; the records for
+      @p component_name are then written to @p feature_concentrations.
+      If no matching record is produced, @p feature_concentrations is left
+      unchanged.
 
-      @warning The method checks for the FeatureMaps' sample names with FeatureMap::getPrimaryMSRunPath()
-
-      @param[in] run_concentrations A list of runConcentration structs (e.g., from file upload).
-      @param[in] feature_maps The method maps to these features.
-      @param[in] component_name Only runConcentration with this name will be considered.
-      @param[out] feature_concentrations The list of feature concentrations found.
+      @param[in]  run_concentrations    Calibration entries to filter.
+      @param[in]  feature_maps          Feature maps to search.
+      @param[in]  component_name        Only entries with this component name are considered.
+      @param[out] feature_concentrations Result vector; only assigned when at least one match is produced.
     */
     void getComponentFeatureConcentrations(
       const std::vector<AbsoluteQuantitationStandards::runConcentration>& run_concentrations,
@@ -92,11 +135,16 @@ public:
 
 private:
     /**
-      @brief Finds a feature for a given component name.
+      @brief Locate a subordinate feature whose @c "native_id" meta value equals @p component_name.
 
-      @param[in] feature_map The container of features.
-      @param[in] component_name The feature must have this name as its "native_id".
-      @param[out] feature_found If found, the feature is saved in this parameter.
+      Walks every @ref Feature in @p feature_map and, for each, its
+      subordinates; the first subordinate whose @c "native_id" meta value
+      equals @p component_name is copied into @p feature_found.
+
+      @param[in]  feature_map    Features to search (top-level features and their subordinates).
+      @param[in]  component_name Required value of the subordinate's @c "native_id" meta value.
+      @param[out] feature_found  The matching subordinate feature; only written on a successful return.
+      @return @c true if a matching subordinate was found, @c false otherwise.
     */
     bool findComponentFeature_(
       const FeatureMap& feature_map,


### PR DESCRIPTION
## Summary

- **Fix factual mistake** in the existing `findComponentFeature_` doc: it claimed "the feature must have this name as its `native_id`", but the cpp (`AbsoluteQuantitationStandards.cpp:19-30`) actually searches **subordinate** features for the `"native_id"` meta value, not the top-level features. Doc corrected.
- Rewrite the class brief: bridges a per-sample concentration table to `FeatureMap`s from a feature finder for absolute-quantitation calibration curves.
- Add `///<` field docs to `runConcentration` and `featureConcentration` grounded against the cpp:
  - `sample_name` is matched against `FeatureMap::getPrimaryMSRunPath()[0]` after stripping a trailing `.mzML` or `.txt` suffix (`AbsoluteQuantitationStandards.cpp:48-63`).
  - `component_name` is matched against the **subordinate**'s `"native_id"` meta value.
  - `featureConcentration::IS_feature` may stay default-constructed when the entry has no IS or no IS subordinate is found, yet the record is still emitted (`AbsoluteQuantitationStandards.cpp:70-73`).
- Document `mapComponentsToConcentrations` fully: empty-skip rule, primary-run-path-empty fallthrough, "first match wins" `break`, and the **cleared-at-start contract** on the output map.
- Document `getComponentFeatureConcentrations`: the output vector is only assigned when at least one record is produced (otherwise left unchanged -- `AbsoluteQuantitationStandards.cpp:112-115`).
- Add `@ingroup Quantitation`.

All claims grounded against `AbsoluteQuantitationStandards.cpp:13-116`. No behaviour change.

## Test plan
- [x] `cmake --build OpenMS-build --target OpenMS` builds cleanly.
- [ ] CI Doxygen warning check passes (Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and standardized documentation for absolute quantitation standards: clarified how calibration entries map to measured features, detailed per-field matching rules and fallback behaviors, and provided a step-by-step description of the feature-to-concentration mapping and candidate selection process. Clarified helper/search behavior and filter-then-map semantics. No code logic or public APIs were changed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9330)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->