### PR TITLE
[DOC] CachedmzML: full per-method docs, ground side-car layout and seekg ParseError

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/CachedMzML.h
+++ b/src/openms/include/OpenMS/FORMAT/CachedMzML.h
@@ -36,10 +36,22 @@ public:
     /** @name Constructors and Destructor
     */
     //@{
-    /// Default constructor; produces an empty instance with no associated file.
+    /**
+      @brief Default constructor.
+
+      Produces an empty instance with no associated file.
+    */
     CachedmzML();
 
-    /// Construct and load metadata + side-car index from @p filename in one step. See @ref load for the exact behaviour.
+    /**
+      @brief Construct and load metadata + side-car index from @p filename in one step.
+
+      Equivalent to default-constructing and then calling @ref load. See
+      @ref load for the exact behaviour, file layout and exceptions.
+
+      @param[in] filename Path of the @c .mzML metadata file; the side-car
+                          is expected next to it as @p filename + @c ".cached".
+    */
     CachedmzML(const String& filename);
 
     /**
@@ -48,10 +60,16 @@ public:
       Each instance keeps its own file handle on the @c .mzML.cached
       side-car, so the copy opens a fresh stream on the same path -- the
       original's stream is not shared.
+
+      @param[in] rhs Instance to copy.
     */
     CachedmzML(const CachedmzML & rhs);
 
-    /// Destructor; closes the open file stream on the @c .mzML.cached side-car.
+    /**
+      @brief Destructor.
+
+      Closes the open file stream on the @c .mzML.cached side-car.
+    */
     ~CachedmzML();
     //@}
 
@@ -87,13 +105,29 @@ public:
     */
     MSChromatogram getChromatogram(Size id);
 
-    /// Number of spectra in the loaded experiment.
+    /**
+      @brief Number of spectra in the loaded experiment.
+
+      @return Spectrum count.
+    */
     size_t getNrSpectra() const;
 
-    /// Number of chromatograms in the loaded experiment.
+    /**
+      @brief Number of chromatograms in the loaded experiment.
+
+      @return Chromatogram count.
+    */
     size_t getNrChromatograms() const;
 
-    /// Experiment-level metadata (instrument, acquisition settings, per-spectrum/chromatogram headers) loaded from the @c .mzML file. Empty until @ref load has been called.
+    /**
+      @brief Experiment-level metadata loaded from the @c .mzML file.
+
+      The returned experiment contains instrument and acquisition settings
+      as well as the per-spectrum / per-chromatogram headers. Empty until
+      @ref load has been called.
+
+      @return Const reference to the loaded metadata experiment.
+    */
     const MSExperiment& getMetaData() const
     {
       return meta_ms_experiment_;

--- a/src/openms/include/OpenMS/FORMAT/CachedMzML.h
+++ b/src/openms/include/OpenMS/FORMAT/CachedMzML.h
@@ -16,13 +16,17 @@ namespace OpenMS
 {
 
   /**
-    @brief An class that uses on-disk caching to read and write spectra and chromatograms
+    @brief Random-access reader/writer for the OpenMS on-disk cache format.
 
-    This class provides functions to read and write spectra and chromatograms
-    to disk using a time-efficient format. Reading the data items from disk can
-    be very fast and done in random order (once the in-memory index is built
-    for the file).
+    Spectra and chromatograms are split across two files: an @c .mzML file
+    holding the experiment-level metadata and a side-car @c .mzML.cached
+    binary file holding the per-spectrum / per-chromatogram payload. After
+    @ref load (or constructing with a filename) the side-car's stream
+    offsets are kept in an in-memory index, so single spectra or
+    chromatograms can be fetched in any order from disk without scanning
+    the full file.
 
+    @ingroup FileIO
   */
   class OPENMS_DLLAPI CachedmzML
   {
@@ -32,49 +36,96 @@ public:
     /** @name Constructors and Destructor
     */
     //@{
-    /// Default constructor
+    /// Default constructor; produces an empty instance with no associated file.
     CachedmzML();
 
+    /// Construct and load metadata + side-car index from @p filename in one step. See @ref load for the exact behaviour.
     CachedmzML(const String& filename);
 
-    /// Copy constructor
+    /**
+      @brief Copy constructor.
+
+      Each instance keeps its own file handle on the @c .mzML.cached
+      side-car, so the copy opens a fresh stream on the same path -- the
+      original's stream is not shared.
+    */
     CachedmzML(const CachedmzML & rhs);
 
-    /// Default destructor
+    /// Destructor; closes the open file stream on the @c .mzML.cached side-car.
     ~CachedmzML();
     //@}
 
+    /**
+      @brief Read one spectrum from the side-car file.
+
+      Seeks the cached stream to the indexed offset for @p id, parses the
+      binary payload and returns the resulting @c MSSpectrum. The metadata
+      for the spectrum (instrument settings, native id, ...) is taken
+      from the in-memory experiment loaded at @ref load time.
+
+      @param[in] id Index of the spectrum to read; must be smaller than
+                    @ref getNrSpectra. Out-of-range access is a programming
+                    error (checked in debug builds).
+      @return Decoded spectrum.
+
+      @throws Exception::ParseError when @c seekg on the side-car stream
+                                    fails (e.g. a 32-bit-system overflow
+                                    on a > 2 GB cache file).
+    */
     MSSpectrum getSpectrum(Size id);
 
+    /**
+      @brief Read one chromatogram from the side-car file.
+
+      @param[in] id Index of the chromatogram to read; must be smaller than
+                    @ref getNrChromatograms. Out-of-range access is a
+                    programming error (checked in debug builds).
+      @return Decoded chromatogram.
+
+      @throws Exception::ParseError when @c seekg on the side-car stream
+                                    fails.
+    */
     MSChromatogram getChromatogram(Size id);
 
+    /// Number of spectra in the loaded experiment.
     size_t getNrSpectra() const;
 
+    /// Number of chromatograms in the loaded experiment.
     size_t getNrChromatograms() const;
 
+    /// Experiment-level metadata (instrument, acquisition settings, per-spectrum/chromatogram headers) loaded from the @c .mzML file. Empty until @ref load has been called.
     const MSExperiment& getMetaData() const
     {
       return meta_ms_experiment_;
     }
 
     /**
-      @brief Stores a map in a cached MzML file.
+      @brief Write @p map to disk as a cached @c .mzML pair.
 
-      @p filename The data location (ends in .mzML)
-      @p map has to be an MSExperiment or have the same interface.
+      Produces two files: a binary side-car at @p filename + @c ".cached"
+      holding the spectrum / chromatogram payload, and an @c .mzML file at
+      @p filename holding the metadata.
 
-      @exception Exception::UnableToCreateFile is thrown if the file could not be created
+      @param[in] filename Path of the metadata file (should end in @c .mzML); the side-car is written next to it as @p filename + @c ".cached".
+      @param[in] map      Experiment to write.
+
+      @throws Exception::UnableToCreateFile when either output file cannot be created.
     */
     static void store(const String& filename, const PeakMap& map);
 
     /**
-      @brief Loads a map from a cached MzML file
+      @brief Load a cached @c .mzML pair into @p map.
 
-      @p filename The data location (ends in .mzML, expects an adjacent .mzML.cached file)
-      @p map A CachedmzML result object
+      Reads the metadata from @p filename and builds the in-memory index
+      for the side-car at @p filename + @c ".cached"; subsequent calls to
+      @ref getSpectrum / @ref getChromatogram on @p map fetch the payload
+      from the side-car on demand.
 
-      @exception Exception::FileNotFound is thrown if the file could not be opened
-      @exception Exception::ParseError is thrown if an error occurs during parsing
+      @param[in]  filename Path of the @c .mzML metadata file (the side-car is expected next to it as @p filename + @c ".cached").
+      @param[out] map      Destination instance; previous contents are replaced.
+
+      @throws Exception::FileNotFound when either file cannot be opened.
+      @throws Exception::ParseError   when parsing the metadata or building the side-car index fails.
     */
     static void load(const String& filename, CachedmzML& map);
 


### PR DESCRIPTION
## Summary

- Fix the "An class" typo and tighten the class brief: the cache uses **two files** -- an `.mzML` for metadata plus an `.mzML.cached` side-car for the binary payload -- with an in-memory index built at load time for random access.
- Add `@ingroup FileIO`.
- Document the previously-undocumented single-arg constructor (loads from filename), copy constructor (each instance opens its own ifstream on the side-car -- `CachedMzML.cpp:35-42`), `getSpectrum`, `getChromatogram`, `getNrSpectra`, `getNrChromatograms`, `getMetaData`.
- **`getSpectrum` / `getChromatogram` `@throws`**: the previous docs were silent on this, but the cpp raises `Exception::ParseError` when `seekg` on the side-car stream fails (`CachedMzML.cpp:64-72`, `81-89`). Documented.
- Make the precondition explicit on the same two methods (`id < getNrSpectra/Chromatograms`, checked in debug builds -- consistent with the `OPENMS_PRECONDITION` style I've been using on other doc PRs).
- Refresh `store()` and `load()` docs to call out the explicit side-car filename rule (`filename + ".cached"`) and reflect the actual two-file write at `CachedMzML.cpp:106-110` and two-file read at `CachedMzML.cpp:44-60`.

No behaviour change.

## Test plan
- [x] `cmake --build OpenMS-build --target OpenMS` builds cleanly.
- [ ] CI Doxygen warning check passes (Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified cached data format and on-disk side‑car/payload structure and in-memory indexing for random access.
  * Expanded method docs with clearer parameter/return descriptions for spectrum/chromatogram access and counts.
  * Added detailed error and exception guidance covering indexing, stream seek, and file open/parse failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9331)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->