### PR TITLE
[DOC] ZlibCompression: drop stale QtByteArray reference; document all throws

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/ZlibCompression.h
+++ b/src/openms/include/OpenMS/FORMAT/ZlibCompression.h
@@ -20,54 +20,77 @@ namespace OpenMS
   class String;
 
   /**
-    * @brief Compresses and uncompresses data using zlib
-    *
-    * @note The 'strings' here are not really null-terminated but rather
-    * containers of data. If you want safe conversions, use QtByteArray.
-    * 
+    @brief Compresses and uncompresses arbitrary byte buffers using zlib.
+
+    Static utility class. All methods treat the @c std::string / @c String
+    arguments as raw byte containers; the data is not assumed to be NUL-
+    terminated and may contain embedded zeros.
+
+    @note Only the raw zlib format is supported on the decompression side;
+          gzip-framed streams are rejected.
+
+    @ingroup FileIO
   */
   class OPENMS_DLLAPI ZlibCompression
   {
 public:
 
     /**
-      * @brief Compresses data using zlib directly
-      *
-      * @param[in] raw_data Data to be compressed
-      * @param[out] compressed_data Compressed result data
-      * 
+      @brief Compress @p raw_data into @p compressed_data using zlib.
+
+      @param[in]  raw_data        Data to compress (treated as a raw byte buffer; the reference is read-only despite the non-const type).
+      @param[out] compressed_data Receives the compressed payload; any previous contents are replaced.
+
+      @throws Exception::OutOfMemory     if zlib cannot allocate an output buffer of the worst-case size.
+      @throws Exception::InvalidValue    if the destination buffer turns out to be too small for the compressed output.
+      @throws Exception::ConversionError if zlib reports any other failure during compression.
     */
     static void compressString(std::string& raw_data, std::string& compressed_data);
 
     /**
-     * @brief Compresses data using zlib directly
-     *
-     * @param[in] raw_data Data to be compressed
-     * @param[in] in_length Length of @p raw_data in bytes
-     * @param[out] compressed_data Compressed result data
-     *
-     */
+      @brief Compress the @p in_length bytes pointed to by @p raw_data into @p compressed_data using zlib.
+
+      @param[in]  raw_data        Pointer to the bytes to compress.
+      @param[in]  in_length       Length of @p raw_data in bytes.
+      @param[out] compressed_data Receives the compressed payload; any previous contents are replaced.
+
+      @throws Exception::OutOfMemory     if zlib cannot allocate an output buffer of the worst-case size.
+      @throws Exception::InvalidValue    if the destination buffer turns out to be too small for the compressed output.
+      @throws Exception::ConversionError if zlib reports any other failure during compression.
+    */
     static void compressData(const void* raw_data, const size_t in_length, std::string& compressed_data);
 
     /**
-      * @brief Uncompresses data using zlib
-        
-        If available, provide the size of the uncompressed data in @p output_size for a small performance gain.
+      @brief Uncompress @p compressed_data using zlib.
 
-        @note Does not support gzip format decompression (only zlib format).
-       
-        @param[in] compressed_data The zlib compressed data
-        @param[in] nr_bytes Number of bytes in @p compressed data
-        @param[out] out Uncompressed result data
-        @param[in] output_size [optional] If known (!=0), provide the size of the uncompressed data
-        
-        @throws Exception::InvalidValue if output_size was specified (>0) and turns out to be smaller than actual size of uncompressed data.
-        @throws Exception::InternalToolError if zlib cannot decompress the data (e.g. due to data corruption or unsupported gzip format)
-      * 
+      When the uncompressed size is known up front, pass it as @p output_size
+      to skip the iterative chunked path and decompress straight into a
+      single preallocated buffer. Pass @c 0 (the default) when the size is
+      not known; decompression then proceeds chunk by chunk.
+
+      @note Only zlib-format data is accepted; gzip-framed streams are
+            rejected with @c Exception::InternalToolError.
+
+      @param[in]  compressed_data Pointer to the zlib-compressed bytes.
+      @param[in]  nr_bytes        Length of @p compressed_data in bytes; passing @c 0 with a non-zero @p output_size results in an empty @p out.
+      @param[out] out             Receives the decompressed bytes; any previous contents are replaced.
+      @param[in]  output_size     Expected uncompressed size (optional). When @c 0, an iterative path is taken; when positive, @p out is sized to @p output_size up front. If the actual decompressed size turns out to be smaller, @p out is shrunk to match and an informational message is logged.
+
+      @throws Exception::InvalidValue      if @p output_size was specified (>0) but is smaller than the actual uncompressed size.
+      @throws Exception::InternalToolError if zlib cannot decompress the data (corrupted input, unsupported gzip framing, or any other zlib failure).
     */
     static void uncompressData(const void* compressed_data, size_t nr_bytes, std::string& out, size_t output_size = 0);
 
-    /// Convencience function calling @p uncompressData
+    /**
+      @brief Convenience wrapper around @ref uncompressData that takes a @c String input.
+
+      @param[in]  in          Compressed input.
+      @param[out] out         Receives the decompressed bytes; any previous contents are replaced.
+      @param[in]  output_size Expected uncompressed size; see @ref uncompressData.
+
+      @throws Exception::InvalidValue      see @ref uncompressData.
+      @throws Exception::InternalToolError see @ref uncompressData.
+    */
     static void uncompressString(const String& in, std::string& out, size_t output_size = 0);
 
   };


### PR DESCRIPTION
## Summary

- **Drop stale reference**: the existing class brief said "If you want safe conversions, use QtByteArray", but Qt has been removed from OpenMS core (`#8965`). Misleading; removed.
- Add `@ingroup FileIO`.
- **Surface three throw paths on `compressString` / `compressData`** that the previous docs were silent about: `Exception::OutOfMemory` (Z_MEM_ERROR), `Exception::InvalidValue` (Z_BUF_ERROR), `Exception::ConversionError` (any other zlib error). Verified against `ZlibCompression.cpp:36-48`.
- Tighten `uncompressData` doc: spell out the two code paths (known vs unknown `output_size`); note the `nr_bytes == 0` shortcut from `ZlibCompression.cpp:55-58`; note that the "actual size smaller than `output_size`" path **resizes and logs informational** (not a throw) -- `ZlibCompression.cpp:64-71`.
- Promote `uncompressString` from a one-line "Convencience" (typo) summary to a proper Doxygen block that delegates `@throws` to `uncompressData`.

No behaviour change.

## Test plan
- [x] `cmake --build OpenMS-build --target OpenMS` builds cleanly.
- [ ] CI Doxygen warning check passes (Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Enhanced documentation for compression and decompression utilities with clarified input/output semantics, supported/unsupported format details, exception type mappings, and optional parameter behaviors in different allocation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9334)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->