### PR TITLE
[DOC] QuadraticRegression: fix unparsed brief, off-by-one getter docs; add @ingroup + @throws

### DIFF
--- a/src/openms/include/OpenMS/ML/REGRESSION/QuadraticRegression.h
+++ b/src/openms/include/OpenMS/ML/REGRESSION/QuadraticRegression.h
@@ -18,49 +18,102 @@ namespace OpenMS
 {
   namespace Math
   {
-    /*
-      @brief Estimates model parameters for a quadratic equation
+    /**
+      @brief Estimates model parameters for a quadratic equation.
 
-      The quadratic equation is of the form 
-       y = a + b*x + c*x^2
+      Fits the coefficients of
+       @c y = a + b*x + c*x^2
+      via the normal equations of a (weighted) least-squares problem.
+      Both an unweighted (@ref computeRegression) and a weighted
+      (@ref computeRegressionWeighted) overload are provided.
 
-      Weighted inputs are supported. 
+      Once a fit is computed the coefficients and the chi-squared sum
+      can be queried via @ref getA / @ref getB / @ref getC / @ref getChiSquared,
+      and the resulting polynomial can be evaluated via @ref eval. A
+      static overload of @ref eval is available for evaluating an
+      externally-supplied @c (A,B,C) triple.
 
+      Before the first successful fit the coefficients and the
+      chi-squared sum read back as @c 0.
+
+      @ingroup Math
     */
     class OPENMS_DLLAPI QuadraticRegression
     {
 public:
+      /// Default constructor; leaves all coefficients and the chi-squared sum at @c 0.
       QuadraticRegression();
 
-      /** compute the quadratic regression over 2D points */
+      /**
+        @brief Fit @c y = a + b*x + c*x^2 to unweighted 2D points.
+
+        Equivalent to calling @ref computeRegressionWeighted with a
+        uniform weight of @c 1 for every point. On success the
+        coefficients and @ref getChiSquared are updated.
+
+        @param[in] x_begin Iterator to the first @c x value.
+        @param[in] x_end   Past-the-end iterator for the @c x range.
+        @param[in] y_begin Iterator to the first @c y value; the @c y range must contain at least @c std::distance(x_begin, x_end) elements.
+
+        @throws Exception::UnableToFit if the resulting linear system is singular (e.g. fewer than three distinct @c x values).
+      */
       void computeRegression(
-        std::vector<double>::const_iterator x_begin, 
-        std::vector<double>::const_iterator x_end, 
+        std::vector<double>::const_iterator x_begin,
+        std::vector<double>::const_iterator x_end,
         std::vector<double>::const_iterator y_begin);
 
-      /** compute the weighted quadratic regression over 2D points */
+      /**
+        @brief Fit @c y = a + b*x + c*x^2 to weighted 2D points.
+
+        Solves the weighted normal equations for the quadratic model. On
+        success the coefficients and @ref getChiSquared are updated.
+
+        @param[in] x_begin Iterator to the first @c x value.
+        @param[in] x_end   Past-the-end iterator for the @c x range.
+        @param[in] y_begin Iterator to the first @c y value; the @c y range must contain at least @c std::distance(x_begin, x_end) elements.
+        @param[in] w_begin Iterator to the first weight; the weight range must contain at least @c std::distance(x_begin, x_end) elements.
+
+        @throws Exception::UnableToFit if the resulting linear system is singular (e.g. fewer than three distinct @c x values).
+      */
       void computeRegressionWeighted(
-        std::vector<double>::const_iterator x_begin, 
+        std::vector<double>::const_iterator x_begin,
         std::vector<double>::const_iterator x_end,
-        std::vector<double>::const_iterator y_begin, 
+        std::vector<double>::const_iterator y_begin,
         std::vector<double>::const_iterator w_begin);
 
-      /** evaluate the quadratic function */
+      /**
+        @brief Evaluate the fitted polynomial at @p x.
+
+        @param[in] x Input value.
+        @return @c a + b*x + c*x^2 using the currently stored coefficients.
+      */
       double eval(double x) const;
 
-      /** evaluate using external coefficients */
+      /**
+        @brief Evaluate a quadratic polynomial at @p x using externally-supplied coefficients.
+
+        @param[in] A Constant term.
+        @param[in] B Linear coefficient.
+        @param[in] C Quadratic coefficient.
+        @param[in] x Input value.
+        @return @c A + B*x + C*x*x.
+      */
       static double eval(double A, double B, double C, double x);
 
-      double getA() const; /// A = the intercept
-      double getB() const; /// B*X
-      double getC() const; /// C*X^2
+      /// Constant term (@c a) of the last successful fit.
+      double getA() const;
+      /// Linear coefficient (@c b) of the last successful fit.
+      double getB() const;
+      /// Quadratic coefficient (@c c) of the last successful fit.
+      double getC() const;
+      /// Weighted residual sum @c sum(weight * (y - a - b*x - c*x*x)^2) of the last successful fit.
       double getChiSquared() const;
 
 protected:
-      double a_;
-      double b_;
-      double c_;
-      double chi_squared_;
+      double a_;           ///< Constant term of the last successful fit.
+      double b_;           ///< Linear coefficient of the last successful fit.
+      double c_;           ///< Quadratic coefficient of the last successful fit.
+      double chi_squared_; ///< Weighted residual sum of the last successful fit.
     }; //class
 
   } //namespace

--- a/src/openms/include/OpenMS/ML/REGRESSION/QuadraticRegression.h
+++ b/src/openms/include/OpenMS/ML/REGRESSION/QuadraticRegression.h
@@ -41,7 +41,14 @@ namespace OpenMS
     class OPENMS_DLLAPI QuadraticRegression
     {
 public:
-      /// Default constructor; leaves all coefficients and the chi-squared sum at @c 0.
+      /**
+        @brief Default constructor.
+
+        Leaves all coefficients and the chi-squared sum at @c 0; the
+        instance produces meaningful results only after the first
+        successful call to @ref computeRegression or
+        @ref computeRegressionWeighted.
+      */
       QuadraticRegression();
 
       /**
@@ -100,13 +107,34 @@ public:
       */
       static double eval(double A, double B, double C, double x);
 
-      /// Constant term (@c a) of the last successful fit.
+      /**
+        @brief Constant term of the fitted polynomial.
+
+        @return @c a from the last successful fit (or @c 0 if no fit has been computed yet).
+      */
       double getA() const;
-      /// Linear coefficient (@c b) of the last successful fit.
+
+      /**
+        @brief Linear coefficient of the fitted polynomial.
+
+        @return @c b from the last successful fit (or @c 0 if no fit has been computed yet).
+      */
       double getB() const;
-      /// Quadratic coefficient (@c c) of the last successful fit.
+
+      /**
+        @brief Quadratic coefficient of the fitted polynomial.
+
+        @return @c c from the last successful fit (or @c 0 if no fit has been computed yet).
+      */
       double getC() const;
-      /// Weighted residual sum @c sum(weight * (y - a - b*x - c*x*x)^2) of the last successful fit.
+
+      /**
+        @brief Weighted residual sum of squares of the last successful fit.
+
+        @return @c sum(weight * (y - a - b*x - c*x*x)^2) over the last
+                fit's input points (or @c 0 if no fit has been computed
+                yet).
+      */
       double getChiSquared() const;
 
 protected:


### PR DESCRIPTION
## Summary

- **Fix unparsed brief**: the class doc block was opened with `/*` (single asterisk) instead of `/**`, so Doxygen ignored it entirely and the class had no brief in the generated API docs. Reopened with `/**`.
- **Fix off-by-one getter docs**: the previous header had
  ```cpp
  double getA() const; /// A = the intercept
  double getB() const; /// B*X
  double getC() const; /// C*X^2
  ```
  These trailing `///` comments were not `///<`, so Doxygen attached each line to the *next* declaration (i.e. `getA()` had no doc, `getB()` got "A = the intercept", `getC()` got "B*X", `getChiSquared()` got "C*X^2"). Replaced with proper `/// @brief` lines on the correct declarations.
- Add `@ingroup Math` (consistent with `LinearRegression`, `LinearRegressionWithoutIntercept`).
- **Surface `Exception::UnableToFit`** on `computeRegression` / `computeRegressionWeighted` when the normal-equations system is singular (e.g. fewer than three distinct `x` values). Verified against `QuadraticRegression.cpp:117-128`.
- Document the iterator-pair preconditions: `y` and `w` ranges must be at least as long as the `x` range.
- Promote the single-line `/** */` comments on each method to proper Doxygen blocks with `@brief` / `@param[in]` / `@return`.

No behaviour change.

## Test plan
- [x] `cmake --build OpenMS-build --target OpenMS` builds cleanly.
- [ ] CI Doxygen warning check passes (Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved documentation for quadratic regression functionality with clearer descriptions, expanded parameter and iterator requirements, updated exception guidance, and enhanced member/field comments for easier use and interpretation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9335)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->