### PR TITLE
[DOC] MRMFeaturePickerFile: ground column convention, type-cast table, cleared-output contract

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/MRMFeaturePickerFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MRMFeaturePickerFile.h
@@ -16,45 +16,68 @@
 namespace OpenMS
 {
   /**
-    @brief _MRMFeaturePickerFile_ loads components and components groups parameters
-    from a .csv file.
+    @brief Loads MRM component and component-group parameter sets from a comma-separated file.
 
-    The structures defined in [MRMFeaturePicker](@ref MRMFeaturePicker) are used.
+    Produces parallel @c ComponentParams and @c ComponentGroupParams
+    vectors (see @ref MRMFeaturePicker) for use by @ref MRMFeaturePicker.
 
-    It is required that columns `component_name` and `component_group_name` are present.
-    Lines whose `component_name`'s or `component_group_name`'s value is an empty string, will be skipped.
-    The class supports the absence of information within other columns.
+    @par File format
+    Two required columns: @c "component_name" and @c "component_group_name".
+    Any additional column is interpreted by its header name:
+      - @c "TransitionGroupPicker:PeakPickerChromatogram:&lt;param&gt;" feeds the
+        per-component parameter set (@c ComponentParams::params).
+      - @c "TransitionGroupPicker:&lt;param&gt;" (without the
+        @c PeakPickerChromatogram prefix) feeds the per-component-group
+        parameter set (@c ComponentGroupParams::params).
+      - Any other column is ignored.
+    Cells whose value is empty are not written into the parameter set.
+    Lines whose @c component_name or @c component_group_name cell is
+    empty are skipped entirely.
 
-    A reduced example of the expected format (fewer columns are shown here):
+    A reduced example (fewer columns are shown here):
     > component_name,component_group_name,TransitionGroupPicker:stop_after_feature,TransitionGroupPicker:PeakPickerChromatogram:sgolay_frame_length
     > arg-L.arg-L_1.Heavy,arg-L,2,15
     > arg-L.arg-L_1.Light,arg-L,2,17
     > orn.orn_1.Heavy,orn,3,21
     > orn.orn_1.Light,orn,3,13
+
+    @ingroup FileIO
   */
   class OPENMS_DLLAPI MRMFeaturePickerFile :
     public CsvFile
   {
 public:
-    /// Constructor
+    /// Default constructor.
     MRMFeaturePickerFile() = default;
-    /// Destructor
+    /// Destructor.
     ~MRMFeaturePickerFile() override = default;
 
     /**
-      @brief Loads the file's data and saves it into vectors of `ComponentParams` and `ComponentGroupParams`.
+      @brief Read @p filename and populate @p cp_list / @p cgp_list.
 
-      The file is expected to contain at least two columns: `component_name` and `component_group_name`. Otherwise,
-      an exception is thrown.
+      Both output vectors are cleared at the start of the call. The file
+      is parsed as comma-separated; the first non-empty line is treated
+      as the header. For every subsequent line with non-empty
+      @c component_name and @c component_group_name cells one
+      @c ComponentParams entry is appended to @p cp_list. A
+      @c ComponentGroupParams entry is appended to @p cgp_list only the
+      first time a given @c component_group_name is encountered;
+      subsequent rows with the same group name extend @p cp_list but do
+      not produce a new @p cgp_list entry.
 
-      If a component group (identified by its name) is found multiple times, only the first one is saved.
+      @note If the file contains zero or one line, no header validation
+            is performed and the output vectors stay empty.
 
-      @param[in] filename Path to the .csv input file
-      @param[out] cp_list Component params are saved in this list
-      @param[out] cgp_list Component Group params are saved in this list
+      @param[in]  filename Path to the @c .csv input file.
+      @param[out] cp_list  Receives the per-row component parameters.
+      @param[out] cgp_list Receives one entry per unique @c component_group_name.
 
-      @throw Exception::MissingInformation If the required columns are not found.
-      @throw Exception::FileNotFound If input file is not found.
+      @throws Exception::MissingInformation When the required
+                                            @c component_name and/or
+                                            @c component_group_name
+                                            columns are absent.
+      @throws Exception::FileNotFound       When @p filename cannot be
+                                            opened.
     */
     void load(
       const String& filename,
@@ -64,14 +87,22 @@ public:
 
 protected:
     /**
-      @brief Extracts the information from a `StringList` and saves it into the correct data structures.
+      @brief Extract the @c ComponentParams and @c ComponentGroupParams entries from a single parsed CSV line.
 
-      @param[in] line The line parsed from the input file
-      @param[in] headers A mapping from a given header to its value's position
-      @param[out] cp The extracted component parameters
-      @param[out] cgp The extracted component group parameters
+      Reads @c component_name and @c component_group_name from @p line via
+      @p headers; if either is empty, the call returns @c false and
+      @p cp / @p cgp are left in an unspecified state. Otherwise every
+      column whose header matches one of the @c TransitionGroupPicker:
+      prefixes feeds the corresponding parameter set as described in the
+      class brief.
 
-      @return Returns `false` if `component_name` or `component_group_name` are empty strings. Otherwise, it returns `true`.
+      @param[in]  line    Tokens of the input line, indexed by @p headers.
+      @param[in]  headers Mapping from header name to column index in @p line.
+      @param[out] cp      Receives the per-component parameters.
+      @param[out] cgp     Receives the per-component-group parameters (@c component_group_name plus any matching values).
+
+      @return @c true on a fully-populated pair; @c false when either
+              required name cell was empty.
     */
     bool extractParamsFromLine_(
       const StringList& line,
@@ -81,12 +112,27 @@ protected:
     ) const;
 
     /**
-      @brief Helper method which takes care of converting the given value to the desired type,
-      based on the header (here `key`) information.
+      @brief Insert @p value into @p params under @p key, converting the string to the type expected for that parameter name.
 
-      @param[in] key The header name with which the correct conversion is chosen
-      @param[in] value The value to be converted
-      @param[in,out] params The object where the new value is saved
+      Empty values are dropped without modifying @p params. The target
+      type is selected by looking @p key up in a hard-coded table:
+        - @c "gauss_width", @c "peak_width", @c "signal_to_noise",
+          @c "sn_win_len", @c "stop_after_intensity_ratio",
+          @c "min_peak_width", @c "recalculate_peaks_max_z",
+          @c "minimal_quality", @c "resample_boundary" -> @c double.
+        - @c "use_gauss", @c "write_sn_log_messages",
+          @c "remove_overlapping_peaks", @c "recalculate_peaks",
+          @c "use_precursors", @c "compute_peak_quality",
+          @c "compute_peak_shape_metrics" -> @c bool (case-insensitive
+          @c "true" maps to @c "true", everything else to @c "false").
+        - @c "sgolay_frame_length", @c "sgolay_polynomial_order",
+          @c "sn_bin_count" -> @c UInt (via @c double rounding).
+        - @c "stop_after_feature" -> @c Int.
+        - Anything else -> stored as a @c String.
+
+      @param[in]     key    Parameter name (the column header with any @c TransitionGroupPicker: prefix already stripped).
+      @param[in]     value  Value to convert.
+      @param[in,out] params Parameter container to update.
     */
     void setCastValue_(const String& key, const String& value, Param& params) const;
   };


### PR DESCRIPTION
## Summary

- **Class brief now spells out the column-naming convention**, grounded against the regex at `MRMFeaturePickerFile.cpp:83-90`:
  - `TransitionGroupPicker:PeakPickerChromatogram:<param>` -> the per-component parameter set.
  - `TransitionGroupPicker:<param>` (without the `PeakPickerChromatogram` middle segment) -> the per-component-group parameter set.
  - Other columns are ignored.
- `load()`: document that **both output vectors are cleared** at the start (`MRMFeaturePickerFile.cpp:21-22`) and that a 0- or 1-line file produces empty output without throwing.
- Document the **first-occurrence-wins** rule for `component_group_name` (`MRMFeaturePickerFile.cpp:48-58`).
- `setCastValue_()`: document the hard-coded key→type table (double / bool / UInt / Int / String) from `MRMFeaturePickerFile.cpp:101-134`, including the case-insensitive `"true"` rule for the bool path.
- Add `@ingroup FileIO`.

No behaviour change.

## Test plan
- [x] `cmake --build OpenMS-build --target OpenMS` builds cleanly.
- [ ] CI Doxygen warning check passes (Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation to clarify CSV parsing rules, parameter handling, and value conversion behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9338)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->