### PR TITLE
[DOC] ims::Weights: tighten brief; fix @param directions; ground rounding-error and parent-mass throw

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/MASSDECOMPOSITION/IMS/Weights.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/MASSDECOMPOSITION/IMS/Weights.h
@@ -19,24 +19,26 @@ namespace OpenMS
   namespace ims
   {
     /**
-      @brief Represents a set of weights (double values and scaled with a certain
-      precision their integer counterparts) with a quick access.
+      @brief Pairs an alphabet of double-valued masses with the scaled
+             integer weights derived from them.
 
-      Many algorithms can't work with real-valued alphabets and need integer
-      weights. Those are usually obtained by dividing all alphabet masses by
-      a "precision" parameter (0; 1) and rounding the result to integers.
-      Class @c Weights allows access to the scaled masses (the weights) and to the
-      original masses as well. Weights are cached and will not be recalculated on
-      access.
+      Many mass-decomposition algorithms only operate on integer weights;
+      this class provides those integers alongside the original
+      double-valued masses, derived once at construction (or on the next
+      @ref setPrecision call) by computing
+      @c round(mass / precision) per entry. Subsequent access is plain
+      vector lookup -- no recomputation happens on read.
 
-      @note Words 'weights' and 'masses' were used deliberately for naming
-      corresponding values to help users quickly understand how they can be used.
-      Names were chosen due to similarity in 'weights' and 'masses' interconnection
-      in this class with real life. In reality mass value is always the same, and
-      weight value depends on circumstances. The same as here original double
-      masses stay the same, and scaled integer weights depend on precision applied.
+      Typical @c precision values are in @c (0, @c 1] (smaller values
+      mean a finer-grained integer grid); the cpp itself does not enforce
+      a range.
 
-      @author Anton Pervukhin <Anton.Pervukhin@CeBiTec.Uni-Bielefeld.DE>
+      @note The terms "weights" (the scaled integers) and "masses" (the
+            original doubles) are intentionally kept distinct: the masses
+            are invariants of the alphabet, while the weights depend on
+            the chosen precision.
+
+      @ingroup Analysis_DeNovo
     */
     class OPENMS_DLLAPI Weights
     {
@@ -56,14 +58,25 @@ public:
       /// Type of container's size
       typedef weights_type::size_type size_type;
 
-      /// Empty constructor.
+      /**
+        @brief Default constructor.
+
+        Produces an empty instance; @ref size returns @c 0 until masses
+        and a precision have been supplied.
+      */
       Weights() {}
 
       /**
-        Constructor with double values and precision.
+        @brief Construct from a set of masses and a precision.
 
-        @param[in] masses Original double values to be scaled.
-        @param[in] precision Precision to scale double values.
+        Stores @p masses as the alphabet masses and computes the integer
+        weights via @c round(mass / precision) for each entry (so the
+        @ref size of both the alphabet-mass and the weight container is
+        @c masses.size() after the call).
+
+        @param[in] masses    Original double-valued alphabet masses.
+        @param[in] precision Precision used to scale the masses; smaller
+                             values yield finer-grained integer weights.
       */
       Weights(const alphabet_masses_type & masses, alphabet_mass_type precision) :
         alphabet_masses_(masses),
@@ -112,9 +125,11 @@ public:
       }
 
       /**
-        Sets a new precision to scale double values to integer.
+        @brief Replace the precision and recompute the integer weights from the stored alphabet masses.
 
-        @param[in] precision A new precision.
+        @param[in] precision New precision; the integer weights are
+                             refreshed as @c round(mass / precision) for
+                             every stored alphabet mass.
       */
       void setPrecision(alphabet_mass_type precision);
 
@@ -163,34 +178,61 @@ public:
       }
 
       /**
-        Returns a parent mass for a given \c decomposition
+        @brief Reconstruct a parent mass from a decomposition expressed as multiplicities of the alphabet.
+
+        @param[in] decomposition Per-alphabet-entry multiplicities; must
+                                 have the same length as the alphabet.
+        @return @c sum(alphabet_mass[i] * decomposition[i]) using the
+                stored original (double) masses.
+
+        @throws Exception::InvalidParameter when @c decomposition.size()
+                                            does not equal @ref size.
       */
       alphabet_mass_type getParentMass(const std::vector<unsigned int> & decomposition) const;
 
       /**
-        Exchanges weight and mass at index1 with weight and mass at index2.
+        @brief Exchange the alphabet mass @b and the integer weight at @p index1 with those at @p index2.
 
-        @param[in,out] index1 Index of weight and mass to be exchanged.
-        @param[in,out] index2 Index of weight and mass to be exchanged.
+        Both the @c alphabet_mass entry and its corresponding integer
+        @c weight at the two indices are swapped, so the mass / weight
+        pairing is preserved.
+
+        @param[in] index1 First index to swap.
+        @param[in] index2 Second index to swap.
       */
       void swap(size_type index1, size_type index2);
 
       /**
-        Divides the integer weights by their gcd. The precision is also
-        adjusted.
+        @brief Divide every integer weight by the greatest common divisor of all weights and scale the precision accordingly.
 
-        For example, given alphabet weights 3.0, 5.0, 8.0 with precision 0.1, the
-        integer weights would be 30, 50, 80. After calling this method, the new
-        weights are 3, 5, 8 with precision 1.0 (since the gcd of 30, 50, and 80
-        is 10).
+        For example, given alphabet weights @c 3.0, @c 5.0, @c 8.0 with
+        precision @c 0.1, the integer weights would be @c 30, @c 50,
+        @c 80. After calling this method the integer weights become
+        @c 3, @c 5, @c 8 and the precision becomes @c 1.0 (since the
+        gcd of @c 30, @c 50, @c 80 is @c 10).
 
-        @return true if anything was changed, that is, if the gcd was &gt; 1.
-        false if the gcd was already 1 or there are less than two weights.
+        @return @c true when the integer weights and the precision were
+                changed (gcd > 1); @c false when the gcd was already
+                @c 1 or fewer than two weights are stored.
       */
       bool divideByGCD();
 
+      /**
+        @brief Largest negative relative rounding error introduced by the current precision.
+
+        @return The minimum of @c (precision * weight[i] - mass[i]) / mass[i]
+                over all entries with a negative value, or @c 0 if no
+                entry's scaled weight under-estimates its mass.
+      */
       alphabet_mass_type getMinRoundingError() const;
 
+      /**
+        @brief Largest positive relative rounding error introduced by the current precision.
+
+        @return The maximum of @c (precision * weight[i] - mass[i]) / mass[i]
+                over all entries with a positive value, or @c 0 if no
+                entry's scaled weight over-estimates its mass.
+      */
       alphabet_mass_type getMaxRoundingError() const;
 private:
       /**
@@ -210,10 +252,11 @@ private:
     };
 
     /**
-      Prints weights to the stream @c os.
+      @brief Print every integer weight of @p weights to @p os, one per line.
 
-      @param[out] os Output stream to which weights are written.
-      @param[out] weights Weights to be written.
+      @param[out] os      Output stream.
+      @param[in]  weights Weights container whose integer weights are written.
+      @return Reference to @p os for chaining.
     */
     OPENMS_DLLAPI std::ostream & operator<<(std::ostream & os, const Weights & weights);
 


### PR DESCRIPTION
## Summary

- **Class brief** now describes the two-container layout (alphabet masses plus scaled integer weights), the `round(mass / precision)` computation triggered at construction or by `setPrecision`, and that subsequent access is plain vector lookup. Drops the verbose "real-life mass/weight" digression and the stale `@author` tag (already present in the `$Authors$` banner at the top).
- **Fix wrong `@param[in,out]` on `swap()`**'s two index arguments (they are `size_type` values, passed by value → `@param[in]`).
- **Fix wrong `@param[out]`** on `operator<<`'s `weights` argument; the weights container is only read → `@param[in]`.
- Document the **previously-undocumented** `getMinRoundingError` / `getMaxRoundingError` with their actual formula and the "or 0" fallback, grounded in `Weights.cpp:96-122`.
- **Surface `getParentMass`'s `InvalidParameter` throw** on length mismatch (`Weights.cpp:55-58`), and clarify that the **original double masses** are used, not the scaled integer weights.
- Note the typical `(0, 1]` precision range but that the cpp does **not** enforce it.
- Add `@ingroup Analysis_DeNovo` (consistent with the recently-documented `IMSAlphabet` sibling).

No behaviour change.

## Test plan
- [x] `cmake --build OpenMS-build --target OpenMS` builds cleanly.
- [ ] CI Doxygen warning check passes (Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation clarity and accuracy for library components and methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9339)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->