### PR TITLE
[DOC] TraceFitter: replace 'todo docu needs update' with grounded contract; document optimize_ throws

### DIFF
--- a/src/openms/include/OpenMS/FEATUREFINDER/TraceFitter.h
+++ b/src/openms/include/OpenMS/FEATUREFINDER/TraceFitter.h
@@ -115,19 +115,39 @@ protected:
     */
     virtual void fit(FeatureFinderAlgorithmPickedHelperStructs::MassTraces& traces) = 0;
 
-    /// Lower RT bound of the fitted RT model.
+    /**
+      @brief Lower RT bound of the fitted RT model.
+
+      @return Lower RT bound (retention-time units).
+    */
     virtual double getLowerRTBound() const = 0;
 
-    /// Upper RT bound of the fitted RT model.
+    /**
+      @brief Upper RT bound of the fitted RT model.
+
+      @return Upper RT bound (retention-time units).
+    */
     virtual double getUpperRTBound() const = 0;
 
-    /// Height of the fitted RT model at its centre.
+    /**
+      @brief Height of the fitted RT model at its centre.
+
+      @return Model intensity at the centre RT.
+    */
     virtual double getHeight() const = 0;
 
-    /// Centre (RT) of the fitted RT model.
+    /**
+      @brief Centre of the fitted RT model.
+
+      @return Centre retention time of the fitted model.
+    */
     virtual double getCenter() const = 0;
 
-    /// Full width at half maximum of the fitted RT model.
+    /**
+      @brief Full width at half maximum of the fitted RT model.
+
+      @return FWHM in retention-time units.
+    */
     virtual double getFWHM() const = 0;
 
     /**
@@ -170,7 +190,11 @@ protected:
     */
     virtual bool checkMaximalRTSpan(const double max_rt_span) = 0;
 
-    /// Area under the fitted RT model.
+    /**
+      @brief Area under the fitted RT model.
+
+      @return Integrated intensity of the fitted model.
+    */
     virtual double getArea() = 0;
 
     /**

--- a/src/openms/include/OpenMS/FEATUREFINDER/TraceFitter.h
+++ b/src/openms/include/OpenMS/FEATUREFINDER/TraceFitter.h
@@ -17,152 +17,218 @@ namespace OpenMS
 {
 
   /**
-   * @brief Abstract fitter for RT profile fitting
-   *
-   * This class provides the basic interface and some functionality to fit multiple mass traces to
-   * a given RT shape model using the Levenberg-Marquardt algorithm.
-   *
-   * @todo docu needs update
-   *
-   */
+    @brief Abstract base class for fitting an RT-shape model to one or more mass traces.
+
+    Provides the shared parameter handling and a Levenberg-Marquardt
+    driver (@ref optimize_) for subclasses that supply a concrete RT
+    profile (Gaussian, EGH, ...). Subclasses implement @ref fit, the
+    geometric query methods (@ref getLowerRTBound,
+    @ref getUpperRTBound, @ref getHeight, @ref getCenter,
+    @ref getFWHM, @ref getValue, @ref getArea), the validation hooks
+    (@ref checkMinimalRTSpan, @ref checkMaximalRTSpan), the plot
+    helper @ref getGnuplotFormula, and @ref getOptimizedParameters_.
+
+    @par Parameters
+    - @c "max_iteration" (singular): maximum number of LM iterations
+      (default @c 500).
+    - @c "weighted" (@c "true"/@c "false"): whether mass traces are
+      weighted by their theoretical intensity during fitting (default
+      @c "false"). The flag is exposed as @ref weighted_ for use by
+      subclasses.
+
+    @ingroup FeatureFinder
+  */
   class OPENMS_DLLAPI TraceFitter :
     public DefaultParamHandler
   {
 
 public:
-    /** Generic functor for LM-Optimization
-     *  Uses raw pointer interface to avoid Eigen in public headers.
-     *  Implementations should use Eigen::Map to wrap these pointers.
-     */
+    /**
+      @brief Generic LM functor with a raw-pointer interface, used to keep Eigen out of the public API.
+
+      Subclasses implement @ref operator() to fill the residual vector
+      and @ref df to fill the Jacobian; the cpp wraps each side in an
+      @c Eigen::Map before handing it to the LM solver.
+    */
     //TODO: This is copy and paste from LevMarqFitter1d.h. Make a generic wrapper for LM optimization
     class GenericFunctor
     {
 public:
+      /// Number of free parameters (input dimensionality).
       int inputs() const;
+      /// Number of residuals (data points).
       int values() const;
 
+      /**
+        @brief Construct with the given problem dimensions.
+
+        @param[in] dimensions      Number of free parameters.
+        @param[in] num_data_points Number of residuals.
+      */
       GenericFunctor(int dimensions, int num_data_points);
 
       virtual ~GenericFunctor();
 
-      /// Compute residuals. x has size inputs(), fvec has size values()
+      /**
+        @brief Compute residuals at the current parameter vector.
+
+        @param[in]  x    Parameter vector of size @ref inputs.
+        @param[out] fvec Residual vector of size @ref values.
+        @return @c 0 on success.
+      */
       virtual int operator()(const double* x, double* fvec) = 0;
-      /// Compute Jacobian matrix. x has size inputs(), J is values() x inputs() (column-major)
+
+      /**
+        @brief Compute the Jacobian at the current parameter vector.
+
+        @param[in]  x Parameter vector of size @ref inputs.
+        @param[out] J Jacobian matrix, @ref values rows by @ref inputs
+                      columns, stored column-major.
+        @return @c 0 on success.
+      */
       virtual int df(const double* x, double* J) = 0;
 
 protected:
       const int m_inputs, m_values;
     };
 
-    /// default constructor
+    /// Default constructor; registers the @c "max_iteration" and @c "weighted" defaults on @ref DefaultParamHandler.
     TraceFitter();
 
-    /// copy constructor
+    /// Copy constructor.
     TraceFitter(const TraceFitter& source);
 
-    /// assignment operator
+    /// Assignment operator.
     TraceFitter& operator=(const TraceFitter& source);
 
-    /// destructor
+    /// Destructor.
     ~TraceFitter() override;
 
     /**
-     * Main method of the TraceFitter which triggers the actual fitting.
-     */
+      @brief Run the LM fit on @p traces.
+
+      Subclasses fill the model parameters and (typically) call
+      @ref optimize_ on a problem-specific functor.
+
+      @param[in,out] traces Mass traces to fit; subclasses may set
+                            additional bookkeeping on @p traces.
+    */
     virtual void fit(FeatureFinderAlgorithmPickedHelperStructs::MassTraces& traces) = 0;
 
-    /**
-     * Returns the lower bound of the fitted RT model
-     */
+    /// Lower RT bound of the fitted RT model.
     virtual double getLowerRTBound() const = 0;
 
-    /**
-     * Returns the upper bound of the fitted RT model
-     */
+    /// Upper RT bound of the fitted RT model.
     virtual double getUpperRTBound() const = 0;
 
-    /**
-     * Returns the height of the fitted model
-     */
+    /// Height of the fitted RT model at its centre.
     virtual double getHeight() const = 0;
 
-    /**
-     * Returns the center position of the fitted model
-     */
+    /// Centre (RT) of the fitted RT model.
     virtual double getCenter() const = 0;
 
-    /**
-     * Returns the mass trace width at half max (FWHM)
-     */
+    /// Full width at half maximum of the fitted RT model.
     virtual double getFWHM() const = 0;
 
     /**
-     * Evaluate the fitted model at a time point
-     */
+      @brief Evaluate the fitted model at retention time @p rt.
+
+      @param[in] rt Retention time at which to evaluate the model.
+      @return Model intensity at @p rt.
+    */
     virtual double getValue(double rt) const = 0;
 
     /**
-     * Returns the theoretical value of the fitted model at position k in the passed mass trace
-     *
-     * @param[in] trace the mass trace for which the value should be computed
-     * @param[in] k  use the position of the k-th peak to compute the value
-     */
+      @brief Evaluate the fitted model at the RT of the @p k-th peak of @p trace, scaled by the trace's theoretical intensity.
+
+      @param[in] trace Mass trace; only the RT of its @p k-th peak is read.
+      @param[in] k     Index of the peak in @p trace.peaks.
+      @return @c trace.theoretical_int * getValue(trace.peaks[k].first).
+    */
     double computeTheoretical(const FeatureFinderAlgorithmPickedHelperStructs::MassTrace& trace, Size k) const;
 
     /**
-     * Checks if the fitted model fills out at least 'min_rt_span' of the RT span
-     *
-     * @param[in] rt_bounds RT boundaries of the fitted model
-     * @param[in] min_rt_span Minimum RT span in relation to extended area that has to remain after model fitting
-     */
+      @brief Whether the fitted RT model covers at least @p min_rt_span of the extended search area.
+
+      @param[in] rt_bounds   RT boundaries of the extended search area
+                             (lower, upper).
+      @param[in] min_rt_span Minimum RT span the fitted model must cover
+                             relative to @p rt_bounds, as a fraction.
+      @return @c true when the model spans at least @p min_rt_span of
+              the search area.
+    */
     virtual bool checkMinimalRTSpan(const std::pair<double, double>& rt_bounds, const double min_rt_span) = 0;
 
     /**
-     * Checks if the fitted model is not to big
-     *
-     * @param[in] max_rt_span Maximum RT span in relation to extended area that the model is allowed to have
-     */
+      @brief Whether the fitted RT model stays within @p max_rt_span of the extended search area.
+
+      @param[in] max_rt_span Maximum allowed RT span of the fitted
+                             model relative to the extended search
+                             area, as a fraction.
+      @return @c true when the model does not exceed @p max_rt_span of
+              the search area.
+    */
     virtual bool checkMaximalRTSpan(const double max_rt_span) = 0;
 
-    /**
-     * Returns the peak area of the fitted model
-     */
+    /// Area under the fitted RT model.
     virtual double getArea() = 0;
 
     /**
-     * Returns a textual representation of the fitted model function, that can be plotted using Gnuplot
-     *
-     * @param[in] trace The mass trace that should be plotted
-     * @param[in] function_name The name of the function (e.g. f(x) -> function_name = f)
-     * @param[in] baseline The intensity of the baseline
-     * @param[in] rt_shift A shift value, that allows to plot all RT profiles side by side, even if they would overlap in reality.
-     *                 This should be 0 for the first mass trace and increase by a fixed value for each mass trace.
-     */
+      @brief Gnuplot expression of the fitted model for @p trace.
+
+      @param[in] trace         Mass trace whose theoretical intensity scales the expression.
+      @param[in] function_name Name of the function in the resulting expression (e.g. @c 'f' for @c "f(x)").
+      @param[in] baseline      Intensity of the plotted baseline.
+      @param[in] rt_shift      RT offset added to the expression so several traces can be plotted side by side
+                               (typically @c 0 for the first trace and incremented for subsequent traces).
+      @return Gnuplot expression as a @c String.
+    */
     virtual String getGnuplotFormula(const FeatureFinderAlgorithmPickedHelperStructs::MassTrace& trace, const char function_name, const double baseline, const double rt_shift) = 0;
 
 protected:
+    /// Helper bundle passed to functors so they can read both the traces and the weighting flag.
     struct ModelData
     {
-      FeatureFinderAlgorithmPickedHelperStructs::MassTraces* traces_ptr;
-      bool weighted;
+      FeatureFinderAlgorithmPickedHelperStructs::MassTraces* traces_ptr; ///< Mass traces being fitted.
+      bool weighted;                                                     ///< Mirror of @ref weighted_ at fit time.
     };
 
     void updateMembers_() override;
 
     /**
-     * Updates all member variables to the fitted values stored in the solver.
-     *
-     * @param[in] s The solver containing the fitted parameter values.
-     */
+      @brief Subclass hook: copy the optimised parameter vector back into the subclass's model fields.
+
+      Called by @ref optimize_ after the LM solver has converged.
+
+      @param[in] s Optimised parameter vector (size matches the functor's @c inputs).
+    */
     virtual void getOptimizedParameters_(const std::vector<double>& s) = 0;
+
     /**
-     * Optimize the given parameters using the Levenberg-Marquardt algorithm.
-     */
+      @brief Run Levenberg-Marquardt on @p functor starting from @p x_init.
+
+      On return, @p x_init holds the optimised parameter vector and
+      @ref getOptimizedParameters_ has been called. The LM iteration
+      limit is taken from the @c "max_iteration" parameter.
+
+      @param[in,out] x_init  Initial parameter vector; replaced with
+                             the optimised vector on success.
+      @param[in,out] functor LM functor providing residuals and the
+                             Jacobian.
+
+      @throws Exception::UnableToFit when the number of residuals
+                                     reported by @p functor is smaller
+                                     than its number of free
+                                     parameters, or when the LM solver
+                                     reports a non-recoverable state
+                                     (@c NotStarted / @c Running /
+                                     @c ImproperInputParameters).
+    */
     void optimize_(std::vector<double>& x_init, GenericFunctor& functor);
 
-    /// Maximum number of iterations
+    /// Maximum number of LM iterations; refreshed from @c "max_iteration" in @ref updateMembers_.
     SignedSize max_iterations_;
-    /// Whether to weight mass traces by theoretical intensity during the optimization
+    /// Whether mass traces are weighted by theoretical intensity during fitting; refreshed from @c "weighted" in @ref updateMembers_.
     bool weighted_;
 
   };

--- a/src/openms/include/OpenMS/FEATUREFINDER/TraceFitter.h
+++ b/src/openms/include/OpenMS/FEATUREFINDER/TraceFitter.h
@@ -46,9 +46,9 @@ public:
     /**
       @brief Generic LM functor with a raw-pointer interface, used to keep Eigen out of the public API.
 
-      Subclasses implement @ref operator() to fill the residual vector
-      and @ref df to fill the Jacobian; the cpp wraps each side in an
-      @c Eigen::Map before handing it to the LM solver.
+      Subclasses implement the @c operator() to fill the residual
+      vector and @ref df to fill the Jacobian; the cpp wraps each side
+      in an @c Eigen::Map before handing it to the LM solver.
     */
     //TODO: This is copy and paste from LevMarqFitter1d.h. Make a generic wrapper for LM optimization
     class GenericFunctor


### PR DESCRIPTION
## Summary

- **Class brief**: drop the placeholder `@todo docu needs update` and describe the actual abstract-fitter contract -- shared parameter handling + LM driver plus the subclass hooks (RT profile, geometric queries, validation, plot helper, post-optimisation copy-back).
- **Document the two parameters** with their actual default values, grounded against `TraceFitter.cpp:62-65`:
  - `max_iteration` (singular, default `500`).
  - `weighted` (default `"false"`; valid: `"true"` / `"false"`).
- **Document the previously-undocumented `optimize_()`** with its two `Exception::UnableToFit` throw paths:
  - `data_count < num_params` (`TraceFitter.cpp:109-112`)
  - LM solver reports a non-recoverable state (`NotStarted` / `Running` / `ImproperInputParameters`) at `TraceFitter.cpp:122-130`
  and the post-call invocation of `getOptimizedParameters_` (`TraceFitter.cpp:134`).
- Tighten the pure-virtual method docs (`getLowerRTBound` / `getUpperRTBound` / `getHeight` / `getCenter` / `getFWHM` / `getValue` / `getArea` / `checkMinimalRTSpan` / `checkMaximalRTSpan` / `getGnuplotFormula`) and the `GenericFunctor` nested-class docs.
- Document `computeTheoretical`'s actual contract: `trace.theoretical_int * getValue(trace.peaks[k].first)` (`TraceFitter.cpp:88-93`).
- Add `///<` field docs on `ModelData` / `max_iterations_` / `weighted_`.
- Add `@ingroup FeatureFinder`.

No behaviour change.

## Test plan
- [x] `cmake --build OpenMS-build --target OpenMS` builds cleanly.
- [ ] CI Doxygen warning check passes (Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified TraceFitter documentation: improved class overview, clearer descriptions of fitting behavior, interfaces, validation hooks, solver/optimizer parameters, and plotting guidance.
  * Confirmed no changes to public APIs or runtime behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9341)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->