### PR TITLE
[DOC] CubicSpline2d: fix wrong derivative-order claim; surface IllegalArgument throws

### DIFF
--- a/src/openms/include/OpenMS/MATH/MISC/CubicSpline2d.h
+++ b/src/openms/include/OpenMS/MATH/MISC/CubicSpline2d.h
@@ -16,75 +16,115 @@
 namespace OpenMS
 {
   /**
-    @brief cubic spline interpolation
-    as described in R.L. Burden, J.D. Faires, Numerical Analysis, 4th ed.
-    PWS-Kent, 1989, ISBN 0-53491-585-X, pp. 126-131.
-    
-    Construction of the spline takes by far the most time. Evaluating it is rather fast 
-    (one evaluation is about 50x faster than construction -- depending on number of points etc.).
-   
-   */
+    @brief Natural cubic-spline interpolation of a 2D data set.
+
+    Fits a piecewise cubic polynomial through the supplied (x, y)
+    knots so that the resulting spline is twice continuously
+    differentiable. The construction follows R.L. Burden, J.D. Faires,
+    @e Numerical @e Analysis, 4th ed., PWS-Kent 1989,
+    ISBN 0-53491-585-X, pp. 126-131.
+
+    Construction is the expensive step; subsequent evaluations are
+    roughly an order of magnitude (~50x) faster than construction in
+    typical cases. After construction, the spline can be sampled at
+    any @c x in the closed interval @c [x_first, x_last] via
+    @ref eval, and its first three derivatives are available via
+    @ref derivative / @ref derivatives.
+
+    @ingroup Math
+  */
   class OPENMS_DLLAPI CubicSpline2d
   {
 
-    std::vector<double> a_; ///< constant spline coefficients
-    std::vector<double> b_; ///< linear spline coefficients
-    std::vector<double> c_; ///< quadratic spline coefficients
-    std::vector<double> d_; ///< cubic spline coefficients
-    std::vector<double> x_; ///< knots
+    std::vector<double> a_; ///< Per-segment constant coefficient (degree 0); same value as the @c y at the segment's left knot.
+    std::vector<double> b_; ///< Per-segment linear coefficient (degree 1).
+    std::vector<double> c_; ///< Per-segment quadratic coefficient (degree 2); contains one extra trailing zero from the natural boundary condition.
+    std::vector<double> d_; ///< Per-segment cubic coefficient (degree 3).
+    std::vector<double> x_; ///< Sorted knot abscissae (length = number of segments + 1).
 
 public:
 
     /**
-     * @brief constructor of spline interpolation
-     *
-     * The coordinates must match by index. Both vectors must be
-     * the same size and sorted in x. Sortedness in x is required
-     * for @see SplinePackage.
-     *
-     * @param[in] x x-coordinates of input data points (knots)
-     * @param[in] y y-coordinates of input data points
-     */
+      @brief Build the spline from parallel @p x / @p y vectors.
+
+      @param[in] x Knot abscissae; must contain at least two entries
+                   and be sorted in non-decreasing order.
+      @param[in] y Knot ordinates; must have the same length as @p x.
+
+      @throws Exception::IllegalArgument when @p x and @p y differ in
+                                         length, when fewer than two
+                                         knots are supplied, or when
+                                         @p x is not non-decreasing.
+    */
     CubicSpline2d(const std::vector<double>& x, const std::vector<double>& y);
 
     /**
-     * @brief constructor of spline interpolation
-     *
-     * @param[in] m (x,y) coordinates of input data points
-     */
+      @brief Build the spline from a map of (x, y) knots.
+
+      The map is automatically sorted by @c x; passing an empty or
+      single-entry map is an error.
+
+      @param[in] m Knots as @c std::map<x, y>. Must contain at least two entries.
+
+      @throws Exception::IllegalArgument when @p m contains fewer than
+                                         two entries.
+    */
     CubicSpline2d(const std::map<double, double>& m);
 
     /**
-     * @brief evaluates the spline at position x
-     *
-     * @param[in] x x-position
-     */
+      @brief Evaluate the spline at @p x.
+
+      @param[in] x Position; must lie in the closed interval @c [first_knot, last_knot].
+      @return Interpolated value at @p x.
+
+      @throws Exception::IllegalArgument when @p x lies outside the
+                                         knot range.
+    */
     double eval(double x) const;
 
     /**
-     * @brief evaluates first derivative of spline at position x
-     *
-     * @param[in] x x-position
-     */
+      @brief First derivative of the spline at @p x.
+
+      Equivalent to @c derivatives(x, @c 1).
+
+      @param[in] x Position; must lie in the closed interval @c [first_knot, last_knot].
+      @return First derivative at @p x.
+
+      @throws Exception::IllegalArgument when @p x lies outside the
+                                         knot range.
+    */
     double derivative(double x) const;
 
     /**
-     * @brief evaluates derivative of spline at position x
-     *
-     * @param[in] x x-position
-     * @param[in] order order of the derivative
-     * Only order 1 or 2 make sense for cubic splines.
-     */
+      @brief Derivative of the spline at @p x.
+
+      @param[in] x     Position; must lie in the closed interval
+                       @c [first_knot, last_knot].
+      @param[in] order Derivative order. Cubic splines provide
+                       meaningful first, second, and third derivatives;
+                       this method accepts @c order in @c {1, 2, 3}.
+                       Higher orders are zero everywhere and are
+                       rejected with an exception.
+      @return @p order -th derivative of the spline at @p x.
+
+      @throws Exception::IllegalArgument when @p x lies outside the
+                                         knot range, or when @p order
+                                         is not @c 1, @c 2, or @c 3.
+    */
     double derivatives(double x, unsigned order) const;
 
 private:
 
     /**
-     * @brief initialize the spline
-     *
-     * @param[in] x x-coordinates of input data points (knots)
-     * @param[in] y y-coordinates of input data points
-     */
+      @brief Initialise the spline coefficients from the supplied knots.
+
+      Called from both public constructors after their argument
+      validation; assumes the caller has already verified that the
+      inputs are well-formed.
+
+      @param[in] x Knot abscissae.
+      @param[in] y Knot ordinates.
+    */
     void init_(const std::vector<double>& x, const std::vector<double>& y);
 
   };


### PR DESCRIPTION
## Summary

- **Fix factually wrong claim**: the previous `derivatives()` doc said *"Only order 1 or 2 make sense for cubic splines"*, but the cpp at `CubicSpline2d.cpp:94-118` actually accepts orders `1`, `2`, **and** `3` (and rejects anything else with `IllegalArgument`). Documented correctly with the `{1, 2, 3}` range.
- Add `@ingroup Math` (consistent with sibling `BSplineSmoothingSpline`).
- **Surface three previously-silent throw sites**:
  - Vector ctor: size mismatch / fewer than 2 entries / non-monotonic `x` (`CubicSpline2d.cpp:22-36`).
  - Map ctor: fewer than 2 entries (`CubicSpline2d.cpp:43-46`).
  - `eval` / `derivative` / `derivatives`: `x` outside the knot range (`CubicSpline2d.cpp:66-69, 89-92`).
- Tighten member-variable docs to reflect the actual relationship: `c_` is one longer than the other coefficient vectors due to the natural boundary condition stored at the end (`CubicSpline2d.cpp:151-152`).
- Drop the broken `"@see SplinePackage"` usage from the old vector-ctor doc (the `@see` was placed inline inside a sentence so the link was effectively dead) and rephrase the sortedness requirement.

No behaviour change.

## Test plan
- [x] `cmake --build OpenMS-build --target OpenMS` builds cleanly.
- [ ] CI Doxygen warning check passes (Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Substantially rewrote and expanded documentation for mathematical spline algorithms, including clearer descriptions of behavior, construction and evaluation considerations, detailed member field semantics and their relationships, comprehensive parameter validation requirements, supported derivative operations at multiple orders, and thorough exception handling specifications for improved developer guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9342)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->