### PR TITLE
[DOC] NonNegativeLeastSquaresSolver: fix wrong x>0 claim; document enum values and dimension throws

### DIFF
--- a/src/openms/include/OpenMS/ML/NNLS/NonNegativeLeastSquaresSolver.h
+++ b/src/openms/include/OpenMS/ML/NNLS/NonNegativeLeastSquaresSolver.h
@@ -14,70 +14,109 @@
 namespace OpenMS
 {
   /**
-      @brief Wrapper for a non-negative least squares (NNLS) solver.
+    @brief Wrapper around the Lawson-Hanson non-negative least squares (NNLS)
+           Fortran routine.
 
-      It solves Ax=b, where x>0 in the least squares sense (i.e. minimum residual)
+    Solves the constrained least-squares problem
+    @c argmin_{x >= 0} ||Ax - b||_2 with all entries of @c x required
+    to be non-negative.
+
+    Three overloads are provided:
+      - a non-destructive @c Matrix-based one that copies its inputs;
+      - an in-place pointer-based one for callers that already own a
+        column-major buffer;
+      - an in-place @c Matrix / @c std::vector convenience wrapper
+        around the pointer overload.
+
+    @ingroup Math
   */
   class OPENMS_DLLAPI NonNegativeLeastSquaresSolver
   {
 public:
 
+    /// Return status of @ref solve.
     enum RETURN_STATUS
     {
-      SOLVED,
-      ITERATION_EXCEEDED
+      SOLVED,             ///< NNLS converged within the iteration limit; @p x holds the solution.
+      ITERATION_EXCEEDED  ///< NNLS hit the iteration limit; @p x holds the best result so far.
     };
 
     /**
-      @brief Solve the non-negative least square problem Ax=b, where x>0
+      @brief Solve @c argmin_{x >= 0} ||Ax - b||_2 without modifying the inputs.
 
-      This overload copies the input matrix and vector before solving, preserving the originals.
+      Copies @p A and @p b internally, then runs NNLS on the copies and
+      writes the result into @p x (resized to @c A.cols() rows, 1 column).
 
-      @param[in] A Input matrix A of size m x n
-      @param[in] b Input vector (OpenMS::Matrix with one column) b of size m x 1
-      @param[out] x Output vector (OpenMS::Matrix with one column) with non-negative least square solution of size n x 1
-      @return status of solution (either NonNegativeLeastSquaresSolver::SOLVED, NonNegativeLeastSquaresSolver::ITERATION_EXCEEDED)
+      @param[in]  A Input matrix of size @c m x @c n.
+      @param[in]  b Input vector as a column matrix of size @c m x 1.
+      @param[out] x Receives the non-negative solution as a column matrix of size @c n x 1.
+      @return @ref SOLVED on convergence, @ref ITERATION_EXCEEDED when
+              the iteration limit was reached.
 
-      @throws Exception::InvalidParameters if Matrix dimensions do not fit
+      @throws Exception::InvalidParameter when @c A.rows() does not
+                                          match @c b.rows(), or when
+                                          the underlying NNLS routine
+                                          reports an invalid dimension
+                                          (should not happen in
+                                          practice).
     */
     static Int solve(const Matrix<double>& A, const Matrix<double>& b, Matrix<double>& x);
 
     /**
-      @brief Solve the non-negative least square problem Ax=b, where x>0. Works in-place.
+      @brief In-place pointer overload of @ref solve.
 
-      This version works directly on raw buffers and modifies inputs in-place for efficiency.
+      Operates directly on the caller-owned buffer for @p A and the
+      @p b vector, so neither needs to be copied. After the call the
+      contents of @p A and @p b are clobbered by the NNLS workspace
+      and should not be read again.
 
-      @param[in,out] A Pointer to matrix data of size m x n (need memory-contiguous representation
-                       in column-major order, i.e., A_rows * A_cols doubles). Must be non-null and
-                       point to a buffer of at least A_rows * A_cols doubles. The caller retains
-                       ownership and must ensure A remains valid for the duration of this call.
-                       Modified in-place by the solver; contents are undefined after the call.
-                       Passing nullptr or an insufficiently sized buffer results in undefined behavior.
-      @param[in] A_rows Number of rows in A (must be > 0)
-      @param[in] A_cols Number of columns in A (must be > 0)
-      @param[in,out] b Input vector b of size m. Modified in-place by the solver.
-      @param[out] x Output vector with non-negative least square solution of size n.
-      @return status of solution (either NonNegativeLeastSquaresSolver::SOLVED, NonNegativeLeastSquaresSolver::ITERATION_EXCEEDED)
+      @param[in,out] A      Pointer to a column-major @c double buffer of
+                            length @c A_rows * @c A_cols. The caller
+                            retains ownership, must keep the buffer
+                            valid for the duration of the call, and
+                            must not pass @c nullptr or a buffer that
+                            is shorter than required. The contents are
+                            unspecified on return.
+      @param[in]     A_rows Number of rows of @p A (@c > @c 0).
+      @param[in]     A_cols Number of columns of @p A (@c > @c 0).
+      @param[in,out] b      Right-hand side of size @c A_rows; contents
+                            are unspecified on return.
+      @param[out]    x      Receives the non-negative solution of size
+                            @c A_cols (resized internally).
+      @return @ref SOLVED on convergence, @ref ITERATION_EXCEEDED when
+              the iteration limit was reached.
 
-      @throws Exception::InvalidParameters if A_rows does not match b.size()
+      @throws Exception::InvalidParameter when @c A_rows does not match
+                                          @c b.size(), or when the
+                                          underlying NNLS routine
+                                          reports an invalid dimension.
 
-      @note For a safer interface with bounds checking, prefer the Matrix<double>& overload.
-            A future revision may adopt std::span for improved pointer safety.
+      @note Prefer the @c Matrix overload for additional bounds
+            checking; a future revision may adopt @c std::span.
     */
     static Int solve(double* A, int A_rows, int A_cols,
                      std::vector<double>& b, std::vector<double>& x);
 
     /**
-      @brief Solve the non-negative least square problem Ax=b using Matrix and vectors.
+      @brief In-place @c Matrix / @c std::vector overload of @ref solve.
 
-      This overload works with OpenMS Matrix and std::vector, modifying inputs in-place for efficiency.
+      Delegates to the pointer overload using @c A.data(), so @p A and
+      @p b are clobbered by the NNLS workspace and should not be read
+      after the call.
 
-      @param[in,out] A Input matrix A of size m x n. Modified in-place by the solver.
-      @param[in,out] b Input vector b of size m. Modified in-place by the solver.
-      @param[out] x Output vector with non-negative least square solution of size n.
-      @return status of solution (either NonNegativeLeastSquaresSolver::SOLVED, NonNegativeLeastSquaresSolver::ITERATION_EXCEEDED)
+      @param[in,out] A Input matrix of size @c m x @c n; contents are
+                       unspecified on return.
+      @param[in,out] b Right-hand side of size @c m; contents are
+                       unspecified on return.
+      @param[out]    x Receives the non-negative solution of size @c n
+                       (resized internally).
+      @return @ref SOLVED on convergence, @ref ITERATION_EXCEEDED when
+              the iteration limit was reached.
 
-      @throws Exception::InvalidParameters if Matrix dimensions do not fit
+      @throws Exception::InvalidParameter when @c A.rows() does not
+                                          match @c b.size(), or when
+                                          the underlying NNLS routine
+                                          reports an invalid dimension.
     */
     static Int solve(Matrix<double>& A, std::vector<double>& b, std::vector<double>& x);
   };


### PR DESCRIPTION
## Summary

- **Fix factually wrong inequality**: the previous class brief and per-overload `@brief` said *"x>0"*, but NNLS solves under `x >= 0` (non-negative, not strict positive). Now uses the standard `argmin_{x>=0} ||Ax-b||_2` formulation.
- Add `@ingroup Math` (matches `LinearRegression` / `LinearRegressionWithoutIntercept`).
- Document the `RETURN_STATUS` enum values (`SOLVED`, `ITERATION_EXCEEDED`).
- **Surface the second `InvalidParameter` path** that was silent before: all three overloads can additionally throw `InvalidParameter` when the underlying `nnls_` routine reports `mode == 2` ("bad dimension"), grounded against `NonNegativeLeastSquaresSolver.cpp:45-49, 140-144`.
- Tighten the per-overload contracts and consolidate the in-place warnings: the contents of `A` and `b` are clobbered by the NNLS workspace on return, not just "modified".

No behaviour change.

## Test plan
- [x] `cmake --build OpenMS-build --target OpenMS` builds cleanly.
- [ ] CI Doxygen warning check passes (Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Significantly expanded and clarified documentation for a core numerical solver class, with more detailed explanations of method parameters, expected input data dimensions and output formats, various return conditions under different scenarios, and specific exception cases. These improvements provide developers with precise guidance needed for correct integration and optimal usage patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9343)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->