### PR TITLE
[DOC] NeedlemanWunsch: surface uppercase-A-Z input constraint; ground enum values and throws

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/SEQUENCE/NeedlemanWunsch.h
+++ b/src/openms/include/OpenMS/ANALYSIS/SEQUENCE/NeedlemanWunsch.h
@@ -51,10 +51,16 @@ namespace OpenMS
     */
     NeedlemanWunsch(ScoringMatrix matrix, int penalty);
 
-    /// Default constructor; uses @c ScoringMatrix::PAM30MS and a gap penalty of @c 5.
+    /**
+      @brief Default constructor.
+
+      Uses @c ScoringMatrix::PAM30MS and a gap penalty of @c 5.
+    */
     NeedlemanWunsch() = default;
 
-    /// Destructor.
+    /**
+      @brief Destructor.
+    */
     ~NeedlemanWunsch()=default;
 
     /// Lookup table for @ref setMatrix(const std::string&); current entries: @c "identity", @c "PAM30MS".

--- a/src/openms/include/OpenMS/ANALYSIS/SEQUENCE/NeedlemanWunsch.h
+++ b/src/openms/include/OpenMS/ANALYSIS/SEQUENCE/NeedlemanWunsch.h
@@ -14,61 +14,116 @@
 namespace OpenMS
 {
   /**
-   @brief This class contains functions that are used to calculate the global alignment score of two amino acid sequences. 
-   This class uses the Needleman-Wunsch algorithm. For match and mismatch it uses a similarity scoring matrix.
-   */
+    @brief Global-alignment similarity score for two amino-acid sequences using the Needleman-Wunsch algorithm.
+
+    Computes the score (not the alignment itself) of the best global
+    alignment of two amino-acid sequences against a substitution matrix
+    plus a linear gap penalty. The implementation uses a two-row
+    rolling buffer.
+
+    @note The implementation indexes the substitution matrix by
+          @c c - 'A', so the input strings must contain only uppercase
+          ASCII letters in @c [A-Z]. Characters @c J, @c O, and @c U
+          have @c INT16_MAX rows/columns in both bundled matrices and
+          effectively forbid any alignment involving them. Lowercase or
+          non-ASCII characters lead to out-of-bounds reads.
+
+    @ingroup Analysis_ID
+  */
   class OPENMS_DLLAPI NeedlemanWunsch
   {
 
   public:
 
-    /// contains the valid matrices and the number of them
+    /// Substitution matrices bundled with this class.
     enum class ScoringMatrix
     {
-      identity,
-      PAM30MS,
-      SIZE_OF_SCORINGMATRIX
+      identity,                ///< +1 on the diagonal, 0 elsewhere; @c J / @c O / @c U columns and rows are forbidden (@c INT16_MAX).
+      PAM30MS,                 ///< PAM30 matrix extended for MS-style substitutions (default).
+      SIZE_OF_SCORINGMATRIX    ///< Number of valid matrices.
     };
 
-    /// Constructor that sets the scoring matrix and the gap penalty
+    /**
+      @brief Construct with a chosen scoring matrix and gap penalty.
+
+      @param[in] matrix  Scoring matrix to use.
+      @param[in] penalty Linear gap penalty (subtracted per gap step).
+    */
     NeedlemanWunsch(ScoringMatrix matrix, int penalty);
 
-    /// Default constructor (scoring matrix PAM30MS and penalty 5)
+    /// Default constructor; uses @c ScoringMatrix::PAM30MS and a gap penalty of @c 5.
     NeedlemanWunsch() = default;
 
-    /// Default destructor
+    /// Destructor.
     ~NeedlemanWunsch()=default;
 
-    /// Names of valid matrices
+    /// Lookup table for @ref setMatrix(const std::string&); current entries: @c "identity", @c "PAM30MS".
     static const std::vector<std::string> NamesOfScoringMatrices;
 
     /**
-     @brief Calculates the similarity score of the global alignment of two amino acid sequences using Needleman-Wunsch-
-     Algorithm.
-     */
+      @brief Compute the Needleman-Wunsch similarity score of @p seq1 vs. @p seq2.
+
+      Uses the currently selected scoring matrix and gap penalty. The
+      sequences must contain only uppercase @c [A-Z] characters; see
+      the class brief for the constraints.
+
+      @param[in] seq1 First amino-acid sequence.
+      @param[in] seq2 Second amino-acid sequence.
+      @return Score of the best global alignment.
+    */
     int align(const String& seq1, const String& seq2);
 
     /**
-     @brief sets the scoring matrix. Takes either a string or the enum ScoringMatrix.
-     @exception Exception: illegal argument is thrown if the input is not a member of the valid matrices.
-     */
+      @brief Select the scoring matrix used by @ref align.
+
+      @param[in] matrix Scoring matrix to use.
+    */
     void setMatrix(const ScoringMatrix& matrix);
+
+    /**
+      @brief Select the scoring matrix by name; the accepted names are listed in @ref NamesOfScoringMatrices.
+
+      @param[in] matrix Matrix name (currently @c "identity" or @c "PAM30MS").
+
+      @throws Exception::IllegalArgument when @p matrix is not one of
+                                         the names in
+                                         @ref NamesOfScoringMatrices.
+                                         The error message lists the
+                                         valid names.
+    */
     void setMatrix(const std::string& matrix);
 
-    /// sets the cost of gaps
+    /**
+      @brief Set the linear gap penalty subtracted per gap step.
+
+      @param[in] penalty Gap penalty (typically positive); the
+                         algorithm subtracts @p penalty from the score
+                         for each gap step.
+    */
     void setPenalty(const int penalty);
 
-    /// returns the scoring matrix
+    /**
+      @brief Currently selected scoring matrix.
+
+      @return The scoring matrix passed to the last @ref setMatrix call
+              (or the default @c PAM30MS if @ref setMatrix has not been
+              called).
+    */
     ScoringMatrix getMatrix() const;
 
-    /// returns the gap penalty
+    /**
+      @brief Currently configured gap penalty.
+
+      @return The penalty passed to the last @ref setPenalty call (or
+              the default @c 5 if @ref setPenalty has not been called).
+    */
     int getPenalty() const;
 
   private:
-    int gap_penalty_ = 5; ///< penalty for alignment score calculation
-    ScoringMatrix my_matrix_ = ScoringMatrix::PAM30MS; ///< scoring matrix for the alignment score calculation
-    std::vector<int> first_row_{}; ///< alignment score calculation with two rows
-    std::vector<int> second_row_{};
+    int gap_penalty_ = 5; ///< Linear gap penalty.
+    ScoringMatrix my_matrix_ = ScoringMatrix::PAM30MS; ///< Currently selected scoring matrix.
+    std::vector<int> first_row_{};  ///< First row of the two-row rolling buffer used by @ref align.
+    std::vector<int> second_row_{}; ///< Second row of the two-row rolling buffer used by @ref align.
   };
 
 }


### PR DESCRIPTION
## Summary

- **Class brief**: spell out the actual constraint discovered in `NeedlemanWunsch.cpp:152-153` -- the substitution matrix is indexed by `c - 'A'`, so:
  - Input strings must use uppercase ASCII `[A-Z]`.
  - `J` / `O` / `U` rows-columns are `INT16_MAX` in both bundled matrices and effectively forbid any alignment involving those letters.
  - Non-A-Z characters trigger out-of-bounds reads.
  None of this was documented anywhere before.
- Add `@ingroup Analysis_ID`.
- Document the `ScoringMatrix` enum values with `///<` (`identity`, `PAM30MS`, `SIZE_OF_SCORINGMATRIX`).
- Document the default constructor's default values (`PAM30MS` + penalty `5`), grounded in the in-class initializers.
- Convert each method to `/** @brief / @param[in] / @return / @throws */` blocks. `setMatrix(string)` now spells out the actual exception type (`IllegalArgument`) and links to `NamesOfScoringMatrices`.

No behaviour change.

## Test plan
- [x] `cmake --build OpenMS-build --target OpenMS` builds cleanly.
- [ ] CI Doxygen warning check passes (Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified docs for the NeedlemanWunsch sequence-alignment algorithm, detailing scoring behavior and memory approach, and specifying input constraints (uppercase ASCII A–Z and special handling for certain residues).
  * Added comprehensive parameter and return-value descriptions and an explicit exception contract for invalid matrix inputs to improve API clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9344)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->