### PR TITLE
[DOC] ConsensusMapNormalizerAlgorithmQuantile: fix wrong access-tag comments; ground the algorithm

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/ConsensusMapNormalizerAlgorithmQuantile.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/ConsensusMapNormalizerAlgorithmQuantile.h
@@ -14,51 +14,120 @@ namespace OpenMS
 {
 
   /**
-   * @brief Algorithms of ConsensusMapNormalizer
-   *
-   */
+    @brief Quantile-normalisation of feature intensities across the maps of a @ref ConsensusMap.
+
+    Stateless utility class. @ref normalizeMaps rescales every map's
+    sorted intensity distribution to a shared reference distribution
+    derived from the average of the per-map quantiles, so that all maps
+    end up sharing the same intensity distribution while their internal
+    intensity ranks are preserved.
+
+    Copy construction and assignment are deliberately suppressed.
+
+    @ingroup Quantitation
+  */
   class OPENMS_DLLAPI ConsensusMapNormalizerAlgorithmQuantile
   {
 private:
-    /// copy constructor is not implemented -> private
+    /// Copy construction is deliberately suppressed.
     ConsensusMapNormalizerAlgorithmQuantile(const ConsensusMapNormalizerAlgorithmQuantile & copyin);
 
-    /// assignment operator is not implemented -> private
+    /// Assignment is deliberately suppressed.
     ConsensusMapNormalizerAlgorithmQuantile & operator=(const ConsensusMapNormalizerAlgorithmQuantile & rhs);
 
 public:
-    /// default constructor is not implemented -> private
+    /// Default constructor.
     ConsensusMapNormalizerAlgorithmQuantile();
 
-    /// destructor is not implemented -> private
+    /// Destructor.
     virtual ~ConsensusMapNormalizerAlgorithmQuantile();
 
     /**
-     * @brief normalizes the maps of the consensusMap
-     * @param[in,out] map ConsensusMap
-     */
+      @brief Quantile-normalise the feature intensities of @p map in place.
+
+      Builds a reference intensity distribution by sorting each map's
+      feature intensities, resampling each sorted distribution to a
+      common length (the size of the largest map), and averaging the
+      resampled distributions per quantile. The intensities are then
+      written back to the consensus features rank-preservingly: the
+      feature with the @c k -th smallest intensity in map @c j gets the
+      @c k -th smallest value of the resampled reference distribution
+      for map @c j (after a second resampling step that shrinks the
+      reference back to map @c j 's original length).
+
+      @param[in,out] map Consensus map whose feature-handle intensities
+                         are rewritten in place. Per-map column-header
+                         indices @c 0 ... @c N-1 must each be present
+                         (@ref extractIntensityVectors throws
+                         otherwise).
+
+      @throws Exception::ElementNotFound when a column-header index in
+                                         @c 0 ... @c N-1 is missing
+                                         from @p map (propagated from
+                                         @ref extractIntensityVectors).
+    */
     static void normalizeMaps(ConsensusMap & map);
 
     /**
-     * @brief resamples data_in and writes the results to data_out
-     * @param[in] data_in the data to be resampled
-     * @param[out] data_out the results are written to this vector
-     * @param[in] n_resampling_points the number of points to resample from data_in
-     */
+      @brief Linearly resample @p data_in to @p n_resampling_points evenly-spaced positions.
+
+      The output is cleared, resized to @p n_resampling_points and
+      filled by linear interpolation between consecutive @p data_in
+      entries:
+
+      - @c data_out.front() takes @c data_in.front() and
+        @c data_out.back() takes @c data_in.back().
+      - Intermediate positions are interpolated between the two
+        neighbouring source entries.
+      - When @p n_resampling_points is @c 0 the output is just cleared
+        and the function returns.
+
+      @param[in]  data_in             Source vector; assumed sorted by
+                                      the caller (@ref normalizeMaps
+                                      sorts before calling).
+      @param[out] data_out            Destination vector; cleared and
+                                      resized.
+      @param[in]  n_resampling_points Number of points to produce.
+    */
     static void resample(const std::vector<double> & data_in, std::vector<double> & data_out, UInt n_resampling_points);
 
     /**
-     * @brief extracts the intensities of the features of the different maps
-     * @param[in] map ConsensusMap
-     * @param[out] out_intensities resulting data, contains the feature intensities for each map of the consensus map
-     */
+      @brief Collect the feature-handle intensities of @p map into one vector per source map.
+
+      @p out_intensities is cleared and resized to the number of
+      column-header entries; the per-map row receives the intensities
+      of every feature handle whose @c map_index points at it (in the
+      iteration order of the consensus features).
+
+      @param[in]  map             Source @ref ConsensusMap.
+      @param[out] out_intensities Per-map intensity vectors; index
+                                  @c j contains the intensities of all
+                                  feature handles whose map-index is
+                                  @c j.
+
+      @throws Exception::ElementNotFound when the column-header lookup
+                                         for one of the expected map
+                                         indices fails.
+    */
     static void extractIntensityVectors(const ConsensusMap & map, std::vector<std::vector<double> > & out_intensities);
 
     /**
-     * @brief writes the intensity values in feature_ints to the corresponding features in map
-     * @param[in] feature_ints contains the new feature intensities for each map of the consensus map
-     * @param[in] map ConsensusMap the map to be updated
-     */
+      @brief Push the per-map intensity vectors back into the corresponding feature handles.
+
+      Iterates the consensus features of @p map in the same order as
+      @ref extractIntensityVectors and writes
+      @c feature_ints[map_index][k] into the @c k -th feature handle of
+      that map index. The caller is responsible for keeping
+      @p feature_ints in lock-step with the iteration order used by
+      @ref extractIntensityVectors -- @ref normalizeMaps does this by
+      mutating the same per-map vector in place.
+
+      @param[in]     feature_ints Per-map intensity vectors (same shape
+                                  as the output of
+                                  @ref extractIntensityVectors).
+      @param[in,out] map          Consensus map whose feature-handle
+                                  intensities are updated in place.
+    */
     static void setNormalizedIntensityValues(const std::vector<std::vector<double> > & feature_ints, ConsensusMap & map);
   };
 


### PR DESCRIPTION
## Summary

Same pattern as the Threshold sibling (#9329):

- **Fix factually wrong comments**: the default constructor and destructor carry `/// ... is not implemented -> private`, but both are `public:` AND defined as `= default` in the cpp.
- Reword the copy-ctor / assignment-operator comments to "deliberately suppressed" -- they are declared private and undefined.
- **Class brief** now explains what quantile normalisation actually does (sort each map's intensities, resample to a common length, average per-quantile into a reference distribution, then push the reference back into each map's original ranks).
- **`normalizeMaps`**: document the full algorithm and the `ElementNotFound` propagation from `extractIntensityVectors`.
- **`resample`**: describe the linear-interpolation contract, the `n == 0` no-op shortcut (`ConsensusMapNormalizerAlgorithmQuantile.cpp:105-108`) and the fixed-endpoints behaviour at the front/back.
- **`extractIntensityVectors`**: document the cleared-output contract and the `Exception::ElementNotFound` throw when a column-header index is missing (`ConsensusMapNormalizerAlgorithmQuantile.cpp:140`).
- **`setNormalizedIntensityValues`**: document the iteration-order lock-step requirement with `extractIntensityVectors`.
- Add `@ingroup Quantitation` (consistent with #9329).

All claims grounded against `ConsensusMapNormalizerAlgorithmQuantile.cpp:17-172`. No behaviour change.

## Test plan
- [x] `cmake --build OpenMS-build --target OpenMS` builds cleanly.
- [ ] CI Doxygen warning check passes (Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal API documentation for improved clarity and detail.

---

**Note:** This release contains no end-user visible changes. The updates are limited to internal code documentation enhancements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->