### PR TITLE
[DOC] CometModification: ground ctor switch, merge rules, and toCometString format

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/CometModification.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/CometModification.h
@@ -120,7 +120,7 @@ struct OPENMS_DLLAPI CometModification
     @verbatim
     variable_mod<II> = <mass> <residues> <binary_group> <max_mods_per_peptide> <term_distance> <nc_term> <required> 0.0
     @endverbatim
-    with @c <II> being @p index zero-padded to two digits. The last
+    with the @c II suffix being @p index zero-padded to two digits. The last
     column is hard-coded to @c "0.0" (neutral loss; OpenMS does not
     currently surface it). Numeric formatting uses @c std::ostream
     default precision (six significant digits).

--- a/src/openms/include/OpenMS/ANALYSIS/ID/CometModification.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/CometModification.h
@@ -21,53 +21,127 @@ namespace OpenMS
 {
 
 /**
- * @brief Helper struct to represent a Comet variable modification entry.
- *
- * This struct facilitates merging of modifications with the same mass and compatible
- * term specificity. Comet supports specifying multiple residues in a single modification
- * entry (e.g., "KR" for lysine and arginine), which significantly improves search performance.
- *
- * Merging rules based on Comet's internal logic and documentation:
- * - Modifications with the same mass and binary group can be merged
- * - Amino acid mods can merge with each other (e.g., "K" + "R" -> "KR")
- * - Peptide N-term and amino acids can be merged (e.g., "n" + "RST" -> "nRST")
- * - Peptide C-term and amino acids can be merged (e.g., "c" + "KR" -> "cKR")
- * - Protein terminal mods (nc_term 0 or 1) must remain separate
- * - Peptide N-term and C-term cannot merge with each other
- *
- * When terminal and amino acid mods merge, term_distance becomes -1 and nc_term
- * becomes 0, because the terminal specificity is encoded by 'n'/'c' in the residue
- * string (as per Comet documentation: e.g., "42.010565 nK 0 3 -1 0 0 0.0").
- */
+  @brief Helper struct that represents one Comet @c variable_modXX entry and supports merging compatible entries.
+
+  Comet supports specifying multiple residues in a single modification
+  entry (e.g. @c "KR" for lysine and arginine), which significantly
+  improves search performance. This struct mirrors the @c variable_modXX
+  fields and bundles the rules used to collapse compatible entries.
+
+  Merging rules (verified against the cpp):
+    - Two entries must have the same mass (within @ref MASS_TOLERANCE) and the same @ref binary_group.
+    - Plain amino-acid mods (@c term_distance @c == @c -1) can merge with each other (e.g. @c "K" + @c "R" -> @c "KR").
+    - Peptide N-term (@c nc_term @c == @c 2, @c term_distance @c == @c 0) and amino acids can merge (e.g. @c "n" + @c "RST" -> @c "nRST").
+    - Peptide C-term (@c nc_term @c == @c 3, @c term_distance @c == @c 0) and amino acids can merge (e.g. @c "c" + @c "KR" -> @c "cKR").
+    - Protein terminal mods (@c nc_term @c == @c 0 or @c 1 with @c term_distance @c == @c 0) only merge with another protein terminal mod of the same kind.
+    - Peptide N-term and peptide C-term cannot merge with each other.
+
+  When a terminal and an amino-acid mod merge, @c term_distance is set
+  to @c -1 and @c nc_term to @c 0 because the terminal specificity is
+  encoded by the @c 'n' / @c 'c' character in the residue string (per
+  Comet convention, e.g. @c "42.010565 nK 0 3 -1 0 0 0.0").
+
+  @ingroup Analysis_ID
+*/
 struct OPENMS_DLLAPI CometModification
 {
-  /// Mass tolerance for comparing modification masses
+  /// Absolute tolerance used by @ref isMergeableWith when comparing the @ref mass field.
   static constexpr double MASS_TOLERANCE = 1e-6;
 
-  double mass{0.0};              ///< Modification mass difference
-  String residues;               ///< Residue(s) this modification applies to (e.g., "K", "KR", "n", "nKR")
-  int binary_group{0};           ///< Binary modification group (for SILAC etc.)
-  int max_mods_per_peptide{5};   ///< Maximum number of this modification per peptide
-  int term_distance{-1};         ///< Terminal distance (-1 = no constraint, 0 = terminal only)
-  int nc_term{0};                ///< Terminal specificity: 0=protein N-term, 1=protein C-term, 2=peptide N-term, 3=peptide C-term
-  bool required{false};          ///< Whether this modification is required
+  double mass{0.0};              ///< Modification mass difference (in Da).
+  String residues;               ///< Residue(s) this modification applies to (e.g. @c "K", @c "KR", @c "n", @c "nKR").
+  int binary_group{0};           ///< Comet binary modification group (used e.g. for SILAC).
+  int max_mods_per_peptide{5};   ///< Maximum number of occurrences of this modification per peptide.
+  int term_distance{-1};         ///< Terminal distance constraint: @c -1 = no constraint, @c 0 = terminal only.
+  int nc_term{0};                ///< Terminal specificity: @c 0 = protein N-term, @c 1 = protein C-term, @c 2 = peptide N-term, @c 3 = peptide C-term. Only meaningful when @c term_distance @c == @c 0.
+  bool required{false};          ///< Whether this modification is required to appear in every peptide.
 
-  /// Default constructor
+  /// Default constructor; produces a zeroed entry with @c mass @c == @c 0.
   CometModification() = default;
 
-  /// Constructor from ResidueModification
+  /**
+    @brief Build an entry from an OpenMS @ref ResidueModification.
+
+    Copies the modification's diff-monoisotopic mass into @ref mass and
+    the residue origin character into @ref residues, then sets
+    @ref term_distance and @ref nc_term according to @p mod 's term
+    specificity:
+      - @c PEPTIDE_C_TERM -> @c term_distance @c = @c 0, @c nc_term @c = @c 3.
+      - @c PEPTIDE_N_TERM -> @c term_distance @c = @c 0, @c nc_term @c = @c 2.
+      - @c PROTEIN_N_TERM -> @c term_distance @c = @c 0, @c nc_term @c = @c 0.
+      - @c PROTEIN_C_TERM -> @c term_distance @c = @c 0, @c nc_term @c = @c 1.
+      - Anywhere -> @c term_distance and @c nc_term are left at their defaults.
+    Terminal mods whose origin is @c 'X' are translated into a residue
+    string of @c "n" or @c "c" so Comet recognises them; non-@c 'X'
+    terminal mods keep the original residue character.
+
+    @param[in] mod         Source OpenMS modification.
+    @param[in] binary_grp  Value for @ref binary_group.
+    @param[in] max_mods    Value for @ref max_mods_per_peptide.
+  */
   CometModification(const ResidueModification* mod, int binary_grp, int max_mods);
 
-  /// Check if this modification can be merged with another
+  /**
+    @brief Whether two entries can be combined into a single Comet @c variable_modXX line.
+
+    Implements the merging rules listed in the struct brief. Returns
+    @c false when the masses differ by more than @ref MASS_TOLERANCE,
+    the @ref binary_group values differ, when only one of the two is a
+    protein-terminal mod (or they are different protein-terminal kinds),
+    or when one is a peptide N-term and the other a peptide C-term.
+
+    @param[in] other Candidate merge partner.
+    @return @c true if the entries can be merged.
+  */
   bool isMergeableWith(const CometModification& other) const;
 
-  /// Merge another modification into this one
+  /**
+    @brief Merge another compatible entry into this one.
+
+    Unions @p other 's residue characters into @ref residues (skipping
+    duplicates), keeps the larger @ref max_mods_per_peptide, and ORs
+    the @ref required flag. When a terminal mod is merged with a
+    non-terminal mod the terminal information moves into the residue
+    string and @ref term_distance / @ref nc_term are reset to
+    @c -1 / @c 0; same-kind terminal merges leave both fields
+    unchanged.
+
+    Behaviour is only defined for pairs that @ref isMergeableWith
+    accepts; the caller is responsible for that check.
+
+    @param[in] other Compatible entry to absorb.
+  */
   void merge(const CometModification& other);
 
-  /// Generate the Comet param file line format for the given 1-based index
+  /**
+    @brief Render this entry as a Comet @c variable_modXX parameter line.
+
+    The output is one whitespace-separated line of the form
+    @verbatim
+    variable_mod<II> = <mass> <residues> <binary_group> <max_mods_per_peptide> <term_distance> <nc_term> <required> 0.0
+    @endverbatim
+    with @c <II> being @p index zero-padded to two digits. The last
+    column is hard-coded to @c "0.0" (neutral loss; OpenMS does not
+    currently surface it). Numeric formatting uses @c std::ostream
+    default precision (six significant digits).
+
+    @param[in] index 1-based modification index used to form the @c variable_modXX key.
+    @return The fully-formed @c variable_modXX = ... line.
+  */
   String toCometString(Size index) const;
 
-  /// Merge a vector of CometModifications, combining compatible entries
+  /**
+    @brief Greedy first-fit merge of a vector of entries.
+
+    Walks @p mods in input order; each entry is merged into the first
+    compatible existing result entry (via @ref isMergeableWith and
+    @ref merge), or appended verbatim if no compatible partner is found.
+    The relative order of the kept entries follows the input order; no
+    entry is dropped.
+
+    @param[in] mods Input modifications.
+    @return Merged modifications.
+  */
   static std::vector<CometModification> mergeModifications(const std::vector<CometModification>& mods);
 };
 


### PR DESCRIPTION
## Summary

- **Constructor from `ResidueModification`**: enumerate the term-specificity -> `(term_distance, nc_term)` mapping (`PEPTIDE_C_TERM` -> `(0, 3)`, `PEPTIDE_N_TERM` -> `(0, 2)`, `PROTEIN_N_TERM` -> `(0, 0)`, `PROTEIN_C_TERM` -> `(0, 1)`, anywhere -> defaults) grounded in `CometModification.cpp:19-55`, including the `'X'` origin shortcut that produces `"n"` / `"c"` residue strings.
- **`isMergeableWith`**: spell out the actual rejection paths (mass / `binary_group` / protein-terminal asymmetry / peptide-N + peptide-C clash) per `CometModification.cpp:60-99` instead of "check if mergeable".
- **`merge`**: document the actual field arithmetic -- residues unioned (de-duplicated), `max_mods_per_peptide` max-ed, mixed terminal/non-terminal collapses to `term_distance=-1` / `nc_term=0`, `required` OR-ed (`CometModification.cpp:104-132`). Note that the method trusts the caller to have run `isMergeableWith`.
- **`toCometString`**: spell out the actual line format including the zero-padded index, the **hard-coded `0.0` neutral-loss column**, and the default `ostream` precision (`CometModification.cpp:135-150`).
- **`mergeModifications`**: describe the greedy first-fit algorithm and the preserved input order (`CometModification.cpp:153-176`).
- Add `@ingroup Analysis_ID` (consistent with `AccurateMassSearchEngine`, `ConsensusIDAlgorithm*`).

No behaviour change.

## Test plan
- [x] `cmake --build OpenMS-build --target OpenMS` builds cleanly.
- [ ] CI Doxygen warning check passes (Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified documentation for modification handling: variable modification rules, merge compatibility (mass tolerance, grouping, terminal vs residue constraints), constructor behavior, and how merges resolve residues and limits.
  * Documented output formatting and merge strategy (greedy first‑fit) and noted preservation of input order for merged entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9350?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->