### PR TITLE
[DOC] Contaminants: surface digested-DB caching, NaN-on-zero-denominator, and side effects

### DIFF
--- a/src/openms/include/OpenMS/QC/Contaminants.h
+++ b/src/openms/include/OpenMS/QC/Contaminants.h
@@ -18,88 +18,128 @@
 namespace OpenMS
 {
   /**
-   * @brief This class is a metric for the QualityControl TOPP tool.
-   *
-   * This class checks whether a peptide is a contaminant (given a protein DB) and adds that result as metavalue "is_contaminant"
-   * to the first hit of each PeptideIdentification.
-   */
+    @brief QualityControl metric: flag PSMs whose peptide sequences match
+           a user-supplied contaminants FASTA (e.g. cRAP) after digestion.
+
+    Each call to @ref compute marks the first @c PeptideHit of every
+    @c PeptideIdentification in the supplied @c FeatureMap (both
+    feature-attached and unassigned) with an @c "is_contaminant"
+    meta value (@c 1 if its unmodified sequence matches an entry in
+    the digested contaminants database, @c 0 otherwise) and appends a
+    @ref ContaminantsSummary to the internal results list returned by
+    @ref getResults.
+
+    @note The digested contaminants database is cached on the first
+          @ref compute call; subsequent calls reuse the same cache
+          and ignore the @p contaminants argument's actual contents.
+          The enzyme and missed-cleavage settings used for the initial
+          digestion are also frozen at that point (taken from
+          @c FeatureMap::getProteinIdentifications()[0].getSearchParameters()
+          of the @c FeatureMap supplied on the first call).
+
+    @ingroup Metadata
+  */
   class OPENMS_DLLAPI Contaminants : public QCBase
   {
   public:
-    /// structure for storing results
+    /**
+      @brief Result bundle returned per @ref compute call.
+
+      All four ratios are unitless and lie in @c [0, 1] for non-empty
+      denominators; when the corresponding denominator is @c 0 the
+      ratio evaluates to @c NaN.
+    */
     struct ContaminantsSummary {
-      ///(\#contaminants in assigned/ \#peptides in assigned)
-      double assigned_contaminants_ratio;
-
-      ///(\#contaminants in unassigned/ \#peptides in unassigned)
-      double unassigned_contaminants_ratio;
-
-      ///(\#all contaminants/ \#peptides in all)
-      double all_contaminants_ratio;
-
-      ///(intensity of contaminants in assigned/ intensity of peptides in assigned)
-      double assigned_contaminants_intensity_ratio;
-
-      ///(features without peptideidentification or with peptideidentifications but without hits; all features)
-      std::pair<Int64, Int64> empty_features;
+      double assigned_contaminants_ratio;            ///< \#contaminants in feature-attached PSMs / \#feature-attached PSMs.
+      double unassigned_contaminants_ratio;          ///< \#contaminants in unassigned PSMs / \#unassigned PSMs.
+      double all_contaminants_ratio;                 ///< \#contaminants in all PSMs / \#all PSMs.
+      double assigned_contaminants_intensity_ratio;  ///< Sum of feature intensities of contaminant feature-attached PSMs / sum of feature intensities of all feature-attached PSMs.
+      std::pair<Int64, Int64> empty_features;        ///< (Number of features without a peptide hit, total number of features).
     };
 
-    /// Constructor
+    /// Default constructor.
     Contaminants() = default;
 
-    /// Destructor
+    /// Destructor.
     virtual ~Contaminants() = default;
 
     /**
-     * @brief Checks if the peptides are in the contaminant database.
-     *
-     * "is_contaminant" metavalue is added to the first hit of each PeptideIdentification of each feature
-     * and to the first hit of all unsigned PeptideIdentifications.
-     * The enzyme and number of missed cleavages used to digest the given protein DB is taken
-     * from the ProteinIdentification[0].getSearchParameters() within the given FeatureMap.
-     *
-     * @param[in,out] features Input FeatureMap with peptideidentifications of features
-     * @param[in] contaminants Vector of FASTAEntries that need to be digested to check whether a peptide is a contaminant or not
-     * @exception Exception::MissingInformation if the contaminants database is empty
-     * @exception Exception::MissingInformation if no enzyme is given
-     * @exception Exception::MissingInformation if proteinidentification of FeatureMap is empty
-     * @warning LOG_WARN if the FeatureMap is empty
-     */
+      @brief Annotate the PSMs of @p features with @c "is_contaminant" and append a summary to @ref getResults.
+
+      On the first call (when the internal digested-DB cache is empty),
+      the FASTA entries in @p contaminants are digested using the
+      enzyme and missed-cleavage count from
+      @c features.getProteinIdentifications()[0].getSearchParameters()
+      and stored in a hash set. Every subsequent call to @ref compute
+      reuses that cache without consulting @p contaminants again.
+
+      The first @c PeptideHit of every @c PeptideIdentification in
+      @p features (both attached to features and in
+      @c getUnassignedPeptideIdentifications()) is annotated with
+      @c "is_contaminant" set to @c 0 or @c 1. The aggregated ratios
+      and the empty-feature counters are then pushed onto the internal
+      results list (see @ref getResults).
+
+      @param[in,out] features    Source of the PSMs (annotated in place)
+                                 and -- on the first call -- of the
+                                 digestion enzyme used to build the
+                                 cache.
+      @param[in]     contaminants Contaminants FASTA. Only consulted on
+                                  the first call; subsequent calls
+                                  ignore it.
+
+      @throws Exception::MissingInformation when @p contaminants is
+                                            empty.
+      @throws Exception::MissingInformation when the FeatureMap has no
+                                            protein identification
+                                            (only on the first call).
+      @throws Exception::MissingInformation when the configured
+                                            digestion enzyme is
+                                            @c "unknown_enzyme" (only
+                                            on the first call).
+
+      @note When @p features is empty, a warning is logged and the
+            method still runs (and may produce @c NaN ratios).
+    */
     void compute(FeatureMap& features, const std::vector<FASTAFile::FASTAEntry>& contaminants);
 
-    /// returns the name of the metric
+    /// Name of this QC metric (@c "Contaminants").
     const String& getName() const override;
 
-    /// returns results
+    /// Per-call summaries appended by @ref compute, in call order.
     const std::vector<Contaminants::ContaminantsSummary>& getResults();
 
     /**
-     * @brief Returns the input data requirements of the compute(...) function
-     * @return Status for POSTFDRFEAT and CONTAMINANTS
-     */
+      @brief Input-data requirements of @ref compute.
+
+      @return Status flags with @c POSTFDRFEAT and @c CONTAMINANTS set.
+    */
     Status requirements() const override;
 
   private:
-    /// name of the metric
+    /// Metric name returned by @ref getName.
     const String name_ = "Contaminants";
 
-    /// container that stores results
+    /// Per-call summaries; @ref compute appends one entry per invocation.
     std::vector<Contaminants::ContaminantsSummary> results_;
 
-    /// unordered set that contains the contaminant sequences
+    /// Cached digested contaminants database, filled on the first @ref compute call and reused thereafter.
     std::unordered_set<String> digested_db_;
 
     /**
-     * @brief
-     * checks if the peptide is in the contaminant database
-     * @param[in] key String that will be the key for searching in the unordered set
-     * @param[in,out] pep_hit PeptideHit to store the result "is_contaminant = 0/1"
-     * @param[in,out] total counter of all checked peptides
-     * @param[in,out] cont counter of all checked peptides that are contaminants
-     * @param[in,out] sum_total intensity of all checked peptides
-     * @param[in,out] sum_cont intensity of all checked peptides that are contaminants
-     * @param[in] intensity intensity of current peptide
-     */
+      @brief Increment the contaminant counters and annotate one hit with @c "is_contaminant".
+
+      Looks @p key up in @ref digested_db_ and updates the counters
+      and @p pep_hit accordingly.
+
+      @param[in]     key       Unmodified peptide sequence to look up.
+      @param[in,out] pep_hit   Hit to annotate with @c "is_contaminant" set to @c 0 (not found) or @c 1 (found).
+      @param[in,out] total     Total-PSMs counter; incremented by @c 1.
+      @param[in,out] cont      Contaminant-PSMs counter; incremented only on a hit.
+      @param[in,out] sum_total Total-intensity accumulator; incremented by @p intensity.
+      @param[in,out] sum_cont  Contaminant-intensity accumulator; incremented by @p intensity only on a hit.
+      @param[in]     intensity Intensity associated with this PSM.
+    */
     void compare_(const String& key, PeptideHit& pep_hit, Int64& total, Int64& cont, double& sum_total, double& sum_cont, double intensity);
   };
 } // namespace OpenMS


### PR DESCRIPTION
## Summary

- **Surface the previously-undocumented first-call-wins caching** of `digested_db_` (cpp lines 34-67): subsequent `compute()` calls reuse the cache and ignore the `contaminants` argument's actual contents. The enzyme and missed-cleavage settings are also frozen on the first call. This was absent from the previous header docs.
- **Document the NaN-on-zero-denominator behaviour** of every ratio in `ContaminantsSummary` (`cont / total`, `ucont / utotal`, `sum_cont / sum_total` at `Contaminants.cpp:100, 135-137`).
- **Document the side effects** of `compute()`: writes `"is_contaminant"` meta value on the first hit of every PSM (feature-attached **and** unassigned) and appends one `ContaminantsSummary` to the internal results list.
- Replace the misleading `@warning LOG_WARN if FeatureMap is empty` with a plain `@note` -- it's an informational log, not a thrown warning.
- Reword the `ContaminantsSummary` field docs from the cryptic `\#a / \#b` formulas into prose grounded in the cpp.
- Tighten `getResults` / `requirements` / `compare_` docs.
- Add `@ingroup Metadata` (matches `MQEvidenceExporter`, `MQMsmsExporter`, `MQExporterHelper`).

No behaviour change.

## Test plan
- [x] `cmake --build OpenMS-build --target OpenMS` builds cleanly.
- [ ] CI Doxygen warning check passes (Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved and expanded documentation for quality control metrics with enhanced clarity on calculation behavior, field specifications, and handling of edge cases in data processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9351?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->