### PR TITLE
doc(VALIDATORS): fix copy-pasted "MzXML" brief on MzML / mzIdentML / mzData validators + flesh out behaviour

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/VALIDATORS/MzDataValidator.h
+++ b/src/openms/include/OpenMS/FORMAT/VALIDATORS/MzDataValidator.h
@@ -17,18 +17,29 @@ namespace OpenMS
   {
 
     /**
-      @brief Semantically validates MzXML files.
+      @brief Semantic validator for mzData files.
+
+      Specialises @ref SemanticValidator with mzData-specific checks in
+      addition to the generic CV-mapping checks: for each CV term encountered,
+      the recorded unit accession (if any) must be listed among the term's
+      allowed units, and the term name attribute must match the name registered
+      in the controlled vocabulary (whitespace is ignored and the comparison is
+      case-insensitive). Mismatches are reported as errors.
+
+      Unit checking is enabled.
+
+      @ingroup FileIO
     */
     class OPENMS_DLLAPI MzDataValidator :
       public SemanticValidator
     {
 public:
       /**
-        @brief Constructor
+        @brief Constructor.
 
-                @param[in] mapping The mapping rules
-                @param[in] cv @em All controlled vocabularies required for the mapping
-            */
+        @param[in] mapping The mapping rules
+        @param[in] cv @em All controlled vocabularies required for the mapping
+      */
       MzDataValidator(const CVMappings & mapping, const ControlledVocabulary & cv);
 
       /// Destructor

--- a/src/openms/include/OpenMS/FORMAT/VALIDATORS/MzIdentMLValidator.h
+++ b/src/openms/include/OpenMS/FORMAT/VALIDATORS/MzIdentMLValidator.h
@@ -17,18 +17,24 @@ namespace OpenMS
   {
 
     /**
-      @brief Semantically validates MzXML files.
+      @brief Semantic validator for mzIdentML files.
+
+      Thin specialisation of @ref SemanticValidator that enables unit
+      checking; all rule matching is performed by the base class against
+      the supplied CV-mapping rules and controlled vocabularies.
+
+      @ingroup FileIO
     */
     class OPENMS_DLLAPI MzIdentMLValidator :
       public SemanticValidator
     {
 public:
       /**
-        @brief Constructor
+        @brief Constructor.
 
-                @param[in] mapping The mapping rules
-                @param[in] cv @em All controlled vocabularies required for the mapping
-            */
+        @param[in] mapping The mapping rules
+        @param[in] cv @em All controlled vocabularies required for the mapping
+      */
       MzIdentMLValidator(const CVMappings & mapping, const ControlledVocabulary & cv);
 
       /// Destructor

--- a/src/openms/include/OpenMS/FORMAT/VALIDATORS/MzMLValidator.h
+++ b/src/openms/include/OpenMS/FORMAT/VALIDATORS/MzMLValidator.h
@@ -18,14 +18,30 @@ namespace OpenMS
   {
 
     /**
-      @brief Semantically validates MzXML files.
+      @brief Semantic validator for mzML files.
+
+      Specialises @ref SemanticValidator with mzML-specific rules in addition to
+      the generic CV-mapping checks:
+      - Terms placed inside a @c referenceableParamGroup are remembered and
+        re-validated wherever the group is referenced via @c referenceableParamGroupRef.
+      - For each @c binaryDataArray, the data-array CV term and the data-type CV
+        term are cross-checked: the value type must be listed as a valid pairing
+        for the data array (otherwise an error is reported).
+      - The leading @c indexedmzML wrapper, if present, is stripped from the
+        reported element path so validation messages refer to the mzML body.
+      - GO and BTO terms are skipped because they use @c part_of relations
+        which the @c is_a-based inheritance check cannot evaluate.
+
+      Unit checking is enabled.
+
+      @ingroup FileIO
     */
     class OPENMS_DLLAPI MzMLValidator :
       public SemanticValidator
     {
 public:
       /**
-        @brief Constructor
+        @brief Constructor.
 
         @param[in] mapping The mapping rules
         @param[in] cv @em All controlled vocabularies required for the mapping


### PR DESCRIPTION
## Summary

All three concrete semantic validators (`MzMLValidator`, `MzIdentMLValidator`, `MzDataValidator`) carried a copy-pasted class brief claiming they *"Semantically validate MzXML files"* -- which is factually wrong for every one of them (MzXML is a different, much older format from ISB, not handled by any of these classes).

This PR fixes the format name in each brief and expands each one with the format-specific behaviour the override actually adds on top of `SemanticValidator`. Every claim was grounded against the matching `.cpp`.

## Per-file rationale

- **`MzMLValidator.h`** (grounded in `src/openms/source/FORMAT/VALIDATORS/MzMLValidator.cpp`)
  - `referenceableParamGroup` terms are cached and re-played when a `referenceableParamGroupRef` appears (`startElement`).
  - `binaryDataArray`: the array-type CV term and the value-type CV term are cross-checked via `xref_binary`; mismatches go into `errors_` (`handleTerm_`).
  - Path normalisation strips a leading `indexedmzML` wrapper (`getPath_`).
  - `GO:` and `BTO:` prefixed terms are skipped because their `part_of` relations break the inheritance check (`handleTerm_`).

- **`MzIdentMLValidator.h`** (grounded in `src/openms/source/FORMAT/VALIDATORS/MzIdentMLValidator.cpp`)
  - Only the ctor and dtor are defined; `setCheckUnits(true)` is the entire customisation. No `handleTerm_`/`startElement` override, so the brief now says so.

- **`MzDataValidator.h`** (grounded in `src/openms/source/FORMAT/VALIDATORS/MzDataValidator.cpp`)
  - `handleTerm_` validates the unit accession against the term's allowed unit set and compares the recorded name to the CV name (case-insensitive, whitespace stripped); mismatches go into `errors_`.

Also adds `@ingroup FileIO` to all three so they appear under the I/O group (matching `XMLValidator.h`), and fixes the previously over-indented `@param` block in two of the three files.

## Test plan

- [x] Each prose claim verified against the corresponding `.cpp` -- no method names or `OPENMS_PRECONDITION`-style internals leaked into the contract.
- [ ] CI `Doxygen_Warning_test` (Linux): no new warnings (no `@ref` to ambiguous names, no HTML-tag traps in the prose, no operator/constructor refs).
- [ ] No `.cpp` changes -> no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated validator documentation to accurately specify supported file formats (mzData, mzIdentML, mzML), improving API reference clarity for developers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->