### PR TITLE
doc(FIAMSScheduler): fix unparsed brief + correct CSV column names

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/FIAMSScheduler.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/FIAMSScheduler.h
@@ -14,73 +14,111 @@
 namespace OpenMS
 {
 class MzMLFile;
-/*
-    @brief Scheduler for FIA-MS data batches. Works with FIAMSDataProcessor.
+/**
+    @brief Batch driver for FIA-MS analyses. Dispatches each sample of a CSV-described batch to @ref FIAMSDataProcessor.
 
-    The class is initialised with the path to the csv file that must contain the following columns:
-    - *filename* - the mzML filename for the sample. Must not contains the extension and path. The results filenames follow the pattern @filename_@n_seconds.
-    - *dir_input* - the location of the subdirectory (relative to the `base_dir`) with the mzML file
-    - *dir_output* - the location of the subdirectory (relative to the `output_dir`) where the results will be stored
-    - *resolution* - the resolution of the instrument
-    - *polarity* - the charge of the instrument, accepts "positive" or "negative"
-    - *db:mapping* - database input file in `base_dir` containing three tab-separated columns of mass, formula, identifier for the accurate mass search
-    - *db:struct* - database input file in `base_dir` containing four tab-separated columns of identifier, name, SMILES, INCHI for the accurate mass search
-    - *positive_adducts* - file in `base_dir` containing the list of potential positive adducts for the accurate mass search
-    - *negative_adducts* - file in `base_dir` containing the list of potential negative adducts for the accurate mass search
-    - *time* - ";"-separated numbers of seconds to process, f.e. "30;60;90;180"
+    A CSV file describing the batch is parsed during construction. Each row defines one sample
+    and is consumed by @ref run, which loads the corresponding mzML file, configures a
+    @ref FIAMSDataProcessor instance, and runs the analysis once per requested time window.
+    Samples are processed in parallel (OpenMP-parallelised loop).
+
+    The CSV is comma-delimited; the first row is taken as the header. Each subsequent row is
+    stored as a header-keyed @c std::map<String, String>. The implementation looks up the
+    following keys per row (column names as read from the CSV):
+
+    - @c filename — base filename of the sample's mzML (no path, no @c .mzML extension);
+      the loader appends @c .mzML.
+    - @c dir_input — sample subdirectory relative to @p base_dir.
+    - @c dir_output — sample subdirectory relative to @p output_dir; created on demand.
+    - @c resolution — instrument resolution; parsed with @c std::stof.
+    - @c charge — instrument polarity; forwarded as the @c polarity parameter of
+      @ref FIAMSDataProcessor (typical values @c "positive" / @c "negative").
+    - @c db_mapping — accurate-mass database mapping file (relative to @p base_dir); forwarded
+      as the @c db:mapping parameter (three tab-separated columns: mass, formula, identifier).
+    - @c db_struct — accurate-mass database structure file (relative to @p base_dir);
+      forwarded as the @c db:struct parameter (four tab-separated columns: identifier, name,
+      SMILES, InChI).
+    - @c positive_adducts / @c negative_adducts — adduct list files (relative to @p base_dir).
+    - @c time — @c ";"-separated list of time windows in seconds (e.g. @c "30;60;90;180");
+      @ref FIAMSDataProcessor::run is invoked once per window.
+
+    The mzML path opened for each sample is therefore @c base_dir + dir_input + "/" + filename + ".mzML".
+
+    No column validation is performed; missing or mis-named keys raise the usual
+    @c std::map::at exception.
+
+    @ingroup Analysis_ID
 */
-class OPENMS_DLLAPI FIAMSScheduler 
+class OPENMS_DLLAPI FIAMSScheduler
   {
 public:
+    /// Default-construct an empty scheduler (no samples loaded, paths set to defaults).
     FIAMSScheduler() = default;
 
-    /// Default constructor
+    /**
+      @brief Construct from a batch CSV and parse it immediately.
+
+      The CSV at @p filename is read during construction (see class documentation for the
+      expected columns) and the parsed rows are kept for subsequent @ref run calls.
+
+      @param filename     Full path to the batch CSV file.
+      @param base_dir     Base directory used to resolve the per-row @c dir_input, @c db_mapping,
+                          @c db_struct, and adduct paths. Must end with a path separator.
+      @param output_dir   Output directory under which each row's @c dir_output is created.
+                          Must end with a path separator.
+      @param load_cached_ Forwarded to @ref FIAMSDataProcessor::run as its @c load_cached
+                          flag; if @c true, cached intermediate results are reused.
+    */
     FIAMSScheduler(
-      String filename, ///< full path to the csv file
-      String base_dir = "/",  ///< base directory, where subdirectories within the CSV are located; must include a trailing slash at the end of the directory
-      String output_dir = "/", ///< output dir for results; must include a trailing slash at the end of the directory
-      bool load_cached_ = true ///< load the cached results if they exist
+      String filename,
+      String base_dir = "/",
+      String output_dir = "/",
+      bool load_cached_ = true
     );
 
-    /// Default destructor
+    /// Default destructor.
     ~FIAMSScheduler() = default;
 
-    /// Copy constructor
+    /// Copy constructor.
     FIAMSScheduler(const FIAMSScheduler& cp) = default;
 
-    /// Assignment
+    /// Copy assignment.
     FIAMSScheduler& operator=(const FIAMSScheduler& fdp) = default;
 
     /**
-      @brief Run the FIA-MS data analysis for the batch defined in the @p filename_
+      @brief Run the batch: process every sample loaded from the CSV.
+
+      For each sample (rows are processed by an @c \#pragma @c omp @c parallel @c for loop),
+      this loads the mzML at @c base_dir/dir_input/filename.mzML, creates a fresh
+      @ref FIAMSDataProcessor with the per-row parameters, creates the per-sample
+      @c dir_output directory if missing, and runs the processor once per time window
+      listed in the row's @c time cell. Progress messages are emitted via @c OPENMS_LOG_INFO
+      at the start and end of every (sample, time) pair.
     */
     void run();
 
-    /**
-      @brief Get the batch
-    */
+    /// Return the parsed batch as a vector of header-keyed @c std::map rows.
     const std::vector<std::map<String, String>>& getSamples();
 
-    /**
-      @brief Get the base directory for the relevant paths from the csv file
-    */
+    /// Return the base directory passed to the constructor.
     const String& getBaseDir();
 
-    /**
-         @brief Get the output directory for the results
-    */
+    /// Return the output directory passed to the constructor.
     const String& getOutputDir();
 
 private:
     /**
-      @brief Load the batch from the csv file and store as the vector of maps
+      @brief Parse the batch CSV at @c filename_ and populate @c samples_.
+
+      Treats the first row as headers and every subsequent row as a sample; each row is
+      stored as a header-keyed @c std::map<String, String>. Invoked by the constructor.
     */
     void loadSamples_();
 
-    String filename_;
-    String base_dir_;
-    String output_dir_;
-    bool load_cached_;
-    std::vector<std::map<String, String>> samples_;
+    String filename_;                                       ///< CSV file describing the batch.
+    String base_dir_;                                       ///< Base directory for per-sample input paths (must end with a path separator).
+    String output_dir_;                                     ///< Base directory under which per-sample outputs are written (must end with a path separator).
+    bool load_cached_;                                      ///< Forwarded to @ref FIAMSDataProcessor::run; reuse cached results when @c true.
+    std::vector<std::map<String, String>> samples_;         ///< Parsed CSV rows; populated by @ref loadSamples_.
   };
 } // namespace OpenMS


### PR DESCRIPTION
## Summary

The class-level Doxygen block on \`FIAMSScheduler\` opened with \`/*\` instead of \`/**\`, so the entire CSV-column contract was silently dropped by Doxygen — the class rendered with **no description** in the generated docs. This PR replaces the block with a proper Doxygen contract grounded against \`src/openms/source/ANALYSIS/ID/FIAMSScheduler.cpp\`.

## Surfaces real doc bugs in the existing prose

The original (broken) comment listed CSV column names that **don't match what the cpp actually reads**:

| Comment claimed | Cpp actually reads | Where (\`FIAMSScheduler.cpp\`) |
|---|---|---|
| \`polarity\` | \`charge\` | line 63: \`p.setValue(\"polarity\", samples_[i].at(\"charge\"));\` |
| \`db:mapping\` | \`db_mapping\` | line 64 |
| \`db:struct\` | \`db_struct\` | line 65 |

The corrected docs use the column names \`samples_[i].at(...)\` actually queries. \`std::map::at\` throws on missing keys, so prior users following the original docs would have hit confusing exceptions.

## Other grounded claims

- The constructor parses the CSV eagerly: \`FIAMSScheduler::FIAMSScheduler\` calls \`loadSamples_()\` from its body (\`FIAMSScheduler.cpp:33\`).
- \`run()\` is OpenMP-parallelised (\`#pragma omp parallel for\`, line 52), creates the per-row \`dir_output\` directory on demand (line 61: \`File::makeDir(...)\`), and invokes \`FIAMSDataProcessor::run\` once per \`;\`-separated time window from the \`time\` cell (lines 70-78).
- The mzML path resolution is \`base_dir + dir_input + \"/\" + filename + \".mzML\"\` (line 55), with the file type pinned to \`FileTypes::MZML\`.

## Other improvements

- Adds \`@ingroup Analysis_ID\`.
- Per-method docs (constructor, run, getters, private loader).
- Member briefs on every field.
- Tightened getter briefs (e.g. \`getBaseDir\` → \"Return the base directory passed to the constructor\").

## What I did NOT change

- No behaviour changes, no \`.cpp\` edits.
- I did **not** rename the CSV columns to match the original docs (e.g. \`charge\` → \`polarity\`), nor change the cpp to read \`polarity\`. The docs now describe what the code does. Whether the column names *should* be the prettier originals is a question for a separate behaviour-change PR.
- Did not change the const-correctness of the getters (they're not const-qualified despite returning const refs — out of scope for a docs PR).
- Did not change the misnamed ctor parameter \`load_cached_\` (trailing underscore on a public parameter — odd but out of scope).

## Test plan

- [x] Every prose claim cross-checked against \`FIAMSScheduler.cpp\` lines 18-93.
- [ ] CI \`Doxygen_Warning_test\` (Linux): no new warnings.
- [ ] No \`.cpp\` / test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced developer documentation with clearer specifications for configuration format, required parameters, input file handling, time window management, parallel processing, and comprehensive error handling guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->