### PR TITLE
doc(OPXLSpectrumProcessingAlgorithms): add class brief; tighten per-method contracts

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLSpectrumProcessingAlgorithms.h
+++ b/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLSpectrumProcessingAlgorithms.h
@@ -18,49 +18,114 @@
 
 namespace OpenMS
 {
+  /**
+    @brief Spectrum preprocessing and theoretical-vs-experimental peak alignment helpers used by the OpenPepXL cross-link search engines.
+
+    Static utilities (the class carries no state) that the cross-link identification
+    workflows in OpenPepXL build on:
+      - Pre-filter an MS2 dataset before searching — drop spectra with too few peaks or
+        with precursor charges outside the configured range, normalise intensities, and
+        (optionally) deisotope.
+      - Merge two annotated spectra into a single peak list while preserving paired
+        FloatDataArray / StringDataArray / IntegerDataArray annotations.
+      - Align a theoretical and an experimental fragment spectrum honouring per-peak
+        charge annotations, with optional intensity-ratio filtering.
+
+    @ingroup Analysis_ID
+  */
   class OPENMS_DLLAPI OPXLSpectrumProcessingAlgorithms
   {
     public:
 
-    /**
-       * @brief Merges two spectra into one while correctly considering metainfo in DataArrays
-       * @param[in,out] first_spectrum
-       * @param[in,out] second_spectrum
-       * @return A PeakSpectrum containing all peaks from both input spectra
+      /**
+       * @brief Merge two annotated spectra into one peak list, preserving paired DataArrays.
+       *
+       * Peaks of @p first_spectrum and @p second_spectrum are concatenated and the result
+       * is sorted by m/z. For each kind of DataArray (Float / String / Integer) the i-th
+       * array of @p first_spectrum is paired with the i-th array of @p second_spectrum and
+       * their contents are concatenated; the output array inherits its name from
+       * @p first_spectrum's i-th array. Extra arrays present only in @p second_spectrum are
+       * dropped — pairing is positional, not by name.
+       *
+       * Despite the non-const references in the signature, neither input is modified.
+       *
+       * @param[in,out] first_spectrum  Spectrum whose DataArray names and ordering define the output.
+       * @param[in,out] second_spectrum Spectrum whose peaks and (positionally paired) DataArrays are appended.
+       * @return Merged spectrum, sorted by m/z.
        */
       static PeakSpectrum mergeAnnotatedSpectra(PeakSpectrum & first_spectrum, PeakSpectrum & second_spectrum);
 
       /**
-       * @brief Preprocesses spectra
+       * @brief Preprocess an MSExperiment for cross-link search and return the surviving MS2 spectra.
        *
-       * Filters out spectra with too few peaks (based on @p peptide_min_size) and those that do not fit into the precursor charge range.
-       * Removes zero intensity peaks and normalizes intensities from all spectra in @p exp.
-       * MS2 spectra are reduced in peak count using a WindowMower, if @p labeled is false.
-       * The number of returned spectra (MS2 only) is equal to the number of input MS2 spectra for labeled data (otherwise not necessarily).
+       * Two phases — first the input @p exp is modified in place: zero-intensity peaks are
+       * removed (ThresholdMower), intensities are normalised, and the spectra are sorted by
+       * retention time. Then the MS2 spectra are iterated (OpenMP-parallelised loop) and
+       * those that pass the per-spectrum filters are copied into a freshly built PeakMap
+       * that is returned. MS1 spectra are not copied to the output.
        *
-       * @param[in,out] exp Input data, which contains MS1 and MS2 spectra. Will be modified.
-       * @param[in] fragment_mass_tolerance For deisotoping (used only if @p deisotope is true)
-       * @param[in] fragment_mass_tolerance_unit_ppm For deisotoping (used only if @p deisotope is true)
-       * @param[in] peptide_min_size Minimum length of a peptide (used to filter spectra with few peaks)
-       * @param[in] min_precursor_charge MS2 spectra's minimal PC charge (ignored if @p labeled is true)
-       * @param[in] max_precursor_charge MS2 spectra's maximal PC charge (ignored if @p labeled is true)
-       * @param[in] deisotope Deisotope MS2 spectra?
-       * @param[in] labeled Is the data labeled? (i.e. keep all MS2 spectra irrespective of precursor)
-       * @return A PeakMap of preprocessed spectra (MS2 spectra only)
+       * For unlabeled data (@p labeled is @c false) a spectrum is retained only if it has a
+       * single precursor whose charge lies in @c [min_precursor_charge, max_precursor_charge]
+       * and at least @c 2 @c * @c peptide_min_size peaks. Such spectra are further reduced
+       * by a WindowMower with hardcoded settings (window size @c 100, keep @c 20 peaks per
+       * window, @c "jump" mode). The final peak count must again exceed
+       * @c 2 @c * @c peptide_min_size.
+       *
+       * For labeled data (@p labeled is @c true) the precursor and peak-count filters are
+       * bypassed, the WindowMower is not applied, and every MS2 spectrum of the input is
+       * present in the output — keeping spectrum indices stable across the heavy/light
+       * pairing performed downstream via consensusXML.
+       *
+       * When @p deisotope is @c true, each surviving spectrum is run through
+       * Deisotoper::deisotopeAndSingleCharge with a simple averagine model, charge range
+       * @c [1,7], isopeak counts in @c [3,10]; charge and isotopic-peak counts are
+       * annotated and monoisotopic intensity is summed. The deisotoped result is kept only
+       * if it still exceeds the post-filter peak count or @p labeled is @c true.
+       *
+       * @param[in,out] exp                              Input data (MS1 + MS2). Modified in place.
+       * @param[in]     fragment_mass_tolerance          Peak mass tolerance used by deisotoping (ignored if @p deisotope is @c false).
+       * @param[in]     fragment_mass_tolerance_unit_ppm Interpret @p fragment_mass_tolerance as ppm (true) or Da (false).
+       * @param[in]     peptide_min_size                 Lower bound on peak count: spectra must have at least @c 2 @c * @c peptide_min_size peaks both before and after the WindowMower / Deisotoper step.
+       * @param[in]     min_precursor_charge             Minimum allowed precursor charge for unlabeled data.
+       * @param[in]     max_precursor_charge             Maximum allowed precursor charge for unlabeled data.
+       * @param[in]     deisotope                        If @c true, deisotope each surviving spectrum.
+       * @param[in]     labeled                          If @c true, bypass precursor/peak-count filters and the WindowMower, keeping every MS2 spectrum.
+       *
+       * @return PeakMap containing only the preprocessed MS2 spectra that passed all filters; for @p labeled inputs this contains every input MS2 spectrum.
        */
       static PeakMap preprocessSpectra(PeakMap& exp, double fragment_mass_tolerance, bool fragment_mass_tolerance_unit_ppm, Size peptide_min_size, Int min_precursor_charge, Int max_precursor_charge, bool deisotope, bool labeled);
 
       /**
-       * @brief Computes a spectrum alignment while considering fragment charges stored in a IntegerDataArray and a cut-off for the intensity difference ratio
-       * @param[out] alignment The empty alignment, that will be filled by the algorithm
-       * @param[in] fragment_mass_tolerance The peak mass tolerance
-       * @param[in] fragment_mass_tolerance_unit_ppm True if the given tolerance is a ppm tolerance, false if tolerance is in Da
-       * @param[in] theo_spectrum The first spectrum to be aligned (preferably the theoretical one)
-       * @param[in] exp_spectrum the second spectrum to be aligned (preferably the experimental one)
-       * @param[in] theo_charges IntegerDataArray with charges for the theo_spectrum
-       * @param[in] exp_charges IntegerDataArray with charges for the exp_spectrum
-       * @param[out] ppm_error_array empty FloatDataArray to be filled with per peak ppm errors
-       * @param[in] intensity_cutoff Peaks will only be aligned if intensity1 / intensity2 > intensity_cutoff, with intensity1 being the lower of the two compared peaks and intensity2 the higher one. Set to 0 to ignore intensity differences.
+       * @brief Align a theoretical and an experimental fragment spectrum using charge annotations and an intensity-ratio cut-off.
+       *
+       * For each theoretical peak, the closest experimental peak inside the mass-tolerance
+       * window is picked, restricted to peaks whose charge and intensity also pass the
+       * per-peak filters.
+       *
+       * Tolerance window half-width: @c theo_mz @c * @p fragment_mass_tolerance @c * @c 1e-6
+       * when @p fragment_mass_tolerance_unit_ppm is @c true, else @p fragment_mass_tolerance Da.
+       *
+       * Charge filter: a pair (theoretical charge @c tz, experimental charge @c ez) matches
+       * when @c tz @c == @c ez or either side is @c 0 (treated as "unknown"). If
+       * @p theo_charges or @p exp_charges is empty, the charge filter degrades to permissive.
+       *
+       * Intensity filter: a pair (theoretical intensity @c ti, experimental intensity @c ei)
+       * matches when @c min(ti,ei) @c / @c max(ti,ei) @c > @p intensity_cutoff. Pass
+       * @c 0 to disable.
+       *
+       * Both spectra must be sorted by m/z; @p alignment and @p ppm_error_array must be
+       * empty on entry (precondition). When either spectrum is empty, the function returns
+       * with no output.
+       *
+       * @param[out] alignment                       Receives (theo-index, exp-index) match pairs. Must be empty on entry.
+       * @param[in]  fragment_mass_tolerance         Tolerance window half-width.
+       * @param[in]  fragment_mass_tolerance_unit_ppm Interpret @p fragment_mass_tolerance as ppm (true) or Da (false).
+       * @param[in]  theo_spectrum                   Theoretical spectrum (sorted by m/z).
+       * @param[in]  exp_spectrum                    Experimental spectrum (sorted by m/z).
+       * @param[in]  theo_charges                    Per-peak charges for @p theo_spectrum; an empty array disables the charge filter.
+       * @param[in]  exp_charges                     Per-peak charges for @p exp_spectrum; an empty array disables the charge filter.
+       * @param[out] ppm_error_array                 Receives per-match ppm errors @c (exp_mz @c - @c theo_mz) @c / @c theo_mz @c * @c 1e6. Must be empty on entry.
+       * @param[in]  intensity_cutoff                Minimum smaller-over-larger intensity ratio for a match; @c 0 disables the intensity filter.
        */
       static void getSpectrumAlignmentFastCharge(
             std::vector<std::pair<Size, Size> > & alignment, double fragment_mass_tolerance,
@@ -73,13 +138,25 @@ namespace OpenMS
             double intensity_cutoff = 0.0);
 
             /**
-             * @brief Computes a spectrum alignment while considering fragment charges. Uses TSGXLMS::SimplePeak for the theoretical spectrum and its charges. Does not consider intensities.
-             * @param[out] alignment The empty alignment, that will be filled by the algorithm
-             * @param[in] fragment_mass_tolerance The peak mass tolerance
-             * @param[in] fragment_mass_tolerance_unit_ppm True if the given tolerance is a ppm tolerance, false if tolerance is in Da
-             * @param[in] theo_spectrum The first spectrum to be aligned (preferably the theoretical one)
-             * @param[in] exp_spectrum the second spectrum to be aligned (preferably the experimental one)
-             * @param[in] exp_charges IntegerDataArray with charges for the exp_spectrum
+             * @brief Align a SimplePeak-based theoretical spectrum to an experimental spectrum using charge annotations only.
+             *
+             * Mirror of @ref getSpectrumAlignmentFastCharge but without the
+             * intensity-ratio filter and without ppm-error output, and with the
+             * theoretical side expressed as a @c vector<SimpleTSGXLMS::SimplePeak>
+             * (charges carried per peak inside the @c SimplePeak struct, not as a
+             * separate DataArray). @p alignment is cleared on entry — it does not need
+             * to start empty.
+             *
+             * Charge filter rule is identical to the fast-charge variant: @c (theo_charge
+             * @c == @c exp_charge or either side is @c 0) matches. An empty @p exp_charges
+             * array makes the charge filter permissive.
+             *
+             * @param[out] alignment                       Receives (theo-index, exp-index) match pairs. Cleared on entry.
+             * @param[in]  fragment_mass_tolerance         Tolerance window half-width.
+             * @param[in]  fragment_mass_tolerance_unit_ppm Interpret @p fragment_mass_tolerance as ppm (true) or Da (false).
+             * @param[in]  theo_spectrum                   Theoretical spectrum (vector of SimplePeak; per-peak m/z and charge).
+             * @param[in]  exp_spectrum                    Experimental spectrum (sorted by m/z).
+             * @param[in]  exp_charges                     Per-peak charges for @p exp_spectrum; an empty array disables the charge filter.
              */
             static void getSpectrumAlignmentSimple(
                   std::vector<std::pair<Size, Size> > & alignment,


### PR DESCRIPTION
## Summary

\`OPXLSpectrumProcessingAlgorithms\` is the spectrum-preprocessing / alignment helper used by the OpenPepXL cross-link search engines. Its per-method docs were decent but the class itself had **no \`@brief\`, no \`@ingroup\`, and no description** — it rendered under the generic Class List with zero context. This PR adds a class-level Doxygen block tagged \`@ingroup Analysis_ID\` (matching its siblings \`OPXLDataStructs\` and \`OpenPepXLAlgorithm\`) and tightens every per-method block grounded against \`src/openms/source/ANALYSIS/XLMS/OPXLSpectrumProcessingAlgorithms.cpp\`.

## What I corrected / surfaced

- **\`mergeAnnotatedSpectra\`** (\`OPXLSpectrumProcessingAlgorithms.cpp:30-78\`):
  - Inputs are passed by non-\`const\` ref but **not modified** — only iterated. Now stated.
  - DataArray pairing is **positional**, not by name (\`// TODO instead of this \"if\", get second array by name if available\` is in the cpp). Extra arrays present only in \`second_spectrum\` are dropped. Output array names come from the **first** spectrum.
  - Output is sorted by m/z (the old doc said "considering metainfo" without spelling out what that meant).
- **\`preprocessSpectra\`** (\`OPXLSpectrumProcessingAlgorithms.cpp:80-176\`):
  - Two-phase behaviour: phase 1 mutates the input \`PeakMap\` (\`ThresholdMower\` removes 0-intensity peaks, \`Normalizer\` normalises, \`sortSpectra(false)\`). Phase 2 builds a fresh \`PeakMap\` of the surviving MS2 spectra and returns it.
  - **Hardcoded** \`WindowMower\` settings: windowsize=100, peakcount=20, movetype=\"jump\" (lines 97-99). Bypassed entirely for labeled data.
  - **Hardcoded** \`Deisotoper\` settings: charge range \`[1,7]\`, isopeaks \`[3,10]\`, simple averagine model, monoisotopic intensity summed.
  - The \`2 * peptide_min_size\` peak-count threshold is applied **both** before and after the filter step (the old doc only described "few peaks" without spelling out the threshold).
  - Labeled-data semantics: every input MS2 spectrum is kept so spectrum indices stay stable across the heavy/light pairing performed downstream via consensusXML.
- **\`getSpectrumAlignmentFastCharge\`** (\`OPXLSpectrumProcessingAlgorithms.cpp:178-335\`):
  - Tolerance window formula written out explicitly.
  - **Surfaces:** empty \`theo_charges\` OR \`exp_charges\` degrades the charge filter to permissive (line 195: \`has_charge = !(exp_charges.empty() || theo_charges.empty())\`). Not obvious from the signature — callers would think they always have to provide one.
  - **Surfaces:** the \`0\`-as-unknown convention in the charge match (line 214: \`ez == tz || !ez || !tz\`).
  - **Surfaces:** the smaller-over-larger intensity ratio rule (line 218).
  - Empty-input early return documented.
- **\`getSpectrumAlignmentSimple\`** (\`OPXLSpectrumProcessingAlgorithms.cpp:337-470\`):
  - Framed as a mirror of \`getSpectrumAlignmentFastCharge\` minus intensity/ppm.
  - **Surfaces:** \`alignment.clear()\` is called on entry (line 345) — does NOT require empty input, differing from the fast-charge variant which asserts emptiness. The old doc said "empty alignment, that will be filled" for both, masking the asymmetry.
  - Per-peak charge lives in the \`SimplePeak\` struct, not in a separate \`IntegerDataArray\`.

## What I did NOT change

- No behaviour changes; no \`.cpp\` edits.
- Did not change the inputs of \`mergeAnnotatedSpectra\` from \`PeakSpectrum &\` to \`const PeakSpectrum &\` even though they're effectively const — that would be a public API/ABI change, out of scope for a docs PR.

## Test plan

- [x] Every prose claim cross-checked against the \`.cpp\` lines listed above.
- [x] Diff scanned for known Doxygen \`@ref\` pitfalls (trailing-colon-glued refs, HTML-tag traps, \`#\` auto-link): none detected.
- [ ] CI \`Doxygen_Warning_test\` (Linux): no new warnings.
- [ ] No \`.cpp\` / test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for spectrum processing algorithms to clarify preprocessing behavior, deisotoping application, charge/intensity thresholds, and alignment specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->