### PR TITLE
doc(OpenMSOSInfo/OpenMSBuildInfo): add class briefs and runtime-vs-build-time framing

### DIFF
--- a/src/openms/include/OpenMS/SYSTEM/BuildInfo.h
+++ b/src/openms/include/OpenMS/SYSTEM/BuildInfo.h
@@ -33,11 +33,11 @@ namespace OpenMS
   namespace Internal
   {
 
-    /// Operating systems @ref OpenMSOSInfo can report. @c SIZE_OF_OPENMS_OS is a sentinel for array sizing.
+    /// Operating systems @c OpenMSOSInfo can report. @c SIZE_OF_OPENMS_OS is a sentinel for array sizing.
     enum class OpenMS_OS {OS_UNKNOWN, OS_MACOS, OS_WINDOWS, OS_LINUX, SIZE_OF_OPENMS_OS};
     /// String labels paired with @ref OpenMS_OS; index by @c static_cast<size_t>(enum_value).
     inline const std::string OpenMS_OSNames[] = {"unknown", "MacOS", "Windows", "Linux"};
-    /// Pointer-width architectures @ref OpenMSOSInfo can report. @c SIZE_OF_OPENMS_ARCHITECTURE is a sentinel for array sizing.
+    /// Pointer-width architectures @c OpenMSOSInfo can report. @c SIZE_OF_OPENMS_ARCHITECTURE is a sentinel for array sizing.
     enum class OpenMS_Architecture {ARCH_UNKNOWN, ARCH_32BIT, ARCH_64BIT, SIZE_OF_OPENMS_ARCHITECTURE};
     /// String labels paired with @ref OpenMS_Architecture; index by @c static_cast<size_t>(enum_value).
     inline const std::string OpenMS_ArchNames[] = {"unknown", "32 bit", "64 bit"};

--- a/src/openms/include/OpenMS/SYSTEM/BuildInfo.h
+++ b/src/openms/include/OpenMS/SYSTEM/BuildInfo.h
@@ -33,12 +33,26 @@ namespace OpenMS
   namespace Internal
   {
 
+    /// Operating systems @ref OpenMSOSInfo can report. @c SIZE_OF_OPENMS_OS is a sentinel for array sizing.
     enum class OpenMS_OS {OS_UNKNOWN, OS_MACOS, OS_WINDOWS, OS_LINUX, SIZE_OF_OPENMS_OS};
+    /// String labels paired with @ref OpenMS_OS; index by @c static_cast<size_t>(enum_value).
     inline const std::string OpenMS_OSNames[] = {"unknown", "MacOS", "Windows", "Linux"};
+    /// Pointer-width architectures @ref OpenMSOSInfo can report. @c SIZE_OF_OPENMS_ARCHITECTURE is a sentinel for array sizing.
     enum class OpenMS_Architecture {ARCH_UNKNOWN, ARCH_32BIT, ARCH_64BIT, SIZE_OF_OPENMS_ARCHITECTURE};
+    /// String labels paired with @ref OpenMS_Architecture; index by @c static_cast<size_t>(enum_value).
     inline const std::string OpenMS_ArchNames[] = {"unknown", "32 bit", "64 bit"};
 
-    /// @brief Helper: get OS version string using platform APIs
+    /**
+      @brief Return the running OS version using a platform-specific probe.
+
+      Windows uses @c RtlGetVersion from @c ntdll.dll to bypass the compatibility shim
+      and return the real version as @c "MAJOR.MINOR.BUILD".
+      macOS uses @c sysctlbyname("kern.osproductversion", ...).
+      Linux (and other @c __unix__) parses @c /etc/os-release and returns the
+      @c VERSION_ID value with surrounding quotes stripped.
+
+      Returns @c "unknown" if the platform query fails or the platform is unsupported.
+    */
     inline std::string getOSVersionString_()
     {
 #if defined(_WIN32)
@@ -91,6 +105,20 @@ namespace OpenMS
 #endif
     }
 
+    /**
+      @brief Snapshot of the runtime operating system: name, version, and pointer-width architecture.
+
+      Populated via the static factory @ref getOSInfo, which probes the running platform
+      with preprocessor defines (@c WIN32, @c __MACH__ @c && @c __APPLE__, @c __unix__).
+      All accessors return string labels suitable for logging or display; the underlying
+      enum values are kept private and only exposed via the @c *AsString accessors.
+
+      Distinct from the build-time view of the binary: @ref getBinaryArchitecture and
+      @ref getActiveSIMDExtensions return what the compiler emitted, not what the
+      running kernel reports.
+
+      @ingroup System
+    */
     class OPENMS_DLLAPI OpenMSOSInfo
     {
       OpenMS_OS os_;
@@ -98,31 +126,37 @@ namespace OpenMS
       OpenMS_Architecture arch_;
 
     public:
+      /// Construct an empty instance with all fields set to "unknown". Use @ref getOSInfo to probe the runtime platform.
       OpenMSOSInfo() :
           os_(OpenMS_OS::OS_UNKNOWN),
           os_version_("unknown"),
           arch_(OpenMS_Architecture::ARCH_UNKNOWN)
       {}
 
-      /// @brief Get the current operating system (Windows, MacOS, Linux)
+      /// Return the running operating system name (@c "Windows", @c "MacOS", @c "Linux", or @c "unknown").
       String getOSAsString() const
       {
         return OpenMS_OSNames[static_cast<size_t>(os_)];
       }
 
-      /// @brief Get the current architecture (32-bit or 64-bit)
+      /// Return the running architecture (@c "32 bit", @c "64 bit", or @c "unknown") as detected by @ref getOSInfo from the pointer width.
       String getArchAsString() const
       {
         return OpenMS_ArchNames[static_cast<size_t>(arch_)];
       }
 
-      /// @brief Get the OS version (e.g. 10.15 for macOS or 10 for Windows)
+      /// Return the OS version captured by @ref getOSInfo (e.g. @c "10.15" on macOS or @c "10.0.19045" on Windows); @c "unknown" if the platform query failed.
       String getOSVersionAsString() const
       {
         return os_version_;
       }
 
-      /// @brief Get Architecture of this binary (simply by looking at size of a pointer, i.e. size_t).
+      /**
+        @brief Return the pointer width of this binary, derived from @c sizeof(size_t).
+
+        @c "32 bit" if @c sizeof(size_t) is 4, @c "64 bit" if 8, otherwise @c "unknown".
+        This reflects how the binary was compiled, independent of the running OS.
+      */
       static String getBinaryArchitecture()
       {
         size_t bytes = sizeof(size_t);
@@ -137,10 +171,23 @@ namespace OpenMS
         }
       }
 
-      /// @brief Obtain a list of SIMD extensions which are currently in use (i.e. used by the compiler during optimization, as well as for SIMDe code within OpenMS)
+      /**
+        @brief Return a comma-separated list of SIMD instruction sets compiled into this binary.
+
+        Reflects the SIMDe preprocessor probes that were defined at build time: any of
+        @c neon, @c SSE, @c SSE2, @c SSE3, @c SSE4.1, @c SSE4.2, @c AVX, @c AVX2, @c FMA.
+        Returns an empty string if none of those is set.
+      */
       static String getActiveSIMDExtensions();
 
-      /// @brief Constructs and returns an OpenMSOSInfo object
+      /**
+        @brief Probe the running platform and return a populated @ref OpenMSOSInfo.
+
+        Sets @c os_ from compile-time platform macros (@c WIN32 / @c __MACH__ @c && @c __APPLE__ /
+        @c __unix__), @c os_version_ via @ref getOSVersionString_, and @c arch_ from
+        @c sizeof(void*) (@c 4 → 32-bit, otherwise 64-bit). Fields stay at their
+        @c OS_UNKNOWN / @c ARCH_UNKNOWN defaults if the running platform isn't recognised.
+      */
       static OpenMSOSInfo getOSInfo()
       {
         OpenMSOSInfo info;
@@ -169,13 +216,21 @@ namespace OpenMS
       }
     };
 
-    /// @brief Struct with some static methods to get informations on the build configuration
+    /**
+      @brief Build-configuration accessors: build type, OpenMP availability, and OpenMP thread count.
+
+      Static utility methods only; the struct carries no state. All values reflect how the
+      OpenMS library was compiled, not the running platform — see @ref OpenMSOSInfo for the
+      runtime view.
+
+      @ingroup System
+    */
     struct OpenMSBuildInfo
 
     {
     public:
 
-      /// @brief Checks if OpenMP was enabled during build, based on the _OPENMP macro
+      /// Return @c true when the library was compiled with OpenMP support (@c _OPENMP defined), @c false otherwise.
       static bool isOpenMPEnabled()
       {
         #ifdef _OPENMP
@@ -185,15 +240,19 @@ namespace OpenMS
         #endif
       }
 
-      /// @brief Get the build type used during building the OpenMS library
+      /// Return the CMake build type baked into the library (e.g. @c "Release", @c "Debug"), captured from the @c OPENMS_BUILD_TYPE configure-time macro.
       static String getBuildType()
       {
         return OPENMS_BUILD_TYPE;
       }
 
-      /// @brief Get the maximum number of threads that OpenMP will use (including hyperthreads)
-      /// Note: This could also be limited by the OMP_NUM_THREADS environment variable
-      /// Returns 1 if OpenMP was disabled.
+      /**
+        @brief Return the maximum number of OpenMP threads (including hyperthreads).
+
+        Wraps @c omp_get_max_threads(). Returns @c 1 if the library was compiled without
+        OpenMP. The value can be capped by the @c OMP_NUM_THREADS environment variable
+        and/or by @ref setOpenMPNumThreads.
+      */
       static Size getOpenMPMaxNumThreads()
       {
         #ifdef _OPENMP
@@ -202,8 +261,12 @@ namespace OpenMS
         return 1;
         #endif
       }
-      /// @brief Set the number of threads that OpenMP will use (including hyperthreads)
-      /// Note: Can be initialized by the OMP_NUM_THREADS environment variable. This function can overwrite this at runtime.
+      /**
+        @brief Override the OpenMP thread count for subsequent parallel regions.
+
+        Wraps @c omp_set_num_threads. No-op when the library was compiled without OpenMP.
+        Takes precedence over the initial @c OMP_NUM_THREADS environment variable.
+      */
       static void setOpenMPNumThreads(Int num_threads)
       {
         #ifdef _OPENMP


### PR DESCRIPTION
## Summary

\`OpenMSOSInfo\` (the runtime-OS snapshot used by logging, error reports, and the \`--help\` banner of TOPP tools) carried **no class-level Doxygen brief** — it appeared in the generated docs with no description of what runtime data it exposes. \`OpenMSBuildInfo\` had a one-line brief but no \`@ingroup\` tag, so it didn't surface under the System group.

This PR adds class-level Doxygen blocks for both, tags them \`@ingroup System\` (matching \`JavaInfo\`, \`PythonInfo\`, \`File\`, \`StopWatch\`, \`UpdateCheck\`, \`RWrapper\` in the same directory), and tightens every per-method brief with grounded behaviour from \`BuildInfo.h\` itself and \`BuildInfo.cpp\` (the latter holds the out-of-line \`getActiveSIMDExtensions\`).

## Runtime vs build-time framing

The two classes are easy to confuse. The new prose makes the distinction explicit:

| Class | Reflects | Examples |
|---|---|---|
| \`OpenMSOSInfo\` | running platform | \`getOSAsString\`, \`getOSVersionAsString\` |
| \`OpenMSOSInfo\` (static) | compile-time binary | \`getBinaryArchitecture\`, \`getActiveSIMDExtensions\` |
| \`OpenMSBuildInfo\` (static) | compile-time library | \`isOpenMPEnabled\`, \`getBuildType\`, \`getOpenMP*\` |

## Grounded claims

- **\`getOSVersionString_\`**: spell out each platform's probe with the exact API used:
  - Windows uses \`RtlGetVersion\` from \`ntdll.dll\` to bypass the compatibility shim (\`BuildInfo.h:42-62\`).
  - macOS uses \`sysctlbyname(\"kern.osproductversion\", ...)\` (\`BuildInfo.h:63-70\`).
  - Linux / \`__unix__\` parses \`/etc/os-release\` and returns the \`VERSION_ID\` value with surrounding quotes stripped (\`BuildInfo.h:71-88\`).
  - Returns \`\"unknown\"\` on probe failure or unsupported platform.
- **\`getActiveSIMDExtensions\`**: enumerate the SIMDe probes the cpp checks: \`neon\`, \`SSE\`, \`SSE2\`, \`SSE3\`, \`SSE4.1\`, \`SSE4.2\`, \`AVX\`, \`AVX2\`, \`FMA\` (\`BuildInfo.cpp:23-50\`).
- **\`getOSInfo\`**: document the preprocessor cascade order (\`WIN32\` → \`__MACH__&&__APPLE__\` → \`__unix__\`) and the \`sizeof(void*)\` architecture rule.
- **\`getOpenMPMaxNumThreads\` / \`setOpenMPNumThreads\`**: surface the \`OMP_NUM_THREADS\` environment variable interaction explicitly. The old comments mentioned it but didn't clarify that \`setOpenMPNumThreads\` *takes precedence* over the env var at runtime.
- **\`getBuildType\`**: now stated to come from the \`OPENMS_BUILD_TYPE\` configure-time macro (e.g. \`\"Release\"\` / \`\"Debug\"\`) rather than \"the build type\".

## What I did NOT change

- No behaviour changes; no \`.cpp\` edits.
- Did not change the \`OpenMS::Internal\` namespace placement — these classes are project-internal helpers, and that's an intentional API choice (out of scope for a docs PR).
- Did not split the file into separate \`OpenMSOSInfo.h\` / \`OpenMSBuildInfo.h\` headers despite the file being doing double duty.

## Test plan

- [x] Every prose claim cross-checked against \`BuildInfo.h\` and \`BuildInfo.cpp\`.
- [x] Diff scanned for known Doxygen \`@ref\` pitfalls (no trailing-colon-glued refs, no operator()/sig refs, no HTML-tag traps, no \`#\` auto-link sigils).
- [ ] CI \`Doxygen_Warning_test\` (Linux): no new warnings.
- [ ] No source/test changes outside this header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified internal documentation for system/architecture and build-configuration information, including descriptions of runtime snapshots and build-time settings to help developers understand platform and build details.
  * Clarified comments around concurrency-related build helpers.
  * No changes to public APIs or user-facing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->