### PR TITLE
doc(Network): expand class brief; surface collision/error/log contract

### DIFF
--- a/src/openms/include/OpenMS/SYSTEM/Network.h
+++ b/src/openms/include/OpenMS/SYSTEM/Network.h
@@ -13,16 +13,45 @@
 
 namespace OpenMS
 {
-  /// Utility class for network operations (HTTP downloads)
+  /**
+    @brief Convenience wrapper around @c NetworkGetRequest for one-shot HTTP/HTTPS downloads.
+
+    Single-method utility used by tooling that needs to fetch a remote URL to disk without
+    composing a @c NetworkGetRequest pipeline by hand. Synchronous (the call blocks until
+    the transfer finishes or fails).
+
+    @ingroup System
+  */
   class OPENMS_DLLAPI Network
   {
   public:
     /**
-      @brief Download file from given URL into a download folder. Returns when done.
+      @brief Download @p url to @p download_folder and return when the file is fully written.
 
-      If a file with same filename already exists, creates a new file with '.number' appended to the basename.
+      Internally creates a @ref NetworkGetRequest with a 10-minute (@c 600 second) timeout
+      and runs it synchronously. The destination filename is derived from the URL:
+        - any @c "?query" and @c "#fragment" suffixes are stripped first;
+        - the basename of the remaining path component is used (e.g. @c "https://host/a/b/c.tsv" → @c "c.tsv");
+        - if the resulting basename is empty, @c "download" is used as a fallback.
+      If a file with the same name already exists in @p download_folder, the suffixes
+      @c ".0", @c ".1", @c ".2", ... are tried in order until an unused name is found —
+      existing files are never overwritten.
 
-      @throw IOException if download failed.
+      An empty @p download_folder is treated as @c "./" (the current working directory).
+      No trailing-slash normalisation is performed on the directory string.
+
+      Success path: writes the response bytes to the destination in binary mode and
+      emits two @c OPENMS_LOG_INFO lines (download successful + final on-disk path).
+      Failure paths throw:
+        - download error (HTTP error or timeout in @c NetworkGetRequest),
+        - opening the destination file fails (e.g. permission denied, missing folder),
+        - writing the response bytes fails partway.
+      A partially-written file is not cleaned up on write failure.
+
+      @param[in] url             Source URL.
+      @param[in] download_folder Destination directory; @c "" is treated as @c "./".
+
+      @throws OpenMS::Exception::IOException on any of the failure paths described above.
     */
     static void downloadFile(const std::string& url, const std::string& download_folder);
   };


### PR DESCRIPTION
## Summary

\`Network::downloadFile\` is a one-shot HTTP/HTTPS downloader used by tooling and tests. The header carried a one-line class comment and a minimal method block; the new docs expand the contract with several pieces of behaviour grounded in \`src/openms/source/SYSTEM/Network.cpp\` that the previous comments left out or got slightly wrong.

## What I surfaced (grounded against the cpp)

- **Hardcoded 10-minute timeout**: \`NetworkGetRequest::setTimeout(600)\` (\`Network.cpp:54\`). Not a parameter; callers can't override it without going around this wrapper.
- **Filename derivation**:
  - \`?query\` and \`#fragment\` are stripped from the URL first (\`Network.cpp:31-34\`).
  - \`std::filesystem::path::filename()\` picks the basename of the remaining path.
  - Empty basename → falls back to literal string \`\"download\"\` (\`Network.cpp:36-37\`).
- **Collision rule**: the existing comment said *\".number\" appended\"*. The cpp actually appends \`.0\`, \`.1\`, \`.2\`, ... — it **starts at 0**, increments by 1, picks the first unused name (\`Network.cpp:42-46\`). Existing files are never overwritten.
- **Empty \`download_folder\`** is silently treated as \`\"./\"\` (\`Network.cpp:59\`).
- **Three distinct \`IOException\` paths** (the old \`@throw\` documented only "download failed"):
  - Underlying \`NetworkGetRequest\` reports an HTTP/timeout error (\`Network.cpp:80-81\`).
  - Output file fails to open — e.g. permission denied, missing folder (\`Network.cpp:62-66\`).
  - \`ofs.write\` fails partway (\`Network.cpp:69-73\`).
- **Partial-write residue**: the cpp does not delete a partially-written file when the write throws. Worth flagging so callers can decide whether to clean up.
- **Success-path side effects**: emits two \`OPENMS_LOG_INFO\` lines (success message + final on-disk path, \`Network.cpp:75-76\`). Operators tailing logs see these per successful download.

Also adds \`@ingroup System\` (matching \`JavaInfo\`, \`PythonInfo\`, \`File\`, \`StopWatch\`, \`UpdateCheck\`, \`RWrapper\` in the same directory).

## What I did NOT change

- No behaviour changes; no \`.cpp\` edits.
- Did not propose making the timeout a parameter, fixing the trailing-slash heuristic, or cleaning up partial-write residue — those are behaviour changes and out of scope for a docs PR. The new prose surfaces all three as observable behaviour so a follow-up can address them with full context.

## Test plan

- [x] Every prose claim cross-checked against \`Network.cpp\` lines listed above.
- [x] Diff scanned for known Doxygen \`@ref\` pitfalls (no trailing-colon-glued refs, no HTML-tag traps): clean.
- [ ] CI \`Doxygen_Warning_test\` (Linux): no new warnings.
- [ ] No \`.cpp\` / test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for the file download functionality with improved clarity on timeout settings, filename derivation from URLs, collision handling in download folders, and error handling scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->