### PR TITLE
doc(NuXLModificationsGenerator): full class brief + grounded @param contract

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/NUXL/NuXLModificationsGenerator.h
+++ b/src/openms/include/OpenMS/ANALYSIS/NUXL/NuXLModificationsGenerator.h
@@ -18,20 +18,27 @@
 #include <iostream>
 
 namespace OpenMS
-{  
+{
   class AASequence;
 
-  /*
-      formula2mass holds the map from empirical formula to mass
+  /**
+    @brief Result of @ref NuXLModificationsGenerator::initModificationMassesNA — empirical formulas with their monoisotopic mass and the disambiguating nucleotide-composition lookup.
 
-      mod_combinations holds the map from empirical formula to (potentially ambigious) nucleotide formulae
-      e.g.,: 
-       C10H14N5O7P   -> {A}
-       C10H14N5O8P   -> {G}
-       C18H22N4O16P2 -> { CU-H3N1, UU-H2O1 }
-   */
+    Two parallel maps keyed by the same empirical-formula string:
+      - @c formula2mass — empirical formula → monoisotopic mass.
+      - @c mod_combinations — empirical formula → set of nucleotide-composition strings that
+        produce that formula. A set rather than a single value because different oligos can
+        share a chemical formula, e.g. @c C18H22N4O16P2 → @c {CU-H3N1, UU-H2O1}.
+
+    The nested @ref MyStringLengthCompare comparator orders the composition strings primarily
+    by length and lexicographically within the same length so the shortest (most likely)
+    composition appears first when iterating a value.
+
+    @ingroup Analysis_ID
+  */
   struct OPENMS_DLLAPI NuXLModificationMassesResult
   {
+    /// Comparator that orders strings primarily by length (shortest first) and lexicographically within the same length.
     struct MyStringLengthCompare
     {
       bool operator () (const std::string & p_lhs, const std::string & p_rhs) const
@@ -47,24 +54,82 @@ namespace OpenMS
         return (lhsLength < rhsLength) ; // compares with the length
       }
     };
-    std::map<String, double> formula2mass; ///< empirical formula -> mass
+    std::map<String, double> formula2mass; ///< Empirical formula → monoisotopic mass.
 
+    /// Length-ordered set of nucleotide-composition strings producing the same empirical formula.
     using NucleotideFormulas = std::set<String, MyStringLengthCompare>;
+    /// Empirical formula → @ref NucleotideFormulas.
     using MapSumFormulaToNucleotideFormulas = std::map<String, NucleotideFormulas>;
-    MapSumFormulaToNucleotideFormulas mod_combinations; ///< empirical formula -> nucleotide formula(s) (formulas if modifications lead to ambiguities)
+    MapSumFormulaToNucleotideFormulas mod_combinations; ///< Empirical formula → all nucleotide compositions yielding that formula (kept as a set because mutations / losses can make the mapping ambiguous).
   };
 
+  /**
+    @brief Enumerator of precursor-adduct masses for NuXL cross-link searches.
+
+    Builds the table of empirical formulas + monoisotopic masses + disambiguating
+    nucleotide compositions that NuXL searches against. Driven by:
+      - the list of target nucleotides with their monophosphate empirical formulas
+        (e.g. @c "U=C9H13N2O9P" entries in @p target_nucleotides),
+      - the list of source→target mappings used to express modifications
+        (e.g. @c "C->T" entries in @p mappings),
+      - the list of @c "nucleotide:+formula-formula" modifications applied to each
+        target nucleotide (e.g. @c "U:+H2O-H2O" entries in @p modifications),
+      - and an optional @p sequence_restriction limiting which oligomer compositions
+        survive (only adducts whose nucleotide string is a substring of the restriction
+        sequence, sort-insensitive at each window, are kept).
+
+    Optional @p cysteine_adduct toggles a hardcoded DTT-derived @c C4H8S2O2 entry
+    (commonly referred to as the @em 152 modification) into the result.
+
+    @ingroup Analysis_ID
+  */
   class OPENMS_DLLAPI NuXLModificationsGenerator
   {
     public:
-      /* @brief generate all combinations of precursor adducts
-         @param[in] target_nucleotides the list of nucleotides: e.g., "U", "C", "G", "A" or "U", "T", "G", "A"
-         @param[in] can_xl the set of cross-linkable nucleotides
-         @param[in] mappings
-         @param[in] modifications additional losses associated with the precursor adduct: e.g., "-H2O"
-         @param[in] sequence_restriction only precursor adducts that are substrings of this NA sequence are generated
-         @param[in] cysteine_adduct special DTT adduct
-         @param[in] max_length maximum oligo length
+      /**
+        @brief Build the full set of precursor adducts (formula + mass + nucleotide composition) for the given configuration.
+
+        Iterates source-nucleotide combinations up to @p max_length, applies the
+        per-nucleotide modifications, and (optionally) keeps only those compositions that
+        are substrings of @p sequence_restriction. When @p sequence_restriction is empty,
+        every length-@c k combination of source nucleotides for @c k @c in @c [1, max_length]
+        is considered.
+
+        @param[in] target_nucleotides    Entries in the form @c "N=Empirical_formula"
+                                         giving the monophosphate formula for each target
+                                         nucleotide (e.g. @c "U=C9H13N2O9P"). The entries
+                                         are split on @c '='.
+        @param[in] nt_groups             Group identifiers consulted during the
+                                         combinatorial expansion (forwarded verbatim into
+                                         the per-modification application loop).
+        @param[in] can_xl                Set of nucleotides eligible to carry a cross-link;
+                                         compositions without at least one cross-linkable
+                                         nucleotide are dropped.
+        @param[in] mappings              Source→target nucleotide mappings in the form
+                                         @c "X->Y" (split on @c "->"). Used to expand
+                                         source-nucleotide sequences into target sequences
+                                         and to derive the @em source alphabet for the
+                                         combinatorial enumeration.
+        @param[in] modifications         Per-nucleotide modification descriptors in the
+                                         form @c "N:+formula-formula" (e.g.
+                                         @c "U:+H2O-H2O"). The second character must be
+                                         @c ':' — otherwise the call throws.
+        @param[in] sequence_restriction  Optional NA reference sequence; when set, only
+                                         oligo compositions that appear as a length-matched
+                                         windowed permutation of the reference survive.
+                                         Default empty (no restriction → all combinations
+                                         up to @p max_length).
+        @param[in] cysteine_adduct       If @c true, insert the hardcoded DTT-derived
+                                         @c C4H8S2O2 adduct (the @em 152 modification) into
+                                         the result.
+        @param[in] max_length            Maximum oligomer length to enumerate when
+                                         @p sequence_restriction is empty. Default @c 4.
+
+        @return Populated @ref NuXLModificationMassesResult.
+
+        @throws OpenMS::Exception::MissingInformation when a @p modifications entry does
+                not follow the @c "N:+formula-formula" format (specifically when the
+                second character of the entry is not @c ':').
       */
       static NuXLModificationMassesResult initModificationMassesNA(const StringList& target_nucleotides,
                                                                      const StringList& nt_groups,
@@ -75,9 +140,28 @@ namespace OpenMS
                                                                      bool cysteine_adduct = false,
                                                                      Int max_length = 4);
     private:
-      /// return true if qery is not in sequence
+      /**
+        @brief Test whether @p query is @em not present as a sorted-window permutation of @p res_seq.
+
+        Returns @c true iff no contiguous window of length @c query.size() in @p res_seq
+        has the same multi-set of characters as @p query. The window comparison sorts both
+        sides first, so the test is permutation-insensitive. Empty @p query short-circuits
+        to @c false (treated as always present).
+      */
       static bool notInSeq(const String& res_seq, const String& query);
 
+      /**
+        @brief Recursively expand @p res_seq into every target-substituted variant according to @p map_source2target.
+
+        Starting at @p param_pos, walks @p res_seq character by character. Whenever the
+        current character is a key in @p map_source2target with more than one candidate
+        target, recurses once per candidate that differs from the current character; the
+        unchanged path falls through. After the recursive walk, the resulting sequence is
+        appended to @p target_sequences only when every position is either a non-mapped
+        character or a character that is simultaneously a source and a valid target
+        nucleotide (i.e. no @em pure source nucleotide is left). @p target_sequences is
+        appended to; existing entries are preserved.
+      */
       static void generateTargetSequences(const String& res_seq, Size param_pos, const std::map<char, std::vector<char> >& map_source2target, StringList& target_sequences);
     };
 }


### PR DESCRIPTION
## Summary

\`NuXLModificationsGenerator\` and its companion result struct \`NuXLModificationMassesResult\` both opened with \`/*\` instead of \`/**\` — Doxygen silently dropped both brief comments. The result struct's nested \`MyStringLengthCompare\` comparator had no documentation at all. The class entry point \`initModificationMassesNA\` had partial \`@param\` tags with several entries left empty (e.g. \`@param[in] mappings\` with no description).

This PR replaces the dropped blocks with proper Doxygen contracts grounded against \`src/openms/source/ANALYSIS/NUXL/NuXLModificationsGenerator.cpp\`.

## Non-obvious behaviour surfaced

- **Parser conventions** for the three string-list parameters of \`initModificationMassesNA\` — all of them are split on a specific delimiter and follow a specific format:
  - \`target_nucleotides\` entries: \`"N=EmpiricalFormula"\` split on \`'='\` (\`cpp:67-68\`).
  - \`mappings\` entries: \`"X->Y"\` split on \`"->"\` (\`cpp:75-77\`).
  - \`modifications\` entries: \`"N:+formula-formula"\` — the second character **must** be \`':'\`.
- **\`@throws Exception::MissingInformation\`** when a \`modifications\` entry doesn't have \`m[1] == ':'\` (\`cpp:163-167\`). Previously not documented at all.
- **\`cysteine_adduct\` is a hardcoded \`C4H8S2O2\`** (the @em 152 modification, DTT-derived) inserted into the result when the flag is \`true\` (\`cpp:56-57\`, \`441-444\`).
- **Empty \`sequence_restriction\`** triggers the combinatorial enumeration up to \`max_length\` (default \`4\`); non-empty triggers the substring filter.
- **\`notInSeq\` is a sorted-window permutation test, not a substring test** (\`cpp:30-38\`) — the window is sorted on both sides before comparison, so the test is order-insensitive within the window. Empty query short-circuits to \`false\`.
- **\`generateTargetSequences\` recursion semantics**:
  - branches once per non-identity target-candidate at each source-mapped position (\`cpp:516-525\`),
  - after the walk, only sequences whose every position is non-mapped OR is simultaneously source-and-target are appended (\`cpp:530-554\`),
  - the output vector is appended to, not cleared.

## What I did NOT change

- No behaviour changes; no \`.cpp\` edits.
- Did not address the FIXME on the cysteine adduct formula constant.
- Did not propose validation for the other parser conventions (\`'='\` / \`"->"\` splits silently assume well-formed input; a malformed entry would crash with \`std::out_of_range\` from \`fields[1]\`). Behaviour change, out of scope.

## Pre-push checks

- Diff scanned for known Doxygen \`@ref\` / HTML-tag pitfalls (no \`:\`-glued / \`(\`-glued / hyphen-glued refs; no lowercase angle-bracket placeholders).
- Param-name sanity check confirmed every \`@param\` tag matches the actual identifier in the signature.

## Test plan

- [x] Every prose claim cross-checked against \`NuXLModificationsGenerator.cpp\` lines listed above.
- [ ] CI \`Doxygen_Warning_test\` (Linux): no new warnings.
- [ ] No \`.cpp\` / test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and type definitions for the NuXL modifications module.

* **Documentation**
  * Expanded and clarified technical documentation for modification processing methods and helper functions, including parameter format specifications and behavior descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->