### PR TITLE
doc(NuXLAnnotateAndLocate): add class brief + ground annotateAndLocate_ contract

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/NUXL/NuXLAnnotateAndLocate.h
+++ b/src/openms/include/OpenMS/ANALYSIS/NUXL/NuXLAnnotateAndLocate.h
@@ -21,19 +21,87 @@
 
 namespace OpenMS
 {
+/**
+  @brief Post-scoring step of the OpenNuXL pipeline: annotates fragment-ion peaks of each candidate hit and localises the NA cross-link to a residue.
+
+  Consumes the per-scan vectors of @ref NuXLAnnotatedHit produced upstream by the
+  OpenNuXL search, reconstructs each hit's fully-modified peptide sequence, generates
+  the theoretical fragment spectrum (b/a/y ions plus precursor + immonium variants),
+  aligns it against the experimental spectrum, and writes the alignment results plus a
+  per-residue localisation score back into the hit. Single-purpose helper class — only
+  the static @ref annotateAndLocate_ entry point is exposed.
+
+  @ingroup Analysis_ID
+*/
 class OPENMS_DLLAPI NuXLAnnotateAndLocate
 {
   public:
 
+  /**
+    @brief Annotate every candidate hit in @p annotated_hits and localise the NA cross-link site.
+
+    Iterates over @p annotated_hits in parallel (OpenMP @c parallel @c for over the scan
+    dimension). For each non-empty @c annotated_hits[scan_index]:
+      -# Reads the experimental @c PeakSpectrum and its first precursor charge from
+         @p exp[scan_index].
+      -# For each candidate hit @c a:
+         - Rebuilds @c a.sequence's fully-modified form by reapplying
+           @ref ModifiedPeptideGenerator::applyFixedModifications and
+           @ref ModifiedPeptideGenerator::applyVariableModifications (the upstream search
+           only stored modification indices to save memory) and selects the entry at
+           @c a.peptide_mod_index.
+         - Picks the precursor NA adduct from @p mm via @c a.NA_mod_index (using the
+           first entry of the composition set at that key).
+         - Generates a total-loss theoretical spectrum (b/a/y + precursor + manually
+           added abundant immoniums for charge 1 and precursor peaks for every charge)
+           via @ref TheoreticalSpectrumGenerator with hardcoded settings
+           (@c add_first_prefix_ion, @c add_metainfo, @c add_a_ions, @c add_b_ions,
+           @c add_y_ions enabled; @c add_c_ions, @c add_x_ions, @c add_z_ions,
+           @c add_internal_fragments, @c add_abundant_immonium_ions,
+           @c add_all_precursor_charges disabled — the latter two are added manually).
+         - Aligns the theoretical and experimental spectra under @p fragment_mass_tolerance
+           (in @em ppm when @p fragment_mass_tolerance_unit_ppm is @c true, else Da),
+           with charge matching enforced.
+         - Annotates the matched peaks as b/a/y ions, immoniums, marker ions and
+           precursor variants (the immoniums / precursors are added by the NuXL fragment
+           generator using the per-adduct definitions in @p all_feasible_adducts).
+         - Computes per-residue site scores from the aligned shifted-ion evidence,
+           lowercases every residue that ties for the maximum score in the resulting
+           @c best_localization string, and stores the last-tied position in
+           @c best_localization_position (the cpp's @c "Note: check if there are
+           situations where multiple have the same score" caveat applies — ties resolve
+           to the last index, not the first).
+         - Writes @c localization_scores (comma-separated @c "0..100" percentages),
+           @c best_localization, @c best_localization_score, and
+           @c best_localization_position back into the hit.
+
+    All output goes into @p annotated_hits — no exceptions are thrown by this function;
+    malformed alignments emit @c OPENMS_LOG_WARN. Hits whose first precursor adduct
+    cannot be resolved fall back to an unmodified-sequence localisation
+    (@c best_localization @c == @c unmodified_sequence, @c best_localization_score @c = @c 0).
+
+    The trailing underscore on the method name is a historical artefact from the
+    OpenNuXL feature branch; the entry point is still public.
+
+    @param[in]     exp                              MS2 experiment whose spectra are aligned against the theoretical spectra of the candidate hits.
+    @param[in,out] annotated_hits                   Per-scan vectors of candidate hits to annotate and localise in place.
+    @param[in]     mm                               Precursor-adduct mass table (see @ref NuXLModificationsGenerator::initModificationMassesNA); indexed by @c NuXLAnnotatedHit::NA_mod_index.
+    @param[in]     fixed_modifications              Cached fixed-modification table consumed by @ref ModifiedPeptideGenerator.
+    @param[in]     variable_modifications           Cached variable-modification table consumed by @ref ModifiedPeptideGenerator.
+    @param[in]     max_variable_mods_per_peptide    Cap on the number of variable modifications placed per peptide.
+    @param[in]     fragment_mass_tolerance          Half-width of the fragment-alignment tolerance window.
+    @param[in]     fragment_mass_tolerance_unit_ppm Interpret @p fragment_mass_tolerance as ppm (true) or Da (false).
+    @param[in]     all_feasible_adducts             Per-precursor-adduct fragment-adduct definitions used to generate marker and shifted immonium ions.
+  */
   static void annotateAndLocate_(
-    const PeakMap& exp, 
+    const PeakMap& exp,
     std::vector<std::vector<NuXLAnnotatedHit>>& annotated_hits,
     const NuXLModificationMassesResult& mm,
-    const ModifiedPeptideGenerator::MapToResidueType& fixed_modifications, 
-    const ModifiedPeptideGenerator::MapToResidueType& variable_modifications, 
-    Size max_variable_mods_per_peptide, 
-    double fragment_mass_tolerance, 
-    bool fragment_mass_tolerance_unit_ppm, 
+    const ModifiedPeptideGenerator::MapToResidueType& fixed_modifications,
+    const ModifiedPeptideGenerator::MapToResidueType& variable_modifications,
+    Size max_variable_mods_per_peptide,
+    double fragment_mass_tolerance,
+    bool fragment_mass_tolerance_unit_ppm,
     const NuXLParameterParsing::PrecursorsToMS2Adducts & all_feasible_adducts);
 
 };


### PR DESCRIPTION
## Summary

\`NuXLAnnotateAndLocate\` had **zero documentation** — no class brief, no \`@ingroup\`, no method docs. The single static method \`annotateAndLocate_\` is the post-scoring annotation/localisation step of the OpenNuXL pipeline (called once per OpenNuXL run, expensive, OpenMP-parallelised). This PR adds a full Doxygen contract grounded against \`src/openms/source/ANALYSIS/NUXL/NuXLAnnotateAndLocate.cpp\`.

## Non-obvious behaviour surfaced

- **OpenMP parallelism**: \`#pragma omp parallel for\` over the scan dimension (\`cpp:327-329\`). Worth documenting because this is an internal helper with non-thread-safe writes — the per-scan independence is what makes the parallel iteration safe.
- **Re-application of modifications per hit**: upstream search stores only a \`peptide_mod_index\` into a vector built by \`ModifiedPeptideGenerator::applyVariableModifications\`. This method **rebuilds** the modified peptide list for every hit on demand to save memory (\`cpp:349-354\`). Useful to know — the cost scales with hit count × peptide mod-combinatorics.
- **Hardcoded \`TheoreticalSpectrumGenerator\` configuration** (\`cpp:312-326\`): b/a/y enabled, c/x/z/internal disabled, \`first_prefix_ion\` and \`metainfo\` enabled, \`abundant_immonium_ions\` / \`all_precursor_charges\` disabled and added **manually** by the NuXL fragment generator. The "added manually" detail explains why this disabled-then-manual pattern exists.
- **Localisation ties resolve to the last index**: \`best_localization\` lowercases every position that ties for the maximum site score, but \`best_localization_position\` is overwritten on each tie so the **last** tied index wins (\`cpp:800-803\`). The cpp itself has a \`// Note: check if there are situations where multiple have the same score\` warning — this is now in the docs.
- **Charge matching is enforced** during alignment; mismatched charges trigger \`OPENMS_LOG_WARN\` and the fragment is skipped (\`cpp:146\`).
- **Fallback on failed precursor adduct resolution**: \`best_localization = unmodified_sequence\`, \`best_localization_score = 0\` (\`cpp:343-344\`).
- **Trailing underscore on \`annotateAndLocate_\`**: historical artefact from the OpenNuXL feature branch; the method is still public.

## What I did NOT change

- No behaviour changes; no \`.cpp\` edits.
- Did not propose renaming \`annotateAndLocate_\` to drop the trailing underscore — would be an API change.
- Did not propose fixing the tie-resolution ambiguity in localisation — the cpp's own comment flags it; behaviour change needs a separate PR.

## Pre-push checks

- Diff scanned for Doxygen \`@ref\` / HTML-tag pitfalls (none).
- All 9 \`@param\` tags match the actual signature identifiers verbatim.

## Test plan

- [x] Every prose claim cross-checked against \`NuXLAnnotateAndLocate.cpp\` line ranges noted.
- [ ] CI \`Doxygen_Warning_test\` (Linux): no new warnings.
- [ ] No \`.cpp\` / test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for annotation and localization features with improved parameter descriptions and detailed explanations of process behavior, including alignment and fallback mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->