### PR TITLE
doc(MRMFeatureSelectorQMIP/Score): add proper @brief, replace TODO placeholder with grounded algorithm summary

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureSelector.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureSelector.h
@@ -236,20 +236,36 @@ private:
   };
 
   /**
-    Class used to select MRMFeatures based on relative retention time using a
-    quadratic mixed integer programming (QMIP) formulation.
-    The method is described in [TODO: update when published]
+    @brief @ref MRMFeatureSelector implementation that selects MRM features via a quadratic-programming formulation over relative retention time.
+
+    For each transition, considers neighbouring transitions inside
+    @ref MRMFeatureSelector::SelectorParameters::nn_threshold and adds locality-weighted
+    pairwise terms keyed on the expected retention-time delta. Per-feature score is
+    normalised by the @c nth root of the number of @c score_weights entries (with @c n
+    the number of weights) so multi-weight configurations don't dominate the QP.
+
+    Companion to @ref MRMFeatureSelectorScore (linear, no nearest-neighbour coupling).
+
+    @ingroup TargetedQuantitation
   */
   class OPENMS_DLLAPI MRMFeatureSelectorQMIP : public MRMFeatureSelector
   {
 public:
     /**
-      Set up the linear programming problem and solve it.
+      @brief Build the quadratic LP problem for @p time_to_name and write the names of selected features to @p result.
 
-      @param[in] time_to_name Pairs representing a mapping of retention times to transition names
-      @param[in] feature_name_map Transitions' names to their features objects
-      @param[out] result Transitions' names filtered out of the LP problem
-      @param[in] parameters Parameters
+      Uses @c LPWrapper with @c LPWrapper::MIN objective sense. For each transition,
+      registers one binary (or continuous, depending on
+      @ref MRMFeatureSelector::SelectorParameters::variable_type) variable per feature,
+      then for every neighbour within @c nn_threshold adds a locality-weighted pairwise
+      term keyed on the expected RT delta. After solving, every column whose value is
+      @c >= @c parameters.optimal_threshold contributes its name to @p result.
+      @p result is cleared on entry.
+
+      @param[in]  time_to_name      Pairs of (retention time, transition name); the order of this vector defines the neighbour sliding window.
+      @param[in]  feature_name_map  Transition name → its candidate features.
+      @param[out] result            Names of the selected features (one per column whose solver value clears @c optimal_threshold). Cleared on entry.
+      @param[in]  parameters        Algorithm parameters (@c nn_threshold, @c locality_weight, @c variable_type, @c score_weights, @c optimal_threshold, ...).
     */
     void optimize(
       const std::vector<std::pair<double, String>>& time_to_name,
@@ -260,20 +276,35 @@ public:
   };
 
   /**
-    Class used to select MRMFeatures based on a linear programming where each
-    possible transition is weighted by a user defined score (most often retention
-    time and peak intensity). The method is described in [TODO: update when published].
+    @brief @ref MRMFeatureSelector implementation that selects MRM features via a linear program with score-weighted per-feature variables.
+
+    Simpler than @ref MRMFeatureSelectorQMIP — no nearest-neighbour coupling, no
+    pairwise quadratic terms. Each transition contributes one binary (or continuous)
+    variable per candidate feature plus an equality constraint forcing exactly one
+    feature to be picked per transition (sum @c == @c 1). The objective is the sum of
+    per-feature scores produced by @c computeScore_ from
+    @ref MRMFeatureSelector::SelectorParameters::score_weights.
+
+    @ingroup TargetedQuantitation
   */
   class OPENMS_DLLAPI MRMFeatureSelectorScore : public MRMFeatureSelector
   {
 public:
     /**
-      Set up the linear programming problem and solve it.
+      @brief Build the linear program for @p time_to_name and write the names of selected features to @p result.
 
-      @param[in] time_to_name Pairs representing a mapping of retention times to transition names
-      @param[in] feature_name_map Transitions' names to their features objects
-      @param[out] result Transitions' names filtered out of the LP problem
-      @param[in] parameters Parameters
+      Uses @c LPWrapper with @c LPWrapper::MIN objective sense. For each transition,
+      registers one variable per candidate feature (binary or continuous, per
+      @c parameters.variable_type) scored by @c computeScore_, and adds a
+      @c DOUBLE_BOUNDED constraint with both bounds equal to @c 1.0 (i.e. exactly one
+      feature must be picked per transition). After solving, every column whose value
+      is @c >= @c parameters.optimal_threshold contributes its name to @p result.
+      @p result is cleared on entry.
+
+      @param[in]  time_to_name      Pairs of (retention time, transition name). Order is irrelevant — unlike the QMIP variant, no neighbour window is used.
+      @param[in]  feature_name_map  Transition name → its candidate features.
+      @param[out] result            Names of the selected features (one per column whose solver value clears @c optimal_threshold). Cleared on entry.
+      @param[in]  parameters        Algorithm parameters (@c variable_type, @c score_weights, @c optimal_threshold; @c nn_threshold and @c locality_weight are not consulted).
     */
     void optimize(
       const std::vector<std::pair<double, String>>& time_to_name,


### PR DESCRIPTION
## Summary

The two derived classes \`MRMFeatureSelectorQMIP\` and \`MRMFeatureSelectorScore\` both had:
- a bare class-level comment with no \`@brief\` tag — Doxygen used the implicit first sentence as the brief but the resulting entry started with the same generic wording for both classes, making them indistinguishable in the generated class list;
- a literal \`"[TODO: update when published]"\` stub instead of a description of the algorithm.

Replace both with grounded \`@brief\` tags that actually distinguish the two algorithms, and document what \`optimize()\` does on each. Every behaviour claim is verified against \`src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureSelector.cpp\`.

## Grounded contracts

### \`MRMFeatureSelectorQMIP::optimize\` (\`MRMFeatureSelector.cpp:116-...\`)
- **Nearest-neighbour coupling**: iterates a sliding window over \`[cnt1 - nn_threshold, cnt1 + nn_threshold + 1]\` (lines 129-130) and adds pairwise terms for each neighbour pair.
- **Locality weight**: when \`parameters.locality_weight\` is true, the pairwise term is scaled by \`1.0 / (nn_threshold - |delta_index| + 1)\` (line 167) — closer neighbours weigh more.
- **Multi-weight normalisation**: when \`parameters.score_weights.size() > 1\`, the per-feature score is raised to the \`1 / n\` power (lines 151-154) so multiple weights don't dominate the QP.
- LPWrapper objective sense: \`MIN\` (line 126).
- Output: every column with solver value \`>= optimal_threshold\` contributes its name to \`result\` (analogous to the Score variant's post-solve filter).

### \`MRMFeatureSelectorScore::optimize\` (\`MRMFeatureSelector.cpp:70-107\`)
- **No nearest-neighbour coupling**: \`nn_threshold\` and \`locality_weight\` are not consulted.
- **One variable per (transition, feature) pair**: registered with \`addVariable_\` (line 90); type chosen by \`parameters.variable_type\`.
- **Exactly-one constraint per transition**: a \`DOUBLE_BOUNDED\` constraint with both bounds set to \`1.0\` (line 96), forcing the LP to pick exactly one feature per transition.
- LPWrapper objective sense: \`MIN\` (line 80).
- Post-solve filter: every column with value \`>= optimal_threshold\` contributes its name to \`result\` (lines 100-106).
- \`result.clear()\` on entry (line 77).

Both \`optimize\` blocks now document the cleared-on-entry contract, the \`MIN\` objective sense, and the post-solve threshold filter. The QMIP doc explicitly flags that \`nn_threshold\` controls the sliding window; the Score doc explicitly states those parameters are ignored — both differences were silent in the previous doc.

## What I did NOT change

- No behaviour changes; no \`.cpp\` edits.
- Did not modify the parent \`MRMFeatureSelector\` class doc — it's already well-documented.
- Did not remove the test-friend \`MRMFeatureSelector_test\` class (it's an existing oddity of having a test fixture in the public header; out of scope for a docs PR).
- Did not add a citation to replace the original \`[TODO: update when published]\` reference — the publication info isn't recorded anywhere in the codebase I could find.

## Test plan

- [x] Every prose claim cross-checked against \`MRMFeatureSelector.cpp\` lines listed above.
- [x] Diff scanned for Doxygen \`@ref\` / HTML-tag pitfalls (only \`@ref X::Y\` scope-resolution patterns, which are known-safe false-positives in the scan).
- [ ] CI \`Doxygen_Warning_test\` (Linux): no new warnings.
- [ ] No \`.cpp\` / test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Improved internal documentation for MRM feature selection implementations with detailed explanations of mathematical formulations and algorithms.

---

*Note: This release contains no user-facing changes.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->