### PR TITLE
doc(TargetedSpectraExtractor::Comparator/BinnedSpectrumComparator): document the spectral-library scoring interface

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.h
@@ -147,10 +147,14 @@ public:
       /**
         @brief Bin @p spec with the configured bin parameters and score it against every entry of the cached library; keep only matches @c >= @p min_score.
 
-        @p scores is cleared on entry. The query spectrum is wrapped in a new
-        @c BinnedSpectrum with the current @c bin_size, @c peak_spread, and @c bin_offset
-        (no precursor m/z carried over) and then compared one-by-one against the cached
-        library bins via @ref BinnedSpectralContrastAngle.
+        The query spectrum is wrapped in a new @c BinnedSpectrum with the current
+        @c bin_size, @c peak_spread, and @c bin_offset (no precursor m/z carried over)
+        and then compared one-by-one against the cached library bins via
+        @ref BinnedSpectralContrastAngle.
+
+        @param[in]  spec      Query spectrum to bin and score.
+        @param[out] scores    Cleared on entry, then filled with @c (library_index, score) pairs for matches that clear the threshold; unsorted.
+        @param[in]  min_score Lower bound on the kept score (inclusive).
       */
       void generateScores (
         const MSSpectrum& spec,

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.h
@@ -85,21 +85,44 @@ public:
       double score = 0.0;
     };
 
+    /**
+      @brief Abstract base interface for spectral-library scoring strategies consumed by @ref matchSpectrum.
+
+      Implementations cache a reference library on @ref init and then score query spectra
+      against it via @ref generateScores. The scoring direction is "higher is better" — the
+      @ref matchSpectrum caller sorts the returned pairs by descending score and keeps the
+      top entries. Implementations are free to interpret the @c options map however they
+      see fit; the caller passes user-supplied parameters through verbatim.
+    */
     class OPENMS_DLLAPI Comparator
     {
     public:
       virtual ~Comparator() = default;
+      /**
+        @brief Score @p spec against every entry of the cached library; keep only matches @c >= @p min_score.
+
+        @param[in]  spec      Query spectrum.
+        @param[out] scores    @c (library_index, score) pairs for matches that clear the threshold; unsorted.
+        @param[in]  min_score Lower bound on the kept score (inclusive).
+      */
       virtual void generateScores(
         const MSSpectrum& spec,
         std::vector<std::pair<Size,double>>& scores,
         double min_score
       ) const = 0;
 
+      /**
+        @brief Load the reference library and (re)configure the comparator.
+
+        @param[in] library Reference spectra to score against in subsequent @ref generateScores calls.
+        @param[in] options Implementation-specific knobs. @ref BinnedSpectrumComparator consults @c "bin_size", @c "peak_spread", @c "bin_offset" — see its override for details.
+      */
       virtual void init(
         const std::vector<MSSpectrum>& library,
         const std::map<String,DataValue>& options
       ) = 0;
 
+      /// Return the reference library passed to the most recent @ref init call.
       const std::vector<MSSpectrum>& getLibrary() const
       {
         return library_;
@@ -109,10 +132,26 @@ public:
       std::vector<MSSpectrum> library_;
     };
 
+    /**
+      @brief @ref Comparator implementation that scores query spectra against the library using @ref BinnedSpectralContrastAngle on pre-binned spectra.
+
+      The reference library is binned exactly once at @ref init time and the cached
+      @c BinnedSpectrum objects are reused across @ref generateScores calls; only the
+      query spectrum is re-binned on each call. Bin parameters can be overridden through
+      the @c options map passed to @ref init.
+    */
     class OPENMS_DLLAPI BinnedSpectrumComparator : public Comparator
     {
     public:
       ~BinnedSpectrumComparator() override = default;
+      /**
+        @brief Bin @p spec with the configured bin parameters and score it against every entry of the cached library; keep only matches @c >= @p min_score.
+
+        @p scores is cleared on entry. The query spectrum is wrapped in a new
+        @c BinnedSpectrum with the current @c bin_size, @c peak_spread, and @c bin_offset
+        (no precursor m/z carried over) and then compared one-by-one against the cached
+        library bins via @ref BinnedSpectralContrastAngle.
+      */
       void generateScores (
         const MSSpectrum& spec,
         std::vector<std::pair<Size,double>>& scores,
@@ -131,6 +170,18 @@ public:
         }
       }
 
+      /**
+        @brief Cache @p library, pre-binning each spectrum with the current parameters, and apply any @c options overrides.
+
+        Honours three optional keys in @p options:
+          - @c "bin_size"    (double) — m/z bin width. Default @c 0.02 (suited for high-resolution data; the comment in the header lists @c 1.0 as the nominal-mass default).
+          - @c "peak_spread" (UInt)   — how many neighbour bins receive contributions from each peak. Default @c 0.
+          - @c "bin_offset"  (double) — m/z offset added to the bin boundaries. Default @c 0.0.
+
+        Both the inherited @c library_ vector and the internal @c bs_library_ vector of
+        @c BinnedSpectrum objects are cleared and rebuilt on every call. Emits one
+        @c OPENMS_LOG_INFO line reporting the loaded library size.
+      */
       void init(const std::vector<MSSpectrum>& library, const std::map<String,DataValue>& options) override;
 
     private:


### PR DESCRIPTION
## Summary

The two nested helper classes inside \`TargetedSpectraExtractor\` carried **no documentation at all**:
- \`Comparator\` — the abstract base interface for spectral-library scoring.
- \`BinnedSpectrumComparator\` — the only concrete override (delivered as part of OpenMS).

Both are public types intended for use by callers building custom comparator strategies; they should not have been undocumented. This PR adds grounded Doxygen contracts. Every behaviour claim is verified against \`src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp\`.

## Grounded contracts

### \`Comparator\` (abstract base)
- **Scoring direction is "higher is better"** — confirmed by \`matchSpectrum\` sorting descending and taking the first N (\`TargetedSpectraExtractor.cpp:749-757\`).
- **Cache-on-init / score-many-times pattern** — \`init\` populates the library cache; \`generateScores\` re-uses it across many query spectra.
- \`getLibrary\` simply returns the reference vector set by the latest \`init\`.
- The \`@p options\` map is implementation-defined; the new doc cross-references \`BinnedSpectrumComparator::init\` for the concrete keys.

### \`BinnedSpectrumComparator\` (concrete)
- **Pre-binning at init time**: the library is wrapped into \`BinnedSpectrum\` objects once and cached in \`bs_library_\`; only the **query** spectrum is re-binned on every \`generateScores\` call (visible in the inline impl at \`TargetedSpectraExtractor.h:123-131\`).
- **\`generateScores\` clears \`scores\` on entry** — surfaced explicitly.
- **\`init\` options**: \`"bin_size"\`, \`"peak_spread"\`, \`"bin_offset"\` are all **optional** (gated by \`options.count(...)\` checks at \`cpp:1110\`, \`1114\`, \`1118\`). Defaults: \`bin_size = 0.02\`, \`peak_spread = 0\`, \`bin_offset = 0.0\` (in-class initialisers in the header). The original comment hints at \`1.0\` and \`0.4\` as nominal-mass alternatives — preserved as a useful note.
- **Both \`library_\` and \`bs_library_\` are cleared and rebuilt on every \`init\` call** (\`cpp:1122-1128\`).
- **Side effect**: emits one \`OPENMS_LOG_INFO\` line reporting the loaded library size (\`cpp:1129\`).

The two classes are nested inside \`TargetedSpectraExtractor\`, which already carries \`@ingroup TargetedQuantitation\`, so no separate \`@ingroup\` is needed on the nested classes.

## What I did NOT change

- No behaviour changes; no \`.cpp\` edits.
- Did not change the inline implementation in the header.
- Did not propose making the implementation-defined \`options\` map type-safe (e.g. a struct) — that's an API change, out of scope for a docs PR.

## Pre-push checks

- Diff scanned for Doxygen \`@ref\` / HTML-tag pitfalls: clean.

## Test plan

- [x] Every prose claim cross-checked against \`TargetedSpectraExtractor.cpp\` lines listed above.
- [ ] CI \`Doxygen_Warning_test\` (Linux): no new warnings.
- [ ] No \`.cpp\` / test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public accessor to retrieve the active reference spectral library from library-scoring components to improve integration and inspection.

* **Documentation**
  * Expanded documentation for spectral-library comparators, clarifying caching and pre-binning behavior and which initialization options are honored.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->