### PR TITLE
doc(NuXLConstants): document the IntegerDataArray slot layout

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/NUXL/NuXLConstants.h
+++ b/src/openms/include/OpenMS/ANALYSIS/NUXL/NuXLConstants.h
@@ -21,11 +21,26 @@
 
 namespace OpenMS
 {
+/**
+  @brief Index positions of the per-peak @c IntegerDataArrays used by the OpenNuXL pipeline.
+
+  OpenNuXL annotates each @c MSSpectrum with a fixed layout of parallel
+  @c IntegerDataArrays: the array at slot @c i carries the data described by
+  @c IA_*_INDEX @c == @c i. Code that accesses these slots indexes them through
+  these constants so the layout stays consistent between the spectrum builders in
+  @c TOPP_OpenNuXL and the alignment / scoring helpers in
+  @ref NuXLAnnotateAndLocate.
+
+  @ingroup Analysis_ID
+*/
 class OPENMS_DLLAPI NuXLConstants
 {
   public:
+  /// IntegerDataArray slot holding the per-peak charge.
   static constexpr size_t IA_CHARGE_INDEX = 0;
+  /// IntegerDataArray slot holding the per-peak intensity rank (named @c "intensity_rank"; @c 0 marks the most intense peak, ascending).
   static constexpr size_t IA_RANK_INDEX = 1;
+  /// IntegerDataArray slot holding the length of the longest amino-acid de novo tag found in the spectrum (named @c "longest_tag"; a single-element array broadcast over the whole spectrum). Always @c 0 unless OpenNuXL is built with the @c CALCULATE_LONGEST_TAG macro defined.
   static constexpr size_t IA_DENOVO_TAG_INDEX = 2;
 };
 }


### PR DESCRIPTION
## Summary

\`NuXLConstants\` is a tiny constants-only class with three \`IA_*_INDEX\` slot indices. It carried **zero documentation** — the names alone don't communicate what they index, what data is at each slot, or under what conditions the slots are populated. To understand them I had to chase usages across \`NuXLAnnotateAndLocate.cpp\` and \`OpenNuXL.cpp\`.

This PR adds a class-level Doxygen brief describing it as the layout descriptor for OpenNuXL's per-peak \`IntegerDataArrays\`, plus a one-liner per constant grounded against the call sites that populate them.

## Grounded claims

- **\`IA_CHARGE_INDEX = 0\`** — per-peak charge. Populated by \`NuXLAnnotateAndLocate.cpp:54\` and consulted by alignment / matching code (\`cpp:144\`, \`cpp:150\`, \`cpp:382\`, ...).
- **\`IA_RANK_INDEX = 1\`** — per-peak intensity rank. Named \`"intensity_rank"\`. Populated by \`OpenNuXL.cpp:2927-2934\` after sorting indexes by descending intensity, so \`0\` marks the most intense peak.
- **\`IA_DENOVO_TAG_INDEX = 2\`** — length of the longest amino-acid de novo tag. Named \`"longest_tag"\`. Stored as a **single-element array broadcast over the whole spectrum** (\`OpenNuXL.cpp:2946-2954\`); the value is always \`0\` unless OpenNuXL is built with the \`CALCULATE_LONGEST_TAG\` macro defined (\`OpenNuXL.cpp:2949-2953\`).

Adds \`@ingroup Analysis_ID\` matching the rest of the NuXL family.

## What I did NOT change

- No behaviour changes; no \`.cpp\` edits.
- Did not propose enabling \`CALCULATE_LONGEST_TAG\` by default (the value is gated by a build-time macro for performance — out of scope).
- Did not propose renaming the constants to drop the \`IA_\` prefix (would be an API change across multiple files).

## Pre-push checks

- Diff scanned for Doxygen \`@ref\` / HTML-tag pitfalls: clean.

## Test plan

- [x] Every prose claim cross-checked against \`NuXLAnnotateAndLocate.cpp\` and \`OpenNuXL.cpp\` lines listed above.
- [ ] CI \`Doxygen_Warning_test\` (Linux): no new warnings.
- [ ] No \`.cpp\` / test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal documentation for analysis constants to clarify how array indices map to data meanings, improving code maintainability without affecting end-user functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->