### PR TITLE
doc(VersionInfo::VersionDetails): document parser, comparators, and sentinel

### DIFF
--- a/src/openms/include/OpenMS/CONCEPT/VersionInfo.h
+++ b/src/openms/include/OpenMS/CONCEPT/VersionInfo.h
@@ -37,34 +37,70 @@ namespace OpenMS
   {
 public:
 
+    /**
+      @brief Parsed semver-style version: @c major.minor.patch with an optional pre-release identifier.
+
+      Result type of @ref VersionInfo::getVersionStruct (and of @ref create when called with
+      a free-form version string). Default-constructed instances compare equal to
+      @ref EMPTY and represent both the "0.0.0 with no pre-release" version and the
+      parse-failure sentinel returned by @ref create.
+    */
     struct OPENMS_DLLAPI VersionDetails
     {
-      Int version_major = 0;
-      Int version_minor = 0;
-      Int version_patch = 0;
-      String pre_release_identifier;
+      Int version_major = 0;             ///< Major number ahead of the first @c '.'.
+      Int version_minor = 0;             ///< Minor number between the first and (optional) second @c '.'.
+      Int version_patch = 0;             ///< Patch number after the second @c '.'; left at @c 0 when the version string had only two components.
+      String pre_release_identifier;     ///< Pre-release suffix after a trailing @c '-' (everything to the end of the string); empty when no @c '-' is present.
 
+      /// Default-construct to @c 0.0.0 with an empty pre-release identifier (equivalent to @ref EMPTY).
       VersionDetails() = default;
 
-      /// Copy constructor
+      /// Copy constructor.
       VersionDetails(const VersionDetails & other) = default;
 
-      /// Copy assignment
+      /// Copy assignment.
       VersionDetails& operator=(const VersionDetails& other) = default;
 
       /**
-        @brief parse String and return as proper struct
+        @brief Parse a semver-style @c major[.minor[.patch[-pre_release]]] string into the struct.
 
-        @returns VersionInfo::empty on failure
+        Splits on @c '.' and the optional trailing @c '-':
+          - At least one @c '.' is required — strings without a dot return @ref EMPTY.
+          - The major number must parse as an integer.
+          - The minor number must parse as an integer; if no second @c '.' follows, @c patch
+            is left at @c 0 and parsing succeeds.
+          - The patch number must parse as an integer; if no trailing @c '-' is present,
+            @c pre_release_identifier is left empty and parsing succeeds.
+          - Everything after the trailing @c '-' (verbatim, no further parsing) becomes
+            @c pre_release_identifier.
+
+        Any integer conversion failure (caught @c OpenMS::Exception::ConversionError) yields
+        @ref EMPTY; the function does not propagate the exception.
+
+        @param[in] version Version string in @c "X.Y[.Z[-PRE]]" form.
+        @return Parsed struct on success, @ref EMPTY on any of the failure paths above.
       */
       static VersionDetails create(const String & version);
 
+      /**
+        @brief Compare two versions in @em descending pre-release order.
+
+        Compares lexicographically on @c (major, minor, patch). Tie-break on the pre-release
+        identifier follows the convention that "pre-release < release of the same triple",
+        but only checks presence — i.e. @c "1.0.0-alpha @c < @c 1.0.0" holds, while
+        @c "1.0.0-alpha @c < @c 1.0.0-beta" is @c false (both have a pre-release, so the
+        triples are compared as equal).
+      */
       bool operator<(const VersionDetails & rhs) const;
+      /// Field-wise equality on all four members, including string equality on the pre-release identifier.
       bool operator==(const VersionDetails & rhs) const;
+      /// Field-wise inequality (the logical negation of @ref operator==).
       bool operator!=(const VersionDetails & rhs) const;
+      /// Equivalent to @c !(*this @c < @c rhs @c || @c *this @c == @c rhs); inherits the @c operator< caveat about pre-release ties.
       bool operator>(const VersionDetails & rhs) const;
 
-      static const VersionDetails EMPTY; // 0.0.0 version for comparison
+      /// Sentinel @c 0.0.0 version used both as the default-constructed value and as the parse-failure return of @ref create.
+      static const VersionDetails EMPTY;
     };
 
     /// Return the build time of OpenMS

--- a/src/openms/include/OpenMS/CONCEPT/VersionInfo.h
+++ b/src/openms/include/OpenMS/CONCEPT/VersionInfo.h
@@ -62,7 +62,7 @@ public:
       VersionDetails& operator=(const VersionDetails& other) = default;
 
       /**
-        @brief Parse a semver-style @c major[.minor[.patch[-pre_release]]] string into the struct.
+        @brief Parse a semver-style @c "X.Y[.Z[-PRE]]" string into the struct.
 
         Splits on @c '.' and the optional trailing @c '-':
           - At least one @c '.' is required — strings without a dot return @ref EMPTY.
@@ -83,16 +83,15 @@ public:
       static VersionDetails create(const String & version);
 
       /**
-        @brief Compare two versions in @em descending pre-release order.
+        @brief Compare two versions lexicographically by (major, minor, patch).
 
-        Compares lexicographically on @c (major, minor, patch). Tie-break on the pre-release
-        identifier follows the convention that "pre-release < release of the same triple",
-        but only checks presence — i.e. @c "1.0.0-alpha @c < @c 1.0.0" holds, while
-        @c "1.0.0-alpha @c < @c 1.0.0-beta" is @c false (both have a pre-release, so the
-        triples are compared as equal).
+        Versions are compared lexicographically by the (major, minor, patch) triple. A version
+        with a pre-release identifier is considered less than the same triple without a pre-release
+        (e.g., \c 1.0.0-alpha \c < \c 1.0.0). When both sides have a pre-release identifier, the
+        triples are treated as equal for ordering (e.g., \c 1.0.0-alpha is not \c < \c 1.0.0-beta).
 
         @param[in] rhs Version to compare against.
-        @return @c true if @c *this is strictly less than @p rhs by the rule above.
+        @return \c true if \c *this is strictly less than @p rhs by the rule above.
       */
       bool operator<(const VersionDetails & rhs) const;
       /**

--- a/src/openms/include/OpenMS/CONCEPT/VersionInfo.h
+++ b/src/openms/include/OpenMS/CONCEPT/VersionInfo.h
@@ -90,13 +90,31 @@ public:
         but only checks presence — i.e. @c "1.0.0-alpha @c < @c 1.0.0" holds, while
         @c "1.0.0-alpha @c < @c 1.0.0-beta" is @c false (both have a pre-release, so the
         triples are compared as equal).
+
+        @param[in] rhs Version to compare against.
+        @return @c true if @c *this is strictly less than @p rhs by the rule above.
       */
       bool operator<(const VersionDetails & rhs) const;
-      /// Field-wise equality on all four members, including string equality on the pre-release identifier.
+      /**
+        @brief Field-wise equality on all four members, including string equality on the pre-release identifier.
+
+        @param[in] rhs Version to compare against.
+        @return @c true if every field of @c *this equals the corresponding field of @p rhs.
+      */
       bool operator==(const VersionDetails & rhs) const;
-      /// Field-wise inequality (the logical negation of @ref operator==).
+      /**
+        @brief Field-wise inequality (the logical negation of @ref operator==).
+
+        @param[in] rhs Version to compare against.
+        @return @c true if at least one field differs.
+      */
       bool operator!=(const VersionDetails & rhs) const;
-      /// Equivalent to @c !(*this @c < @c rhs @c || @c *this @c == @c rhs); inherits the @c operator< caveat about pre-release ties.
+      /**
+        @brief Equivalent to @c !(*this @c < @c rhs @c || @c *this @c == @c rhs); inherits the @c operator< caveat about pre-release ties.
+
+        @param[in] rhs Version to compare against.
+        @return @c true if @c *this is strictly greater than @p rhs.
+      */
       bool operator>(const VersionDetails & rhs) const;
 
       /// Sentinel @c 0.0.0 version used both as the default-constructed value and as the parse-failure return of @ref create.


### PR DESCRIPTION
## Summary

\`VersionInfo::VersionDetails\` is the parsed-semver result type returned by \`VersionInfo::getVersionStruct\` and the standalone \`create()\` parser. The outer \`VersionInfo\` class is well documented, but the nested struct carried:
- no class brief,
- no field briefs on its four data members,
- no operator docs,
- a one-line note on \`create()\` that just said *"parse String and return as proper struct"* with an unfinished sentence (*"returns VersionInfo::empty"*).

This PR replaces those with grounded Doxygen blocks. Every behaviour claim is verified against \`src/openms/source/CONCEPT/VersionInfo.cpp\`.

## Non-obvious behaviour surfaced

- **Parse-failure paths return \`EMPTY\` silently**: \`create()\` catches \`OpenMS::Exception::ConversionError\` at every integer conversion and returns the sentinel rather than re-throwing (\`VersionInfo.cpp:65-72\`, \`76-83\`, \`93-100\`). The old doc didn't mention exception handling at all.
- **\`X.Y\` (no second dot) succeeds** with \`version_patch = 0\` (\`cpp:86-89\`) — not documented previously.
- **Pre-release identifier is everything after the trailing \`-\` verbatim**, with no further parsing (\`cpp:107\`).
- **\`operator<\` pre-release tie-break is presence-only**: \`"1.0.0-alpha" < "1.0.0"\` is \`true\` (line 33's \`(!this->pre_release_identifier.empty() && rhs.pre_release_identifier.empty())\` check), but **\`"1.0.0-alpha" < "1.0.0-beta"\` is \`false\`** because both sides have a pre-release and the operator doesn't compare the strings. Semver would say true. Worth documenting because operators relying on this for "newer pre-release wins" will hit the surprise.
- **\`operator>\` inherits the same caveat** through its \`!(less || equal)\` definition.
- **\`EMPTY\`** doubles as the default-constructed value and the parse-failure sentinel — so equality with \`EMPTY\` is ambiguous (could mean "0.0.0 with no pre-release" or "failed to parse"). Worth documenting.

## What I did NOT change

- No behaviour changes; no \`.cpp\` edits.
- Did not propose fixing the pre-release tie-break to follow semver — that would change comparator semantics and could break downstream code.
- Did not propose splitting the parse-failure sentinel from the default value (e.g., via \`std::optional\`) — API change.

## Pre-push checks

- Diff scanned for Doxygen \`@ref\` / HTML-tag pitfalls: clean.

## Test plan

- [x] Every prose claim cross-checked against \`VersionInfo.cpp\` lines listed above.
- [ ] CI \`Doxygen_Warning_test\` (Linux): no new warnings.
- [ ] No \`.cpp\` / test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified semver-style version-string parsing rules and accepted formats.
  * Explained default/empty and parse-failure sentinel behavior for ambiguous inputs.
  * Expanded descriptions of version fields and the role of pre-release identifiers.
  * Clarified ordering and equality semantics for version comparisons, including pre-release handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->