### PR TITLE
doc(LogStreamNotifier): document the LogStream notification hook contract

### DIFF
--- a/src/openms/include/OpenMS/CONCEPT/LogStream.h
+++ b/src/openms/include/OpenMS/CONCEPT/LogStream.h
@@ -249,30 +249,61 @@ protected:
       //@}
     };
 
-    ///
+    /**
+      @brief Sink-side hook that is notified whenever a @ref LogStream flushes a complete message.
+
+      Subclass this and override @ref logNotify to react to log events programmatically.
+      Register the notifier at a @ref LogStream via @ref registerAt — the log stream then
+      treats the notifier's internal @c stream_ as one of its output sinks, writes each
+      flushed line into it, and invokes the override at the end of every message. Use
+      @ref stream_ inside @ref logNotify to read the formatted message body.
+
+      Lifecycle: @ref unregister is called automatically by the destructor (RAII); calling
+      @ref registerAt while already registered first detaches from the previous stream.
+
+      @ingroup Concept
+    */
     class OPENMS_DLLAPI LogStreamNotifier
     {
 public:
 
-      /// Empty constructor.
+      /// Construct a detached notifier; @c registered_at_ starts at @c nullptr.
       LogStreamNotifier();
 
-      /// Destructor
+      /// Destructor; calls @ref unregister so the @ref LogStream stops dispatching to this notifier.
       virtual ~LogStreamNotifier();
 
-      ///
+      /**
+        @brief Hook called by the registered @ref LogStream after each complete message has been flushed.
+
+        The default implementation is a no-op. Override in a subclass to react to log events
+        (read @ref stream_ to get the formatted message body).
+      */
       virtual void logNotify();
 
-      ///
+      /**
+        @brief Attach this notifier to @p log_stream so its @ref logNotify is invoked after every flushed message.
+
+        If this notifier is already registered at another stream, the prior registration is
+        released first (via @ref unregister). After the call, the @ref stream_ buffer is
+        added to @p log_stream's output list and tagged as the notification target.
+
+        @param[in,out] log_stream LogStream that will dispatch notifications to this notifier.
+      */
       void registerAt(LogStream & log_stream);
 
-      ///
+      /**
+        @brief Detach from the currently registered @ref LogStream, if any.
+
+        Removes @ref stream_ from the log stream's output list and resets @c registered_at_
+        to @c nullptr. No-op when the notifier is not currently registered.
+      */
       void unregister();
 
 protected:
-      std::stringstream stream_;
+      std::stringstream stream_;   ///< Buffer that receives the formatted log line from the registered @ref LogStream; read inside @ref logNotify.
 
-      LogStream * registered_at_;
+      LogStream * registered_at_;  ///< The @ref LogStream this notifier is currently attached to, or @c nullptr if detached. Managed by @ref registerAt / @ref unregister.
     };
 
 


### PR DESCRIPTION
## Summary

\`LogStreamNotifier\` carried **empty \`///\` briefs** on the class itself and on three of its public methods (\`logNotify\`, \`registerAt\`, \`unregister\`). It's a subclass-and-override notification hook for \`LogStream\` flush events, but without docs no caller can figure out how to use it from the header alone.

This PR replaces those with grounded Doxygen blocks. Every behaviour claim is verified against \`src/openms/source/CONCEPT/LogStream.cpp\`.

## Grounded contracts

- **\`logNotify\`** — base implementation is a no-op (\`LogStream.cpp:418-420\`). Subclasses override and read \`stream_\` to access the formatted message body. The dispatch site is \`LogStreamBuf::sync_\` at \`cpp:236-239\`, which writes the message to each registered sink and then calls the registered target's \`logNotify()\`.
- **\`registerAt\`** — calls \`unregister()\` first to release any prior registration (\`cpp:435\`), then sets \`registered_at_\` and calls \`LogStream::insertNotification\` which adds \`stream_\` to the log stream's output list and tags this notifier as the notification target (\`cpp:519-522\`).
- **\`unregister\`** — early-returns when \`registered_at_\` is \`nullptr\` (\`cpp:425-428\`), otherwise calls \`LogStream::remove\` on the buffer and clears the back-pointer.
- **Destructor** — calls \`unregister()\` so the \`LogStream\` stops dispatching to this notifier (RAII; \`cpp:413-416\`).
- **Constructor** — starts in detached state with \`registered_at_ = nullptr\` (\`cpp:408-411\`).

Per-field briefs added for \`stream_\` (formatted message buffer read inside the override) and \`registered_at_\` (the currently-attached \`LogStream\`, or \`nullptr\` when detached).

Class-level brief frames the lifecycle (RAII unregister; re-registration detaches the prior stream first) and cross-references \`LogStream\`.

Adds \`@ingroup Concept\` matching the surrounding \`LogStream\` class.

## What I did NOT change

- No behaviour changes; no \`.cpp\` edits.
- Did not redesign the notifier API to take a callback instead of requiring inheritance — out of scope for a docs PR.

## Pre-push checks

- Diff scanned for Doxygen \`@ref\` / HTML-tag pitfalls: clean.

## Test plan

- [x] Every prose claim cross-checked against \`LogStream.cpp\` lines listed above.
- [ ] CI \`Doxygen_Warning_test\` (Linux): no new warnings.
- [ ] No \`.cpp\` / test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for the LogStream notifier component, clarifying lifecycle management, attachment behavior, and message notification flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->