### PR TITLE
fix(SwathMapMassCorrection): remove leaked *new(SpectrumPtr) fallback

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/SwathMapMassCorrection.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/SwathMapMassCorrection.cpp
@@ -236,12 +236,12 @@ namespace OpenMS
         if (ms1_im_)
         {
           std::vector<OpenSwath::SpectrumPtr> fetchSpectrumArr = OpenSwathScoring().fetchSpectrumSwath(ms1_maps, bestRT, 1, im_range);
-          sp_ms1 = (!fetchSpectrumArr.empty()) ? fetchSpectrumArr[0] : *new(OpenSwath::SpectrumPtr);
+          sp_ms1 = (!fetchSpectrumArr.empty()) ? fetchSpectrumArr[0] : OpenSwath::SpectrumPtr();
         }
         else
         {
           std::vector<OpenSwath::SpectrumPtr> fetchSpectrumArr = OpenSwathScoring().fetchSpectrumSwath(used_maps, bestRT, 1, im_range);
-          sp_ms2 = (!fetchSpectrumArr.empty()) ? fetchSpectrumArr[0] : *new(OpenSwath::SpectrumPtr);
+          sp_ms2 = (!fetchSpectrumArr.empty()) ? fetchSpectrumArr[0] : OpenSwath::SpectrumPtr();
         }
       }
 
@@ -263,7 +263,7 @@ namespace OpenMS
         }
 
         // Check that the spectrum really has a drift time array
-        if (sp_ms2->getDriftTimeArray() == nullptr)
+        if (!sp_ms2 || sp_ms2->getDriftTimeArray() == nullptr)
         {
           OPENMS_LOG_DEBUG << "Did not find a drift time array for peptide " << pepref << " at RT " << bestRT  << '\n';
           for (const auto& m : used_maps)
@@ -350,7 +350,7 @@ namespace OpenMS
         im_range.minSpanIfSingular(im_extraction_win);
 
         // Check that the spectrum really has a drift time array
-        if (sp_ms1->getDriftTimeArray() == nullptr)
+        if (!sp_ms1 || sp_ms1->getDriftTimeArray() == nullptr)
         {
           OPENMS_LOG_DEBUG << "Did not find a drift time array for peptide " << pepref << " at RT " << bestRT  << '\n';
           for (const auto& m : used_maps)
@@ -537,7 +537,11 @@ namespace OpenMS
       // Get the spectrum for this RT and extract raw data points for all the
       // calibrating transitions (fragment m/z values) from the spectrum
       std::vector<OpenSwath::SpectrumPtr> spArr = OpenSwathScoring().fetchSpectrumSwath(used_maps, bestRT, 1, im_range);
-      OpenSwath::SpectrumPtr sp = (!spArr.empty()) ? spArr[0] : *new(OpenSwath::SpectrumPtr);
+      if (spArr.empty())
+      {
+        continue;
+      }
+      OpenSwath::SpectrumPtr sp = spArr[0];
       for (const auto& tr : transition_group->getTransitions())
       {
         double mz, intensity, im;


### PR DESCRIPTION
## Summary
- `*new(OpenSwath::SpectrumPtr)` in `SwathMapMassCorrection.cpp` heap-allocated a default-constructed `std::shared_ptr<Spectrum>`, dereferenced the raw pointer, copied the null `shared_ptr`, and never `delete`d the heap object — a small leak per empty-fetch fallback in a per-peptide loop.
- The same construct also yielded a **null** `shared_ptr` that the downstream `DIAHelpers::integrateWindow` / `sp->getDriftTimeArray()` calls would dereference (precondition violation in debug, null deref in release). The fallback wasn't actually safe — it just deferred the crash.
- Three call sites in this file were affected (introduced in #8743, Dec 2023). Note that the MS1 branch added later (line 578) already used the correct `OpenSwath::SpectrumPtr()` idiom — this PR brings the older sites in line.

## Changes
- `correctMZ`: when `fetchSpectrumSwath` returns empty, `continue` to the next transition group — mirrors the existing `used_maps.empty()` guard a few lines above.
- `correctIM`: replace `*new(OpenSwath::SpectrumPtr)` with a default-constructed `OpenSwath::SpectrumPtr()` for both `sp_ms1` and `sp_ms2`, and extend the two existing `getDriftTimeArray() == nullptr` guards to also check for a null `shared_ptr`.

## Test plan
- [x] `cmake --build OpenMS-build --target SwathMapMassCorrection_test` — builds clean
- [x] `ctest --test-dir OpenMS-build -R SwathMapMassCorrection_test` — passes (0.40s)
- [ ] CI green on full OpenSWATH test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect handling of missing spectrum data in SWATH-MS analysis operations, improving stability during spectrum processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->