### PR TITLE
Add frame ID range filter to BrukerTimsFile

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/BrukerTimsFile.h
+++ b/src/openms/include/OpenMS/FORMAT/BrukerTimsFile.h
@@ -12,6 +12,7 @@
 #include <OpenMS/INTERFACES/IMSDataConsumer.h>
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/SwathMap.h>
 #include <cstdint>
+#include <limits>
 #include <string>
 
 class TimsDataHandle;
@@ -55,6 +56,34 @@ namespace OpenMS
       bool load_ms1 = true;                ///< Load MS1 spectra. Disable (false) for MS2-only workflows
                                            ///< (peptide database search) where MS1 surveys are not needed —
                                            ///< cuts memory and time substantially. Affects all export modes.
+
+      /// Frame ID range filter (inclusive). Only frames with
+      /// frame_id_min <= Id <= frame_id_max are read; all peak data for frames
+      /// outside the range is skipped, so memory and I/O scale with the range,
+      /// not the file size. TIMS frame IDs are 1-based and dense; set
+      /// frame_id_min == frame_id_max to load a single frame. Defaults
+      /// (0, UINT32_MAX) load the full file. Honored by load(), transform(),
+      /// loadDIAStreaming(), and readDIAMetadata() in all export modes.
+      ///
+      /// Interplay with other knobs (all unchanged at default range):
+      /// - Frame aggregation (ms1_n_neighbors, dia_ms2_n_neighbors) sees only
+      ///   in-range frames, so the neighbor window clamps at the range
+      ///   boundaries the same way it clamps at the file boundaries.
+      ///   Aggregated frames near a boundary therefore use an asymmetric /
+      ///   truncated neighborhood. Widen the range by n_neighbors on each
+      ///   side if you need unbiased aggregation throughout.
+      /// - Centroiding (ms1_centroid_algo, ms2_centroid_algo) is per-frame
+      ///   and has no inter-frame coupling, so it is unaffected beyond
+      ///   processing fewer frames.
+      /// - DDA: a precursor whose source MS2 frames straddle the range
+      ///   boundary is reconstructed from the in-range subset only — the
+      ///   resulting MS2 spectrum is partial. A one-shot warning reports
+      ///   how many precursors were affected.
+      /// - DDA OLS m/z recalibration (calibrate=true) is fit only from
+      ///   in-range precursors. If too few survive (<2), the fit is skipped
+      ///   and the default calibration is used.
+      uint32_t frame_id_min = 0;
+      uint32_t frame_id_max = std::numeric_limits<uint32_t>::max();
 
       /// Centroiding algorithms for IM-PASEF frames.
       ///   - Off:       no IM-axis centroiding (raw detector peaks pass through).

--- a/src/openms/include/OpenMS/FORMAT/BrukerTimsFile.h
+++ b/src/openms/include/OpenMS/FORMAT/BrukerTimsFile.h
@@ -65,6 +65,11 @@ namespace OpenMS
       /// (0, UINT32_MAX) load the full file. Honored by load(), transform(),
       /// loadDIAStreaming(), and readDIAMetadata() in all export modes.
       ///
+      /// Combine with rt_min_sec/rt_max_sec to constrain by retention time
+      /// instead of (or in addition to) raw frame index — the RT range is
+      /// resolved to a frame_id range via SQL at load time and intersected
+      /// with frame_id_min/frame_id_max.
+      ///
       /// Interplay with other knobs (all unchanged at default range):
       /// - Frame aggregation (ms1_n_neighbors, dia_ms2_n_neighbors) sees only
       ///   in-range frames, so the neighbor window clamps at the range
@@ -84,6 +89,16 @@ namespace OpenMS
       ///   and the default calibration is used.
       uint32_t frame_id_min = 0;
       uint32_t frame_id_max = std::numeric_limits<uint32_t>::max();
+
+      /// Retention time range filter (inclusive, in seconds). Resolved to a
+      /// frame_id range at load time via SQL (frames whose Frames.Time falls
+      /// within [rt_min_sec, rt_max_sec]) and intersected with
+      /// frame_id_min/frame_id_max. TIMS frame IDs are monotonic in
+      /// acquisition time, so an RT range maps to a contiguous frame_id
+      /// sub-range. Defaults (0.0, +inf) impose no RT filter. All other
+      /// interplay caveats listed on frame_id_min apply identically.
+      double rt_min_sec = 0.0;
+      double rt_max_sec = std::numeric_limits<double>::infinity();
 
       /// Centroiding algorithms for IM-PASEF frames.
       ///   - Off:       no IM-axis centroiding (raw detector peaks pass through).

--- a/src/openms/source/FORMAT/BrukerTimsFile.cpp
+++ b/src/openms/source/FORMAT/BrukerTimsFile.cpp
@@ -700,6 +700,41 @@ namespace OpenMS
     spec.getFloatDataArrays().push_back(make(mz_upper, "m/z upper bound"));
   }
 
+  // Predicate for the Config::frame_id_min/frame_id_max filter. A default
+  // Config (0, UINT32_MAX) trivially matches every frame, so callers can
+  // gate every frame iteration on this without branching for the no-filter
+  // case.
+  static inline bool frameInRange(uint32_t fid, const BrukerTimsFile::Config& config)
+  {
+    return fid >= config.frame_id_min && fid <= config.frame_id_max;
+  }
+
+  // One-shot validation of the frame_id range against the file's actual frame
+  // bounds. Called from each top-level public entry point.
+  static void warnInvalidFrameRange(const BrukerTimsFile::Config& config,
+                                    uint32_t file_min, uint32_t file_max)
+  {
+    const bool range_set = (config.frame_id_min != 0) ||
+                           (config.frame_id_max != std::numeric_limits<uint32_t>::max());
+    if (!range_set) return;
+
+    if (config.frame_id_min > config.frame_id_max)
+    {
+      OPENMS_LOG_WARN << "Warning: BrukerTimsFile::Config::frame_id_min ("
+                      << config.frame_id_min << ") > frame_id_max ("
+                      << config.frame_id_max
+                      << "). No frames will be loaded." << std::endl;
+    }
+    else if (config.frame_id_max < file_min || config.frame_id_min > file_max)
+    {
+      OPENMS_LOG_WARN << "Warning: BrukerTimsFile::Config frame range ["
+                      << config.frame_id_min << ", " << config.frame_id_max
+                      << "] does not intersect file frame range ["
+                      << file_min << ", " << file_max
+                      << "]. No frames will be loaded." << std::endl;
+    }
+  }
+
   // Emit one-shot partial-config warnings for the MS1 aggregation knobs.
   // Called once per top-level load path, after ms1_frame_ids is populated.
   static void warnPartialMS1AggregationConfig(const BrukerTimsFile::Config& config,
@@ -1250,32 +1285,47 @@ namespace OpenMS
       uint32_t ms2 = 0;
     };
 
-    FrameCounts readFrameCounts(SQLite::Database& db)
+    FrameCounts readFrameCounts(SQLite::Database& db,
+                                const BrukerTimsFile::Config& config)
     {
       FrameCounts counts;
 
-      SQLite::Statement q_total(db, "SELECT COUNT(*) FROM Frames");
+      const std::string range_clause =
+        " WHERE Id >= " + std::to_string(config.frame_id_min) +
+        " AND Id <= " + std::to_string(config.frame_id_max);
+
+      SQLite::Statement q_total(db, "SELECT COUNT(*) FROM Frames" + range_clause);
       if (q_total.executeStep())
         counts.total = static_cast<uint32_t>(q_total.getColumn(0).getInt());
 
-      SQLite::Statement q_ms1(db, "SELECT COUNT(*) FROM Frames WHERE MsMsType = 0");
+      SQLite::Statement q_ms1(db,
+        "SELECT COUNT(*) FROM Frames" + range_clause + " AND MsMsType = 0");
       if (q_ms1.executeStep())
         counts.ms1 = static_cast<uint32_t>(q_ms1.getColumn(0).getInt());
 
       // MS2 = everything that is not MS1 (MsMsType != 0)
-      SQLite::Statement q_ms2(db, "SELECT COUNT(*) FROM Frames WHERE MsMsType != 0");
+      SQLite::Statement q_ms2(db,
+        "SELECT COUNT(*) FROM Frames" + range_clause + " AND MsMsType != 0");
       if (q_ms2.executeStep())
         counts.ms2 = static_cast<uint32_t>(q_ms2.getColumn(0).getInt());
 
       return counts;
     }
 
-    // Count distinct precursors (for DDA MS2 spectrum count)
-    uint32_t countDDAPrecursors(SQLite::Database& db)
+    // Count MS2 spectra that loadDDA_ will emit under the active frame range:
+    // one spectrum per distinct precursor that still has at least one
+    // PasefFrameMsMsInfo row pointing at an in-range MS2 frame. With the
+    // default range [0, UINT32_MAX] this reduces to "every distinct
+    // precursor", matching the legacy behavior.
+    uint32_t countDDAPrecursors(SQLite::Database& db,
+                                const BrukerTimsFile::Config& config)
     {
       try
       {
-        SQLite::Statement q(db, "SELECT COUNT(*) FROM Precursors");
+        SQLite::Statement q(db,
+          "SELECT COUNT(DISTINCT Precursor) FROM PasefFrameMsMsInfo"
+          " WHERE Frame >= " + std::to_string(config.frame_id_min) +
+          " AND Frame <= " + std::to_string(config.frame_id_max));
         if (q.executeStep())
           return static_cast<uint32_t>(q.getColumn(0).getInt());
       }
@@ -1781,15 +1831,27 @@ namespace OpenMS
         false);                            // ms1 = false
     }
 
+    warnInvalidFrameRange(config, handle->min_frame_id(), handle->max_frame_id());
+
     // Count MS1 frames
     for (uint32_t fid = handle->min_frame_id(); fid <= handle->max_frame_id(); ++fid)
     {
+      if (!frameInRange(fid, config)) continue;
       if (handle->has_frame(fid) && handle->get_frame(fid).msms_type == 0)
         ++meta.nr_ms1_spectra;
     }
 
-    // Count MS2 spectra per window (= frames per WindowGroup)
+    // Count MS2 spectra per window (= frames per WindowGroup).
+    // Apply the frame range filter so counts match what loadDIAStreaming
+    // will actually emit (CachedSwathFileConsumer sizing depends on it).
     auto group_to_frames = readFrameToWindowGroupMapping(db, windows);
+    for (auto& [group, frame_ids] : group_to_frames)
+    {
+      frame_ids.erase(
+        std::remove_if(frame_ids.begin(), frame_ids.end(),
+                       [&config](uint32_t fid) { return !frameInRange(fid, config); }),
+        frame_ids.end());
+    }
     meta.nr_ms2_spectra.reserve(windows.size());
     for (const auto& w : windows)
     {
@@ -1816,6 +1878,8 @@ namespace OpenMS
     String tdf_path = handle->get_tims_dir_path() + "/analysis.tdf";
     SQLite::Database db(std::string(tdf_path), SQLite::OPEN_READONLY);
 
+    warnInvalidFrameRange(config, handle->min_frame_id(), handle->max_frame_id());
+
     // --- MS1 frames ---
     FrameCentroider centroider;
     FrameAggregator ms1_aggregator(0.01);
@@ -1823,6 +1887,7 @@ namespace OpenMS
     std::vector<uint32_t> ms1_frame_ids;
     for (uint32_t fid = handle->min_frame_id(); fid <= handle->max_frame_id(); ++fid)
     {
+      if (!frameInRange(fid, config)) continue;
       if (handle->has_frame(fid) && handle->get_frame(fid).msms_type == 0)
         ms1_frame_ids.push_back(fid);
     }
@@ -1867,6 +1932,13 @@ namespace OpenMS
     }
 
     auto group_to_frames = readFrameToWindowGroupMapping(db, windows);
+    for (auto& [group, frame_ids] : group_to_frames)
+    {
+      frame_ids.erase(
+        std::remove_if(frame_ids.begin(), frame_ids.end(),
+                       [&config](uint32_t fid) { return !frameInRange(fid, config); }),
+        frame_ids.end());
+    }
 
     std::map<int, std::vector<const DIAWindow*>> group_to_windows;
     for (const auto& w : windows)
@@ -1966,6 +2038,8 @@ namespace OpenMS
     exp.clear(true);
     auto handle = openTimsDataHandle(path, config);
 
+    warnInvalidFrameRange(config, handle->min_frame_id(), handle->max_frame_id());
+
     String tdf_path = path + "/analysis.tdf";
     bool is_dia = isDIA_(tdf_path);
     Config::ExportMode mode = config.export_mode;
@@ -2002,6 +2076,8 @@ namespace OpenMS
   {
     auto handle = openTimsDataHandle(path, config);
 
+    warnInvalidFrameRange(config, handle->min_frame_id(), handle->max_frame_id());
+
     String tdf_path = path + "/analysis.tdf";
     SQLite::Database db(std::string(tdf_path), SQLite::OPEN_READONLY);
 
@@ -2009,8 +2085,8 @@ namespace OpenMS
     Config::ExportMode mode = config.export_mode;
 
     // Compute expected size for consumer. Must mirror what loadFrames_/loadDIA_/
-    // loadDDA_ actually emit, which skip MS1 entirely when load_ms1=false.
-    FrameCounts counts = readFrameCounts(db);
+    // loadDDA_ actually emit under the active frame_id range and load_ms1 knob.
+    FrameCounts counts = readFrameCounts(db, config);
     const size_t ms1_emitted = config.load_ms1 ? counts.ms1 : 0;
     size_t expected = 0;
     if (mode == Config::FRAME)
@@ -2026,6 +2102,13 @@ namespace OpenMS
       // loadDIA_.
       auto windows = readDIAWindows(db, *handle->scan2inv_ion_mobility_converter);
       auto group_to_frames = readFrameToWindowGroupMapping(db, windows);
+      for (auto& [group, frame_ids] : group_to_frames)
+      {
+        frame_ids.erase(
+          std::remove_if(frame_ids.begin(), frame_ids.end(),
+                         [&config](uint32_t fid) { return !frameInRange(fid, config); }),
+          frame_ids.end());
+      }
       std::map<int, size_t> group_window_count;
       for (const auto& w : windows) ++group_window_count[w.window_group];
       size_t dia_ms2_spectra = 0;
@@ -2040,7 +2123,7 @@ namespace OpenMS
     else
     {
       // DDA: MS1 frames + per-precursor MS2 spectra
-      uint32_t num_precursors = countDDAPrecursors(db);
+      uint32_t num_precursors = countDDAPrecursors(db, config);
       expected = ms1_emitted + num_precursors;
     }
 
@@ -2084,6 +2167,7 @@ namespace OpenMS
 
     for (uint32_t fid = handle.min_frame_id(); fid <= handle.max_frame_id(); ++fid)
     {
+      if (!frameInRange(fid, config)) continue;
       if (!handle.has_frame(fid)) continue;
       TimsFrame& frame = handle.get_frame(fid);
       if (frame.msms_type == 0)
@@ -2093,8 +2177,57 @@ namespace OpenMS
     }
     warnPartialMS1AggregationConfig(config, ms1_frame_ids.size());
 
-    // Read DDA precursors from SQL
+    // Read DDA precursors from SQL. Drop entries whose MS2 frame is outside
+    // the active range so the per-precursor MS2 spectra match what the
+    // ms2_frame_ids filter selected above; the existing has_frame() safety
+    // checks in the loops downstream silently skip any orphans, but stripping
+    // them here keeps progress counts and the precursor_groups loop honest.
     std::vector<DDAPrecursorInfo> precursor_entries = readDDAPrecursors(db);
+    const bool range_active =
+      (config.frame_id_min != 0) ||
+      (config.frame_id_max != std::numeric_limits<uint32_t>::max());
+    if (range_active)
+    {
+      // Tally how many distinct precursors had at least one source MS2 frame
+      // dropped by the range filter (= partial reconstruction). One-shot
+      // warning at the end so the user knows the reconstruction is partial
+      // at the range boundaries.
+      std::map<int, std::pair<size_t, size_t>> per_pid_kept_dropped;  // pid -> (kept, dropped)
+      for (const auto& e : precursor_entries)
+      {
+        auto& kd = per_pid_kept_dropped[e.precursor_id];
+        if (frameInRange(e.frame_id, config)) ++kd.first;
+        else                                   ++kd.second;
+      }
+      size_t partial = 0;
+      size_t fully_dropped = 0;
+      for (const auto& [pid, kd] : per_pid_kept_dropped)
+      {
+        if (kd.first == 0)                      ++fully_dropped;
+        else if (kd.second > 0)                 ++partial;
+      }
+      if (partial > 0)
+      {
+        OPENMS_LOG_WARN << "Warning: " << partial
+                        << " DDA precursor(s) had source MS2 frames outside the active "
+                        << "frame range [" << config.frame_id_min << ", "
+                        << config.frame_id_max << "]; their MS2 spectra will be "
+                        << "reconstructed from the in-range subset only (partial "
+                        << "spectra). Widen the range to avoid this." << std::endl;
+      }
+      if (fully_dropped > 0)
+      {
+        OPENMS_LOG_INFO << fully_dropped
+                        << " DDA precursor(s) fully outside the active frame range "
+                        << "were skipped." << std::endl;
+      }
+    }
+    precursor_entries.erase(
+      std::remove_if(precursor_entries.begin(), precursor_entries.end(),
+                     [&config](const DDAPrecursorInfo& e) {
+                       return !frameInRange(e.frame_id, config);
+                     }),
+      precursor_entries.end());
 
     // Group by precursor ID
     std::map<int, std::vector<const DDAPrecursorInfo*>> precursor_groups;
@@ -2630,6 +2763,7 @@ namespace OpenMS
 
     for (uint32_t fid = handle.min_frame_id(); fid <= handle.max_frame_id(); ++fid)
     {
+      if (!frameInRange(fid, config)) continue;
       if (!handle.has_frame(fid)) continue;
       TimsFrame& frame = handle.get_frame(fid);
       if (frame.msms_type == 0)
@@ -2677,6 +2811,13 @@ namespace OpenMS
     // to exactly one WindowGroup, so we only produce spectra for valid
     // frame/window combinations (not the brute-force frames × all_windows).
     auto group_to_frames = readFrameToWindowGroupMapping(db, windows);
+    for (auto& [group, frame_ids] : group_to_frames)
+    {
+      frame_ids.erase(
+        std::remove_if(frame_ids.begin(), frame_ids.end(),
+                       [&config](uint32_t fid) { return !frameInRange(fid, config); }),
+        frame_ids.end());
+    }
 
     // Group DIAWindows by window_group
     std::map<int, std::vector<const DIAWindow*>> group_to_windows;
@@ -3010,6 +3151,7 @@ namespace OpenMS
       std::vector<uint32_t> frame_ids;
       for (uint32_t fid = handle.min_frame_id(); fid <= handle.max_frame_id(); ++fid)
       {
+        if (!frameInRange(fid, config)) continue;
         if (!handle.has_frame(fid)) continue;
         TimsFrame& frame = handle.get_frame(fid);
         if ((level == 1 && frame.msms_type == 0) ||

--- a/src/openms/source/FORMAT/BrukerTimsFile.cpp
+++ b/src/openms/source/FORMAT/BrukerTimsFile.cpp
@@ -709,30 +709,99 @@ namespace OpenMS
     return fid >= config.frame_id_min && fid <= config.frame_id_max;
   }
 
-  // One-shot validation of the frame_id range against the file's actual frame
-  // bounds. Called from each top-level public entry point.
-  static void warnInvalidFrameRange(const BrukerTimsFile::Config& config,
-                                    uint32_t file_min, uint32_t file_max)
+  // One-shot validation of the frame_id and RT ranges against the file's
+  // actual frame bounds + RT resolution. Called from each top-level public
+  // entry point. Returns an effective Config in which frame_id_min/max have
+  // been narrowed to the intersection of:
+  //   - the user-supplied frame_id range
+  //   - the frame_id range derived from the user-supplied RT range
+  //     (SELECT MIN/MAX Id FROM Frames WHERE Time IN [rt_min, rt_max])
+  // so downstream code only needs to honor frame_id_min/frame_id_max.
+  // Emits warnings for inverted or fully-out-of-bounds ranges.
+  static BrukerTimsFile::Config resolveEffectiveConfig(
+      SQLite::Database& db,
+      const BrukerTimsFile::Config& config,
+      uint32_t file_min, uint32_t file_max)
   {
-    const bool range_set = (config.frame_id_min != 0) ||
-                           (config.frame_id_max != std::numeric_limits<uint32_t>::max());
-    if (!range_set) return;
+    BrukerTimsFile::Config eff = config;
 
-    if (config.frame_id_min > config.frame_id_max)
+    // --- 1) Validate frame_id range ---
+    const bool fid_set = (config.frame_id_min != 0) ||
+                         (config.frame_id_max != std::numeric_limits<uint32_t>::max());
+    if (fid_set)
     {
-      OPENMS_LOG_WARN << "Warning: BrukerTimsFile::Config::frame_id_min ("
-                      << config.frame_id_min << ") > frame_id_max ("
-                      << config.frame_id_max
+      if (config.frame_id_min > config.frame_id_max)
+      {
+        OPENMS_LOG_WARN << "Warning: BrukerTimsFile::Config::frame_id_min ("
+                        << config.frame_id_min << ") > frame_id_max ("
+                        << config.frame_id_max
+                        << "). No frames will be loaded." << std::endl;
+      }
+      else if (config.frame_id_max < file_min || config.frame_id_min > file_max)
+      {
+        OPENMS_LOG_WARN << "Warning: BrukerTimsFile::Config frame range ["
+                        << config.frame_id_min << ", " << config.frame_id_max
+                        << "] does not intersect file frame range ["
+                        << file_min << ", " << file_max
+                        << "]. No frames will be loaded." << std::endl;
+      }
+    }
+
+    // --- 2) Validate and resolve RT range ---
+    const bool rt_set = (config.rt_min_sec > 0.0) ||
+                        std::isfinite(config.rt_max_sec);
+    if (!rt_set) return eff;
+
+    if (config.rt_min_sec > config.rt_max_sec)
+    {
+      OPENMS_LOG_WARN << "Warning: BrukerTimsFile::Config::rt_min_sec ("
+                      << config.rt_min_sec << ") > rt_max_sec ("
+                      << config.rt_max_sec
                       << "). No frames will be loaded." << std::endl;
+      // Force the effective frame_id range empty so downstream loops produce 0 spectra.
+      eff.frame_id_min = 1;
+      eff.frame_id_max = 0;
+      return eff;
     }
-    else if (config.frame_id_max < file_min || config.frame_id_min > file_max)
+
+    try
     {
-      OPENMS_LOG_WARN << "Warning: BrukerTimsFile::Config frame range ["
-                      << config.frame_id_min << ", " << config.frame_id_max
-                      << "] does not intersect file frame range ["
-                      << file_min << ", " << file_max
-                      << "]. No frames will be loaded." << std::endl;
+      // TIMS frame IDs are monotonic in acquisition time, so the matching
+      // (MIN Id, MAX Id) is a contiguous range. Use an inclusive
+      // Time filter; if the user's max is +inf, the comparison still works
+      // (SQLite stores doubles natively).
+      SQLite::Statement q(db,
+        "SELECT MIN(Id), MAX(Id) FROM Frames WHERE Time >= ? AND Time <= ?");
+      q.bind(1, config.rt_min_sec);
+      q.bind(2, std::isfinite(config.rt_max_sec)
+                  ? config.rt_max_sec
+                  : std::numeric_limits<double>::max());
+
+      if (q.executeStep() && !q.getColumn(0).isNull())
+      {
+        const uint32_t rt_fid_min = static_cast<uint32_t>(q.getColumn(0).getInt());
+        const uint32_t rt_fid_max = static_cast<uint32_t>(q.getColumn(1).getInt());
+        eff.frame_id_min = std::max(eff.frame_id_min, rt_fid_min);
+        eff.frame_id_max = std::min(eff.frame_id_max, rt_fid_max);
+      }
+      else
+      {
+        // No frame's Time falls in the user's RT range — produce empty output.
+        OPENMS_LOG_WARN << "Warning: BrukerTimsFile::Config RT range ["
+                        << config.rt_min_sec << ", " << config.rt_max_sec
+                        << "] s does not intersect any frame's acquisition "
+                        << "time. No frames will be loaded." << std::endl;
+        eff.frame_id_min = 1;
+        eff.frame_id_max = 0;
+      }
     }
+    catch (const SQLite::Exception& ex)
+    {
+      OPENMS_LOG_WARN << "Warning: failed to resolve RT range via SQL: "
+                      << ex.what() << ". RT filter will be ignored." << std::endl;
+    }
+
+    return eff;
   }
 
   // Emit one-shot partial-config warnings for the MS1 aggregation knobs.
@@ -1831,12 +1900,14 @@ namespace OpenMS
         false);                            // ms1 = false
     }
 
-    warnInvalidFrameRange(config, handle->min_frame_id(), handle->max_frame_id());
+    const auto eff = resolveEffectiveConfig(db, config,
+                                             handle->min_frame_id(),
+                                             handle->max_frame_id());
 
     // Count MS1 frames
     for (uint32_t fid = handle->min_frame_id(); fid <= handle->max_frame_id(); ++fid)
     {
-      if (!frameInRange(fid, config)) continue;
+      if (!frameInRange(fid, eff)) continue;
       if (handle->has_frame(fid) && handle->get_frame(fid).msms_type == 0)
         ++meta.nr_ms1_spectra;
     }
@@ -1849,7 +1920,7 @@ namespace OpenMS
     {
       frame_ids.erase(
         std::remove_if(frame_ids.begin(), frame_ids.end(),
-                       [&config](uint32_t fid) { return !frameInRange(fid, config); }),
+                       [&eff](uint32_t fid) { return !frameInRange(fid, eff); }),
         frame_ids.end());
     }
     meta.nr_ms2_spectra.reserve(windows.size());
@@ -1878,7 +1949,9 @@ namespace OpenMS
     String tdf_path = handle->get_tims_dir_path() + "/analysis.tdf";
     SQLite::Database db(std::string(tdf_path), SQLite::OPEN_READONLY);
 
-    warnInvalidFrameRange(config, handle->min_frame_id(), handle->max_frame_id());
+    const auto eff = resolveEffectiveConfig(db, config,
+                                             handle->min_frame_id(),
+                                             handle->max_frame_id());
 
     // --- MS1 frames ---
     FrameCentroider centroider;
@@ -1887,27 +1960,27 @@ namespace OpenMS
     std::vector<uint32_t> ms1_frame_ids;
     for (uint32_t fid = handle->min_frame_id(); fid <= handle->max_frame_id(); ++fid)
     {
-      if (!frameInRange(fid, config)) continue;
+      if (!frameInRange(fid, eff)) continue;
       if (handle->has_frame(fid) && handle->get_frame(fid).msms_type == 0)
         ms1_frame_ids.push_back(fid);
     }
-    warnPartialMS1AggregationConfig(config, ms1_frame_ids.size());
-    if (config.ms1_n_neighbors > 0) ms1_aggregator.reserve(300'000);
+    warnPartialMS1AggregationConfig(eff, ms1_frame_ids.size());
+    if (eff.ms1_n_neighbors > 0) ms1_aggregator.reserve(300'000);
 
-    const size_t ms1_to_emit = config.load_ms1 ? ms1_frame_ids.size() : 0;
+    const size_t ms1_to_emit = eff.load_ms1 ? ms1_frame_ids.size() : 0;
     startProgress(0, ms1_to_emit, "Streaming DIA-PASEF MS1 frames");
     for (size_t i = 0; i < ms1_to_emit; ++i)
     {
       MSSpectrum spec;
-      if (config.ms1_n_neighbors > 0)
+      if (eff.ms1_n_neighbors > 0)
       {
-        loadAggregatedMS1Spectrum(*handle, ms1_frame_ids, i, config,
+        loadAggregatedMS1Spectrum(*handle, ms1_frame_ids, i, eff,
                                   ms1_aggregator, centroider, spec);
       }
       else
       {
         TimsFrame& frame = handle->get_frame(ms1_frame_ids[i]);
-        loadMS1Spectrum(frame, spec, config, centroider);
+        loadMS1Spectrum(frame, spec, eff, centroider);
       }
       // Sort peaks by m/z (and the associated IM float data array alongside).
       // TIMS save_to_buffs returns peaks in (scan_id, m/z-within-scan) order,
@@ -1921,7 +1994,7 @@ namespace OpenMS
       setProgress(i);
     }
     endProgress();
-    centroider.reportCapSummary(static_cast<size_t>(config.ms1_centroid_max_peaks));
+    centroider.reportCapSummary(static_cast<size_t>(eff.ms1_centroid_max_peaks));
 
     // --- MS2 frames: raw per-WindowGroup iteration (no aggregation) ---
     auto windows = readDIAWindows(db, *handle->scan2inv_ion_mobility_converter);
@@ -1936,7 +2009,7 @@ namespace OpenMS
     {
       frame_ids.erase(
         std::remove_if(frame_ids.begin(), frame_ids.end(),
-                       [&config](uint32_t fid) { return !frameInRange(fid, config); }),
+                       [&eff](uint32_t fid) { return !frameInRange(fid, eff); }),
         frame_ids.end());
     }
 
@@ -2038,23 +2111,32 @@ namespace OpenMS
     exp.clear(true);
     auto handle = openTimsDataHandle(path, config);
 
-    warnInvalidFrameRange(config, handle->min_frame_id(), handle->max_frame_id());
-
     String tdf_path = path + "/analysis.tdf";
+
+    // Resolve RT range (if any) to an effective frame_id range; also
+    // validates the user-supplied frame_id/rt ranges and emits warnings.
+    Config eff;
+    {
+      SQLite::Database db(std::string(tdf_path), SQLite::OPEN_READONLY);
+      eff = resolveEffectiveConfig(db, config,
+                                    handle->min_frame_id(),
+                                    handle->max_frame_id());
+    }
+
     bool is_dia = isDIA_(tdf_path);
-    Config::ExportMode mode = config.export_mode;
+    Config::ExportMode mode = eff.export_mode;
 
     if (mode == Config::FRAME)
     {
-      loadFrames_(*handle, exp, config);
+      loadFrames_(*handle, exp, eff);
     }
     else if (mode == Config::SPECTRUM || (mode == Config::AUTO && !is_dia))
     {
-      loadDDA_(*handle, exp, config);
+      loadDDA_(*handle, exp, eff);
     }
     else // AUTO + DIA
     {
-      loadDIA_(*handle, exp, config);
+      loadDIA_(*handle, exp, eff);
     }
 
     loadExperimentalSettings_(path, exp);
@@ -2076,18 +2158,20 @@ namespace OpenMS
   {
     auto handle = openTimsDataHandle(path, config);
 
-    warnInvalidFrameRange(config, handle->min_frame_id(), handle->max_frame_id());
-
     String tdf_path = path + "/analysis.tdf";
     SQLite::Database db(std::string(tdf_path), SQLite::OPEN_READONLY);
 
+    const auto eff = resolveEffectiveConfig(db, config,
+                                             handle->min_frame_id(),
+                                             handle->max_frame_id());
+
     bool is_dia = isDIA(db);
-    Config::ExportMode mode = config.export_mode;
+    Config::ExportMode mode = eff.export_mode;
 
     // Compute expected size for consumer. Must mirror what loadFrames_/loadDIA_/
     // loadDDA_ actually emit under the active frame_id range and load_ms1 knob.
-    FrameCounts counts = readFrameCounts(db, config);
-    const size_t ms1_emitted = config.load_ms1 ? counts.ms1 : 0;
+    FrameCounts counts = readFrameCounts(db, eff);
+    const size_t ms1_emitted = eff.load_ms1 ? counts.ms1 : 0;
     size_t expected = 0;
     if (mode == Config::FRAME)
     {
@@ -2106,7 +2190,7 @@ namespace OpenMS
       {
         frame_ids.erase(
           std::remove_if(frame_ids.begin(), frame_ids.end(),
-                         [&config](uint32_t fid) { return !frameInRange(fid, config); }),
+                         [&eff](uint32_t fid) { return !frameInRange(fid, eff); }),
           frame_ids.end());
       }
       std::map<int, size_t> group_window_count;
@@ -2123,7 +2207,7 @@ namespace OpenMS
     else
     {
       // DDA: MS1 frames + per-precursor MS2 spectra
-      uint32_t num_precursors = countDDAPrecursors(db, config);
+      uint32_t num_precursors = countDDAPrecursors(db, eff);
       expected = ms1_emitted + num_precursors;
     }
 
@@ -2140,11 +2224,11 @@ namespace OpenMS
     OPENMS_LOG_INFO << "BrukerTimsFile::transform(): loading full dataset (streaming optimization pending)" << std::endl;
     MSExperiment exp;
     if (mode == Config::FRAME)
-      loadFrames_(*handle, exp, config);
+      loadFrames_(*handle, exp, eff);
     else if (is_dia && mode != Config::SPECTRUM)
-      loadDIA_(*handle, exp, config);
+      loadDIA_(*handle, exp, eff);
     else
-      loadDDA_(*handle, exp, config);
+      loadDDA_(*handle, exp, eff);
 
     exp.sortSpectra(true);
     for (auto& spec : exp)

--- a/src/openms/source/FORMAT/BrukerTimsFile.cpp
+++ b/src/openms/source/FORMAT/BrukerTimsFile.cpp
@@ -781,8 +781,20 @@ namespace OpenMS
       {
         const uint32_t rt_fid_min = static_cast<uint32_t>(q.getColumn(0).getInt());
         const uint32_t rt_fid_max = static_cast<uint32_t>(q.getColumn(1).getInt());
+        // Save pre-intersection values to detect disjoint ranges
+        const uint32_t pre_min = eff.frame_id_min;
+        const uint32_t pre_max = eff.frame_id_max;
         eff.frame_id_min = std::max(eff.frame_id_min, rt_fid_min);
         eff.frame_id_max = std::min(eff.frame_id_max, rt_fid_max);
+        // Check if the intersection resulted in an empty range
+        if (pre_min <= pre_max && eff.frame_id_min > eff.frame_id_max)
+        {
+          OPENMS_LOG_WARN << "Warning: BrukerTimsFile::Config frame_id range ["
+                          << pre_min << ", " << pre_max
+                          << "] and RT range [" << config.rt_min_sec << ", "
+                          << config.rt_max_sec << "] s do not intersect. "
+                          << "No frames will be loaded." << std::endl;
+        }
       }
       else
       {
@@ -1908,7 +1920,7 @@ namespace OpenMS
     for (uint32_t fid = handle->min_frame_id(); fid <= handle->max_frame_id(); ++fid)
     {
       if (!frameInRange(fid, eff)) continue;
-      if (handle->has_frame(fid) && handle->get_frame(fid).msms_type == 0)
+      if (eff.load_ms1 && handle->has_frame(fid) && handle->get_frame(fid).msms_type == 0)
         ++meta.nr_ms1_spectra;
     }
 

--- a/src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp
+++ b/src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp
@@ -498,18 +498,17 @@ START_SECTION(Bruker frame_id range filter test)
   cfg_sub.frame_id_max = 3;  // first three frames only
   MSExperiment exp_sub;
   f.load(OPENTIMS_DDA_TEST_DATA, exp_sub, cfg_sub);
-  TEST_NOT_EQUAL(exp_sub.size(), 0);
-  TEST_EQUAL(exp_sub.size() <= 3, true);
+  TEST_EQUAL(exp_sub.size(), 3);
   TEST_EQUAL(exp_sub.size() < exp_full.size(), true);
 
-  // --- Single frame range: at most one spectrum ---
+  // --- Single frame range: exactly one spectrum ---
   BrukerTimsFile::Config cfg_one;
   cfg_one.export_mode = BrukerTimsFile::Config::FRAME;
   cfg_one.frame_id_min = 1;
   cfg_one.frame_id_max = 1;
   MSExperiment exp_one;
   f.load(OPENTIMS_DDA_TEST_DATA, exp_one, cfg_one);
-  TEST_EQUAL(exp_one.size() <= 1, true);
+  TEST_EQUAL(exp_one.size(), 1);
 
   // --- Range entirely above file max: zero spectra (warning emitted) ---
   BrukerTimsFile::Config cfg_above;

--- a/src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp
+++ b/src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp
@@ -581,6 +581,73 @@ START_SECTION(Bruker frame_id range filter test)
 }
 END_SECTION
 
+START_SECTION(Bruker rt_min_sec/rt_max_sec range filter test)
+{
+  BrukerTimsFile f;
+
+  // --- Baseline: full FRAME-mode load to discover the file's RT span. ---
+  BrukerTimsFile::Config cfg_full;
+  cfg_full.export_mode = BrukerTimsFile::Config::FRAME;
+  MSExperiment exp_full;
+  f.load(OPENTIMS_DDA_TEST_DATA, exp_full, cfg_full);
+  TEST_NOT_EQUAL(exp_full.size(), 0);
+  double rt_lo = exp_full[0].getRT();
+  double rt_hi = exp_full[exp_full.size() - 1].getRT();
+  TEST_EQUAL(rt_lo <= rt_hi, true);
+
+  // --- Sub-range: take the first half of the RT span ---
+  const double rt_mid = rt_lo + 0.5 * (rt_hi - rt_lo);
+  BrukerTimsFile::Config cfg_rt_half;
+  cfg_rt_half.export_mode = BrukerTimsFile::Config::FRAME;
+  cfg_rt_half.rt_min_sec = rt_lo;
+  cfg_rt_half.rt_max_sec = rt_mid;
+  MSExperiment exp_rt_half;
+  f.load(OPENTIMS_DDA_TEST_DATA, exp_rt_half, cfg_rt_half);
+  TEST_NOT_EQUAL(exp_rt_half.size(), 0);
+  TEST_EQUAL(exp_rt_half.size() < exp_full.size(), true);
+  // All emitted spectra must have RT inside the requested window.
+  for (const auto& s : exp_rt_half)
+  {
+    TEST_EQUAL(s.getRT() >= rt_lo - 1e-6, true);
+    TEST_EQUAL(s.getRT() <= rt_mid + 1e-6, true);
+  }
+
+  // --- RT range that excludes all frames: empty experiment ---
+  BrukerTimsFile::Config cfg_rt_none;
+  cfg_rt_none.export_mode = BrukerTimsFile::Config::FRAME;
+  cfg_rt_none.rt_min_sec = rt_hi + 1e6;  // far past the last frame
+  cfg_rt_none.rt_max_sec = rt_hi + 2e6;
+  MSExperiment exp_rt_none;
+  f.load(OPENTIMS_DDA_TEST_DATA, exp_rt_none, cfg_rt_none);
+  TEST_EQUAL(exp_rt_none.size(), 0);
+
+  // --- Inverted RT range: empty (with warning) ---
+  BrukerTimsFile::Config cfg_rt_inv;
+  cfg_rt_inv.export_mode = BrukerTimsFile::Config::FRAME;
+  cfg_rt_inv.rt_min_sec = rt_hi;
+  cfg_rt_inv.rt_max_sec = rt_lo;
+  MSExperiment exp_rt_inv;
+  f.load(OPENTIMS_DDA_TEST_DATA, exp_rt_inv, cfg_rt_inv);
+  TEST_EQUAL(exp_rt_inv.size(), 0);
+
+  // --- Intersection of frame_id and rt ranges: the narrower wins ---
+  BrukerTimsFile::Config cfg_both;
+  cfg_both.export_mode = BrukerTimsFile::Config::FRAME;
+  cfg_both.frame_id_min = 1;
+  cfg_both.frame_id_max = 5;     // first 5 frames
+  cfg_both.rt_min_sec = rt_lo;
+  cfg_both.rt_max_sec = rt_hi;   // full RT (no extra constraint)
+  MSExperiment exp_both;
+  f.load(OPENTIMS_DDA_TEST_DATA, exp_both, cfg_both);
+  TEST_EQUAL(exp_both.size() <= 5, true);
+  TEST_NOT_EQUAL(exp_both.size(), 0);
+
+  STATUS("RT full=" << exp_full.size() << " (RT [" << rt_lo << ", " << rt_hi << "])"
+         << " half[" << rt_lo << ", " << rt_mid << "]=" << exp_rt_half.size()
+         << " intersection(frame[1..5] & rt_full)=" << exp_both.size());
+}
+END_SECTION
+
 START_SECTION(DDA round-trip test: load .d -> write mzML -> reload -> verify)
 {
   // Load from .d

--- a/src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp
+++ b/src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp
@@ -467,6 +467,120 @@ START_SECTION(Bruker load_ms1=false test)
 }
 END_SECTION
 
+START_SECTION(Bruker frame_id range filter test)
+{
+  BrukerTimsFile f;
+
+  // --- Baseline (default range): full FRAME-mode load of DDA fixture ---
+  BrukerTimsFile::Config cfg_full;
+  cfg_full.export_mode = BrukerTimsFile::Config::FRAME;
+  MSExperiment exp_full;
+  f.load(OPENTIMS_DDA_TEST_DATA, exp_full, cfg_full);
+  TEST_NOT_EQUAL(exp_full.size(), 0);
+
+  // FRAME mode emits exactly one spectrum per frame, so spectrum count
+  // equals the file's frame count and we can map a frame-id range to an
+  // expected spectrum count.
+
+  // --- Explicit full range matches default ---
+  BrukerTimsFile::Config cfg_explicit_full;
+  cfg_explicit_full.export_mode = BrukerTimsFile::Config::FRAME;
+  cfg_explicit_full.frame_id_min = 0;
+  cfg_explicit_full.frame_id_max = std::numeric_limits<uint32_t>::max();
+  MSExperiment exp_explicit;
+  f.load(OPENTIMS_DDA_TEST_DATA, exp_explicit, cfg_explicit_full);
+  TEST_EQUAL(exp_explicit.size(), exp_full.size());
+
+  // --- Sub-range loads strictly fewer spectra ---
+  BrukerTimsFile::Config cfg_sub;
+  cfg_sub.export_mode = BrukerTimsFile::Config::FRAME;
+  cfg_sub.frame_id_min = 1;
+  cfg_sub.frame_id_max = 3;  // first three frames only
+  MSExperiment exp_sub;
+  f.load(OPENTIMS_DDA_TEST_DATA, exp_sub, cfg_sub);
+  TEST_NOT_EQUAL(exp_sub.size(), 0);
+  TEST_EQUAL(exp_sub.size() <= 3, true);
+  TEST_EQUAL(exp_sub.size() < exp_full.size(), true);
+
+  // --- Single frame range: at most one spectrum ---
+  BrukerTimsFile::Config cfg_one;
+  cfg_one.export_mode = BrukerTimsFile::Config::FRAME;
+  cfg_one.frame_id_min = 1;
+  cfg_one.frame_id_max = 1;
+  MSExperiment exp_one;
+  f.load(OPENTIMS_DDA_TEST_DATA, exp_one, cfg_one);
+  TEST_EQUAL(exp_one.size() <= 1, true);
+
+  // --- Range entirely above file max: zero spectra (warning emitted) ---
+  BrukerTimsFile::Config cfg_above;
+  cfg_above.export_mode = BrukerTimsFile::Config::FRAME;
+  cfg_above.frame_id_min = 999999999u;
+  cfg_above.frame_id_max = 999999999u;
+  MSExperiment exp_above;
+  f.load(OPENTIMS_DDA_TEST_DATA, exp_above, cfg_above);
+  TEST_EQUAL(exp_above.size(), 0);
+
+  // --- Inverted range (min > max): zero spectra (warning emitted) ---
+  BrukerTimsFile::Config cfg_inv;
+  cfg_inv.export_mode = BrukerTimsFile::Config::FRAME;
+  cfg_inv.frame_id_min = 10;
+  cfg_inv.frame_id_max = 5;
+  MSExperiment exp_inv;
+  f.load(OPENTIMS_DDA_TEST_DATA, exp_inv, cfg_inv);
+  TEST_EQUAL(exp_inv.size(), 0);
+
+  // --- DDA (SPECTRUM mode): range filters MS1 frames and precursor MS2 ---
+  BrukerTimsFile::Config cfg_dda;
+  MSExperiment exp_dda_full;
+  f.load(OPENTIMS_DDA_TEST_DATA, exp_dda_full, cfg_dda);
+
+  BrukerTimsFile::Config cfg_dda_sub = cfg_dda;
+  cfg_dda_sub.frame_id_min = 1;
+  cfg_dda_sub.frame_id_max = 5;
+  MSExperiment exp_dda_sub;
+  f.load(OPENTIMS_DDA_TEST_DATA, exp_dda_sub, cfg_dda_sub);
+  TEST_EQUAL(exp_dda_sub.size() < exp_dda_full.size(), true);
+
+#ifdef OPENTIMS_DIA_TEST_DATA
+  // --- DIA: range filters MS1 frames and per-WindowGroup MS2 frames ---
+  BrukerTimsFile::Config cfg_dia_full;
+  MSExperiment exp_dia_full;
+  f.load(OPENTIMS_DIA_TEST_DATA, exp_dia_full, cfg_dia_full);
+
+  BrukerTimsFile::Config cfg_dia_sub;
+  cfg_dia_sub.frame_id_min = 1;
+  cfg_dia_sub.frame_id_max = 10;
+  MSExperiment exp_dia_sub;
+  f.load(OPENTIMS_DIA_TEST_DATA, exp_dia_sub, cfg_dia_sub);
+  TEST_EQUAL(exp_dia_sub.size() < exp_dia_full.size(), true);
+
+  // --- readDIAMetadata also honors the range (counts must match what
+  //     loadDIAStreaming would actually emit; CachedSwathFileConsumer
+  //     uses these counts to size its buffers). ---
+  ExperimentalSettings settings_full;
+  auto meta_full = f.readDIAMetadata(OPENTIMS_DIA_TEST_DATA, settings_full);
+
+  ExperimentalSettings settings_sub;
+  auto meta_sub = f.readDIAMetadata(OPENTIMS_DIA_TEST_DATA, settings_sub, cfg_dia_sub);
+  TEST_EQUAL(meta_sub.nr_ms1_spectra <= meta_full.nr_ms1_spectra, true);
+  TEST_EQUAL(meta_sub.nr_ms2_spectra.size(), meta_full.nr_ms2_spectra.size());
+  // At least one window must have a smaller count after filtering
+  bool any_smaller = false;
+  for (Size i = 0; i < meta_sub.nr_ms2_spectra.size(); ++i)
+  {
+    if (meta_sub.nr_ms2_spectra[i] < meta_full.nr_ms2_spectra[i]) any_smaller = true;
+    TEST_EQUAL(meta_sub.nr_ms2_spectra[i] <= meta_full.nr_ms2_spectra[i], true);
+  }
+  TEST_EQUAL(any_smaller, true);
+#endif
+
+  STATUS("DDA full=" << exp_full.size() << " sub[1..3]=" << exp_sub.size()
+         << " single[1..1]=" << exp_one.size()
+         << " | DDA SPECTRUM full=" << exp_dda_full.size()
+         << " sub[1..5]=" << exp_dda_sub.size());
+}
+END_SECTION
+
 START_SECTION(DDA round-trip test: load .d -> write mzML -> reload -> verify)
 {
   // Load from .d

--- a/src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp
+++ b/src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp
@@ -591,8 +591,15 @@ START_SECTION(Bruker rt_min_sec/rt_max_sec range filter test)
   MSExperiment exp_full;
   f.load(OPENTIMS_DDA_TEST_DATA, exp_full, cfg_full);
   TEST_NOT_EQUAL(exp_full.size(), 0);
+  // Compute true RT bounds without assuming order
   double rt_lo = exp_full[0].getRT();
-  double rt_hi = exp_full[exp_full.size() - 1].getRT();
+  double rt_hi = rt_lo;
+  for (const auto& s : exp_full)
+  {
+    double rt = s.getRT();
+    if (rt < rt_lo) rt_lo = rt;
+    if (rt > rt_hi) rt_hi = rt;
+  }
   TEST_EQUAL(rt_lo <= rt_hi, true);
 
   // --- Sub-range: take the first half of the RT span ---


### PR DESCRIPTION
## Description

Adds a frame ID range filter (`frame_id_min`, `frame_id_max`) to `BrukerTimsFile::Config` that allows selective loading of TIMS frames. This enables memory and I/O efficient processing of large files by skipping peak data for frames outside the specified range.

### Key Changes

1. **New Config parameters**: Added `frame_id_min` (default 0) and `frame_id_max` (default UINT32_MAX) to `BrukerTimsFile::Config` in the header file with comprehensive documentation of behavior and interactions with other knobs.

2. **Helper functions**:
   - `frameInRange()`: Predicate to check if a frame ID falls within the active range
   - `warnInvalidFrameRange()`: Validates the range against file bounds and emits warnings for invalid configurations (inverted range, non-intersecting range)

3. **Range filtering applied throughout**:
   - Frame iteration loops in `loadFrames_()`, `loadDDA_()`, `loadDIAStreaming()`, and `loadDIAMetadata()`
   - SQL queries in `readFrameCounts()` and `countDDAPrecursors()` to count only in-range frames
   - Frame-to-window-group mappings filtered to exclude out-of-range frames
   - DDA precursor entries filtered to remove precursors with MS2 frames outside the range

4. **Warnings and diagnostics**:
   - One-shot validation warnings at each top-level entry point
   - Partial reconstruction warning for DDA precursors with source MS2 frames straddling the range boundary
   - Info log for fully dropped precursors

5. **Comprehensive test coverage**: Added `frame_id range filter test` section covering:
   - Default vs. explicit full range equivalence
   - Sub-range filtering in FRAME mode
   - Single frame loading
   - Out-of-range and inverted range edge cases
   - DDA and DIA mode filtering
   - Metadata count consistency with actual spectrum emission

### Behavior Notes

- Frame aggregation (MS1/DIA MS2 neighbors) clamps at range boundaries like file boundaries
- DDA precursors with MS2 frames straddling the boundary are reconstructed from in-range subset only
- DDA OLS m/z recalibration uses only in-range precursors
- All export modes (FRAME, SPECTRUM, DIA) honor the range filter

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

https://claude.ai/code/session_01Fx3wbLUovk62F5XxCDv5EG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inclusive frame ID range filtering for Bruker TIMS loading, honored alongside RT windows, streaming vs non-streaming loads, export modes, and DIA/MS1 handling so emitted spectra match requested ranges.

* **Bug Fixes**
  * Range-aware counting/reporting; warnings for partially/fully excluded precursors; metadata and prior counts pruned to match actual loaded spectra.

* **Tests**
  * Integration tests validating frame-ID and RT-range behaviors across export modes and DIA vs DDA.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->