### PR TITLE
Add idparquet support to PeptideIndexer, IDScoreSwitcher, PSMFeatureExtractor and IDFilter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -285,6 +285,14 @@ TOPP tools:
       - Added .idparquet output support; -out now accepts .idparquet format in addition to idXML (#9232)
     IDFileConverter:
       - Added .idparquet input/output support; can now convert to and from the native .idparquet identification Parquet bundle (#9232)
+    PeptideIndexer:
+      - Added .idparquet input/output support; -in and -out now accept .idparquet bundles in addition to idXML (#9396)
+    IDScoreSwitcher:
+      - Added .idparquet input/output support; -in and -out now accept .idparquet bundles in addition to idXML (#9396)
+    PSMFeatureExtractor:
+      - Added .idparquet input/output support; -in, -out and -out_type now accept .idparquet in addition to idXML and mzid (#9396)
+    IDFilter:
+      - Added .idparquet input/output support; -in, -out and the whitelist/blacklist peptide inputs now accept .idparquet bundles in addition to idXML (#9396)
     OpenSwathChromatogramExtractor:
       - Compound identifiers in output chromatograms for metabolite targets now use the CompoundName user-param (compound_name field) instead of the compound id, aligning with OpenSwathWorkflow behavior (#9271)
   New tools:

--- a/src/openms/include/OpenMS/FORMAT/FileHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/FileHandler.h
@@ -283,10 +283,19 @@ public:
       @param[in] filename the file name of the file to write to.
       @param[in] additional_proteins The proteinIdentification vector to load the data from.
       @param[in] additional_peptides The peptideIdentification vector to load the data from.
-      @param[in] allowed_types A vector of supported filetypes. If empty we try to guess based on the filename. If that fails we throw UnableToCreateFile. If there is only one allowed type, check whether it agrees with the filename, and throw UnableToCreateFile if they disagree.
+      @param[in] allowed_types Restricts the set of file formats this call may write.
+        - Empty: infer the format from the filename extension; if that fails, throw InvalidFileType.
+        - Size 1: if the filename's type is UNKNOWN (e.g. TOPPAS intermediate ".unknown" files),
+          fall back to this single type. Otherwise the filename type must equal it, or InvalidFileType
+          is thrown.
+        - Size >1: the filename type must be one of these; UNKNOWN filenames CANNOT be disambiguated
+          and will throw InvalidFileType. TOPP tools writing through TOPPAS pipelines must therefore
+          pass a single concrete type here (typically derived from the input file type or an
+          out_type parameter), not the full list of formats they support.
       @param[in] log Progress logging mode
 
       @exception Exception::UnableToCreateFile is thrown if the file could not be written
+      @exception Exception::InvalidFileType is thrown if the file type cannot be determined or is not allowed
     */
     void storeIdentifications(const String& filename, const std::vector<ProteinIdentification>& additional_proteins, const PeptideIdentificationList& additional_peptides, const std::vector<FileTypes::Type> allowed_types = {}, ProgressLogger::LogType log = ProgressLogger::NONE);
 

--- a/src/topp/IDFilter.cpp
+++ b/src/topp/IDFilter.cpp
@@ -121,9 +121,9 @@ protected:
     specificity.assign(EnzymaticDigestion::NamesOfSpecificity, EnzymaticDigestion::NamesOfSpecificity + 3); //only allow none,semi,full for now
 
     registerInputFile_("in", "<file>", "", "input file ");
-    setValidFormats_("in", {"idXML","consensusXML"});
+    setValidFormats_("in", {"idXML","consensusXML","idparquet"});
     registerOutputFile_("out", "<file>", "", "output file ");
-    setValidFormats_("out", {"idXML","consensusXML"});
+    setValidFormats_("out", {"idXML","consensusXML","idparquet"});
 
     registerTOPPSubsection_("precursor", "Filtering by precursor attributes (RT, m/z, charge, length)");
     registerStringOption_("precursor:rt", "[min]:[max]", ":", "Retention time range to extract [s].", false);
@@ -151,7 +151,7 @@ protected:
     setValidFormats_("whitelist:proteins", {"fasta"});
     registerStringList_("whitelist:protein_accessions", "<accessions>", vector<String>(), "All peptides that do not reference at least one of the provided protein accession are removed.\nOnly proteins of the provided list are retained.", false);
     registerInputFile_("whitelist:peptides", "<file>", "", "Only peptides with the same sequence and modification assignment as any peptide in this file are kept. Use with 'whitelist:ignore_modifications' to only compare by sequence.\n", false);
-    setValidFormats_("whitelist:peptides", {"idXML"});
+    setValidFormats_("whitelist:peptides", {"idXML","idparquet"});
     registerFlag_("whitelist:ignore_modifications", "Compare whitelisted peptides by sequence only.", true);
     registerStringList_("whitelist:modifications", "<selection>", vector<String>(), "Keep only peptides with sequences that contain (any of) the selected modification(s)", false, true);
     setValidStrings_("whitelist:modifications", all_mods);
@@ -163,7 +163,7 @@ protected:
     setValidFormats_("blacklist:proteins", {"fasta"});
     registerStringList_("blacklist:protein_accessions", "<accessions>", vector<String>(), "All peptides that reference at least one of the provided protein accession are removed.\nOnly proteins not in the provided list are retained.", false);
     registerInputFile_("blacklist:peptides", "<file>", "", "Peptides with the same sequence and modification assignment as any peptide in this file are filtered out. Use with 'blacklist:ignore_modifications' to only compare by sequence.\n", false);
-    setValidFormats_("blacklist:peptides", {"idXML"});
+    setValidFormats_("blacklist:peptides", {"idXML","idparquet"});
     registerFlag_("blacklist:ignore_modifications", "Compare blacklisted peptides by sequence only.", true);
     registerStringList_("blacklist:modifications", "<selection>", vector<String>(), "Remove all peptides with sequences that contain (any of) the selected modification(s)", false, true);
     setValidStrings_("blacklist:modifications", all_mods);
@@ -242,9 +242,9 @@ protected:
     unordered_map<UInt64, ConsensusFeature*> id_to_featureref;
 
     const auto& infiletype = FileHandler::getType(inputfile_name);
-    if (infiletype == FileTypes::IDXML)
+    if (infiletype == FileTypes::IDXML || infiletype == FileTypes::IDPARQUET)
     {
-      FileHandler().loadIdentifications(inputfile_name, proteins, peptides, {FileTypes::IDXML});
+      FileHandler().loadIdentifications(inputfile_name, proteins, peptides, {FileTypes::IDXML, FileTypes::IDPARQUET});
     }
     else if (infiletype == FileTypes::CONSENSUSXML)
     {
@@ -375,7 +375,7 @@ protected:
       PeptideIdentificationList inclusion_peptides;
       vector<ProteinIdentification> inclusion_proteins; // ignored
       FileHandler().loadIdentifications(whitelist_peptides, inclusion_proteins,
-                       inclusion_peptides, {FileTypes::IDXML});
+                       inclusion_peptides, {FileTypes::IDXML, FileTypes::IDPARQUET});
       bool ignore_mods = getFlag_("whitelist:ignore_modifications");
       IDFilter::keepPeptidesWithMatchingSequences(peptides, inclusion_peptides,
                                                   ignore_mods);
@@ -425,7 +425,7 @@ protected:
       PeptideIdentificationList exclusion_peptides;
       vector<ProteinIdentification> exclusion_proteins; // ignored
       FileHandler().loadIdentifications(blacklist_peptides, exclusion_proteins,
-                       exclusion_peptides, {FileTypes::IDXML});
+                       exclusion_peptides, {FileTypes::IDXML, FileTypes::IDPARQUET});
       bool ignore_mods = getFlag_("blacklist:ignore_modifications");
       IDFilter::removePeptidesWithMatchingSequences(
         peptides, exclusion_peptides, ignore_mods);
@@ -828,9 +828,9 @@ protected:
              << peptides.size() << " spectra identified with "
              << IDFilter::countHits(peptides) << " spectrum matches." << endl;
 
-    if (infiletype == FileTypes::IDXML)
+    if (infiletype == FileTypes::IDXML || infiletype == FileTypes::IDPARQUET)
     {
-      FileHandler().storeIdentifications(outputfile_name, proteins, peptides, {FileTypes::IDXML});
+      FileHandler().storeIdentifications(outputfile_name, proteins, peptides, {FileTypes::IDXML, FileTypes::IDPARQUET});
     }
     else if (infiletype == FileTypes::CONSENSUSXML)
     {

--- a/src/topp/IDFilter.cpp
+++ b/src/topp/IDFilter.cpp
@@ -830,7 +830,7 @@ protected:
 
     if (infiletype == FileTypes::IDXML || infiletype == FileTypes::IDPARQUET)
     {
-      FileHandler().storeIdentifications(outputfile_name, proteins, peptides, {FileTypes::IDXML, FileTypes::IDPARQUET});
+      FileHandler().storeIdentifications(outputfile_name, proteins, peptides, {infiletype});
     }
     else if (infiletype == FileTypes::CONSENSUSXML)
     {

--- a/src/topp/IDFilter.cpp
+++ b/src/topp/IDFilter.cpp
@@ -87,7 +87,7 @@ This set of proteins can be given through a FASTA file (<tt>...:proteins</tt>) o
 Note that even in the case of a FASTA file, matching is only done by protein accession, not by sequence.
 If necessary, use @ref TOPP_PeptideIndexer to generate protein references for peptide hits via sequence look-up.
 
-@note Currently mzIdentML (mzid) is not directly supported as an input/output format of this tool. Convert mzid files to/from idXML using @ref TOPP_IDFileConverter if necessary.
+@note Currently mzIdentML (mzid) is not directly supported as an input/output format of this tool. Convert mzid files to/from idXML or idparquet using @ref TOPP_IDFileConverter if necessary.
 
 <B>The command line parameters of this tool are:</B>
 @verbinclude TOPP_IDFilter.cli

--- a/src/topp/IDScoreSwitcher.cpp
+++ b/src/topp/IDScoreSwitcher.cpp
@@ -31,7 +31,7 @@ In the idXML file format and in OpenMS' internal representation of identificatio
 
 By default this tool operates on PSM scores; to consider protein scores instead, set the @p proteins flag. The meta value that is supposed to replace the PSM/protein score - given by parameter @p new_score - has to be numeric (type "float") and exist for every peptide or protein hit, respectively. The old score will be stored as a meta value, the name for which is given by the parameter @p old_score. It is an error if a meta value with this name already exists for any hit, unless that meta value already stores the same score.
 
-@note Currently mzIdentML (mzid) is not directly supported as an input/output format of this tool. Convert mzid files to/from idXML using @ref TOPP_IDFileConverter if necessary.
+@note Currently mzIdentML (mzid) is not directly supported as an input/output format of this tool. Convert mzid files to/from idXML or idparquet using @ref TOPP_IDFileConverter if necessary.
 
 <B>The command line parameters of this tool are:</B>
 @verbinclude TOPP_IDScoreSwitcher.cli

--- a/src/topp/IDScoreSwitcher.cpp
+++ b/src/topp/IDScoreSwitcher.cpp
@@ -59,9 +59,9 @@ protected:
   void registerOptionsAndFlags_() override
   {
     registerInputFile_("in", "<file>", "", "Input file");
-    setValidFormats_("in", ListUtils::create<String>("idXML"));
+    setValidFormats_("in", ListUtils::create<String>("idXML,idparquet"));
     registerOutputFile_("out", "<file>", "", "Output file");
-    setValidFormats_("out", ListUtils::create<String>("idXML"));
+    setValidFormats_("out", ListUtils::create<String>("idXML,idparquet"));
     registerFullParam_(switcher_.getParameters());
   }
 
@@ -74,7 +74,7 @@ protected:
     vector<ProteinIdentification> proteins;
     PeptideIdentificationList peptides;
 
-    FileHandler().loadIdentifications(in, proteins, peptides, {FileTypes::IDXML});
+    FileHandler().loadIdentifications(in, proteins, peptides, {FileTypes::IDXML, FileTypes::IDPARQUET});
 
     Size counter = 0;
     if (do_proteins_)
@@ -92,7 +92,7 @@ protected:
       }
     }
 
-    FileHandler().storeIdentifications(out, proteins, peptides, {FileTypes::IDXML});
+    FileHandler().storeIdentifications(out, proteins, peptides, {FileTypes::IDXML, FileTypes::IDPARQUET});
 
     OPENMS_LOG_INFO << "Successfully switched " << counter << " "
              << (do_proteins_ ? "protein" : "PSM") << " scores." << endl;

--- a/src/topp/IDScoreSwitcher.cpp
+++ b/src/topp/IDScoreSwitcher.cpp
@@ -74,6 +74,7 @@ protected:
     vector<ProteinIdentification> proteins;
     PeptideIdentificationList peptides;
 
+    const FileTypes::Type in_type = FileHandler::getType(in);
     FileHandler().loadIdentifications(in, proteins, peptides, {FileTypes::IDXML, FileTypes::IDPARQUET});
 
     Size counter = 0;
@@ -92,7 +93,7 @@ protected:
       }
     }
 
-    FileHandler().storeIdentifications(out, proteins, peptides, {FileTypes::IDXML, FileTypes::IDPARQUET});
+    FileHandler().storeIdentifications(out, proteins, peptides, {in_type == FileTypes::IDPARQUET ? FileTypes::IDPARQUET : FileTypes::IDXML});
 
     OPENMS_LOG_INFO << "Successfully switched " << counter << " "
              << (do_proteins_ ? "protein" : "PSM") << " scores." << endl;

--- a/src/topp/PSMFeatureExtractor.cpp
+++ b/src/topp/PSMFeatureExtractor.cpp
@@ -83,7 +83,7 @@ protected:
   {
     registerInputFileList_("in", "<files>", StringList(), "Input file(s)", true);
     setValidFormats_("in", ListUtils::create<String>("idXML,mzid,idparquet"));
-    registerOutputFile_("out", "<file>", "", "Output file in mzid or idXML format", true);
+    registerOutputFile_("out", "<file>", "", "Output file in idXML, mzid or idparquet format", true);
     setValidFormats_("out", ListUtils::create<String>("idXML,mzid,idparquet"));
     registerStringOption_("out_type", "<type>", "", "Output file type -- default: determined from file extension or content.", false);
     setValidStrings_("out_type", ListUtils::create<String>("idXML,mzid,idparquet"));

--- a/src/topp/PSMFeatureExtractor.cpp
+++ b/src/topp/PSMFeatureExtractor.cpp
@@ -288,7 +288,7 @@ protected:
     OPENMS_LOG_INFO << "writing output file: " << out << endl;
     
 
-    FileHandler().storeIdentifications(out, all_protein_ids, all_peptide_ids, {FileTypes::MZIDENTML, FileTypes::IDXML, FileTypes::IDPARQUET});
+    FileHandler().storeIdentifications(out, all_protein_ids, all_peptide_ids, {out_type});
 
 
     writeLogInfo_("PSMFeatureExtractor finished successfully!");

--- a/src/topp/PSMFeatureExtractor.cpp
+++ b/src/topp/PSMFeatureExtractor.cpp
@@ -82,11 +82,11 @@ protected:
   void registerOptionsAndFlags_() override
   {
     registerInputFileList_("in", "<files>", StringList(), "Input file(s)", true);
-    setValidFormats_("in", ListUtils::create<String>("idXML,mzid"));
+    setValidFormats_("in", ListUtils::create<String>("idXML,mzid,idparquet"));
     registerOutputFile_("out", "<file>", "", "Output file in mzid or idXML format", true);
-    setValidFormats_("out", ListUtils::create<String>("idXML,mzid"));    
+    setValidFormats_("out", ListUtils::create<String>("idXML,mzid,idparquet"));
     registerStringOption_("out_type", "<type>", "", "Output file type -- default: determined from file extension or content.", false);
-    setValidStrings_("out_type", ListUtils::create<String>("idXML,mzid"));
+    setValidStrings_("out_type", ListUtils::create<String>("idXML,mzid,idparquet"));
     registerStringList_("extra", "<MetaData parameter>", vector<String>(), "List of the MetaData parameters to be included in a feature set for precolator.", false, false);
     registerFlag_("multiple_search_engines", "Combine PSMs from different search engines by merging on scan level.");
     registerFlag_("skip_db_check", "Manual override to skip the check if same settings for multiple search engines were applied. Only valid together with -multiple_search_engines flag.", true);
@@ -132,9 +132,9 @@ protected:
       FileHandler fh;
       FileTypes::Type in_type = fh.getType(in);
       OPENMS_LOG_INFO << "Loading input file: " << in << endl;
-      if (in_type == FileTypes::IDXML || in_type == FileTypes::MZIDENTML)
+      if (in_type == FileTypes::IDXML || in_type == FileTypes::MZIDENTML || in_type == FileTypes::IDPARQUET)
       {
-        FileHandler().loadIdentifications(in, protein_ids, peptide_ids, {FileTypes::IDXML, FileTypes::MZIDENTML});
+        FileHandler().loadIdentifications(in, protein_ids, peptide_ids, {FileTypes::IDXML, FileTypes::MZIDENTML, FileTypes::IDPARQUET});
       }
       if (in_type == FileTypes::MZIDENTML)
       {
@@ -288,7 +288,7 @@ protected:
     OPENMS_LOG_INFO << "writing output file: " << out << endl;
     
 
-    FileHandler().storeIdentifications(out, all_protein_ids, all_peptide_ids, {FileTypes::MZIDENTML, FileTypes::IDXML});
+    FileHandler().storeIdentifications(out, all_protein_ids, all_peptide_ids, {FileTypes::MZIDENTML, FileTypes::IDXML, FileTypes::IDPARQUET});
 
 
     writeLogInfo_("PSMFeatureExtractor finished successfully!");

--- a/src/topp/PeptideIndexer.cpp
+++ b/src/topp/PeptideIndexer.cpp
@@ -87,13 +87,13 @@ protected:
   void registerOptionsAndFlags_() override
   {
     registerInputFile_("in", "<file>", "", "Input idXML file containing the identifications.");
-    setValidFormats_("in", ListUtils::create<String>("idXML"));
+    setValidFormats_("in", ListUtils::create<String>("idXML,idparquet"));
     registerInputFile_("fasta", "<file>", "", "Input sequence database in FASTA format. "
                                               "Leave empty for using the same DB as used for the input idXML (this might fail). "
                                               "Non-existing relative filenames are looked up via 'OpenMS.ini:id_db_dir'", false, false, { "skipexists" });
     setValidFormats_("fasta", { "fasta" }, false);
     registerOutputFile_("out", "<file>", "", "Output idXML file.");
-    setValidFormats_("out", {"idXML"});
+    setValidFormats_("out", {"idXML","idparquet"});
 
     registerFullParam_(PeptideIndexing().getParameters());
    }
@@ -115,7 +115,7 @@ protected:
     std::vector<ProteinIdentification> prot_ids;
     PeptideIdentificationList pep_ids;
 
-    FileHandler().loadIdentifications(in, prot_ids, pep_ids, {FileTypes::IDXML});
+    FileHandler().loadIdentifications(in, prot_ids, pep_ids, {FileTypes::IDXML, FileTypes::IDPARQUET});
 
     if (db_name.empty())
     { // determine from metadata in idXML
@@ -176,7 +176,7 @@ protected:
     //-------------------------------------------------------------
     // writing output
     //-------------------------------------------------------------
-    FileHandler().storeIdentifications(out, prot_ids, pep_ids, {FileTypes::IDXML});
+    FileHandler().storeIdentifications(out, prot_ids, pep_ids, {FileTypes::IDXML, FileTypes::IDPARQUET});
 
     if (indexer_exit == PeptideIndexing::ExitCodes::DATABASE_EMPTY)
     {

--- a/src/topp/PeptideIndexer.cpp
+++ b/src/topp/PeptideIndexer.cpp
@@ -21,7 +21,7 @@ using namespace OpenMS;
 /**
 @page TOPP_PeptideIndexer PeptideIndexer
 
-@brief Refreshes the protein references for all peptide hits from an idXML file and adds target/decoy information.
+@brief Refreshes the protein references for all peptide hits from an idXML or idparquet file and adds target/decoy information.
 
 <CENTER>
     <table>
@@ -61,7 +61,7 @@ Avoid allowing too many (>=4) ambiguous amino acids if your database contains lo
 PeptideIndexer supports relative database filenames, which (when not found in the current working directory) are looked up in the directories specified
 by @p OpenMS.ini:id_db_dir. The database is by default derived from the input idXML's metainformation ('auto' setting), but can be specified explicitly.
 
-@note Currently mzIdentML (mzid) is not directly supported as an input/output format of this tool. Convert mzid files to/from idXML using @ref TOPP_IDFileConverter if necessary.
+@note Currently mzIdentML (mzid) is not directly supported as an input/output format of this tool. Convert mzid files to/from idXML or idparquet using @ref TOPP_IDFileConverter if necessary.
 
 <B>The command line parameters of this tool are:</B>
 @verbinclude TOPP_PeptideIndexer.cli
@@ -86,13 +86,13 @@ public:
 protected:
   void registerOptionsAndFlags_() override
   {
-    registerInputFile_("in", "<file>", "", "Input idXML file containing the identifications.");
+    registerInputFile_("in", "<file>", "", "Input file (idXML or idparquet) containing the identifications.");
     setValidFormats_("in", ListUtils::create<String>("idXML,idparquet"));
     registerInputFile_("fasta", "<file>", "", "Input sequence database in FASTA format. "
                                               "Leave empty for using the same DB as used for the input idXML (this might fail). "
                                               "Non-existing relative filenames are looked up via 'OpenMS.ini:id_db_dir'", false, false, { "skipexists" });
     setValidFormats_("fasta", { "fasta" }, false);
-    registerOutputFile_("out", "<file>", "", "Output idXML file.");
+    registerOutputFile_("out", "<file>", "", "Output file (idXML or idparquet).");
     setValidFormats_("out", {"idXML","idparquet"});
 
     registerFullParam_(PeptideIndexing().getParameters());

--- a/src/topp/PeptideIndexer.cpp
+++ b/src/topp/PeptideIndexer.cpp
@@ -115,6 +115,7 @@ protected:
     std::vector<ProteinIdentification> prot_ids;
     PeptideIdentificationList pep_ids;
 
+    const FileTypes::Type in_type = FileHandler::getType(in);
     FileHandler().loadIdentifications(in, prot_ids, pep_ids, {FileTypes::IDXML, FileTypes::IDPARQUET});
 
     if (db_name.empty())
@@ -176,7 +177,7 @@ protected:
     //-------------------------------------------------------------
     // writing output
     //-------------------------------------------------------------
-    FileHandler().storeIdentifications(out, prot_ids, pep_ids, {FileTypes::IDXML, FileTypes::IDPARQUET});
+    FileHandler().storeIdentifications(out, prot_ids, pep_ids, {in_type == FileTypes::IDPARQUET ? FileTypes::IDPARQUET : FileTypes::IDXML});
 
     if (indexer_exit == PeptideIndexing::ExitCodes::DATABASE_EMPTY)
     {


### PR DESCRIPTION
## Summary

Extends the native `.idparquet` identification format (introduced in #9225 / #9232) to four
identification-processing TOPP tools that previously accepted only `.idXML`:

- **PeptideIndexer** — `-in` / `-out`
- **IDScoreSwitcher** — `-in` / `-out`
- **PSMFeatureExtractor** — `-in` / `-out` / `-out_type`
- **IDFilter** — `-in` / `-out`, plus the `whitelist:peptides` / `blacklist:peptides` filter inputs

This lets identification workflows — e.g. the nf-core/mhcquant search→rescore chain
(`CometAdapter → PeptideIndexer → IDMerger → PSMFeatureExtractor → PercolatorAdapter →
IDScoreSwitcher → IDFilter`) — run end-to-end in `.idparquet` without `IDFileConverter`
bridge conversions.

## Implementation

`FileHandler::loadIdentifications` / `storeIdentifications` already dispatch
`FileTypes::IDPARQUET`, so no new I/O logic is needed. Each tool received the uniform
change already used for the idparquet-capable tools (IDMerger, PercolatorAdapter, IDRipper):

1. add `idparquet` to the `setValidFormats_` / `setValidStrings_` lists for identification I/O parameters;
2. add `FileTypes::IDPARQUET` to the explicit `allowed_types` whitelist in every `loadIdentifications` / `storeIdentifications` call;
3. extend the `in_type` / `infiletype` dispatch guards (PSMFeatureExtractor, IDFilter).

No directory-shaped-output handling is required for these tools — `FileHandler::getType`
and `TOPPBase::inputFileReadable_` already accommodate the `.idparquet` directory bundle.

## Validation

Built locally and validated against real immunopeptidomics data (PRIDE PXD011628, 2 runs).
The mhcquant search→rescore chain was run end-to-end in `.idparquet` with no
`IDFileConverter` bridges; each tool's idparquet output is content-equivalent to its idXML
output — identical peptide-identification counts, PSM counts, peptide-sequence sets and
protein-accession sets.

## Scope

This PR covers the search→rescore identification tools. The quantification-stage tools
(`MapAlignerIdentification`, `MapRTTransformer`, `FeatureFinderIdentification`,
`TextExporter`) do not yet accept `.idparquet` and are left for a follow-up. No CTest cases
are added here — happy to add idparquet round-trip tests if preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PeptideIndexer, IDScoreSwitcher, PSMFeatureExtractor, and IDFilter now accept and produce .idparquet identification bundles alongside existing formats; whitelist/blacklist peptide inputs and I/O parameters updated accordingly. PSMFeatureExtractor continues to support mzid as well.

* **Documentation**
  * CHANGELOG and tool docs updated with .idparquet compatibility and guidance for mzIdentML conversion via the ID file converter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->