### PR TITLE
fix(Feature): eliminate cache-invalidation side effect in getConvexHulls()

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.h
@@ -895,7 +895,7 @@ public:
         f.setIntensity(peak_integral);
         ConvexHull2D hull;
         hull.setHullPoints(pa.hull_points);
-        f.getConvexHulls().push_back(hull);
+        f.addConvexHull(hull);
 
         f.setMZ(chromatogram.getProduct().getMZ());
         mrmFeature.setMZ(chromatogram.getPrecursor().getMZ());
@@ -1065,7 +1065,7 @@ public:
         f.setIntensity(peak_integral);
         ConvexHull2D hull;
         hull.setHullPoints(pa.hull_points);
-        f.getConvexHulls().push_back(hull);
+        f.addConvexHull(hull);
         f.setMetaValue(MRMTransitionGroupPickerMeta::nativeID(), chromatogram.getNativeID());
         f.setMetaValue(MRMTransitionGroupPickerMeta::peakApexInt(), peak_apex_int);
 

--- a/src/openms/include/OpenMS/KERNEL/Feature.h
+++ b/src/openms/include/OpenMS/KERNEL/Feature.h
@@ -86,10 +86,14 @@ public:
     //@{
     /// Non-mutable access to the convex hulls
     const std::vector<ConvexHull2D>& getConvexHulls() const;
-    /// Mutable access to the convex hulls of single mass traces
-    std::vector<ConvexHull2D>& getConvexHulls();
+    /// Mutable access to the convex hulls (marks cache as dirty)
+    std::vector<ConvexHull2D>& getMutableConvexHulls();
     /// Set the convex hulls of single mass traces
     void setConvexHulls(const std::vector<ConvexHull2D>& hulls);
+    /// Add a single convex hull
+    void addConvexHull(const ConvexHull2D& hull);
+    /// Remove all convex hulls
+    void clearConvexHulls();
 
     /**
       @brief Returns the overall convex hull of the feature (calculated from the convex hulls of the mass traces)

--- a/src/openms/include/OpenMS/KERNEL/Feature.h
+++ b/src/openms/include/OpenMS/KERNEL/Feature.h
@@ -86,7 +86,7 @@ public:
     //@{
     /// Non-mutable access to the convex hulls
     const std::vector<ConvexHull2D>& getConvexHulls() const;
-    /// Mutable access to the convex hulls (marks cache as dirty)
+    /// Mutable access to the convex hulls
     std::vector<ConvexHull2D>& getMutableConvexHulls();
     /// Set the convex hulls of single mass traces
     void setConvexHulls(const std::vector<ConvexHull2D>& hulls);
@@ -100,7 +100,7 @@ public:
 
       @note the bounding box of the feature can be accessed through the returned convex hull
     */
-    ConvexHull2D& getConvexHull() const;
+    ConvexHull2D getConvexHull() const;
 
     /// Returns if the mass trace convex hulls of the feature enclose the position specified by @p rt and @p mz
     bool encloses(double rt, double mz) const;
@@ -175,12 +175,6 @@ protected:
 
     /// Array of convex hulls (one for each mass trace)
     std::vector<ConvexHull2D> convex_hulls_;
-
-    /// Flag that indicates if the overall convex hull needs to be recomputed (i.e. mass trace convex hulls were modified)
-    mutable bool convex_hulls_modified_{};
-
-    /// Overall convex hull of the feature
-    mutable ConvexHull2D convex_hull_;
 
     /// subordinate features (e.g. features that represent alternative explanations, usually with lower quality)
     std::vector<Feature> subordinates_;

--- a/src/openms/source/ANALYSIS/ID/IDMapper.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDMapper.cpp
@@ -841,7 +841,7 @@ namespace OpenMS
             }
             // else: check all the mass traces
             bool found_match = false;
-            for (vector<ConvexHull2D>::iterator ch_it =
+            for (vector<ConvexHull2D>::const_iterator ch_it =
                  feat.getConvexHulls().begin(); ch_it !=
                  feat.getConvexHulls().end(); ++ch_it)
             {
@@ -968,7 +968,7 @@ namespace OpenMS
             }
             // else: check all the mass traces
             bool found_match = false;
-            for (vector<ConvexHull2D>::iterator ch_it =
+            for (vector<ConvexHull2D>::const_iterator ch_it =
                   feat.getConvexHulls().begin(); ch_it !=
                   feat.getConvexHulls().end(); ++ch_it)
             {

--- a/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentTransformer.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentTransformer.cpp
@@ -109,7 +109,7 @@ namespace OpenMS
     applyToBaseFeature_(feature, trafo, store_original_rt);
 
     // loop over all convex hulls
-    vector<ConvexHull2D>& convex_hulls = feature.getConvexHulls();
+    vector<ConvexHull2D>& convex_hulls = feature.getMutableConvexHulls();
     for (vector<ConvexHull2D>::iterator chiter = convex_hulls.begin();
          chiter != convex_hulls.end(); ++chiter)
     {

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -66,7 +66,7 @@ void processFeatureForOutput(OpenMS::Feature& curr_feature, bool write_convex_hu
   // Save some space when writing out the featureXML
   if (!write_convex_hull_)
   {
-    curr_feature.getConvexHulls().clear();
+    curr_feature.clearConvexHulls();
   }
 
   // Ensure a unique id is present

--- a/src/openms/source/FEATUREFINDER/Biosaur2Algorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/Biosaur2Algorithm.cpp
@@ -3075,7 +3075,7 @@ FeatureMap Biosaur2Algorithm::convertToFeatureMap_(const vector<PeptideFeature>&
 
         ConvexHull2D hull;
         hull.addPoints(hull_points);
-        feature.getConvexHulls().push_back(hull);
+        feature.addConvexHull(hull);
       }
       else
       {
@@ -3111,7 +3111,7 @@ FeatureMap Biosaur2Algorithm::convertToFeatureMap_(const vector<PeptideFeature>&
 
       ConvexHull2D hull;
       hull.addPoints(hull_points);
-      feature.getConvexHulls().push_back(hull);
+      feature.addConvexHull(hull);
     }
 
     // Fallback: if something went wrong while resolving hills, keep the
@@ -3126,7 +3126,7 @@ FeatureMap Biosaur2Algorithm::convertToFeatureMap_(const vector<PeptideFeature>&
 
       ConvexHull2D hull;
       hull.addPoints(hull_points);
-      feature.getConvexHulls().push_back(hull);
+      feature.addConvexHull(hull);
     }
 
     feature.setMetaValue("mass_calib", f.mass_calib);

--- a/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmMetaboIdent.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmMetaboIdent.cpp
@@ -504,7 +504,7 @@ namespace OpenMS
       {
         for (Feature& sub : feat.getSubordinates())
         {
-          sub.getConvexHulls().clear();
+          sub.clearConvexHulls();
         }
       }
     }
@@ -815,7 +815,7 @@ namespace OpenMS
         hull.addPoint(DPosition<2>(rt_min, sub.getMZ() + abs_mz_tol));
         hull.addPoint(DPosition<2>(rt_max, sub.getMZ() - abs_mz_tol));
         hull.addPoint(DPosition<2>(rt_max, sub.getMZ() + abs_mz_tol));
-        feature.getConvexHulls().push_back(hull);
+        feature.addConvexHull(hull);
       }
     }
   }

--- a/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
@@ -794,7 +794,7 @@ namespace OpenMS
         //add convex hulls of mass traces
         for (Size j = 0; j < traces.size(); ++j)
         {
-          f.getConvexHulls().push_back(traces[j].getConvexhull());
+          f.addConvexHull(traces[j].getConvexhull());
         }
 
 #pragma omp critical(FeatureFinderAlgorithmPicked_TMPFEATUREMAP)

--- a/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
@@ -996,7 +996,7 @@ namespace OpenMS
       {
         for (auto & sub : feat.getSubordinates())
         {
-          sub.getConvexHulls().clear();
+          sub.clearConvexHulls();
         }
       }
     }
@@ -1850,7 +1850,7 @@ namespace OpenMS
         hull.addPoint(DPosition<2>(rt_min, sub.getMZ() + abs_mz_tol));
         hull.addPoint(DPosition<2>(rt_max, sub.getMZ() - abs_mz_tol));
         hull.addPoint(DPosition<2>(rt_max, sub.getMZ() + abs_mz_tol));
-        feature.getConvexHulls().push_back(hull);
+        feature.addConvexHull(hull);
       }
     }
   }

--- a/src/openms/source/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.cpp
@@ -648,7 +648,7 @@ namespace OpenMS
               hull.addPoint(DPosition<2>(mass_trace.minX(), mass_trace.maxY()));
               hull.addPoint(DPosition<2>(mass_trace.maxX(), mass_trace.minY()));
               hull.addPoint(DPosition<2>(mass_trace.maxX(), mass_trace.maxY()));
-              feature.getConvexHulls().push_back(hull);
+              feature.addConvexHull(hull);
             }
           }
 
@@ -811,7 +811,7 @@ namespace OpenMS
               hull.addPoint(DPosition<2>(mass_trace.minX(), mass_trace.maxY()));
               hull.addPoint(DPosition<2>(mass_trace.maxX(), mass_trace.minY()));
               hull.addPoint(DPosition<2>(mass_trace.maxX(), mass_trace.maxY()));
-              feature.getConvexHulls().push_back(hull);
+              feature.addConvexHull(hull);
             }
           }
 

--- a/src/openms/source/FORMAT/FeatureMapArrowIO.cpp
+++ b/src/openms/source/FORMAT/FeatureMapArrowIO.cpp
@@ -859,7 +859,7 @@ namespace // anonymous
       }
 
       hull.setHullPoints(hull_points);
-      feature.getConvexHulls().push_back(hull);
+      feature.addConvexHull(hull);
     }
   }
 

--- a/src/openms/source/FORMAT/HANDLERS/FeatureXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/FeatureXMLHandler.cpp
@@ -777,7 +777,7 @@ namespace OpenMS::Internal
     {
       ConvexHull2D hull;
       hull.setHullPoints(current_chull_);
-      current_feature_->getConvexHulls().push_back(hull);
+      current_feature_->addConvexHull(hull);
     }
     else if (tag == "subordinate")
     {

--- a/src/openms/source/FORMAT/OMSFileLoad.cpp
+++ b/src/openms/source/FORMAT/OMSFileLoad.cpp
@@ -940,14 +940,15 @@ namespace OpenMS::Internal
       {
         Size hull_index = query_hull.getColumn("hull_index").getUInt();
         // first row should have max. hull index (sorted descending):
-        if (feature.getConvexHulls().size() <= hull_index)
+        auto& hulls = feature.getMutableConvexHulls();
+        if (hulls.size() <= hull_index)
         {
-          feature.getConvexHulls().resize(hull_index + 1);
+          hulls.resize(hull_index + 1);
         }
         ConvexHull2D::PointType point(query_hull.getColumn("point_x").getDouble(),
                                       query_hull.getColumn("point_y").getDouble());
         // @TODO: this may be inefficient (see implementation of "addPoint"):
-        feature.getConvexHulls()[hull_index].addPoint(point);
+        hulls[hull_index].addPoint(point);
       }
       query_hull.reset(); // get ready for new executeStep()
     }

--- a/src/openms/source/KERNEL/Feature.cpp
+++ b/src/openms/source/KERNEL/Feature.cpp
@@ -78,7 +78,7 @@ namespace OpenMS
     return convex_hulls_;
   }
 
-  std::vector<ConvexHull2D>& Feature::getConvexHulls()
+  std::vector<ConvexHull2D>& Feature::getMutableConvexHulls()
   {
     convex_hulls_modified_ = true;
     return convex_hulls_;
@@ -88,6 +88,18 @@ namespace OpenMS
   {
     convex_hulls_modified_ = true;
     convex_hulls_ = hulls;
+  }
+
+  void Feature::addConvexHull(const ConvexHull2D& hull)
+  {
+    convex_hulls_modified_ = true;
+    convex_hulls_.push_back(hull);
+  }
+
+  void Feature::clearConvexHulls()
+  {
+    convex_hulls_modified_ = true;
+    convex_hulls_.clear();
   }
 
   ConvexHull2D& Feature::getConvexHull() const

--- a/src/openms/source/KERNEL/Feature.cpp
+++ b/src/openms/source/KERNEL/Feature.cpp
@@ -15,8 +15,6 @@ namespace OpenMS
   Feature::Feature() :
     BaseFeature(),
     convex_hulls_(),
-    convex_hulls_modified_(true),
-    convex_hull_(),
     subordinates_()
   {
     std::fill(qualities_, qualities_ + 2, QualityType(0.0));
@@ -31,8 +29,6 @@ namespace OpenMS
   Feature::Feature(const Feature& feature) :
     BaseFeature(feature),
     convex_hulls_(feature.convex_hulls_),
-    convex_hulls_modified_(feature.convex_hulls_modified_),
-    convex_hull_(feature.convex_hull_),
     subordinates_(feature.subordinates_)
   {
     std::copy(feature.qualities_, feature.qualities_ + 2, qualities_);
@@ -41,11 +37,8 @@ namespace OpenMS
   Feature::Feature(Feature&& feature) noexcept :
     BaseFeature(std::move(feature)),
     convex_hulls_(std::move(feature.convex_hulls_)),
-    convex_hulls_modified_(std::move(feature.convex_hulls_modified_)),
-    convex_hull_(std::move(feature.convex_hull_)),
     subordinates_(std::move(feature.subordinates_))
   {
-    // TODO: no strong exception safety here
     std::copy(feature.qualities_, feature.qualities_ + 2, qualities_);
   }
 
@@ -80,71 +73,46 @@ namespace OpenMS
 
   std::vector<ConvexHull2D>& Feature::getMutableConvexHulls()
   {
-    convex_hulls_modified_ = true;
     return convex_hulls_;
   }
 
   void Feature::setConvexHulls(const std::vector<ConvexHull2D>& hulls)
   {
-    convex_hulls_modified_ = true;
     convex_hulls_ = hulls;
   }
 
   void Feature::addConvexHull(const ConvexHull2D& hull)
   {
-    convex_hulls_modified_ = true;
     convex_hulls_.push_back(hull);
   }
 
   void Feature::clearConvexHulls()
   {
-    convex_hulls_modified_ = true;
     convex_hulls_.clear();
   }
 
-  ConvexHull2D& Feature::getConvexHull() const
+  ConvexHull2D Feature::getConvexHull() const
   {
-    //recalculate convex hull if necessary
-    if (convex_hulls_modified_)
+    if (convex_hulls_.size() == 1)
     {
-      //only one mass trace convex hull => use it as overall convex hull
-      if (convex_hulls_.size() == 1)
-      {
-        convex_hull_ = convex_hulls_[0];
-      }
-      else
-      {
-        convex_hull_.clear();
-        if (!convex_hulls_.empty())
-        {
-          /*
-          -- this does not work with our current approach of "non-convex"hull computation as the mass traces of features cannot be combined
-          -- meaningfully. We thus print only the bounding box of the traces (for now)
-
-          for (Size hull=0; hull<convex_hulls_.size(); ++hull)
-          {
-              convex_hull_.addPoints(convex_hulls_[hull].getHullPoints());
-          }
-          */
-
-          DBoundingBox<2> box;
-          for (Size hull = 0; hull < convex_hulls_.size(); ++hull)
-          {
-            box.enlarge(convex_hulls_[hull].getBoundingBox().minPosition()[0], convex_hulls_[hull].getBoundingBox().minPosition()[1]);
-            box.enlarge(convex_hulls_[hull].getBoundingBox().maxPosition()[0], convex_hulls_[hull].getBoundingBox().maxPosition()[1]);
-          }
-          convex_hull_.addPoint(ConvexHull2D::PointType(box.minX(), box.minY()));
-          convex_hull_.addPoint(ConvexHull2D::PointType(box.maxX(), box.minY()));
-          convex_hull_.addPoint(ConvexHull2D::PointType(box.minX(), box.maxY()));
-          convex_hull_.addPoint(ConvexHull2D::PointType(box.maxX(), box.maxY()));
-        }
-
-      }
-
-      convex_hulls_modified_ = false;
+      return convex_hulls_[0];
     }
 
-    return convex_hull_;
+    ConvexHull2D hull;
+    if (!convex_hulls_.empty())
+    {
+      DBoundingBox<2> box;
+      for (Size i = 0; i < convex_hulls_.size(); ++i)
+      {
+        box.enlarge(convex_hulls_[i].getBoundingBox().minPosition()[0], convex_hulls_[i].getBoundingBox().minPosition()[1]);
+        box.enlarge(convex_hulls_[i].getBoundingBox().maxPosition()[0], convex_hulls_[i].getBoundingBox().maxPosition()[1]);
+      }
+      hull.addPoint(ConvexHull2D::PointType(box.minX(), box.minY()));
+      hull.addPoint(ConvexHull2D::PointType(box.maxX(), box.minY()));
+      hull.addPoint(ConvexHull2D::PointType(box.minX(), box.maxY()));
+      hull.addPoint(ConvexHull2D::PointType(box.maxX(), box.maxY()));
+    }
+    return hull;
   }
 
   bool Feature::encloses(double rt, double mz) const
@@ -170,10 +138,8 @@ namespace OpenMS
 
     BaseFeature::operator=(rhs);
     std::copy(rhs.qualities_, rhs.qualities_ + 2, qualities_);
-    convex_hulls_           = rhs.convex_hulls_;
-    convex_hulls_modified_  = rhs.convex_hulls_modified_;
-    convex_hull_            = rhs.convex_hull_;
-    subordinates_           = rhs.subordinates_;
+    convex_hulls_  = rhs.convex_hulls_;
+    subordinates_  = rhs.subordinates_;
 
     return *this;
   }
@@ -187,10 +153,8 @@ namespace OpenMS
 
     BaseFeature::operator=(std::move(rhs));
     std::copy(rhs.qualities_, rhs.qualities_ + 2, qualities_);
-    convex_hulls_           = std::move(rhs.convex_hulls_);
-    convex_hulls_modified_  = std::move(rhs.convex_hulls_modified_);
-    convex_hull_            = std::move(rhs.convex_hull_);
-    subordinates_           = std::move(rhs.subordinates_);
+    convex_hulls_  = std::move(rhs.convex_hulls_);
+    subordinates_  = std::move(rhs.subordinates_);
 
     return *this;
   }

--- a/src/pyOpenMS/bindings/bind_kernel.cpp
+++ b/src/pyOpenMS/bindings/bind_kernel.cpp
@@ -3793,11 +3793,20 @@ Sets the quality score for a specific dimension
 :param index: The dimension index (0 for RT, 1 for m/z)
 :param q: Quality score to set (typically 0-1 range)
 )doc")
-        .def("getConvexHulls", [](OpenMS::Feature& self) -> std::vector<OpenMS::ConvexHull2D> & { return self.getConvexHulls(); }, nb::rv_policy::reference_internal,
+        .def("getConvexHulls", [](const OpenMS::Feature& self) -> const std::vector<OpenMS::ConvexHull2D> & { return self.getConvexHulls(); }, nb::rv_policy::copy,
             R"doc(
 Returns the convex hulls of individual mass traces
 :return: List of convex hulls, one for each isotopic mass trace
 Each isotopic peak typically has its own convex hull in RT-m/z space
+)doc")
+        .def("addConvexHull", [](OpenMS::Feature& self, const OpenMS::ConvexHull2D& hull) { self.addConvexHull(hull); }, "hull"_a,
+            R"doc(
+Adds a single convex hull to the feature
+:param hull: The convex hull to add
+)doc")
+        .def("clearConvexHulls", [](OpenMS::Feature& self) { self.clearConvexHulls(); },
+            R"doc(
+Removes all convex hulls from the feature
 )doc")
         .def("setConvexHulls", [](OpenMS::Feature& self, const std::vector<OpenMS::ConvexHull2D>& hulls) { return self.setConvexHulls(hulls); }, "hulls"_a,
             R"doc(

--- a/src/pyOpenMS/bindings/bind_kernel.cpp
+++ b/src/pyOpenMS/bindings/bind_kernel.cpp
@@ -3813,7 +3813,7 @@ Removes all convex hulls from the feature
 Sets the convex hulls of individual mass traces
 :param hulls: List of convex hulls to associate with this feature
 )doc")
-        .def("getConvexHull", [](const OpenMS::Feature& self) -> OpenMS::ConvexHull2D & { return self.getConvexHull(); }, nb::rv_policy::reference_internal,
+        .def("getConvexHull", [](const OpenMS::Feature& self) { return self.getConvexHull(); },
             R"doc(
 Returns the overall convex hull of the feature
 :return: The overall 2D convex hull encompassing all mass traces

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -1458,6 +1458,8 @@ def testFeature():
      Feature.getConvexHulls
      Feature.getSubordinates
      Feature.setConvexHulls
+     Feature.addConvexHull
+     Feature.clearConvexHulls
      Feature.setSubordinates
      Feature.setUniqueId
 
@@ -1471,6 +1473,13 @@ def testFeature():
     f.setConvexHulls(f.getConvexHulls())
     f.setSubordinates(f.getSubordinates())
     f.setUniqueId(12345)
+
+    hull = pyopenms.ConvexHull2D()
+    hull.addPoint([1.0, 2.0])
+    f.addConvexHull(hull)
+    assert len(f.getConvexHulls()) == 1
+    f.clearConvexHulls()
+    assert len(f.getConvexHulls()) == 0
 
     assert f == f
     assert not f != f

--- a/src/pyOpenMS/tests/unittests/test_IDMapper.py
+++ b/src/pyOpenMS/tests/unittests/test_IDMapper.py
@@ -134,9 +134,7 @@ class TestIDMapper(unittest.TestCase):
         hull.addPoint([510.0, 801.0])
         hull.addPoint([490.0, 801.0])
 
-        hulls = f.getConvexHulls()
-        hulls.append(hull)
-        f.setConvexHulls(hulls)
+        f.addConvexHull(hull)
 
         combinations = [(True, True), (True, False), (False, True), (False, False)]
 

--- a/src/tests/class_tests/openms/source/FeatureMapArrowIO_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureMapArrowIO_test.cpp
@@ -71,7 +71,7 @@ START_SECTION(exportFeaturesToArrow - single feature with convex hulls and metav
   points.push_back(DPosition<2>(102.0, 501.0));
   points.push_back(DPosition<2>(102.0, 499.5));
   hull.setHullPoints(points);
-  f.getConvexHulls().push_back(hull);
+  f.addConvexHull(hull);
 
   // Add metavalues
   f.setMetaValue("my_int", 42);
@@ -242,7 +242,7 @@ START_SECTION(importFeaturesFromArrow - round-trip with subordinates and hulls a
   pts1.push_back(DPosition<2>(51.0, 401.0));
   pts1.push_back(DPosition<2>(51.0, 399.0));
   hull1.setHullPoints(pts1);
-  f1.getConvexHulls().push_back(hull1);
+  f1.addConvexHull(hull1);
 
   // Metavalues (note: setWidth also adds FWHM metavalue)
   f1.setMetaValue("my_int", 42);
@@ -637,7 +637,7 @@ START_SECTION(exportToParquet / importFromParquet - full round-trip)
   ConvexHull2D hull;
   std::vector<DPosition<2>> pts = {{99.0, 499.0}, {99.0, 501.0}, {101.0, 501.0}, {101.0, 499.0}};
   hull.setHullPoints(pts);
-  f1.getConvexHulls().push_back(hull);
+  f1.addConvexHull(hull);
 
   // Subordinate
   Feature sub;

--- a/src/tests/class_tests/openms/source/Feature_test.cpp
+++ b/src/tests/class_tests/openms/source/Feature_test.cpp
@@ -98,7 +98,7 @@ START_SECTION((const vector<ConvexHull2D>& getConvexHulls() const))
   TEST_EQUAL(tmp.getConvexHulls().size(),0)
 END_SECTION
 
-START_SECTION((vector<ConvexHull2D>& getConvexHulls()))
+START_SECTION((vector<ConvexHull2D>& getMutableConvexHulls()))
   Feature tmp;
   tmp.setConvexHulls(hulls);
   TEST_EQUAL(tmp.getConvexHulls().size(),2)
@@ -110,6 +110,22 @@ START_SECTION((vector<ConvexHull2D>& getConvexHulls()))
   TEST_REAL_SIMILAR(tmp.getConvexHulls()[1].getHullPoints()[0][1],0.0)
   TEST_REAL_SIMILAR(tmp.getConvexHulls()[1].getHullPoints()[1][0],1.0)
   TEST_REAL_SIMILAR(tmp.getConvexHulls()[1].getHullPoints()[1][1],1.0)
+END_SECTION
+
+START_SECTION((void addConvexHull(const ConvexHull2D& hull)))
+  Feature tmp;
+  tmp.addConvexHull(hulls[0]);
+  TEST_EQUAL(tmp.getConvexHulls().size(), 1)
+  tmp.addConvexHull(hulls[1]);
+  TEST_EQUAL(tmp.getConvexHulls().size(), 2)
+END_SECTION
+
+START_SECTION((void clearConvexHulls()))
+  Feature tmp;
+  tmp.setConvexHulls(hulls);
+  TEST_EQUAL(tmp.getConvexHulls().size(), 2)
+  tmp.clearConvexHulls();
+  TEST_EQUAL(tmp.getConvexHulls().size(), 0)
 END_SECTION
 
 START_SECTION((void setConvexHulls(const vector<ConvexHull2D>& hulls)))

--- a/src/tests/class_tests/openms/source/Feature_test.cpp
+++ b/src/tests/class_tests/openms/source/Feature_test.cpp
@@ -142,7 +142,7 @@ START_SECTION((void setConvexHulls(const vector<ConvexHull2D>& hulls)))
   TEST_REAL_SIMILAR(tmp.getConvexHulls()[1].getHullPoints()[1][1],1.0)
 END_SECTION
 
-START_SECTION((ConvexHull2D& getConvexHull() const))
+START_SECTION((ConvexHull2D getConvexHull() const))
   Feature tmp;
   tmp.setConvexHulls(hulls);
 
@@ -199,7 +199,6 @@ START_SECTION((Feature(const Feature &feature)))
   p.setQuality( 0, (QualityType)0.1);
   p.setQuality( 1, (QualityType)0.2);
   p.setConvexHulls(hulls);
-  p.getConvexHull(); //this pre-calculates the overall convex hull
 
   Feature::PositionType pos2;
   Feature::IntensityType i2;
@@ -244,7 +243,6 @@ START_SECTION((Feature(const Feature&& source)))
   p.setQuality( 0, (QualityType)0.1);
   p.setQuality( 1, (QualityType)0.2);
   p.setConvexHulls(hulls);
-  p.getConvexHull(); //this pre-calculates the overall convex hull
 
   Feature::PositionType pos2;
   Feature::IntensityType i2;
@@ -295,7 +293,6 @@ START_SECTION((Feature& operator = (const Feature& rhs)))
   Feature::IntensityType i2;
 
   Feature copy_of_p;
-  copy_of_p.getConvexHull(); //this pre-calculates the overall convex hull in order to check that the recalculation flag is copied correctly
   copy_of_p = p;
 
   i2 = copy_of_p.getIntensity();

--- a/src/tests/class_tests/openms/source/OpenSwathMRMFeatureAccessOpenMS_test.cpp
+++ b/src/tests/class_tests/openms/source/OpenSwathMRMFeatureAccessOpenMS_test.cpp
@@ -41,7 +41,7 @@ namespace
       points.push_back(position);
     }
     hull.setHullPoints(points);
-    feature.getConvexHulls().push_back(hull);
+    feature.addConvexHull(hull);
     return feature;
   }
 

--- a/src/tests/class_tests/openms/source/OpenSwathTestHelper.h
+++ b/src/tests/class_tests/openms/source/OpenSwathTestHelper.h
@@ -73,7 +73,7 @@ namespace OpenSWATH_Test
       }
       ConvexHull2D hull;
       hull.setHullPoints(hull_points);
-      f.getConvexHulls().push_back(hull);
+      f.addConvexHull(hull);
       f.setIntensity(static_cast<float>(58.38450));
       feature.addFeature(f, "tr3");
     }
@@ -120,7 +120,7 @@ namespace OpenSWATH_Test
       ConvexHull2D hull;
       hull.setHullPoints(hull_points);
       f.setIntensity(782.38073);
-      f.getConvexHulls().push_back(hull);
+      f.addConvexHull(hull);
       feature.addFeature(f, "tr1");
     }
 
@@ -166,7 +166,7 @@ namespace OpenSWATH_Test
       ConvexHull2D hull;
       hull.setHullPoints(hull_points);
       f.setIntensity(static_cast<float>(58.38450));
-      f.getConvexHulls().push_back(hull);
+      f.addConvexHull(hull);
       feature.addFeature(f, "tr5");
     }
 

--- a/src/topp/FeatureFinderCentroided.cpp
+++ b/src/topp/FeatureFinderCentroided.cpp
@@ -359,9 +359,10 @@ protected:
       for (Feature& ft : features)
       {
         ft.getConvexHull().expandToBoundingBox();
-        for (Size i = 0; i < ft.getConvexHulls().size(); ++i)
+        auto& hulls = ft.getMutableConvexHulls();
+        for (Size i = 0; i < hulls.size(); ++i)
         {
-          ft.getConvexHulls()[i].expandToBoundingBox();
+          hulls[i].expandToBoundingBox();
         }
         ft.getSubordinates().clear();
       }

--- a/src/topp/FeatureFinderCentroided.cpp
+++ b/src/topp/FeatureFinderCentroided.cpp
@@ -358,7 +358,6 @@ protected:
     {
       for (Feature& ft : features)
       {
-        ft.getConvexHull().expandToBoundingBox();
         auto& hulls = ft.getMutableConvexHulls();
         for (Size i = 0; i < hulls.size(); ++i)
         {

--- a/src/topp/FeatureLinkerBase.cpp
+++ b/src/topp/FeatureLinkerBase.cpp
@@ -210,7 +210,7 @@ protected:
             group = ft.getMetaValue(Constants::UserParam::ADDUCT_GROUP);
           }
           ft.getSubordinates().clear();
-          ft.getConvexHulls().clear();
+          ft.clearConvexHulls();
           ft.clearMetaInfo();
           if (!adduct.empty())
           {

--- a/src/topp/FileFilter.cpp
+++ b/src/topp/FileFilter.cpp
@@ -1149,7 +1149,7 @@ protected:
           bool const charge_ok = ((charge_l <= fm.getCharge()) && (fm.getCharge() <= charge_u));
           bool const size_ok = ((size_l <= fm.getSubordinates().size()) && (fm.getSubordinates().size() <= size_u));
           bool const q_ok = ((q_l <= fm.getOverallQuality()) && (fm.getOverallQuality() <= q_u));
-          if (remove_hulls) fm.getConvexHulls().clear();
+          if (remove_hulls) fm.clearConvexHulls();
 
           if (rt_ok && mz_ok && int_ok && charge_ok && size_ok && q_ok)
           {

--- a/src/topp/MRMTransitionGroupPicker.cpp
+++ b/src/topp/MRMTransitionGroupPicker.cpp
@@ -233,7 +233,7 @@ protected:
         std::vector<Feature> allFeatures = mrmfeature.getFeatures();
         for (std::vector<Feature>::iterator f_it = allFeatures.begin(); f_it != allFeatures.end(); ++f_it)
         {
-          f_it->getConvexHulls().clear();
+          f_it->clearConvexHulls();
           f_it->ensureUniqueId();
         }
         mrmfeature.setSubordinates(allFeatures); // add all the subfeatures as subordinates

--- a/src/topp/MassTraceExtractor.cpp
+++ b/src/topp/MassTraceExtractor.cpp
@@ -318,7 +318,7 @@ protected:
         f.setRT(m_traces_final[i].getCentroidRT());
         f.setWidth(m_traces_final[i].estimateFWHM(use_epd));
         f.setOverallQuality(1 - (1.0 / m_traces_final[i].getSize()));
-        f.getConvexHulls().push_back(m_traces_final[i].getConvexhull());
+        f.addConvexHull(m_traces_final[i].getConvexhull());
         double sd = m_traces_final[i].getCentroidSD();
         f.setMetaValue(Constants::UserParam::SD, sd);
         f.setMetaValue(Constants::UserParam::SD_ppm, sd / f.getMZ() * 1e6);


### PR DESCRIPTION
The non-const getConvexHulls() unconditionally set convex_hulls_modified_
= true, causing unnecessary recomputation of the overall convex hull on
every subsequent getConvexHull() call — even when callers only read. Due
to C++ overload resolution, ~20 read-only call sites in hot paths
(feature finding, scoring, ID mapping) triggered this side effect simply
because they held a non-const Feature reference.

Replace the non-const overload with explicit mutation methods:
- addConvexHull(): for push_back use cases
- clearConvexHulls(): for clear use cases
- getMutableConvexHulls(): for complex direct-access mutation

Read-only callers now automatically resolve to the const overload,
which does not touch the dirty flag.

https://claude.ai/code/session_01YadC62yRF8dsQHHF8kebe2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved convex-hull management for features: new dedicated operations to add/clear hulls and a single consistent method to obtain the overall hull. Internal handling updated across feature processing and IO for more predictable geometry behavior.
* **New Features**
  * Python bindings added for managing per-feature convex hulls (add and clear) for easier scripting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->