### PR TITLE
feat(ProSE): DIA precursor search via MS1-derived candidates

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
@@ -74,6 +74,7 @@ namespace OpenMS
       uint32_t subset_bitmask_{};    ///< SNES v1.1: active slots in the slot list returned by buildModSlots_. 0 = unmodified. Ignored in non-SNES mode.
       float    sigma_delta_{};       ///< SNES v1.1: Σ of variable-mod deltas for this match. 0 in non-SNES / unmodified SNES.
       uint16_t precursor_charge_{};  ///< The precursor_charge used for the performed search
+      uint16_t precursor_idx_{};     ///< Index into the spectrum's precursor list (supports multi-precursor DIA spectra)
       int16_t  isotope_error_{};     ///< The isotope_error used for the performed search
       size_t   peptide_idx_{};       ///< The idx this struct belongs to
     };

--- a/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
@@ -349,6 +349,7 @@ class OPENMS_DLLAPI ProSEAlgorithm :
       // Layout: doubles first, then floats, then int, then uint16_t — minimizes padding (40 bytes excluding AASequence)
       double score = 0; ///< main score
       double delta_mass = 0.0; ///< mass difference for open search (Da)
+      double dia_precursor_mz = 0.0; ///< DIA: winning precursor m/z from MS1 (0.0 = use spectrum metadata)
       float prefix_fraction = 0; ///< fraction of annotated prefix ions (a/b/c)
       float suffix_fraction = 0; ///< fraction of annotated suffix ions (x/y/z)
       float mean_error = 0.0f; ///< mean absolute fragment mass error
@@ -525,6 +526,12 @@ class OPENMS_DLLAPI ProSEAlgorithm :
     double calibration_subset_ratio_{0.1};
     Size calibration_min_psms_{50};
 
+    // DIA (Data-Independent Acquisition) support
+    String dia_mode_{"auto"};
+    Size dia_max_precursor_candidates_{20};
+    double dia_isotope_tolerance_ppm_{10.0};
+    double dia_min_isolation_width_{4.0};
+
     /**
      * @brief Result of a calibration pass.
      *
@@ -607,6 +614,52 @@ class OPENMS_DLLAPI ProSEAlgorithm :
                                              precursor_mass_tolerance_upper_,
                                              precursor_mass_tolerance_unit_ == "ppm");
     }
+
+    // ======================= DIA support =======================
+
+    struct PrecursorCandidate_
+    {
+      double mz;
+      double intensity;
+      int charge; ///< 0 = unknown (will enumerate all charges)
+    };
+
+    /// Auto-detect DIA by checking isolation window widths on MS2 spectra.
+    bool isDIAExperiment_(const PeakMap& spectra) const;
+
+    /// Build map from spectrum index → parent MS1 spectrum index (-1 if none).
+    static std::vector<int> buildMS2ToMS1Map_(const PeakMap& full_exp);
+
+    /// Extract top-N MS1 peaks within the isolation window of an MS2 precursor.
+    static std::vector<PrecursorCandidate_> extractMS1PrecursorCandidates_(
+        const MSSpectrum& ms1_spectrum,
+        const Precursor& ms2_precursor,
+        Size max_candidates);
+
+    /// Assign charge by checking for isotope peaks at +1/z spacing.
+    /// Tests charges from max_charge down to min_charge; returns 0 if none found.
+    static int assignChargeByIsotopeSpacing_(
+        const MSSpectrum& ms1_spectrum,
+        double candidate_mz,
+        int min_charge,
+        int max_charge,
+        double mz_tolerance_ppm);
+
+    /// Expand DIA MS2 spectra into pseudo-spectra (one per precursor candidate).
+    /// pseudo_to_original maps each pseudo-spectrum index to its original MS2 index
+    /// (counting only MS2 spectra in the full experiment, in order).
+    PeakMap expandDIASpectra_(
+        const PeakMap& full_exp,
+        const std::vector<int>& ms2_to_ms1_map,
+        std::vector<Size>& pseudo_to_original) const;
+
+    /// Merge annotated hits from pseudo-spectra back to original DIA scans.
+    static void mergeDIAPseudoSpectraHits_(
+        const std::vector<std::vector<AnnotatedHit_>>& pseudo_hits,
+        const std::vector<Size>& pseudo_to_original,
+        Size num_original_scans,
+        Size top_hits,
+        std::vector<std::vector<AnnotatedHit_>>& merged_hits);
 };
 
 } // namespace

--- a/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
@@ -651,6 +651,12 @@ class OPENMS_DLLAPI ProSEAlgorithm :
     PeakMap expandDIASpectra_(
         const PeakMap& full_exp,
         const std::vector<int>& ms2_to_ms1_map) const;
+
+    /// Load spectra from file with DIA-aware handling. In DIA mode, loads the full
+    /// experiment (MS1+MS2), extracts precursor candidates from MS1, and returns
+    /// spectra with multiple precursors. In DDA mode, returns MS2-only spectra.
+    /// Avoids double file loading by detecting DIA from the full experiment.
+    PeakMap loadSpectraForSearch_(const String& in_spectra) const;
 };
 
 } // namespace

--- a/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
@@ -630,20 +630,17 @@ class OPENMS_DLLAPI ProSEAlgorithm :
     /// Build map from spectrum index → parent MS1 spectrum index (-1 if none).
     static std::vector<int> buildMS2ToMS1Map_(const PeakMap& full_exp);
 
-    /// Extract top-N MS1 peaks within the isolation window of an MS2 precursor.
+    /// Extract top-N deisotoped MS1 peaks within the isolation window of an MS2
+    /// precursor. The Deisotoper collapses isotope envelopes to monoisotopic peaks
+    /// and assigns charges as a side effect; candidates whose charge could not be
+    /// determined are returned with charge=0 (FragmentIndex will enumerate charges).
     static std::vector<PrecursorCandidate_> extractMS1PrecursorCandidates_(
         const MSSpectrum& ms1_spectrum,
         const Precursor& ms2_precursor,
-        Size max_candidates);
-
-    /// Assign charge by checking for isotope peaks at +1/z spacing.
-    /// Tests charges from max_charge down to min_charge; returns 0 if none found.
-    static int assignChargeByIsotopeSpacing_(
-        const MSSpectrum& ms1_spectrum,
-        double candidate_mz,
+        Size max_candidates,
         int min_charge,
         int max_charge,
-        double mz_tolerance_ppm);
+        double isotope_tolerance_ppm);
 
     /// Expand DIA MS2 spectra by replacing the isolation-window-center precursor
     /// with multiple precursors (one per MS1 candidate). Returns a PeakMap where

--- a/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
@@ -645,21 +645,12 @@ class OPENMS_DLLAPI ProSEAlgorithm :
         int max_charge,
         double mz_tolerance_ppm);
 
-    /// Expand DIA MS2 spectra into pseudo-spectra (one per precursor candidate).
-    /// pseudo_to_original maps each pseudo-spectrum index to its original MS2 index
-    /// (counting only MS2 spectra in the full experiment, in order).
+    /// Expand DIA MS2 spectra by replacing the isolation-window-center precursor
+    /// with multiple precursors (one per MS1 candidate). Returns a PeakMap where
+    /// each spectrum has N precursors; fragment peaks are shared (no duplication).
     PeakMap expandDIASpectra_(
         const PeakMap& full_exp,
-        const std::vector<int>& ms2_to_ms1_map,
-        std::vector<Size>& pseudo_to_original) const;
-
-    /// Merge annotated hits from pseudo-spectra back to original DIA scans.
-    static void mergeDIAPseudoSpectraHits_(
-        const std::vector<std::vector<AnnotatedHit_>>& pseudo_hits,
-        const std::vector<Size>& pseudo_to_original,
-        Size num_original_scans,
-        Size top_hits,
-        std::vector<std::vector<AnnotatedHit_>>& merged_hits);
+        const std::vector<int>& ms2_to_ms1_map) const;
 };
 
 } // namespace

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -1722,7 +1722,12 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
       }
       else
       {
-        charges = all_charges;
+        // Unknown charge: enumerate the full configured range (not just charges
+        // from other precursors, which would miss valid charge states).
+        for (uint16_t z = min_precursor_charge_; z <= max_precursor_charge_; ++z)
+        {
+          charges.push_back(z);
+        }
       }
 
     for (uint16_t charge : charges)
@@ -2081,7 +2086,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
       for (uint16_t prec_idx = 0; prec_idx < static_cast<uint16_t>(precursors.size()); ++prec_idx)
       {
         vector<size_t> charges;
-        if (precursors[prec_idx].getCharge())
+        if (precursors[prec_idx].getCharge() > 0)
         {
           charges.push_back(precursors[prec_idx].getCharge());
         }

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -1515,23 +1515,28 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
   {
     // Preconditions checked by the public entry point querySpectrum.
 
-    const auto& precursor = spectrum.getPrecursors()[0];
-    vector<uint16_t> charges;
-    // Precursor::getCharge() returns signed Int; treat non-positive (0 = unset,
-    // rare negative-mode encodings) as "unknown" and fall back to the
-    // configured min..max range. Without this guard, static_cast<uint16_t>(-1)
-    // would wrap to 65535 and be used as an actual charge downstream.
-    if (precursor.getCharge() > 0)
+    const auto& precursors_list = spectrum.getPrecursors();
+
+    // Build a global charge list from all precursors for the Phase 1 byte scan.
+    // Per-precursor charge selection happens in Phase 2.
+    vector<uint16_t> all_charges;
+    for (const auto& prec : precursors_list)
     {
-      charges.push_back(static_cast<uint16_t>(precursor.getCharge()));
+      if (prec.getCharge() > 0)
+      {
+        all_charges.push_back(static_cast<uint16_t>(prec.getCharge()));
+      }
     }
-    else
+    if (all_charges.empty())
     {
       for (uint16_t z = min_precursor_charge_; z <= max_precursor_charge_; ++z)
       {
-        charges.push_back(z);
+        all_charges.push_back(z);
       }
     }
+    // Deduplicate for Phase 1 byte scan max-charge computation
+    std::sort(all_charges.begin(), all_charges.end());
+    all_charges.erase(std::unique(all_charges.begin(), all_charges.end()), all_charges.end());
 
     // Phase 1 — byte-count scoring across ALL mothers.
     //
@@ -1549,7 +1554,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
     // queryPeaks — using the static max_precursor_charge_ would inflate byte
     // counts with matches at fragment charges above the actual precursor charge.
     uint16_t byte_scan_max_frag_charge = 0;
-    for (uint16_t c : charges) byte_scan_max_frag_charge = std::max(byte_scan_max_frag_charge, c);
+    for (uint16_t c : all_charges) byte_scan_max_frag_charge = std::max(byte_scan_max_frag_charge, c);
     byte_scan_max_frag_charge = std::min(byte_scan_max_frag_charge, max_fragment_charge_);
 
     for (const Peak1D& peak : spectrum)
@@ -1616,10 +1621,10 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
     thread_local std::vector<uint8_t> emitted;
     emitted.assign(fi_peptides_.size(), 0);
 
-    // Helper: compute the iso-shifted observed (M+H)+ for a given (charge, iso_err).
+    // Helper: compute the iso-shifted observed (M+H)+ for a given (precursor_idx, charge, iso_err).
     // Used by the subset-enumeration post-pass to reconstruct the realization target.
-    auto shifted_mh_for = [&](uint16_t charge, int16_t iso_err) -> float {
-      const float mh_plus = static_cast<float>(precursor.getMZ()) * charge
+    auto shifted_mh_for = [&](uint16_t prec_idx, uint16_t charge, int16_t iso_err) -> float {
+      const float mh_plus = static_cast<float>(precursors_list[prec_idx].getMZ()) * charge
         - (charge - 1) * static_cast<float>(Constants::PROTON_MASS_U);
       return mh_plus + static_cast<float>(iso_err) * static_cast<float>(Constants::C13C12_MASSDIFF_U);
     };
@@ -1630,7 +1635,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
     // max-collapse over-admitted ~20× on the tighter side.
     auto collect_candidates =
       [&](float target_mz, float tol_lo, float tol_hi, bool expect_single_c,
-          int16_t iso_err, uint16_t charge,
+          int16_t iso_err, uint16_t charge, uint16_t p_idx,
           SnesAnchor require_anchor, float sigma_tag)
     {
       auto left_it = std::lower_bound(bucket_min_mz_.begin(), bucket_min_mz_.end(),
@@ -1676,6 +1681,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
           sm.num_matched_ = score_table[id];
           sm.isotope_error_ = iso_err;
           sm.precursor_charge_ = charge;
+          sm.precursor_idx_ = p_idx;
           sm.sigma_delta_ = sigma_tag;
           sms.hits_.push_back(sm);
         }
@@ -1705,6 +1711,19 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
         snes_sigma_delta_set_with_prot_nterm_, snes_sigma_delta_set_);
     const std::vector<double> prot_cterm_extra = set_difference_tol(
         snes_sigma_delta_set_with_prot_cterm_, snes_sigma_delta_set_);
+
+    for (uint16_t prec_idx = 0; prec_idx < static_cast<uint16_t>(precursors_list.size()); ++prec_idx)
+    {
+      const auto& precursor = precursors_list[prec_idx];
+      vector<uint16_t> charges;
+      if (precursor.getCharge() > 0)
+      {
+        charges.push_back(static_cast<uint16_t>(precursor.getCharge()));
+      }
+      else
+      {
+        charges = all_charges;
+      }
 
     for (uint16_t charge : charges)
     {
@@ -1761,10 +1780,10 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
           // configures Acetyl (N-term) / Amidated (C-term) / similar.
           collect_candidates(shifted_mh - static_cast<float>(water)
                                         - static_cast<float>(fixed_cterm_delta_) - s,
-                             prec_tol_lo, prec_tol_hi, /*expect_single_c=*/false, iso_err, charge,
+                             prec_tol_lo, prec_tol_hi, /*expect_single_c=*/false, iso_err, charge, prec_idx,
                              SnesAnchor::NONE, s);
           collect_candidates(shifted_mh - static_cast<float>(fixed_nterm_delta_) - s,
-                             prec_tol_lo, prec_tol_hi, /*expect_single_c=*/true, iso_err, charge,
+                             prec_tol_lo, prec_tol_hi, /*expect_single_c=*/true, iso_err, charge, prec_idx,
                              SnesAnchor::NONE, s);
 
           // Supplementary full-length realization at this Σ — recover b_L and y_L
@@ -1795,6 +1814,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
               sm.num_matched_ = score_table[id];
               sm.isotope_error_ = iso_err;
               sm.precursor_charge_ = charge;
+              sm.precursor_idx_ = prec_idx;
               sm.sigma_delta_ = s;
               sms.hits_.push_back(sm);
             }
@@ -1810,7 +1830,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
           const float s = static_cast<float>(sigma);
           collect_candidates(shifted_mh - static_cast<float>(water)
                                         - static_cast<float>(fixed_cterm_delta_) - s,
-                             prec_tol_lo, prec_tol_hi, /*expect_single_c=*/false, iso_err, charge,
+                             prec_tol_lo, prec_tol_hi, /*expect_single_c=*/false, iso_err, charge, prec_idx,
                              SnesAnchor::PROT_NTERM, s);
           // Supplementary full-length at this Σ, PROT_NTERM-gated.
           {
@@ -1834,6 +1854,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
               sm.num_matched_ = score_table[id];
               sm.isotope_error_ = iso_err;
               sm.precursor_charge_ = charge;
+              sm.precursor_idx_ = prec_idx;
               sm.sigma_delta_ = s;
               sms.hits_.push_back(sm);
             }
@@ -1846,7 +1867,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
           std::fill(emitted.begin(), emitted.end(), 0);
           const float s = static_cast<float>(sigma);
           collect_candidates(shifted_mh - static_cast<float>(fixed_nterm_delta_) - s,
-                             prec_tol_lo, prec_tol_hi, /*expect_single_c=*/true, iso_err, charge,
+                             prec_tol_lo, prec_tol_hi, /*expect_single_c=*/true, iso_err, charge, prec_idx,
                              SnesAnchor::PROT_CTERM, s);
           // Supplementary full-length at this Σ, PROT_CTERM-gated.
           {
@@ -1872,13 +1893,15 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
               sm.num_matched_ = score_table[id];
               sm.isotope_error_ = iso_err;
               sm.precursor_charge_ = charge;
+              sm.precursor_idx_ = prec_idx;
               sm.sigma_delta_ = s;
               sms.hits_.push_back(sm);
             }
           }
         }
       }
-    }
+    } // end charge loop
+    } // end precursor loop
 
     // SNES v1.1 subset enumeration: expand each (mother, Σ) hit in sms.hits_
     // into one SpectrumMatch per valid variable-mod subset on the realized
@@ -1902,7 +1925,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
 
         const Peptide& mother = fi_peptides_[sm_raw.peptide_idx_];
         const double iso_shifted_target =
-            static_cast<double>(shifted_mh_for(sm_raw.precursor_charge_, sm_raw.isotope_error_))
+            static_cast<double>(shifted_mh_for(sm_raw.precursor_idx_, sm_raw.precursor_charge_, sm_raw.isotope_error_))
             - static_cast<double>(sm_raw.sigma_delta_);
         const int realized_len = realizeSNESLength(
             mother, fasta_entries_ref, iso_shifted_target,
@@ -2041,10 +2064,9 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
         return;
       }
 
-      const auto& precursor = spectrum.getPrecursors();
-      if (precursor.size() != 1)
+      const auto& precursors = spectrum.getPrecursors();
+      if (precursors.empty())
       {
-        OPENMS_LOG_WARN << "Number of precursors is not equal 1 \n";
         return;
       }
 
@@ -2054,29 +2076,32 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
         return;
       }
 
-      // Non-SNES path: fasta_entries not needed.
-      // two posible modes. Precursor has a charge or we test all possible charges
-      vector<size_t> charges;
-      if (precursor[0].getCharge())
+      // Loop over all precursors (supports multi-precursor DIA spectra).
+      // For each precursor, determine charge(s) and query the index.
+      for (uint16_t prec_idx = 0; prec_idx < static_cast<uint16_t>(precursors.size()); ++prec_idx)
       {
-        charges.push_back(precursor[0].getCharge());
-      }
-      else
-      {
-        for (uint16_t i = min_precursor_charge_; i <= max_precursor_charge_; i++)
+        vector<size_t> charges;
+        if (precursors[prec_idx].getCharge())
         {
-          charges.push_back(i);
+          charges.push_back(precursors[prec_idx].getCharge());
         }
-      }
+        else
+        {
+          for (uint16_t i = min_precursor_charge_; i <= max_precursor_charge_; i++)
+          {
+            charges.push_back(i);
+          }
+        }
 
-      for (uint16_t charge : charges)
-      {
-        SpectrumMatchesTopN candidates_charge;
-        float mz;
-        mz = (float)precursor[0].getMZ() * charge - ((charge-1) * Constants::PROTON_MASS_U);
-        searchDifferentPrecursorRanges(spectrum, mz, candidates_charge, charge);
+        for (uint16_t charge : charges)
+        {
+          SpectrumMatchesTopN candidates_charge;
+          float mz = (float)precursors[prec_idx].getMZ() * charge - ((charge-1) * Constants::PROTON_MASS_U);
+          searchDifferentPrecursorRanges(spectrum, mz, candidates_charge, charge);
 
-        sms += candidates_charge;
+          for (auto& hit : candidates_charge.hits_) { hit.precursor_idx_ = prec_idx; }
+          sms += candidates_charge;
+        }
       }
       trimHits(sms);
   }

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -242,6 +242,29 @@ namespace OpenMS
       "spectra estimates instrument-specific mass accuracy, then the main search uses the "
       "calibrated (typically tighter) tolerances for better discrimination.");
 
+    defaults_.setValue("dia:enabled", "auto",
+      "DIA (Data-Independent Acquisition) mode. 'auto' = detect from isolation window widths; "
+      "'true' = force DIA mode; 'false' = disable DIA processing.");
+    defaults_.setValidStrings("dia:enabled", {"auto", "true", "false"});
+    defaults_.setValue("dia:max_precursor_candidates", 20,
+      "Maximum number of precursor candidates to extract from the MS1 survey scan "
+      "within each DIA isolation window. Each candidate generates a pseudo-spectrum "
+      "that is searched independently against the database.");
+    defaults_.setMinInt("dia:max_precursor_candidates", 1);
+    defaults_.setMaxInt("dia:max_precursor_candidates", 100);
+    defaults_.setValue("dia:isotope_tolerance_ppm", 10.0,
+      "Tolerance in ppm for matching isotope peaks in the MS1 spectrum during "
+      "charge state assignment of precursor candidates.");
+    defaults_.setMinFloat("dia:isotope_tolerance_ppm", 1.0);
+    defaults_.setValue("dia:min_isolation_width", 4.0,
+      "Minimum total isolation window width (Da) for auto-detection of DIA mode. "
+      "Windows wider than this are classified as DIA windows.");
+    defaults_.setMinFloat("dia:min_isolation_width", 1.0);
+    defaults_.setSectionDescription("dia",
+      "Data-Independent Acquisition (DIA) support. When enabled, each wide-window "
+      "MS2 spectrum is expanded into multiple pseudo-spectra, one per precursor "
+      "candidate extracted from the parent MS1 survey scan.");
+
     defaultsToParam_();
   }
 
@@ -309,6 +332,11 @@ namespace OpenMS
     calibration_enabled_ = param_.getValue("calibration:enabled") == "true";
     calibration_subset_ratio_ = param_.getValue("calibration:subset_ratio");
     calibration_min_psms_ = param_.getValue("calibration:min_psms");
+
+    dia_mode_ = param_.getValue("dia:enabled").toString();
+    dia_max_precursor_candidates_ = param_.getValue("dia:max_precursor_candidates");
+    dia_isotope_tolerance_ppm_ = param_.getValue("dia:isotope_tolerance_ppm");
+    dia_min_isolation_width_ = param_.getValue("dia:min_isolation_width");
   }
 
   // static
@@ -981,11 +1009,12 @@ namespace OpenMS
         ah.matched_suffix_ions = static_cast<uint16_t>(detail.matched_suffix_ions);
         ah.isotope_error = sms.isotope_error_;
         ah.applied_charge = sms.precursor_charge_;
+        ah.dia_precursor_mz = exp_spectrum.getPrecursors()[0].getMZ();
         ah.delta_mass = 0.0;
         if (open_search_mode)
         {
           double theo_mh_plus = ah.sequence.getMZ(1);
-          double exp_mz = exp_spectrum.getPrecursors()[0].getMZ();
+          double exp_mz = ah.dia_precursor_mz;
           double exp_mh_plus = exp_mz * sms.precursor_charge_ - ((sms.precursor_charge_ - 1) * proton_mass_u);
           ah.delta_mass = exp_mh_plus - theo_mh_plus;
         }
@@ -1564,15 +1593,54 @@ namespace OpenMS
       vector<ProteinIdentification>& protein_ids,
       PeptideIdentificationList& peptide_ids) const
   {
-    // load MS2 map
+    // Determine DIA mode: may need full experiment (MS1+MS2)
+    bool use_dia = false;
     PeakMap spectra;
-    FileHandler f;
-    PeakFileOptions options;
-    options.clearMSLevels();
-    options.addMSLevel(2);
-    f.getOptions() = options;
-    f.loadExperiment(in_spectra, spectra, {FileTypes::MZML, FileTypes::BRUKER_TDF});
-    spectra.sortSpectra(true);
+
+    if (dia_mode_ == "true")
+    {
+      use_dia = true;
+    }
+    else if (dia_mode_ == "auto" || dia_mode_ == "false")
+    {
+      // Load MS2-only for auto-detection (and non-DIA path)
+      FileHandler f;
+      PeakFileOptions options;
+      options.clearMSLevels();
+      options.addMSLevel(2);
+      f.getOptions() = options;
+      f.loadExperiment(in_spectra, spectra, {FileTypes::MZML, FileTypes::BRUKER_TDF});
+      spectra.sortSpectra(true);
+
+      if (dia_mode_ == "auto")
+      {
+        use_dia = isDIAExperiment_(spectra);
+      }
+    }
+
+    if (use_dia)
+    {
+      OPENMS_LOG_INFO << "[ProSE] DIA mode active. Loading full experiment (MS1+MS2)..." << std::endl;
+      PeakMap full_exp;
+      FileHandler f2;
+      f2.loadExperiment(in_spectra, full_exp, {FileTypes::MZML, FileTypes::BRUKER_TDF});
+      full_exp.sortSpectra(true);
+
+      auto ms2_to_ms1 = buildMS2ToMS1Map_(full_exp);
+      std::vector<Size> pseudo_to_original;
+      spectra = expandDIASpectra_(full_exp, ms2_to_ms1, pseudo_to_original);
+    }
+    else if (spectra.empty())
+    {
+      // dia_mode_ == "true" skipped MS2-only load above; need to load now
+      FileHandler f;
+      PeakFileOptions options;
+      options.clearMSLevels();
+      options.addMSLevel(2);
+      f.getOptions() = options;
+      f.loadExperiment(in_spectra, spectra, {FileTypes::MZML, FileTypes::BRUKER_TDF});
+      spectra.sortSpectra(true);
+    }
 
     // load FASTA
     vector<FASTAFile::FASTAEntry> fasta_db;
@@ -1726,18 +1794,52 @@ namespace OpenMS
                       << ", +" << precursor_mass_tolerance_upper_ << "] "
                       << precursor_mass_tolerance_unit_ << ")" << std::endl;
 
-      // Phase 1: Load + preprocess all files.
+      // Phase 1: Load + preprocess all files (with DIA expansion if needed).
       std::vector<PeakMap> all_spectra(in_spectra_files.size());
       for (Size i = 0; i < in_spectra_files.size(); ++i)
       {
         OPENMS_LOG_INFO << "[ProSE] Loading " << in_spectra_files[i] << std::endl;
-        FileHandler f;
-        PeakFileOptions options;
-        options.clearMSLevels();
-        options.addMSLevel(2);
-        f.getOptions() = options;
-        f.loadExperiment(in_spectra_files[i], all_spectra[i], {FileTypes::MZML, FileTypes::BRUKER_TDF});
-        all_spectra[i].sortSpectra(true);
+
+        bool file_is_dia = (dia_mode_ == "true");
+        if (dia_mode_ == "auto")
+        {
+          PeakMap ms2_only;
+          FileHandler f_ms2;
+          PeakFileOptions opts_ms2;
+          opts_ms2.clearMSLevels();
+          opts_ms2.addMSLevel(2);
+          f_ms2.getOptions() = opts_ms2;
+          f_ms2.loadExperiment(in_spectra_files[i], ms2_only, {FileTypes::MZML, FileTypes::BRUKER_TDF});
+          file_is_dia = isDIAExperiment_(ms2_only);
+          if (!file_is_dia)
+          {
+            all_spectra[i] = std::move(ms2_only);
+            all_spectra[i].sortSpectra(true);
+          }
+        }
+
+        if (file_is_dia)
+        {
+          OPENMS_LOG_INFO << "[ProSE] DIA mode for " << in_spectra_files[i] << std::endl;
+          PeakMap full_exp;
+          FileHandler f_full;
+          f_full.loadExperiment(in_spectra_files[i], full_exp, {FileTypes::MZML, FileTypes::BRUKER_TDF});
+          full_exp.sortSpectra(true);
+          auto ms2_to_ms1 = buildMS2ToMS1Map_(full_exp);
+          std::vector<Size> pseudo_to_original;
+          all_spectra[i] = expandDIASpectra_(full_exp, ms2_to_ms1, pseudo_to_original);
+        }
+        else if (all_spectra[i].empty())
+        {
+          FileHandler f;
+          PeakFileOptions options;
+          options.clearMSLevels();
+          options.addMSLevel(2);
+          f.getOptions() = options;
+          f.loadExperiment(in_spectra_files[i], all_spectra[i], {FileTypes::MZML, FileTypes::BRUKER_TDF});
+          all_spectra[i].sortSpectra(true);
+        }
+
         preprocessSpectra_(all_spectra[i], fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm);
       }
 
@@ -2025,6 +2127,35 @@ namespace OpenMS
                         << "] Searching " << in_spectra << std::endl;
 
         PeakMap spectra;
+        bool file_is_dia = (dia_mode_ == "true");
+        if (dia_mode_ == "auto")
+        {
+          PeakMap ms2_only;
+          FileHandler f_ms2;
+          PeakFileOptions opts_ms2;
+          opts_ms2.clearMSLevels();
+          opts_ms2.addMSLevel(2);
+          f_ms2.getOptions() = opts_ms2;
+          f_ms2.loadExperiment(in_spectra, ms2_only, {FileTypes::MZML, FileTypes::BRUKER_TDF});
+          file_is_dia = isDIAExperiment_(ms2_only);
+          if (!file_is_dia)
+          {
+            spectra = std::move(ms2_only);
+          }
+        }
+
+        if (file_is_dia)
+        {
+          OPENMS_LOG_INFO << "[ProSE] DIA mode for " << in_spectra << std::endl;
+          PeakMap full_exp;
+          FileHandler f_full;
+          f_full.loadExperiment(in_spectra, full_exp, {FileTypes::MZML, FileTypes::BRUKER_TDF});
+          full_exp.sortSpectra(true);
+          auto ms2_to_ms1 = buildMS2ToMS1Map_(full_exp);
+          std::vector<Size> pseudo_to_original;
+          spectra = expandDIASpectra_(full_exp, ms2_to_ms1, pseudo_to_original);
+        }
+        else if (spectra.empty())
         {
           FileHandler f;
           PeakFileOptions options;
@@ -2657,6 +2788,203 @@ namespace OpenMS
       OPENMS_LOG_INFO << "[ProSE] Statistics tables written to:" << std::endl;
       OPENMS_LOG_INFO << "  - " << output_base_name << "_ModificationAnalysis_DeltaMassStats.tsv" << std::endl;
       OPENMS_LOG_INFO << "  - " << output_base_name << "_ModificationAnalysis_PTMStats.tsv" << std::endl;
+    }
+  }
+
+  // =====================================================================
+  // DIA support: helper methods
+  // =====================================================================
+
+  bool ProSEAlgorithm::isDIAExperiment_(const PeakMap& spectra) const
+  {
+    std::vector<double> widths;
+    widths.reserve(10);
+    for (const auto& spec : spectra)
+    {
+      if (spec.getMSLevel() != 2) continue;
+      const auto& precs = spec.getPrecursors();
+      if (precs.empty()) continue;
+      double lo = precs[0].getIsolationWindowLowerOffset();
+      double hi = precs[0].getIsolationWindowUpperOffset();
+      if (lo <= 0.0 && hi <= 0.0) continue;
+      widths.push_back(lo + hi);
+      if (widths.size() >= 10) break;
+    }
+    if (widths.empty()) return false;
+    std::sort(widths.begin(), widths.end());
+    double median = widths[widths.size() / 2];
+    return median > dia_min_isolation_width_;
+  }
+
+  std::vector<int> ProSEAlgorithm::buildMS2ToMS1Map_(const PeakMap& full_exp)
+  {
+    std::vector<int> map(full_exp.size(), -1);
+    int last_ms1_idx = -1;
+    for (Size i = 0; i < full_exp.size(); ++i)
+    {
+      if (full_exp[i].getMSLevel() == 1)
+      {
+        last_ms1_idx = static_cast<int>(i);
+      }
+      else if (full_exp[i].getMSLevel() == 2)
+      {
+        map[i] = last_ms1_idx;
+      }
+    }
+    return map;
+  }
+
+  std::vector<ProSEAlgorithm::PrecursorCandidate_> ProSEAlgorithm::extractMS1PrecursorCandidates_(
+      const MSSpectrum& ms1_spectrum,
+      const Precursor& ms2_precursor,
+      Size max_candidates)
+  {
+    double center = ms2_precursor.getMZ();
+    double lower_mz = center - ms2_precursor.getIsolationWindowLowerOffset();
+    double upper_mz = center + ms2_precursor.getIsolationWindowUpperOffset();
+
+    auto it_lo = ms1_spectrum.MZBegin(lower_mz);
+    auto it_hi = ms1_spectrum.MZEnd(upper_mz);
+
+    std::vector<PrecursorCandidate_> candidates;
+    for (auto it = it_lo; it != it_hi; ++it)
+    {
+      candidates.push_back({it->getMZ(), it->getIntensity(), 0});
+    }
+
+    std::sort(candidates.begin(), candidates.end(),
+              [](const PrecursorCandidate_& a, const PrecursorCandidate_& b)
+              { return a.intensity > b.intensity; });
+
+    if (candidates.size() > max_candidates)
+    {
+      candidates.resize(max_candidates);
+    }
+    return candidates;
+  }
+
+  int ProSEAlgorithm::assignChargeByIsotopeSpacing_(
+      const MSSpectrum& ms1_spectrum,
+      double candidate_mz,
+      int min_charge,
+      int max_charge,
+      double mz_tolerance_ppm)
+  {
+    for (int z = max_charge; z >= min_charge; --z)
+    {
+      double spacing = Constants::C13C12_MASSDIFF_U / static_cast<double>(z);
+      double expected_mz = candidate_mz + spacing;
+      double tol_da = expected_mz * mz_tolerance_ppm * 1e-6;
+      Size idx = ms1_spectrum.findNearest(expected_mz);
+      if (idx < ms1_spectrum.size())
+      {
+        double actual_mz = ms1_spectrum[idx].getMZ();
+        if (std::abs(actual_mz - expected_mz) <= tol_da)
+        {
+          return z;
+        }
+      }
+    }
+    return 0;
+  }
+
+  PeakMap ProSEAlgorithm::expandDIASpectra_(
+      const PeakMap& full_exp,
+      const std::vector<int>& ms2_to_ms1_map,
+      std::vector<Size>& pseudo_to_original) const
+  {
+    PeakMap expanded;
+    pseudo_to_original.clear();
+
+    Size ms2_count = 0;
+    for (Size i = 0; i < full_exp.size(); ++i)
+    {
+      if (full_exp[i].getMSLevel() != 2) continue;
+
+      const MSSpectrum& ms2 = full_exp[i];
+      int ms1_idx = ms2_to_ms1_map[i];
+      Size original_ms2_idx = ms2_count;
+      ++ms2_count;
+
+      if (ms1_idx < 0) continue;
+      const auto& precs = ms2.getPrecursors();
+      if (precs.empty()) continue;
+
+      const MSSpectrum& ms1 = full_exp[ms1_idx];
+      auto candidates = extractMS1PrecursorCandidates_(
+          ms1, precs[0], dia_max_precursor_candidates_);
+
+      for (auto& cand : candidates)
+      {
+        cand.charge = assignChargeByIsotopeSpacing_(
+            ms1, cand.mz,
+            static_cast<int>(precursor_min_charge_),
+            static_cast<int>(precursor_max_charge_),
+            dia_isotope_tolerance_ppm_);
+      }
+
+      for (Size k = 0; k < candidates.size(); ++k)
+      {
+        MSSpectrum pseudo;
+        pseudo.setRT(ms2.getRT());
+        pseudo.setMSLevel(2);
+        pseudo.setNativeID(ms2.getNativeID() + "_dia_" + String(k));
+        pseudo.insert(pseudo.end(), ms2.begin(), ms2.end());
+        pseudo.getFloatDataArrays() = ms2.getFloatDataArrays();
+        pseudo.getStringDataArrays() = ms2.getStringDataArrays();
+        pseudo.getIntegerDataArrays() = ms2.getIntegerDataArrays();
+
+        Precursor p;
+        p.setMZ(candidates[k].mz);
+        p.setCharge(candidates[k].charge);
+        p.setIntensity(candidates[k].intensity);
+        pseudo.setPrecursors({p});
+
+        expanded.addSpectrum(std::move(pseudo));
+        pseudo_to_original.push_back(original_ms2_idx);
+      }
+    }
+
+    OPENMS_LOG_INFO << "[ProSE-DIA] Expanded " << ms2_count << " DIA MS2 spectra into "
+                    << expanded.size() << " pseudo-spectra ("
+                    << dia_max_precursor_candidates_ << " max candidates per window)." << std::endl;
+    return expanded;
+  }
+
+  void ProSEAlgorithm::mergeDIAPseudoSpectraHits_(
+      const std::vector<std::vector<AnnotatedHit_>>& pseudo_hits,
+      const std::vector<Size>& pseudo_to_original,
+      Size num_original_scans,
+      Size top_hits,
+      std::vector<std::vector<AnnotatedHit_>>& merged_hits)
+  {
+    merged_hits.clear();
+    merged_hits.resize(num_original_scans);
+
+    for (Size pseudo_idx = 0; pseudo_idx < pseudo_hits.size(); ++pseudo_idx)
+    {
+      if (pseudo_idx >= pseudo_to_original.size()) break;
+      Size orig = pseudo_to_original[pseudo_idx];
+      if (orig >= num_original_scans) continue;
+
+      for (const auto& hit : pseudo_hits[pseudo_idx])
+      {
+        merged_hits[orig].push_back(hit);
+      }
+    }
+
+    for (auto& hits : merged_hits)
+    {
+      if (hits.size() > top_hits)
+      {
+        std::partial_sort(hits.begin(), hits.begin() + top_hits, hits.end(),
+                          AnnotatedHit_::hasBetterScore);
+        hits.resize(top_hits);
+      }
+      else
+      {
+        std::sort(hits.begin(), hits.end(), AnnotatedHit_::hasBetterScore);
+      }
     }
   }
 

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -1590,53 +1590,7 @@ namespace OpenMS
       vector<ProteinIdentification>& protein_ids,
       PeptideIdentificationList& peptide_ids) const
   {
-    // Determine DIA mode: may need full experiment (MS1+MS2)
-    bool use_dia = false;
-    PeakMap spectra;
-
-    if (dia_mode_ == "true")
-    {
-      use_dia = true;
-    }
-    else if (dia_mode_ == "auto" || dia_mode_ == "false")
-    {
-      // Load MS2-only for auto-detection (and non-DIA path)
-      FileHandler f;
-      PeakFileOptions options;
-      options.clearMSLevels();
-      options.addMSLevel(2);
-      f.getOptions() = options;
-      f.loadExperiment(in_spectra, spectra, {FileTypes::MZML, FileTypes::BRUKER_TDF});
-      spectra.sortSpectra(true);
-
-      if (dia_mode_ == "auto")
-      {
-        use_dia = isDIAExperiment_(spectra);
-      }
-    }
-
-    if (use_dia)
-    {
-      OPENMS_LOG_INFO << "[ProSE] DIA mode active. Loading full experiment (MS1+MS2)..." << std::endl;
-      PeakMap full_exp;
-      FileHandler f2;
-      f2.loadExperiment(in_spectra, full_exp, {FileTypes::MZML, FileTypes::BRUKER_TDF});
-      full_exp.sortSpectra(true);
-
-      auto ms2_to_ms1 = buildMS2ToMS1Map_(full_exp);
-      spectra = expandDIASpectra_(full_exp, ms2_to_ms1);
-    }
-    else if (spectra.empty())
-    {
-      // dia_mode_ == "true" skipped MS2-only load above; need to load now
-      FileHandler f;
-      PeakFileOptions options;
-      options.clearMSLevels();
-      options.addMSLevel(2);
-      f.getOptions() = options;
-      f.loadExperiment(in_spectra, spectra, {FileTypes::MZML, FileTypes::BRUKER_TDF});
-      spectra.sortSpectra(true);
-    }
+    PeakMap spectra = loadSpectraForSearch_(in_spectra);
 
     // load FASTA
     vector<FASTAFile::FASTAEntry> fasta_db;
@@ -1795,46 +1749,7 @@ namespace OpenMS
       for (Size i = 0; i < in_spectra_files.size(); ++i)
       {
         OPENMS_LOG_INFO << "[ProSE] Loading " << in_spectra_files[i] << std::endl;
-
-        bool file_is_dia = (dia_mode_ == "true");
-        if (dia_mode_ == "auto")
-        {
-          PeakMap ms2_only;
-          FileHandler f_ms2;
-          PeakFileOptions opts_ms2;
-          opts_ms2.clearMSLevels();
-          opts_ms2.addMSLevel(2);
-          f_ms2.getOptions() = opts_ms2;
-          f_ms2.loadExperiment(in_spectra_files[i], ms2_only, {FileTypes::MZML, FileTypes::BRUKER_TDF});
-          file_is_dia = isDIAExperiment_(ms2_only);
-          if (!file_is_dia)
-          {
-            all_spectra[i] = std::move(ms2_only);
-            all_spectra[i].sortSpectra(true);
-          }
-        }
-
-        if (file_is_dia)
-        {
-          OPENMS_LOG_INFO << "[ProSE] DIA mode for " << in_spectra_files[i] << std::endl;
-          PeakMap full_exp;
-          FileHandler f_full;
-          f_full.loadExperiment(in_spectra_files[i], full_exp, {FileTypes::MZML, FileTypes::BRUKER_TDF});
-          full_exp.sortSpectra(true);
-          auto ms2_to_ms1 = buildMS2ToMS1Map_(full_exp);
-          all_spectra[i] = expandDIASpectra_(full_exp, ms2_to_ms1);
-        }
-        else if (all_spectra[i].empty())
-        {
-          FileHandler f;
-          PeakFileOptions options;
-          options.clearMSLevels();
-          options.addMSLevel(2);
-          f.getOptions() = options;
-          f.loadExperiment(in_spectra_files[i], all_spectra[i], {FileTypes::MZML, FileTypes::BRUKER_TDF});
-          all_spectra[i].sortSpectra(true);
-        }
-
+        all_spectra[i] = loadSpectraForSearch_(in_spectra_files[i]);
         preprocessSpectra_(all_spectra[i], fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm);
       }
 
@@ -2121,44 +2036,7 @@ namespace OpenMS
         OPENMS_LOG_INFO << "[ProSE] [" << (i + 1) << "/" << in_spectra_files.size()
                         << "] Searching " << in_spectra << std::endl;
 
-        PeakMap spectra;
-        bool file_is_dia = (dia_mode_ == "true");
-        if (dia_mode_ == "auto")
-        {
-          PeakMap ms2_only;
-          FileHandler f_ms2;
-          PeakFileOptions opts_ms2;
-          opts_ms2.clearMSLevels();
-          opts_ms2.addMSLevel(2);
-          f_ms2.getOptions() = opts_ms2;
-          f_ms2.loadExperiment(in_spectra, ms2_only, {FileTypes::MZML, FileTypes::BRUKER_TDF});
-          file_is_dia = isDIAExperiment_(ms2_only);
-          if (!file_is_dia)
-          {
-            spectra = std::move(ms2_only);
-          }
-        }
-
-        if (file_is_dia)
-        {
-          OPENMS_LOG_INFO << "[ProSE] DIA mode for " << in_spectra << std::endl;
-          PeakMap full_exp;
-          FileHandler f_full;
-          f_full.loadExperiment(in_spectra, full_exp, {FileTypes::MZML, FileTypes::BRUKER_TDF});
-          full_exp.sortSpectra(true);
-          auto ms2_to_ms1 = buildMS2ToMS1Map_(full_exp);
-          spectra = expandDIASpectra_(full_exp, ms2_to_ms1);
-        }
-        else if (spectra.empty())
-        {
-          FileHandler f;
-          PeakFileOptions options;
-          options.clearMSLevels();
-          options.addMSLevel(2);
-          f.getOptions() = options;
-          f.loadExperiment(in_spectra, spectra, {FileTypes::MZML, FileTypes::BRUKER_TDF});
-        }
-        spectra.sortSpectra(true);
+        PeakMap spectra = loadSpectraForSearch_(in_spectra);
 
         SearchResult result;
         result.is_open_search = isOpenSearchMode_();
@@ -2519,6 +2397,7 @@ namespace OpenMS
       AASequence best_seq;
       int best_isotope_error = 0;
       uint16_t best_charge = 0;
+      uint16_t best_precursor_idx = 0;
       float best_mean_error = 0;
 
       for (const auto& sms : top_sms.hits_)
@@ -2539,6 +2418,7 @@ namespace OpenMS
           best_seq = std::move(seq);
           best_isotope_error = sms.isotope_error_;
           best_charge = sms.precursor_charge_;
+          best_precursor_idx = sms.precursor_idx_;
           best_mean_error = static_cast<float>(detail.mean_error);
         }
       }
@@ -2557,7 +2437,7 @@ namespace OpenMS
       // isotope_error * C13C12; the observed-to-monoiso m/z correction is
       //   corrected_mz = observed_mz + isotope_error * C13C12 / charge
       // Matches the sign used by postProcessHits_'s PRECURSOR_ERROR_PPM annotation.
-      double exp_mz = spec.getPrecursors()[0].getMZ();
+      double exp_mz = spec.getPrecursors()[best_precursor_idx].getMZ();
       double theo_mz = best_seq.getMZ(best_charge);
       double corrected_exp_mz = exp_mz + static_cast<double>(best_isotope_error)
                                           * Constants::C13C12_MASSDIFF_U / best_charge;
@@ -2788,6 +2668,45 @@ namespace OpenMS
   // =====================================================================
   // DIA support: helper methods
   // =====================================================================
+
+  PeakMap ProSEAlgorithm::loadSpectraForSearch_(const String& in_spectra) const
+  {
+    if (dia_mode_ == "false")
+    {
+      PeakMap spectra;
+      FileHandler f;
+      PeakFileOptions options;
+      options.clearMSLevels();
+      options.addMSLevel(2);
+      f.getOptions() = options;
+      f.loadExperiment(in_spectra, spectra, {FileTypes::MZML, FileTypes::BRUKER_TDF});
+      spectra.sortSpectra(true);
+      return spectra;
+    }
+
+    // "auto" or "true": load full experiment (MS1+MS2) in a single pass.
+    PeakMap full_exp;
+    FileHandler f;
+    f.loadExperiment(in_spectra, full_exp, {FileTypes::MZML, FileTypes::BRUKER_TDF});
+    full_exp.sortSpectra(true);
+
+    bool use_dia = (dia_mode_ == "true") || isDIAExperiment_(full_exp);
+
+    if (use_dia)
+    {
+      OPENMS_LOG_INFO << "[ProSE] DIA mode active for " << in_spectra << std::endl;
+      auto ms2_to_ms1 = buildMS2ToMS1Map_(full_exp);
+      return expandDIASpectra_(full_exp, ms2_to_ms1);
+    }
+
+    // Not DIA: extract MS2 spectra only
+    PeakMap ms2_only;
+    for (const auto& spec : full_exp)
+    {
+      if (spec.getMSLevel() == 2) ms2_only.addSpectrum(spec);
+    }
+    return ms2_only;
+  }
 
   bool ProSEAlgorithm::isDIAExperiment_(const PeakMap& spectra) const
   {

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -2671,9 +2671,21 @@ namespace OpenMS
 
   PeakMap ProSEAlgorithm::loadSpectraForSearch_(const String& in_spectra) const
   {
-    if (dia_mode_ == "false")
+    if (dia_mode_ == "true")
     {
-      PeakMap spectra;
+      // Forced DIA: load full experiment directly (need MS1 for precursor extraction)
+      PeakMap full_exp;
+      FileHandler f;
+      f.loadExperiment(in_spectra, full_exp, {FileTypes::MZML, FileTypes::BRUKER_TDF});
+      full_exp.sortSpectra(true);
+      OPENMS_LOG_INFO << "[ProSE] DIA mode active for " << in_spectra << std::endl;
+      auto ms2_to_ms1 = buildMS2ToMS1Map_(full_exp);
+      return expandDIASpectra_(full_exp, ms2_to_ms1);
+    }
+
+    // "auto" or "false": load MS2-only first (cheap — avoids holding MS1 in memory for DDA)
+    PeakMap spectra;
+    {
       FileHandler f;
       PeakFileOptions options;
       options.clearMSLevels();
@@ -2681,31 +2693,22 @@ namespace OpenMS
       f.getOptions() = options;
       f.loadExperiment(in_spectra, spectra, {FileTypes::MZML, FileTypes::BRUKER_TDF});
       spectra.sortSpectra(true);
-      return spectra;
     }
 
-    // "auto" or "true": load full experiment (MS1+MS2) in a single pass.
-    PeakMap full_exp;
-    FileHandler f;
-    f.loadExperiment(in_spectra, full_exp, {FileTypes::MZML, FileTypes::BRUKER_TDF});
-    full_exp.sortSpectra(true);
-
-    bool use_dia = (dia_mode_ == "true") || isDIAExperiment_(full_exp);
-
-    if (use_dia)
+    if (dia_mode_ == "auto" && isDIAExperiment_(spectra))
     {
-      OPENMS_LOG_INFO << "[ProSE] DIA mode active for " << in_spectra << std::endl;
+      // Auto-detected DIA: reload with MS1+MS2 for precursor extraction
+      spectra.clear(true);
+      PeakMap full_exp;
+      FileHandler f;
+      f.loadExperiment(in_spectra, full_exp, {FileTypes::MZML, FileTypes::BRUKER_TDF});
+      full_exp.sortSpectra(true);
+      OPENMS_LOG_INFO << "[ProSE] DIA mode auto-detected for " << in_spectra << std::endl;
       auto ms2_to_ms1 = buildMS2ToMS1Map_(full_exp);
       return expandDIASpectra_(full_exp, ms2_to_ms1);
     }
 
-    // Not DIA: extract MS2 spectra only
-    PeakMap ms2_only;
-    for (const auto& spec : full_exp)
-    {
-      if (spec.getMSLevel() == 2) ms2_only.addSpectrum(spec);
-    }
-    return ms2_only;
+    return spectra;
   }
 
   bool ProSEAlgorithm::isDIAExperiment_(const PeakMap& spectra) const

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -473,12 +473,8 @@ namespace OpenMS
         pi.setMetaValue("scan_index", static_cast<unsigned int>(scan_index));
         pi.setScoreType("ln(hyperscore)");
         pi.setHigherScoreBetter(true);
-        // Use the best hit's precursor m/z when available (multi-precursor DIA spectra);
-        // fall back to spectrum metadata for single-precursor (DDA) spectra.
         const auto& best_ah = annotated_hits[scan_index][0];
-        double mz = (best_ah.dia_precursor_mz > 0.0)
-            ? best_ah.dia_precursor_mz
-            : spec.getPrecursors()[0].getMZ();
+        double mz = best_ah.dia_precursor_mz;
         pi.setRT(spec.getRT());
         pi.setMZ(mz);
 
@@ -488,17 +484,17 @@ namespace OpenMS
           pi.setMetaValue(Constants::UserParam::IM, spec.getDriftTime());
         }
 
-        Size charge = (best_ah.applied_charge > 0)
-            ? static_cast<Size>(best_ah.applied_charge)
-            : spec.getPrecursors()[0].getCharge();
-
         // create full peptide hit structure from annotated hits
         vector<PeptideHit> phs;
         for (const auto& ah : annotated_hits[scan_index])
         {
           PeptideHit ph;
-          // Prefer spectrum charge; if absent (0), fall back to the charge actually used by FI for this candidate
-          const Size used_charge = (charge > 0) ? charge : static_cast<Size>(ah.applied_charge);
+          // Use per-hit charge from FragmentIndex (supports multi-precursor DIA where
+          // different hits come from different precursors at different charges).
+          // Fall back to spectrum metadata only when the hit has no charge assigned.
+          const Size used_charge = (ah.applied_charge > 0)
+              ? static_cast<Size>(ah.applied_charge)
+              : spec.getPrecursors()[0].getCharge();
           ph.setCharge(used_charge);
           ph.setScore(ah.score);
           ph.setSequence(ah.sequence);
@@ -518,7 +514,7 @@ namespace OpenMS
             tsg_param.setValue("add_first_prefix_ion", "true");
             tsg.setParameters(tsg_param);
 
-            const int max_frag_z = (charge >= 2) ? std::min<int>(charge - 1, 2) : 1;
+            const int max_frag_z = (used_charge >= 2) ? std::min<int>(used_charge - 1, 2) : 1;
             tsg.getSpectrum(theoretical_spec, ah.sequence, 1, max_frag_z);
             SpectrumAlignment sa;
             Param sa_param(sa.getParameters());
@@ -543,10 +539,7 @@ namespace OpenMS
 
           if (annotation_precursor_error_ppm)
           {
-            // Use per-hit precursor m/z (supports multi-precursor DIA spectra where
-            // each hit may come from a different precursor candidate).
-            const double hit_mz = (ah.dia_precursor_mz > 0.0) ? ah.dia_precursor_mz : mz;
-            const double corrected_mz = hit_mz
+            const double corrected_mz = ah.dia_precursor_mz
               + static_cast<double>(ah.isotope_error) * Constants::C13C12_MASSDIFF_U / used_charge;
             double theo_mz = ah.sequence.getMZ(used_charge);
             double ppm_difference = Math::getPPM(corrected_mz, theo_mz);
@@ -1631,8 +1624,7 @@ namespace OpenMS
       full_exp.sortSpectra(true);
 
       auto ms2_to_ms1 = buildMS2ToMS1Map_(full_exp);
-      std::vector<Size> pseudo_to_original;
-      spectra = expandDIASpectra_(full_exp, ms2_to_ms1, pseudo_to_original);
+      spectra = expandDIASpectra_(full_exp, ms2_to_ms1);
     }
     else if (spectra.empty())
     {
@@ -1830,8 +1822,7 @@ namespace OpenMS
           f_full.loadExperiment(in_spectra_files[i], full_exp, {FileTypes::MZML, FileTypes::BRUKER_TDF});
           full_exp.sortSpectra(true);
           auto ms2_to_ms1 = buildMS2ToMS1Map_(full_exp);
-          std::vector<Size> pseudo_to_original;
-          all_spectra[i] = expandDIASpectra_(full_exp, ms2_to_ms1, pseudo_to_original);
+          all_spectra[i] = expandDIASpectra_(full_exp, ms2_to_ms1);
         }
         else if (all_spectra[i].empty())
         {
@@ -2156,8 +2147,7 @@ namespace OpenMS
           f_full.loadExperiment(in_spectra, full_exp, {FileTypes::MZML, FileTypes::BRUKER_TDF});
           full_exp.sortSpectra(true);
           auto ms2_to_ms1 = buildMS2ToMS1Map_(full_exp);
-          std::vector<Size> pseudo_to_original;
-          spectra = expandDIASpectra_(full_exp, ms2_to_ms1, pseudo_to_original);
+          spectra = expandDIASpectra_(full_exp, ms2_to_ms1);
         }
         else if (spectra.empty())
         {
@@ -2810,7 +2800,7 @@ namespace OpenMS
       if (precs.empty()) continue;
       double lo = precs[0].getIsolationWindowLowerOffset();
       double hi = precs[0].getIsolationWindowUpperOffset();
-      if (lo <= 0.0 && hi <= 0.0) continue;
+      if (lo <= 0.0 || hi <= 0.0) continue;
       widths.push_back(lo + hi);
       if (widths.size() >= 10) break;
     }
@@ -2894,11 +2884,9 @@ namespace OpenMS
 
   PeakMap ProSEAlgorithm::expandDIASpectra_(
       const PeakMap& full_exp,
-      const std::vector<int>& ms2_to_ms1_map,
-      std::vector<Size>& pseudo_to_original) const
+      const std::vector<int>& ms2_to_ms1_map) const
   {
     PeakMap result;
-    pseudo_to_original.clear();
 
     Size ms2_count = 0;
     Size total_candidates = 0;
@@ -2910,15 +2898,26 @@ namespace OpenMS
       int ms1_idx = ms2_to_ms1_map[i];
       ++ms2_count;
 
-      if (ms1_idx < 0) continue;
       const auto& orig_precs = ms2.getPrecursors();
       if (orig_precs.empty()) continue;
+
+      if (ms1_idx < 0)
+      {
+        // No preceding MS1 — keep the original spectrum with its DIA precursor
+        result.addSpectrum(ms2);
+        continue;
+      }
 
       const MSSpectrum& ms1 = full_exp[ms1_idx];
       auto candidates = extractMS1PrecursorCandidates_(
           ms1, orig_precs[0], dia_max_precursor_candidates_);
 
-      if (candidates.empty()) continue;
+      if (candidates.empty())
+      {
+        // No MS1 peaks in isolation window — keep original spectrum
+        result.addSpectrum(ms2);
+        continue;
+      }
 
       for (auto& cand : candidates)
       {
@@ -2951,43 +2950,6 @@ namespace OpenMS
                     << total_candidates << " total precursor candidates, "
                     << dia_max_precursor_candidates_ << " max per window)." << std::endl;
     return result;
-  }
-
-  void ProSEAlgorithm::mergeDIAPseudoSpectraHits_(
-      const std::vector<std::vector<AnnotatedHit_>>& pseudo_hits,
-      const std::vector<Size>& pseudo_to_original,
-      Size num_original_scans,
-      Size top_hits,
-      std::vector<std::vector<AnnotatedHit_>>& merged_hits)
-  {
-    merged_hits.clear();
-    merged_hits.resize(num_original_scans);
-
-    for (Size pseudo_idx = 0; pseudo_idx < pseudo_hits.size(); ++pseudo_idx)
-    {
-      if (pseudo_idx >= pseudo_to_original.size()) break;
-      Size orig = pseudo_to_original[pseudo_idx];
-      if (orig >= num_original_scans) continue;
-
-      for (const auto& hit : pseudo_hits[pseudo_idx])
-      {
-        merged_hits[orig].push_back(hit);
-      }
-    }
-
-    for (auto& hits : merged_hits)
-    {
-      if (hits.size() > top_hits)
-      {
-        std::partial_sort(hits.begin(), hits.begin() + top_hits, hits.end(),
-                          AnnotatedHit_::hasBetterScore);
-        hits.resize(top_hits);
-      }
-      else
-      {
-        std::sort(hits.begin(), hits.end(), AnnotatedHit_::hasBetterScore);
-      }
-    }
   }
 
 } // namespace OpenMS

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -2765,55 +2765,79 @@ namespace OpenMS
   std::vector<ProSEAlgorithm::PrecursorCandidate_> ProSEAlgorithm::extractMS1PrecursorCandidates_(
       const MSSpectrum& ms1_spectrum,
       const Precursor& ms2_precursor,
-      Size max_candidates)
+      Size max_candidates,
+      int min_charge,
+      int max_charge,
+      double isotope_tolerance_ppm)
   {
-    double center = ms2_precursor.getMZ();
-    double lower_mz = center - ms2_precursor.getIsolationWindowLowerOffset();
-    double upper_mz = center + ms2_precursor.getIsolationWindowUpperOffset();
+    const double center = ms2_precursor.getMZ();
+    const double lower_mz = center - ms2_precursor.getIsolationWindowLowerOffset();
+    const double upper_mz = center + ms2_precursor.getIsolationWindowUpperOffset();
 
+    // Copy peaks within the isolation window into a small spectrum for deisotoping.
+    // Extend the upper bound by max_isopeaks / min_charge Da so isotope envelopes
+    // straddling the window edge can be fully resolved.
+    constexpr unsigned int max_isopeaks = 10;
+    const double envelope_extension =
+        static_cast<double>(max_isopeaks) * Constants::C13C12_MASSDIFF_U / std::max(min_charge, 1);
+
+    MSSpectrum window;
     auto it_lo = ms1_spectrum.MZBegin(lower_mz);
-    auto it_hi = ms1_spectrum.MZEnd(upper_mz);
-
-    std::vector<PrecursorCandidate_> candidates;
+    auto it_hi = ms1_spectrum.MZEnd(upper_mz + envelope_extension);
     for (auto it = it_lo; it != it_hi; ++it)
     {
-      candidates.push_back({it->getMZ(), it->getIntensity(), 0});
+      window.push_back(*it);
+    }
+    if (window.empty()) return {};
+
+    // Deisotope: collapse each envelope to a single monoisotopic peak,
+    // annotate charge, drop peaks without an isotope pattern (singletons).
+    // keep_only_deisotoped=true: drop peaks with no detected isotope pattern.
+    // A DIA precursor candidate without a +1 isotope peak is more likely to be
+    // noise than a low-abundance real precursor — the intensity-rank fallback
+    // would also push such peaks down anyway.
+    Deisotoper::deisotopeAndSingleCharge(
+        window,
+        isotope_tolerance_ppm,
+        /*fragment_unit_ppm=*/true,
+        min_charge,
+        max_charge,
+        /*keep_only_deisotoped=*/true,
+        /*min_isopeaks=*/2,
+        max_isopeaks,
+        /*make_single_charged=*/false,
+        /*annotate_charge=*/true,
+        /*annotate_iso_peak_count=*/false,
+        /*use_decreasing_model=*/true,
+        /*start_intensity_check=*/2);
+
+    // Read back charges from the annotated IntegerDataArray.
+    const auto& int_arrays = window.getIntegerDataArrays();
+    const auto charge_array_it = std::find_if(
+        int_arrays.begin(), int_arrays.end(),
+        [](const auto& a) { return a.getName() == "charge"; });
+
+    std::vector<PrecursorCandidate_> candidates;
+    candidates.reserve(window.size());
+    for (Size i = 0; i < window.size(); ++i)
+    {
+      // Drop peaks outside the original window (the envelope_extension was just
+      // a working margin for the deisotoper).
+      if (window[i].getMZ() > upper_mz) continue;
+      int charge = 0;
+      if (charge_array_it != int_arrays.end() && i < charge_array_it->size())
+      {
+        charge = (*charge_array_it)[i];
+      }
+      candidates.push_back({window[i].getMZ(), window[i].getIntensity(), charge});
     }
 
     std::sort(candidates.begin(), candidates.end(),
               [](const PrecursorCandidate_& a, const PrecursorCandidate_& b)
               { return a.intensity > b.intensity; });
 
-    if (candidates.size() > max_candidates)
-    {
-      candidates.resize(max_candidates);
-    }
+    if (candidates.size() > max_candidates) candidates.resize(max_candidates);
     return candidates;
-  }
-
-  int ProSEAlgorithm::assignChargeByIsotopeSpacing_(
-      const MSSpectrum& ms1_spectrum,
-      double candidate_mz,
-      int min_charge,
-      int max_charge,
-      double mz_tolerance_ppm)
-  {
-    for (int z = max_charge; z >= min_charge; --z)
-    {
-      double spacing = Constants::C13C12_MASSDIFF_U / static_cast<double>(z);
-      double expected_mz = candidate_mz + spacing;
-      double tol_da = expected_mz * mz_tolerance_ppm * 1e-6;
-      Size idx = ms1_spectrum.findNearest(expected_mz);
-      if (idx < ms1_spectrum.size())
-      {
-        double actual_mz = ms1_spectrum[idx].getMZ();
-        if (std::abs(actual_mz - expected_mz) <= tol_da)
-        {
-          return z;
-        }
-      }
-    }
-    return 0;
   }
 
   PeakMap ProSEAlgorithm::expandDIASpectra_(
@@ -2844,22 +2868,16 @@ namespace OpenMS
 
       const MSSpectrum& ms1 = full_exp[ms1_idx];
       auto candidates = extractMS1PrecursorCandidates_(
-          ms1, orig_precs[0], dia_max_precursor_candidates_);
+          ms1, orig_precs[0], dia_max_precursor_candidates_,
+          static_cast<int>(precursor_min_charge_),
+          static_cast<int>(precursor_max_charge_),
+          dia_isotope_tolerance_ppm_);
 
       if (candidates.empty())
       {
-        // No MS1 peaks in isolation window — keep original spectrum
+        // No MS1 candidates in isolation window — keep original spectrum
         result.addSpectrum(ms2);
         continue;
-      }
-
-      for (auto& cand : candidates)
-      {
-        cand.charge = assignChargeByIsotopeSpacing_(
-            ms1, cand.mz,
-            static_cast<int>(precursor_min_charge_),
-            static_cast<int>(precursor_max_charge_),
-            dia_isotope_tolerance_ppm_);
       }
 
       // Store one spectrum with multiple precursors (no peak duplication)

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -473,7 +473,12 @@ namespace OpenMS
         pi.setMetaValue("scan_index", static_cast<unsigned int>(scan_index));
         pi.setScoreType("ln(hyperscore)");
         pi.setHigherScoreBetter(true);
-        double mz = spec.getPrecursors()[0].getMZ();
+        // Use the best hit's precursor m/z when available (multi-precursor DIA spectra);
+        // fall back to spectrum metadata for single-precursor (DDA) spectra.
+        const auto& best_ah = annotated_hits[scan_index][0];
+        double mz = (best_ah.dia_precursor_mz > 0.0)
+            ? best_ah.dia_precursor_mz
+            : spec.getPrecursors()[0].getMZ();
         pi.setRT(spec.getRT());
         pi.setMZ(mz);
 
@@ -483,7 +488,9 @@ namespace OpenMS
           pi.setMetaValue(Constants::UserParam::IM, spec.getDriftTime());
         }
 
-        Size charge = spec.getPrecursors()[0].getCharge();
+        Size charge = (best_ah.applied_charge > 0)
+            ? static_cast<Size>(best_ah.applied_charge)
+            : spec.getPrecursors()[0].getCharge();
 
         // create full peptide hit structure from annotated hits
         vector<PeptideHit> phs;
@@ -536,13 +543,10 @@ namespace OpenMS
 
           if (annotation_precursor_error_ppm)
           {
-            // Subtract out the isotope offset FI matched at — FragmentIndex searches
-            // shifted_mass = precursor_mass + isotope_error * C13C12, so M_theo ≈ N_obs
-            // + isotope_error * C13C12, and the observed-to-monoiso correction in m/z is
-            //   corrected_mz = observed_mz + isotope_error * C13C12 / charge
-            // Without this, a ±1 Da FI match reports ~1000 ppm / charge for the Percolator
-            // feature, corrupting target/decoy discrimination.
-            const double corrected_mz = mz
+            // Use per-hit precursor m/z (supports multi-precursor DIA spectra where
+            // each hit may come from a different precursor candidate).
+            const double hit_mz = (ah.dia_precursor_mz > 0.0) ? ah.dia_precursor_mz : mz;
+            const double corrected_mz = hit_mz
               + static_cast<double>(ah.isotope_error) * Constants::C13C12_MASSDIFF_U / used_charge;
             double theo_mz = ah.sequence.getMZ(used_charge);
             double ppm_difference = Math::getPPM(corrected_mz, theo_mz);
@@ -951,7 +955,7 @@ namespace OpenMS
         {
           // Realize the sub-peptide at the length whose mass best matches the
           // observed precursor (iso-corrected per the FI's shifted-mass convention).
-          const double exp_mz = exp_spectrum.getPrecursors()[0].getMZ();
+          const double exp_mz = exp_spectrum.getPrecursors()[sms.precursor_idx_].getMZ();
           const double observed_mh_plus =
               exp_mz * sms.precursor_charge_ - (sms.precursor_charge_ - 1) * proton_mass_u;
           // SNES v1.1: subtract the variable-mod Σ from the realization target
@@ -1009,7 +1013,7 @@ namespace OpenMS
         ah.matched_suffix_ions = static_cast<uint16_t>(detail.matched_suffix_ions);
         ah.isotope_error = sms.isotope_error_;
         ah.applied_charge = sms.precursor_charge_;
-        ah.dia_precursor_mz = exp_spectrum.getPrecursors()[0].getMZ();
+        ah.dia_precursor_mz = exp_spectrum.getPrecursors()[sms.precursor_idx_].getMZ();
         ah.delta_mass = 0.0;
         if (open_search_mode)
         {
@@ -2893,26 +2897,28 @@ namespace OpenMS
       const std::vector<int>& ms2_to_ms1_map,
       std::vector<Size>& pseudo_to_original) const
   {
-    PeakMap expanded;
+    PeakMap result;
     pseudo_to_original.clear();
 
     Size ms2_count = 0;
+    Size total_candidates = 0;
     for (Size i = 0; i < full_exp.size(); ++i)
     {
       if (full_exp[i].getMSLevel() != 2) continue;
 
       const MSSpectrum& ms2 = full_exp[i];
       int ms1_idx = ms2_to_ms1_map[i];
-      Size original_ms2_idx = ms2_count;
       ++ms2_count;
 
       if (ms1_idx < 0) continue;
-      const auto& precs = ms2.getPrecursors();
-      if (precs.empty()) continue;
+      const auto& orig_precs = ms2.getPrecursors();
+      if (orig_precs.empty()) continue;
 
       const MSSpectrum& ms1 = full_exp[ms1_idx];
       auto candidates = extractMS1PrecursorCandidates_(
-          ms1, precs[0], dia_max_precursor_candidates_);
+          ms1, orig_precs[0], dia_max_precursor_candidates_);
+
+      if (candidates.empty()) continue;
 
       for (auto& cand : candidates)
       {
@@ -2923,32 +2929,28 @@ namespace OpenMS
             dia_isotope_tolerance_ppm_);
       }
 
-      for (Size k = 0; k < candidates.size(); ++k)
+      // Store one spectrum with multiple precursors (no peak duplication)
+      MSSpectrum spec(ms2);
+      std::vector<Precursor> new_precs;
+      new_precs.reserve(candidates.size());
+      for (const auto& cand : candidates)
       {
-        MSSpectrum pseudo;
-        pseudo.setRT(ms2.getRT());
-        pseudo.setMSLevel(2);
-        pseudo.setNativeID(ms2.getNativeID() + "_dia_" + String(k));
-        pseudo.insert(pseudo.end(), ms2.begin(), ms2.end());
-        pseudo.getFloatDataArrays() = ms2.getFloatDataArrays();
-        pseudo.getStringDataArrays() = ms2.getStringDataArrays();
-        pseudo.getIntegerDataArrays() = ms2.getIntegerDataArrays();
-
         Precursor p;
-        p.setMZ(candidates[k].mz);
-        p.setCharge(candidates[k].charge);
-        p.setIntensity(candidates[k].intensity);
-        pseudo.setPrecursors({p});
-
-        expanded.addSpectrum(std::move(pseudo));
-        pseudo_to_original.push_back(original_ms2_idx);
+        p.setMZ(cand.mz);
+        p.setCharge(cand.charge);
+        p.setIntensity(cand.intensity);
+        new_precs.push_back(std::move(p));
       }
+      spec.setPrecursors(std::move(new_precs));
+      result.addSpectrum(std::move(spec));
+      total_candidates += candidates.size();
     }
 
-    OPENMS_LOG_INFO << "[ProSE-DIA] Expanded " << ms2_count << " DIA MS2 spectra into "
-                    << expanded.size() << " pseudo-spectra ("
-                    << dia_max_precursor_candidates_ << " max candidates per window)." << std::endl;
-    return expanded;
+    OPENMS_LOG_INFO << "[ProSE-DIA] " << ms2_count << " DIA MS2 spectra, "
+                    << result.size() << " with MS1 candidates ("
+                    << total_candidates << " total precursor candidates, "
+                    << dia_max_precursor_candidates_ << " max per window)." << std::endl;
+    return result;
   }
 
   void ProSEAlgorithm::mergeDIAPseudoSpectraHits_(

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -2774,15 +2774,20 @@ namespace OpenMS
     const double lower_mz = center - ms2_precursor.getIsolationWindowLowerOffset();
     const double upper_mz = center + ms2_precursor.getIsolationWindowUpperOffset();
 
-    // Copy peaks within the isolation window into a small spectrum for deisotoping.
-    // Extend the upper bound by max_isopeaks / min_charge Da so isotope envelopes
-    // straddling the window edge can be fully resolved.
+    // Extend the window symmetrically by max_isopeaks/min_charge Da so the
+    // deisotoper can resolve envelopes straddling either edge:
+    //  - Upper edge: an envelope with mono in-window but +1/+2 above upper_mz
+    //    is correctly collapsed to its mono (kept).
+    //  - Lower edge: an envelope with mono below lower_mz must be visible to
+    //    the deisotoper, otherwise it would mistake the in-window isotope
+    //    peaks for a new (wrong-mz, wrong-charge) envelope. The mono itself
+    //    is then filtered out by the final lower_mz <= mz <= upper_mz check.
     constexpr unsigned int max_isopeaks = 10;
     const double envelope_extension =
         static_cast<double>(max_isopeaks) * Constants::C13C12_MASSDIFF_U / std::max(min_charge, 1);
 
     MSSpectrum window;
-    auto it_lo = ms1_spectrum.MZBegin(lower_mz);
+    auto it_lo = ms1_spectrum.MZBegin(lower_mz - envelope_extension);
     auto it_hi = ms1_spectrum.MZEnd(upper_mz + envelope_extension);
     for (auto it = it_lo; it != it_hi; ++it)
     {
@@ -2821,15 +2826,18 @@ namespace OpenMS
     candidates.reserve(window.size());
     for (Size i = 0; i < window.size(); ++i)
     {
-      // Drop peaks outside the original window (the envelope_extension was just
-      // a working margin for the deisotoper).
-      if (window[i].getMZ() > upper_mz) continue;
+      // Only keep monoisotopic peaks whose m/z falls in the actual isolation
+      // window. The envelope_extension margin was a working area for the
+      // deisotoper — peaks resolved there are precursors NOT isolated by this
+      // DIA window and must be dropped.
+      const double mz = window[i].getMZ();
+      if (mz < lower_mz || mz > upper_mz) continue;
       int charge = 0;
       if (charge_array_it != int_arrays.end() && i < charge_array_it->size())
       {
         charge = (*charge_array_it)[i];
       }
-      candidates.push_back({window[i].getMZ(), window[i].getIntensity(), charge});
+      candidates.push_back({mz, window[i].getIntensity(), charge});
     }
 
     std::sort(candidates.begin(), candidates.end(),

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -2683,7 +2683,33 @@ namespace OpenMS
       return expandDIASpectra_(full_exp, ms2_to_ms1);
     }
 
-    // "auto" or "false": load MS2-only first (cheap — avoids holding MS1 in memory for DDA)
+    if (dia_mode_ == "auto")
+    {
+      // Cheap metadata-only load for DIA detection (skips peak data decoding)
+      PeakMap meta_only;
+      {
+        FileHandler f;
+        PeakFileOptions options;
+        options.clearMSLevels();
+        options.addMSLevel(2);
+        options.setFillData(false);
+        f.getOptions() = options;
+        f.loadExperiment(in_spectra, meta_only, {FileTypes::MZML, FileTypes::BRUKER_TDF});
+      }
+
+      if (isDIAExperiment_(meta_only))
+      {
+        PeakMap full_exp;
+        FileHandler f;
+        f.loadExperiment(in_spectra, full_exp, {FileTypes::MZML, FileTypes::BRUKER_TDF});
+        full_exp.sortSpectra(true);
+        OPENMS_LOG_INFO << "[ProSE] DIA mode auto-detected for " << in_spectra << std::endl;
+        auto ms2_to_ms1 = buildMS2ToMS1Map_(full_exp);
+        return expandDIASpectra_(full_exp, ms2_to_ms1);
+      }
+    }
+
+    // DDA (or dia:false): load MS2-only with peak data
     PeakMap spectra;
     {
       FileHandler f;
@@ -2694,20 +2720,6 @@ namespace OpenMS
       f.loadExperiment(in_spectra, spectra, {FileTypes::MZML, FileTypes::BRUKER_TDF});
       spectra.sortSpectra(true);
     }
-
-    if (dia_mode_ == "auto" && isDIAExperiment_(spectra))
-    {
-      // Auto-detected DIA: reload with MS1+MS2 for precursor extraction
-      spectra.clear(true);
-      PeakMap full_exp;
-      FileHandler f;
-      f.loadExperiment(in_spectra, full_exp, {FileTypes::MZML, FileTypes::BRUKER_TDF});
-      full_exp.sortSpectra(true);
-      OPENMS_LOG_INFO << "[ProSE] DIA mode auto-detected for " << in_spectra << std::endl;
-      auto ms2_to_ms1 = buildMS2ToMS1Map_(full_exp);
-      return expandDIASpectra_(full_exp, ms2_to_ms1);
-    }
-
     return spectra;
   }
 

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -2826,17 +2826,27 @@ namespace OpenMS
     candidates.reserve(window.size());
     for (Size i = 0; i < window.size(); ++i)
     {
-      // Only keep monoisotopic peaks whose m/z falls in the actual isolation
-      // window. The envelope_extension margin was a working area for the
-      // deisotoper — peaks resolved there are precursors NOT isolated by this
-      // DIA window and must be dropped.
+      // Keep envelopes that overlap the actual isolation window. Real DIA
+      // windows have soft edges, and a peptide whose mono is just below the
+      // window can still contribute fragments via its isotope peaks that DO
+      // fall in the window.
+      //
+      // Filter:
+      //  - mono must be at or below upper_mz (otherwise the whole envelope
+      //    is above the window and no fragments are transmitted)
+      //  - mono + C13/charge must reach into the window (envelope's lowest
+      //    isotope is in or above lower_mz). For charge=0 (rare with
+      //    keep_only_deisotoped=true), fall back to max_charge spacing.
       const double mz = window[i].getMZ();
-      if (mz < lower_mz || mz > upper_mz) continue;
+      if (mz > upper_mz) continue;
       int charge = 0;
       if (charge_array_it != int_arrays.end() && i < charge_array_it->size())
       {
         charge = (*charge_array_it)[i];
       }
+      const int z_for_spacing = (charge > 0) ? charge : max_charge;
+      const double first_iso_mz = mz + Constants::C13C12_MASSDIFF_U / z_for_spacing;
+      if (first_iso_mz < lower_mz) continue;
       candidates.push_back({mz, window[i].getIntensity(), charge});
     }
 

--- a/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
@@ -1632,43 +1632,26 @@ START_SECTION(([EXTRA] DIA expandDIASpectra))
   std::vector<Size> pseudo_to_original;
   PeakMap expanded = algo.expandDIASpectra_(full_exp, ms2_to_ms1, pseudo_to_original);
 
-  // Window 1 has 4 MS1 peaks in range, window 2 has 1
-  // (the isotope peaks also count as candidates)
-  TEST_EQUAL(expanded.size(), pseudo_to_original.size())
-  TEST_EQUAL(expanded.size() >= 2, true) // at least 1 per window
+  // Multi-precursor mode: one spectrum per DIA window, multiple precursors per spectrum
+  TEST_EQUAL(expanded.size(), 2) // one per DIA window
 
-  // All pseudo-spectra should be MS level 2
-  for (Size i = 0; i < expanded.size(); ++i)
-  {
-    TEST_EQUAL(expanded[i].getMSLevel(), 2)
-    TEST_EQUAL(expanded[i].getPrecursors().size(), 1)
-  }
+  // Both should be MS level 2 with multiple precursors
+  TEST_EQUAL(expanded[0].getMSLevel(), 2)
+  TEST_EQUAL(expanded[1].getMSLevel(), 2)
 
-  // Check pseudo_to_original mapping: window 1 pseudo-spectra map to 0, window 2 to 1
-  for (Size i = 0; i < pseudo_to_original.size(); ++i)
-  {
-    TEST_EQUAL(pseudo_to_original[i] <= 1, true)
-  }
+  // Window 1 has 4 MS1 peaks in range (498.0, ~498.5, 502.0, ~502.33)
+  TEST_EQUAL(expanded[0].getPrecursors().size(), 4)
+  // Window 2 has 1 MS1 peak in range (523.0)
+  TEST_EQUAL(expanded[1].getPrecursors().size(), 1)
 
-  // The highest-intensity candidate (1000 @ 502.0) should appear first for window 1
-  // and should have charge 3 (isotope at +c13/3)
-  bool found_502 = false;
-  for (Size i = 0; i < expanded.size(); ++i)
-  {
-    if (pseudo_to_original[i] == 0) // window 1
-    {
-      double prec_mz = expanded[i].getPrecursors()[0].getMZ();
-      if (std::abs(prec_mz - 502.0) < 0.01)
-      {
-        found_502 = true;
-        TEST_EQUAL(expanded[i].getPrecursors()[0].getCharge(), 3)
-        // Fragment peaks should be copied from original MS2
-        TEST_EQUAL(expanded[i].size(), 2) // 200.0 and 300.0
-        break;
-      }
-    }
-  }
-  TEST_EQUAL(found_502, true)
+  // Precursors sorted by intensity descending: 502.0 (1000) should be first for window 1
+  const auto& w1_precs = expanded[0].getPrecursors();
+  TEST_REAL_SIMILAR(w1_precs[0].getMZ(), 502.0)
+  TEST_EQUAL(w1_precs[0].getCharge(), 3) // isotope at +c13/3
+
+  // Fragment peaks should be the original MS2 peaks (not duplicated)
+  TEST_EQUAL(expanded[0].size(), 2) // 200.0 and 300.0
+  TEST_EQUAL(expanded[1].size(), 1) // 250.0
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
@@ -52,6 +52,16 @@ public:
   using ProSEAlgorithm::last_calibration_result_;
   using ProSEAlgorithm::last_mod_match_tolerance_used_;
   using ProSEAlgorithm::CalibrationResult_;
+
+  // DIA support
+  using ProSEAlgorithm::PrecursorCandidate_;
+  using ProSEAlgorithm::isDIAExperiment_;
+  using ProSEAlgorithm::buildMS2ToMS1Map_;
+  using ProSEAlgorithm::extractMS1PrecursorCandidates_;
+  using ProSEAlgorithm::assignChargeByIsotopeSpacing_;
+  using ProSEAlgorithm::expandDIASpectra_;
+  using ProSEAlgorithm::mergeDIAPseudoSpectraHits_;
+  using ProSEAlgorithm::AnnotatedHit_;
 };
 
 // --- Shared calibration fixture -------------------------------------------------
@@ -1380,6 +1390,345 @@ START_SECTION(([EXTRA] computeModMatchTolerance_ returns min(lower, upper)))
   p.setValue("precursor:mass_tolerance_upper", 2.0);
   algo.setParameters(p);
   TEST_REAL_SIMILAR(algo.computeModMatchTolerance_(), 0.5)
+}
+END_SECTION
+
+// =====================================================================
+// DIA support tests
+// =====================================================================
+
+START_SECTION(([EXTRA] DIA auto-detection - wide isolation windows))
+{
+  // Build a PeakMap with wide-window MS2 spectra (DIA-like)
+  PeakMap dia_exp;
+  for (int i = 0; i < 5; ++i)
+  {
+    MSSpectrum s;
+    s.setMSLevel(2);
+    s.setRT(100.0 + i);
+    Precursor p;
+    p.setMZ(500.0 + i * 25.0);
+    p.setIsolationWindowLowerOffset(12.5);
+    p.setIsolationWindowUpperOffset(12.5);
+    s.setPrecursors({p});
+    dia_exp.addSpectrum(s);
+  }
+
+  ProSEAlgorithm_test algo;
+  Param params = algo.getParameters();
+  params.setValue("dia:min_isolation_width", 4.0);
+  algo.setParameters(params);
+
+  TEST_EQUAL(algo.isDIAExperiment_(dia_exp), true)
+
+  // Narrow windows (DDA-like) should not trigger DIA
+  PeakMap dda_exp;
+  for (int i = 0; i < 5; ++i)
+  {
+    MSSpectrum s;
+    s.setMSLevel(2);
+    s.setRT(100.0 + i);
+    Precursor p;
+    p.setMZ(500.0 + i);
+    p.setIsolationWindowLowerOffset(0.7);
+    p.setIsolationWindowUpperOffset(0.7);
+    s.setPrecursors({p});
+    dda_exp.addSpectrum(s);
+  }
+  TEST_EQUAL(algo.isDIAExperiment_(dda_exp), false)
+
+  // No isolation window info should return false
+  PeakMap no_iso_exp;
+  for (int i = 0; i < 5; ++i)
+  {
+    MSSpectrum s;
+    s.setMSLevel(2);
+    s.setRT(100.0 + i);
+    Precursor p;
+    p.setMZ(500.0);
+    s.setPrecursors({p});
+    no_iso_exp.addSpectrum(s);
+  }
+  TEST_EQUAL(algo.isDIAExperiment_(no_iso_exp), false)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] DIA buildMS2ToMS1Map))
+{
+  PeakMap exp;
+  // MS1 at index 0
+  MSSpectrum ms1_0;
+  ms1_0.setMSLevel(1);
+  ms1_0.setRT(10.0);
+  exp.addSpectrum(ms1_0);
+
+  // MS2 at index 1, 2 (children of MS1 at 0)
+  for (int i = 0; i < 2; ++i)
+  {
+    MSSpectrum ms2;
+    ms2.setMSLevel(2);
+    ms2.setRT(11.0 + i);
+    Precursor p;
+    p.setMZ(500.0);
+    ms2.setPrecursors({p});
+    exp.addSpectrum(ms2);
+  }
+
+  // MS1 at index 3
+  MSSpectrum ms1_1;
+  ms1_1.setMSLevel(1);
+  ms1_1.setRT(20.0);
+  exp.addSpectrum(ms1_1);
+
+  // MS2 at index 4 (child of MS1 at 3)
+  MSSpectrum ms2_3;
+  ms2_3.setMSLevel(2);
+  ms2_3.setRT(21.0);
+  Precursor p3;
+  p3.setMZ(600.0);
+  ms2_3.setPrecursors({p3});
+  exp.addSpectrum(ms2_3);
+
+  auto map = ProSEAlgorithm_test::buildMS2ToMS1Map_(exp);
+  TEST_EQUAL(map.size(), 5)
+  TEST_EQUAL(map[0], -1) // MS1 itself
+  TEST_EQUAL(map[1], 0)  // MS2 → MS1 at 0
+  TEST_EQUAL(map[2], 0)  // MS2 → MS1 at 0
+  TEST_EQUAL(map[3], -1) // MS1 itself
+  TEST_EQUAL(map[4], 3)  // MS2 → MS1 at 3
+}
+END_SECTION
+
+START_SECTION(([EXTRA] DIA extractMS1PrecursorCandidates))
+{
+  // Build MS1 spectrum with known peaks
+  MSSpectrum ms1;
+  ms1.setMSLevel(1);
+  // Peaks at m/z 490, 495, 500 (high), 505 (highest), 510, 520 (outside window)
+  ms1.push_back(Peak1D(490.0, 100.0));
+  ms1.push_back(Peak1D(495.0, 200.0));
+  ms1.push_back(Peak1D(500.0, 800.0));
+  ms1.push_back(Peak1D(505.0, 1000.0));
+  ms1.push_back(Peak1D(510.0, 150.0));
+  ms1.push_back(Peak1D(520.0, 5000.0)); // outside window
+  ms1.sortByPosition();
+
+  // Precursor with isolation window [487.5, 512.5]
+  Precursor prec;
+  prec.setMZ(500.0);
+  prec.setIsolationWindowLowerOffset(12.5);
+  prec.setIsolationWindowUpperOffset(12.5);
+
+  auto candidates = ProSEAlgorithm_test::extractMS1PrecursorCandidates_(ms1, prec, 3);
+
+  // Should get top 3 by intensity, sorted desc: 505 (1000), 500 (800), 495 (200)
+  TEST_EQUAL(candidates.size(), 3)
+  TEST_REAL_SIMILAR(candidates[0].mz, 505.0)
+  TEST_REAL_SIMILAR(candidates[0].intensity, 1000.0)
+  TEST_REAL_SIMILAR(candidates[1].mz, 500.0)
+  TEST_REAL_SIMILAR(candidates[1].intensity, 800.0)
+  TEST_REAL_SIMILAR(candidates[2].mz, 495.0)
+  TEST_REAL_SIMILAR(candidates[2].intensity, 200.0)
+
+  // 520.0 should NOT appear (outside window)
+  for (const auto& c : candidates)
+  {
+    TEST_NOT_EQUAL(c.mz, 520.0)
+  }
+}
+END_SECTION
+
+START_SECTION(([EXTRA] DIA assignChargeByIsotopeSpacing - high charge first))
+{
+  // Build MS1 with a peak at 500.0 and isotope peaks for charge 2 and charge 3
+  MSSpectrum ms1;
+  ms1.setMSLevel(1);
+  double c13 = Constants::C13C12_MASSDIFF_U;
+
+  ms1.push_back(Peak1D(500.0, 1000.0));
+  // charge 2 isotope: +0.5017
+  ms1.push_back(Peak1D(500.0 + c13 / 2.0, 500.0));
+  // charge 3 isotope: +0.3345
+  ms1.push_back(Peak1D(500.0 + c13 / 3.0, 300.0));
+  ms1.sortByPosition();
+
+  // With max_charge=5, should find charge 3 first (testing high to low)
+  // because charge 5 and 4 won't find isotope peaks, but charge 3 will
+  int charge = ProSEAlgorithm_test::assignChargeByIsotopeSpacing_(ms1, 500.0, 2, 5, 20.0);
+  TEST_EQUAL(charge, 3)
+
+  // With max_charge=2, should find charge 2
+  charge = ProSEAlgorithm_test::assignChargeByIsotopeSpacing_(ms1, 500.0, 2, 2, 20.0);
+  TEST_EQUAL(charge, 2)
+
+  // Peak with no isotope neighbors should return 0
+  MSSpectrum ms1_single;
+  ms1_single.push_back(Peak1D(700.0, 1000.0));
+  ms1_single.push_back(Peak1D(800.0, 500.0)); // too far for any charge
+  ms1_single.sortByPosition();
+
+  charge = ProSEAlgorithm_test::assignChargeByIsotopeSpacing_(ms1_single, 700.0, 2, 5, 10.0);
+  TEST_EQUAL(charge, 0)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] DIA expandDIASpectra))
+{
+  // Build a small DIA experiment: 1 MS1 + 2 MS2
+  PeakMap full_exp;
+
+  // MS1 with known peaks in both DIA windows
+  MSSpectrum ms1;
+  ms1.setMSLevel(1);
+  ms1.setRT(10.0);
+  double c13 = Constants::C13C12_MASSDIFF_U;
+  // Window 1 peaks (around 500)
+  ms1.push_back(Peak1D(498.0, 500.0));
+  ms1.push_back(Peak1D(498.0 + c13 / 2.0, 250.0)); // isotope for charge 2
+  ms1.push_back(Peak1D(502.0, 1000.0));
+  ms1.push_back(Peak1D(502.0 + c13 / 3.0, 400.0)); // isotope for charge 3
+  // Window 2 peaks (around 525)
+  ms1.push_back(Peak1D(523.0, 800.0));
+  ms1.sortByPosition();
+  full_exp.addSpectrum(ms1);
+
+  // MS2 window 1: isolation [487.5, 512.5]
+  MSSpectrum ms2_1;
+  ms2_1.setMSLevel(2);
+  ms2_1.setRT(11.0);
+  ms2_1.setNativeID("scan=1");
+  ms2_1.push_back(Peak1D(200.0, 100.0));
+  ms2_1.push_back(Peak1D(300.0, 200.0));
+  Precursor p1;
+  p1.setMZ(500.0);
+  p1.setIsolationWindowLowerOffset(12.5);
+  p1.setIsolationWindowUpperOffset(12.5);
+  ms2_1.setPrecursors({p1});
+  full_exp.addSpectrum(ms2_1);
+
+  // MS2 window 2: isolation [512.5, 537.5]
+  MSSpectrum ms2_2;
+  ms2_2.setMSLevel(2);
+  ms2_2.setRT(12.0);
+  ms2_2.setNativeID("scan=2");
+  ms2_2.push_back(Peak1D(250.0, 150.0));
+  Precursor p2;
+  p2.setMZ(525.0);
+  p2.setIsolationWindowLowerOffset(12.5);
+  p2.setIsolationWindowUpperOffset(12.5);
+  ms2_2.setPrecursors({p2});
+  full_exp.addSpectrum(ms2_2);
+
+  auto ms2_to_ms1 = ProSEAlgorithm_test::buildMS2ToMS1Map_(full_exp);
+
+  ProSEAlgorithm_test algo;
+  Param params = algo.getParameters();
+  params.setValue("dia:max_precursor_candidates", 20);
+  params.setValue("dia:isotope_tolerance_ppm", 20.0);
+  params.setValue("precursor:min_charge", 2);
+  params.setValue("precursor:max_charge", 5);
+  algo.setParameters(params);
+
+  std::vector<Size> pseudo_to_original;
+  PeakMap expanded = algo.expandDIASpectra_(full_exp, ms2_to_ms1, pseudo_to_original);
+
+  // Window 1 has 4 MS1 peaks in range, window 2 has 1
+  // (the isotope peaks also count as candidates)
+  TEST_EQUAL(expanded.size(), pseudo_to_original.size())
+  TEST_EQUAL(expanded.size() >= 2, true) // at least 1 per window
+
+  // All pseudo-spectra should be MS level 2
+  for (Size i = 0; i < expanded.size(); ++i)
+  {
+    TEST_EQUAL(expanded[i].getMSLevel(), 2)
+    TEST_EQUAL(expanded[i].getPrecursors().size(), 1)
+  }
+
+  // Check pseudo_to_original mapping: window 1 pseudo-spectra map to 0, window 2 to 1
+  for (Size i = 0; i < pseudo_to_original.size(); ++i)
+  {
+    TEST_EQUAL(pseudo_to_original[i] <= 1, true)
+  }
+
+  // The highest-intensity candidate (1000 @ 502.0) should appear first for window 1
+  // and should have charge 3 (isotope at +c13/3)
+  bool found_502 = false;
+  for (Size i = 0; i < expanded.size(); ++i)
+  {
+    if (pseudo_to_original[i] == 0) // window 1
+    {
+      double prec_mz = expanded[i].getPrecursors()[0].getMZ();
+      if (std::abs(prec_mz - 502.0) < 0.01)
+      {
+        found_502 = true;
+        TEST_EQUAL(expanded[i].getPrecursors()[0].getCharge(), 3)
+        // Fragment peaks should be copied from original MS2
+        TEST_EQUAL(expanded[i].size(), 2) // 200.0 and 300.0
+        break;
+      }
+    }
+  }
+  TEST_EQUAL(found_502, true)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] DIA mergeDIAPseudoSpectraHits))
+{
+  // Simulate 3 pseudo-spectra from 2 original scans:
+  // pseudo 0, 1 → original 0; pseudo 2 → original 1
+  std::vector<std::vector<ProSEAlgorithm_test::AnnotatedHit_>> pseudo_hits(3);
+
+  // pseudo 0: one hit with score 10
+  {
+    ProSEAlgorithm_test::AnnotatedHit_ h;
+    h.score = 10.0;
+    h.sequence = AASequence::fromString("PEPTIDE");
+    h.dia_precursor_mz = 500.0;
+    h.applied_charge = 2;
+    pseudo_hits[0].push_back(h);
+  }
+  // pseudo 1: one hit with score 20 (better, same original scan)
+  {
+    ProSEAlgorithm_test::AnnotatedHit_ h;
+    h.score = 20.0;
+    h.sequence = AASequence::fromString("PEPTIDER");
+    h.dia_precursor_mz = 502.0;
+    h.applied_charge = 3;
+    pseudo_hits[1].push_back(h);
+  }
+  // pseudo 2: one hit with score 15 (different original scan)
+  {
+    ProSEAlgorithm_test::AnnotatedHit_ h;
+    h.score = 15.0;
+    h.sequence = AASequence::fromString("ANOTHERSEQ");
+    h.dia_precursor_mz = 525.0;
+    h.applied_charge = 2;
+    pseudo_hits[2].push_back(h);
+  }
+
+  std::vector<Size> pseudo_to_original = {0, 0, 1};
+  std::vector<std::vector<ProSEAlgorithm_test::AnnotatedHit_>> merged;
+
+  ProSEAlgorithm_test::mergeDIAPseudoSpectraHits_(pseudo_hits, pseudo_to_original, 2, 1, merged);
+
+  TEST_EQUAL(merged.size(), 2)
+  // Original scan 0: should keep top-1 by score → score 20 (PEPTIDER)
+  TEST_EQUAL(merged[0].size(), 1)
+  TEST_REAL_SIMILAR(merged[0][0].score, 20.0)
+  TEST_EQUAL(merged[0][0].sequence.toString(), "PEPTIDER")
+  TEST_REAL_SIMILAR(merged[0][0].dia_precursor_mz, 502.0)
+  TEST_EQUAL(merged[0][0].applied_charge, 3)
+
+  // Original scan 1: single hit
+  TEST_EQUAL(merged[1].size(), 1)
+  TEST_REAL_SIMILAR(merged[1][0].score, 15.0)
+
+  // Test with top_hits=2: original scan 0 should keep both hits
+  ProSEAlgorithm_test::mergeDIAPseudoSpectraHits_(pseudo_hits, pseudo_to_original, 2, 2, merged);
+  TEST_EQUAL(merged[0].size(), 2)
+  // Sorted by score descending
+  TEST_REAL_SIMILAR(merged[0][0].score, 20.0)
+  TEST_REAL_SIMILAR(merged[0][1].score, 10.0)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
@@ -1545,6 +1545,70 @@ START_SECTION(([EXTRA] DIA extractMS1PrecursorCandidates - deisotopes envelopes)
 }
 END_SECTION
 
+START_SECTION(([EXTRA] DIA extractMS1PrecursorCandidates - boundary cases))
+{
+  // Isolation window [487.5, 512.5]
+  Precursor prec;
+  prec.setMZ(500.0);
+  prec.setIsolationWindowLowerOffset(12.5);
+  prec.setIsolationWindowUpperOffset(12.5);
+  const double c13 = Constants::C13C12_MASSDIFF_U;
+
+  // Case 1: envelope straddling upper edge — mono in window, +1 outside
+  {
+    MSSpectrum ms1;
+    ms1.setMSLevel(1);
+    // Charge-2 envelope at mono 512.0 (just inside upper edge); +1 at 512.5, +2 at 513.0
+    ms1.push_back(Peak1D(512.0, 1000.0));
+    ms1.push_back(Peak1D(512.0 + c13 / 2.0, 500.0));   // 512.50 — at edge
+    ms1.push_back(Peak1D(512.0 + 2 * c13 / 2.0, 200.0)); // 513.00 — outside
+    ms1.sortByPosition();
+
+    auto candidates = ProSEAlgorithm_test::extractMS1PrecursorCandidates_(
+        ms1, prec, 10, 2, 5, 20.0);
+    TEST_EQUAL(candidates.size(), 1)
+    TEST_REAL_SIMILAR(candidates[0].mz, 512.0)
+    TEST_EQUAL(candidates[0].charge, 2)
+  }
+
+  // Case 2: envelope with mono BELOW window — must NOT be reported as a candidate
+  // Without lower extension, the deisotoper would treat the +1 peak (in window)
+  // as a new (wrong) mono.
+  {
+    MSSpectrum ms1;
+    ms1.setMSLevel(1);
+    // Charge-2 envelope at mono 487.0 (below lower_mz=487.5);
+    // peaks at 487.0, 487.5, 488.0 (the latter two are in the window)
+    ms1.push_back(Peak1D(487.0, 1000.0));
+    ms1.push_back(Peak1D(487.0 + c13 / 2.0, 500.0));   // 487.50 — in window
+    ms1.push_back(Peak1D(487.0 + 2 * c13 / 2.0, 200.0)); // 488.00 — in window
+    ms1.sortByPosition();
+
+    auto candidates = ProSEAlgorithm_test::extractMS1PrecursorCandidates_(
+        ms1, prec, 10, 2, 5, 20.0);
+    // mono (487.0) is below lower_mz → filtered out
+    // the +1/+2 in-window peaks are correctly attributed to the out-of-window mono → not new candidates
+    TEST_EQUAL(candidates.size(), 0)
+  }
+
+  // Case 3: envelope with mono just at lower_mz — kept
+  {
+    MSSpectrum ms1;
+    ms1.setMSLevel(1);
+    ms1.push_back(Peak1D(487.5, 1000.0));
+    ms1.push_back(Peak1D(487.5 + c13 / 2.0, 500.0));
+    ms1.push_back(Peak1D(487.5 + 2 * c13 / 2.0, 200.0));
+    ms1.sortByPosition();
+
+    auto candidates = ProSEAlgorithm_test::extractMS1PrecursorCandidates_(
+        ms1, prec, 10, 2, 5, 20.0);
+    TEST_EQUAL(candidates.size(), 1)
+    TEST_REAL_SIMILAR(candidates[0].mz, 487.5)
+    TEST_EQUAL(candidates[0].charge, 2)
+  }
+}
+END_SECTION
+
 START_SECTION(([EXTRA] DIA expandDIASpectra))
 {
   // Build a small DIA experiment: 1 MS1 + 2 MS2

--- a/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
@@ -60,7 +60,6 @@ public:
   using ProSEAlgorithm::extractMS1PrecursorCandidates_;
   using ProSEAlgorithm::assignChargeByIsotopeSpacing_;
   using ProSEAlgorithm::expandDIASpectra_;
-  using ProSEAlgorithm::mergeDIAPseudoSpectraHits_;
   using ProSEAlgorithm::AnnotatedHit_;
 };
 
@@ -1629,8 +1628,7 @@ START_SECTION(([EXTRA] DIA expandDIASpectra))
   params.setValue("precursor:max_charge", 5);
   algo.setParameters(params);
 
-  std::vector<Size> pseudo_to_original;
-  PeakMap expanded = algo.expandDIASpectra_(full_exp, ms2_to_ms1, pseudo_to_original);
+  PeakMap expanded = algo.expandDIASpectra_(full_exp, ms2_to_ms1);
 
   // Multi-precursor mode: one spectrum per DIA window, multiple precursors per spectrum
   TEST_EQUAL(expanded.size(), 2) // one per DIA window
@@ -1652,66 +1650,6 @@ START_SECTION(([EXTRA] DIA expandDIASpectra))
   // Fragment peaks should be the original MS2 peaks (not duplicated)
   TEST_EQUAL(expanded[0].size(), 2) // 200.0 and 300.0
   TEST_EQUAL(expanded[1].size(), 1) // 250.0
-}
-END_SECTION
-
-START_SECTION(([EXTRA] DIA mergeDIAPseudoSpectraHits))
-{
-  // Simulate 3 pseudo-spectra from 2 original scans:
-  // pseudo 0, 1 → original 0; pseudo 2 → original 1
-  std::vector<std::vector<ProSEAlgorithm_test::AnnotatedHit_>> pseudo_hits(3);
-
-  // pseudo 0: one hit with score 10
-  {
-    ProSEAlgorithm_test::AnnotatedHit_ h;
-    h.score = 10.0;
-    h.sequence = AASequence::fromString("PEPTIDE");
-    h.dia_precursor_mz = 500.0;
-    h.applied_charge = 2;
-    pseudo_hits[0].push_back(h);
-  }
-  // pseudo 1: one hit with score 20 (better, same original scan)
-  {
-    ProSEAlgorithm_test::AnnotatedHit_ h;
-    h.score = 20.0;
-    h.sequence = AASequence::fromString("PEPTIDER");
-    h.dia_precursor_mz = 502.0;
-    h.applied_charge = 3;
-    pseudo_hits[1].push_back(h);
-  }
-  // pseudo 2: one hit with score 15 (different original scan)
-  {
-    ProSEAlgorithm_test::AnnotatedHit_ h;
-    h.score = 15.0;
-    h.sequence = AASequence::fromString("ANOTHERSEQ");
-    h.dia_precursor_mz = 525.0;
-    h.applied_charge = 2;
-    pseudo_hits[2].push_back(h);
-  }
-
-  std::vector<Size> pseudo_to_original = {0, 0, 1};
-  std::vector<std::vector<ProSEAlgorithm_test::AnnotatedHit_>> merged;
-
-  ProSEAlgorithm_test::mergeDIAPseudoSpectraHits_(pseudo_hits, pseudo_to_original, 2, 1, merged);
-
-  TEST_EQUAL(merged.size(), 2)
-  // Original scan 0: should keep top-1 by score → score 20 (PEPTIDER)
-  TEST_EQUAL(merged[0].size(), 1)
-  TEST_REAL_SIMILAR(merged[0][0].score, 20.0)
-  TEST_EQUAL(merged[0][0].sequence.toString(), "PEPTIDER")
-  TEST_REAL_SIMILAR(merged[0][0].dia_precursor_mz, 502.0)
-  TEST_EQUAL(merged[0][0].applied_charge, 3)
-
-  // Original scan 1: single hit
-  TEST_EQUAL(merged[1].size(), 1)
-  TEST_REAL_SIMILAR(merged[1][0].score, 15.0)
-
-  // Test with top_hits=2: original scan 0 should keep both hits
-  ProSEAlgorithm_test::mergeDIAPseudoSpectraHits_(pseudo_hits, pseudo_to_original, 2, 2, merged);
-  TEST_EQUAL(merged[0].size(), 2)
-  // Sorted by score descending
-  TEST_REAL_SIMILAR(merged[0][0].score, 20.0)
-  TEST_REAL_SIMILAR(merged[0][1].score, 10.0)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
@@ -1571,23 +1571,53 @@ START_SECTION(([EXTRA] DIA extractMS1PrecursorCandidates - boundary cases))
     TEST_EQUAL(candidates[0].charge, 2)
   }
 
-  // Case 2: envelope with mono BELOW window — must NOT be reported as a candidate
-  // Without lower extension, the deisotoper would treat the +1 peak (in window)
-  // as a new (wrong) mono.
+  // Case 2: envelope with mono just below window — KEPT because isotopes
+  // reach into the window and contribute fragments. The candidate carries
+  // the true monoisotopic m/z (487.0), not a fabricated in-window mono.
   {
     MSSpectrum ms1;
     ms1.setMSLevel(1);
     // Charge-2 envelope at mono 487.0 (below lower_mz=487.5);
-    // peaks at 487.0, 487.5, 488.0 (the latter two are in the window)
+    // +1 at 487.50 — in window
     ms1.push_back(Peak1D(487.0, 1000.0));
-    ms1.push_back(Peak1D(487.0 + c13 / 2.0, 500.0));   // 487.50 — in window
-    ms1.push_back(Peak1D(487.0 + 2 * c13 / 2.0, 200.0)); // 488.00 — in window
+    ms1.push_back(Peak1D(487.0 + c13 / 2.0, 500.0));
+    ms1.push_back(Peak1D(487.0 + 2 * c13 / 2.0, 200.0));
     ms1.sortByPosition();
 
     auto candidates = ProSEAlgorithm_test::extractMS1PrecursorCandidates_(
         ms1, prec, 10, 2, 5, 20.0);
-    // mono (487.0) is below lower_mz → filtered out
-    // the +1/+2 in-window peaks are correctly attributed to the out-of-window mono → not new candidates
+    TEST_EQUAL(candidates.size(), 1)
+    TEST_REAL_SIMILAR(candidates[0].mz, 487.0)
+    TEST_EQUAL(candidates[0].charge, 2)
+  }
+
+  // Case 2b: envelope with mono FAR below window — excluded (no isotopes reach window)
+  {
+    MSSpectrum ms1;
+    ms1.setMSLevel(1);
+    // Charge-2 envelope at mono 480.0; +1 at 480.50, +2 at 481.00 — none in window
+    ms1.push_back(Peak1D(480.0, 1000.0));
+    ms1.push_back(Peak1D(480.0 + c13 / 2.0, 500.0));
+    ms1.push_back(Peak1D(480.0 + 2 * c13 / 2.0, 200.0));
+    ms1.sortByPosition();
+
+    auto candidates = ProSEAlgorithm_test::extractMS1PrecursorCandidates_(
+        ms1, prec, 10, 2, 5, 20.0);
+    TEST_EQUAL(candidates.size(), 0)
+  }
+
+  // Case 2c: envelope with mono above upper_mz — excluded (whole envelope above window)
+  {
+    MSSpectrum ms1;
+    ms1.setMSLevel(1);
+    // Mono at 513.0 (above upper_mz=512.5)
+    ms1.push_back(Peak1D(513.0, 1000.0));
+    ms1.push_back(Peak1D(513.0 + c13 / 2.0, 500.0));
+    ms1.push_back(Peak1D(513.0 + 2 * c13 / 2.0, 200.0));
+    ms1.sortByPosition();
+
+    auto candidates = ProSEAlgorithm_test::extractMS1PrecursorCandidates_(
+        ms1, prec, 10, 2, 5, 20.0);
     TEST_EQUAL(candidates.size(), 0)
   }
 

--- a/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
@@ -58,7 +58,6 @@ public:
   using ProSEAlgorithm::isDIAExperiment_;
   using ProSEAlgorithm::buildMS2ToMS1Map_;
   using ProSEAlgorithm::extractMS1PrecursorCandidates_;
-  using ProSEAlgorithm::assignChargeByIsotopeSpacing_;
   using ProSEAlgorithm::expandDIASpectra_;
   using ProSEAlgorithm::AnnotatedHit_;
 };
@@ -1498,76 +1497,51 @@ START_SECTION(([EXTRA] DIA buildMS2ToMS1Map))
 }
 END_SECTION
 
-START_SECTION(([EXTRA] DIA extractMS1PrecursorCandidates))
+START_SECTION(([EXTRA] DIA extractMS1PrecursorCandidates - deisotopes envelopes))
 {
-  // Build MS1 spectrum with known peaks
+  // Build MS1 spectrum with two proper isotope envelopes inside the window
+  // plus an isolated peak outside the window.
   MSSpectrum ms1;
   ms1.setMSLevel(1);
-  // Peaks at m/z 490, 495, 500 (high), 505 (highest), 510, 520 (outside window)
-  ms1.push_back(Peak1D(490.0, 100.0));
-  ms1.push_back(Peak1D(495.0, 200.0));
-  ms1.push_back(Peak1D(500.0, 800.0));
-  ms1.push_back(Peak1D(505.0, 1000.0));
-  ms1.push_back(Peak1D(510.0, 150.0));
-  ms1.push_back(Peak1D(520.0, 5000.0)); // outside window
+  const double c13 = Constants::C13C12_MASSDIFF_U;
+
+  // Charge-2 envelope at mono 495.0 (peaks at 495.0, 495.5, 496.0)
+  ms1.push_back(Peak1D(495.0, 1000.0));
+  ms1.push_back(Peak1D(495.0 + c13 / 2.0, 500.0));
+  ms1.push_back(Peak1D(495.0 + 2 * c13 / 2.0, 200.0));
+
+  // Charge-3 envelope at mono 502.0 (peaks at 502.0, 502.334, 502.667)
+  ms1.push_back(Peak1D(502.0, 2000.0));
+  ms1.push_back(Peak1D(502.0 + c13 / 3.0, 800.0));
+  ms1.push_back(Peak1D(502.0 + 2 * c13 / 3.0, 300.0));
+
+  // Peak outside isolation window — must not appear in result
+  ms1.push_back(Peak1D(550.0, 5000.0));
   ms1.sortByPosition();
 
-  // Precursor with isolation window [487.5, 512.5]
+  // Isolation window [487.5, 512.5]
   Precursor prec;
   prec.setMZ(500.0);
   prec.setIsolationWindowLowerOffset(12.5);
   prec.setIsolationWindowUpperOffset(12.5);
 
-  auto candidates = ProSEAlgorithm_test::extractMS1PrecursorCandidates_(ms1, prec, 3);
+  auto candidates = ProSEAlgorithm_test::extractMS1PrecursorCandidates_(
+      ms1, prec, /*max=*/10, /*min_charge=*/2, /*max_charge=*/5, /*tol_ppm=*/20.0);
 
-  // Should get top 3 by intensity, sorted desc: 505 (1000), 500 (800), 495 (200)
-  TEST_EQUAL(candidates.size(), 3)
-  TEST_REAL_SIMILAR(candidates[0].mz, 505.0)
-  TEST_REAL_SIMILAR(candidates[0].intensity, 1000.0)
-  TEST_REAL_SIMILAR(candidates[1].mz, 500.0)
-  TEST_REAL_SIMILAR(candidates[1].intensity, 800.0)
-  TEST_REAL_SIMILAR(candidates[2].mz, 495.0)
-  TEST_REAL_SIMILAR(candidates[2].intensity, 200.0)
+  // Two monoisotopic precursors expected (envelopes collapsed)
+  TEST_EQUAL(candidates.size(), 2)
 
-  // 520.0 should NOT appear (outside window)
+  // Sorted by intensity: 502.0 (2000) first, 495.0 (1000) second
+  TEST_REAL_SIMILAR(candidates[0].mz, 502.0)
+  TEST_EQUAL(candidates[0].charge, 3)
+  TEST_REAL_SIMILAR(candidates[1].mz, 495.0)
+  TEST_EQUAL(candidates[1].charge, 2)
+
+  // Out-of-window peak must not appear
   for (const auto& c : candidates)
   {
-    TEST_NOT_EQUAL(c.mz, 520.0)
+    TEST_NOT_EQUAL(c.mz, 550.0)
   }
-}
-END_SECTION
-
-START_SECTION(([EXTRA] DIA assignChargeByIsotopeSpacing - high charge first))
-{
-  // Build MS1 with a peak at 500.0 and isotope peaks for charge 2 and charge 3
-  MSSpectrum ms1;
-  ms1.setMSLevel(1);
-  double c13 = Constants::C13C12_MASSDIFF_U;
-
-  ms1.push_back(Peak1D(500.0, 1000.0));
-  // charge 2 isotope: +0.5017
-  ms1.push_back(Peak1D(500.0 + c13 / 2.0, 500.0));
-  // charge 3 isotope: +0.3345
-  ms1.push_back(Peak1D(500.0 + c13 / 3.0, 300.0));
-  ms1.sortByPosition();
-
-  // With max_charge=5, should find charge 3 first (testing high to low)
-  // because charge 5 and 4 won't find isotope peaks, but charge 3 will
-  int charge = ProSEAlgorithm_test::assignChargeByIsotopeSpacing_(ms1, 500.0, 2, 5, 20.0);
-  TEST_EQUAL(charge, 3)
-
-  // With max_charge=2, should find charge 2
-  charge = ProSEAlgorithm_test::assignChargeByIsotopeSpacing_(ms1, 500.0, 2, 2, 20.0);
-  TEST_EQUAL(charge, 2)
-
-  // Peak with no isotope neighbors should return 0
-  MSSpectrum ms1_single;
-  ms1_single.push_back(Peak1D(700.0, 1000.0));
-  ms1_single.push_back(Peak1D(800.0, 500.0)); // too far for any charge
-  ms1_single.sortByPosition();
-
-  charge = ProSEAlgorithm_test::assignChargeByIsotopeSpacing_(ms1_single, 700.0, 2, 5, 10.0);
-  TEST_EQUAL(charge, 0)
 }
 END_SECTION
 
@@ -1576,18 +1550,21 @@ START_SECTION(([EXTRA] DIA expandDIASpectra))
   // Build a small DIA experiment: 1 MS1 + 2 MS2
   PeakMap full_exp;
 
-  // MS1 with known peaks in both DIA windows
+  // MS1 with isotope envelopes in both DIA windows
   MSSpectrum ms1;
   ms1.setMSLevel(1);
   ms1.setRT(10.0);
-  double c13 = Constants::C13C12_MASSDIFF_U;
-  // Window 1 peaks (around 500)
+  const double c13 = Constants::C13C12_MASSDIFF_U;
+  // Window 1: charge-2 envelope at 498.0, charge-3 envelope at 502.0
   ms1.push_back(Peak1D(498.0, 500.0));
-  ms1.push_back(Peak1D(498.0 + c13 / 2.0, 250.0)); // isotope for charge 2
+  ms1.push_back(Peak1D(498.0 + c13 / 2.0, 250.0));
+  ms1.push_back(Peak1D(498.0 + 2 * c13 / 2.0, 100.0));
   ms1.push_back(Peak1D(502.0, 1000.0));
-  ms1.push_back(Peak1D(502.0 + c13 / 3.0, 400.0)); // isotope for charge 3
-  // Window 2 peaks (around 525)
+  ms1.push_back(Peak1D(502.0 + c13 / 3.0, 400.0));
+  ms1.push_back(Peak1D(502.0 + 2 * c13 / 3.0, 150.0));
+  // Window 2: charge-2 envelope at 523.0
   ms1.push_back(Peak1D(523.0, 800.0));
+  ms1.push_back(Peak1D(523.0 + c13 / 2.0, 400.0));
   ms1.sortByPosition();
   full_exp.addSpectrum(ms1);
 
@@ -1637,17 +1614,23 @@ START_SECTION(([EXTRA] DIA expandDIASpectra))
   TEST_EQUAL(expanded[0].getMSLevel(), 2)
   TEST_EQUAL(expanded[1].getMSLevel(), 2)
 
-  // Window 1 has 4 MS1 peaks in range (498.0, ~498.5, 502.0, ~502.33)
-  TEST_EQUAL(expanded[0].getPrecursors().size(), 4)
-  // Window 2 has 1 MS1 peak in range (523.0)
+  // After deisotoping: window 1 has 2 monoisotopic precursors (498.0, 502.0),
+  // window 2 has 1 (523.0).
+  TEST_EQUAL(expanded[0].getPrecursors().size(), 2)
   TEST_EQUAL(expanded[1].getPrecursors().size(), 1)
 
-  // Precursors sorted by intensity descending: 502.0 (1000) should be first for window 1
+  // Window 1 precursors sorted by intensity descending: 502.0 (1000) first
   const auto& w1_precs = expanded[0].getPrecursors();
   TEST_REAL_SIMILAR(w1_precs[0].getMZ(), 502.0)
-  TEST_EQUAL(w1_precs[0].getCharge(), 3) // isotope at +c13/3
+  TEST_EQUAL(w1_precs[0].getCharge(), 3)
+  TEST_REAL_SIMILAR(w1_precs[1].getMZ(), 498.0)
+  TEST_EQUAL(w1_precs[1].getCharge(), 2)
 
-  // Fragment peaks should be the original MS2 peaks (not duplicated)
+  // Window 2 precursor
+  TEST_REAL_SIMILAR(expanded[1].getPrecursors()[0].getMZ(), 523.0)
+  TEST_EQUAL(expanded[1].getPrecursors()[0].getCharge(), 2)
+
+  // Fragment peaks unchanged (no duplication)
   TEST_EQUAL(expanded[0].size(), 2) // 200.0 and 300.0
   TEST_EQUAL(expanded[1].size(), 1) // 250.0
 }

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -3381,6 +3381,36 @@ if (WITH_OPENTIMS AND OPENTIMS_DDA_TEST_DATA)
       DEPENDS "TOPP_IDPosteriorErrorProbability_SageDDA"
       TIMEOUT 300)
   endif()
+
+  # DIA search via ProSE with MS1-derived precursor candidates
+  if (OPENTIMS_DIA_TEST_DATA)
+    set(OPENTIMS_DIA_SYMLINK "${CMAKE_BINARY_DIR}/test_data/DIA_HeLa.d")
+    file(CREATE_LINK "${OPENTIMS_DIA_TEST_DATA}" "${OPENTIMS_DIA_SYMLINK}" SYMBOLIC)
+
+    add_test("TOPP_ProSE_DIA" ${TOPP_BIN_PATH}/ProSE -test
+      -in ${OPENTIMS_DIA_SYMLINK}
+      -database ${OPENTIMS_TEST_FASTA}
+      -out_idxml ${TESTS_TEMP_DIR}/ProSE_DIA_out.tmp.idXML
+      -Search:precursor:mass_tolerance_lower 20
+      -Search:precursor:mass_tolerance_upper 20
+      -Search:precursor:mass_tolerance_unit ppm
+      -Search:fragment:mass_tolerance 20
+      -Search:fragment:mass_tolerance_unit ppm
+      -Search:enzyme Trypsin/P
+      -Search:peptide:missed_cleavages 2
+      "-Search:modifications:variable" "Oxidation (M)" "Acetyl (Protein N-term)"
+      -Search:decoys
+      -Search:dia:enabled true
+      -Search:dia:max_precursor_candidates 20)
+    set_tests_properties("TOPP_ProSE_DIA" PROPERTIES TIMEOUT 600)
+
+    add_test("TOPP_FalseDiscoveryRate_ProSEDIA" ${TOPP_BIN_PATH}/FalseDiscoveryRate -test
+      -in ${TESTS_TEMP_DIR}/ProSE_DIA_out.tmp.idXML
+      -out ${TESTS_TEMP_DIR}/ProSE_DIA_fdr.tmp.idXML
+      -FDR:PSM 0.01
+      -protein false)
+    set_tests_properties("TOPP_FalseDiscoveryRate_ProSEDIA" PROPERTIES DEPENDS "TOPP_ProSE_DIA")
+  endif()
 endif()
 
 # FeatureFinderMetaboIdent:

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -3382,35 +3382,37 @@ if (WITH_OPENTIMS AND OPENTIMS_DDA_TEST_DATA)
       TIMEOUT 300)
   endif()
 
-  # DIA search via ProSE with MS1-derived precursor candidates
-  if (OPENTIMS_DIA_TEST_DATA)
-    set(OPENTIMS_DIA_SYMLINK "${CMAKE_BINARY_DIR}/test_data/DIA_HeLa.d")
-    file(CREATE_LINK "${OPENTIMS_DIA_TEST_DATA}" "${OPENTIMS_DIA_SYMLINK}" SYMBOLIC)
+endif()
 
-    add_test("TOPP_ProSE_DIA" ${TOPP_BIN_PATH}/ProSE -test
-      -in ${OPENTIMS_DIA_SYMLINK}
-      -database ${OPENTIMS_TEST_FASTA}
-      -out_idxml ${TESTS_TEMP_DIR}/ProSE_DIA_out.tmp.idXML
-      -Search:precursor:mass_tolerance_lower 20
-      -Search:precursor:mass_tolerance_upper 20
-      -Search:precursor:mass_tolerance_unit ppm
-      -Search:fragment:mass_tolerance 20
-      -Search:fragment:mass_tolerance_unit ppm
-      -Search:enzyme Trypsin/P
-      -Search:peptide:missed_cleavages 2
-      "-Search:modifications:variable" "Oxidation (M)" "Acetyl (Protein N-term)"
-      -Search:decoys
-      -Search:dia:enabled true
-      -Search:dia:max_precursor_candidates 20)
-    set_tests_properties("TOPP_ProSE_DIA" PROPERTIES TIMEOUT 600)
+# DIA search via ProSE with MS1-derived precursor candidates
+if (WITH_OPENTIMS AND OPENTIMS_DIA_TEST_DATA AND OPENTIMS_TEST_FASTA)
+  set(OPENTIMS_DIA_SYMLINK "${CMAKE_BINARY_DIR}/test_data/DIA_HeLa.d")
+  file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/test_data")
+  file(CREATE_LINK "${OPENTIMS_DIA_TEST_DATA}" "${OPENTIMS_DIA_SYMLINK}" SYMBOLIC)
 
-    add_test("TOPP_FalseDiscoveryRate_ProSEDIA" ${TOPP_BIN_PATH}/FalseDiscoveryRate -test
-      -in ${TESTS_TEMP_DIR}/ProSE_DIA_out.tmp.idXML
-      -out ${TESTS_TEMP_DIR}/ProSE_DIA_fdr.tmp.idXML
-      -FDR:PSM 0.01
-      -protein false)
-    set_tests_properties("TOPP_FalseDiscoveryRate_ProSEDIA" PROPERTIES DEPENDS "TOPP_ProSE_DIA")
-  endif()
+  add_test("TOPP_ProSE_DIA" ${TOPP_BIN_PATH}/ProSE -test
+    -in ${OPENTIMS_DIA_SYMLINK}
+    -database ${OPENTIMS_TEST_FASTA}
+    -out_idxml ${TESTS_TEMP_DIR}/ProSE_DIA_out.tmp.idXML
+    -Search:precursor:mass_tolerance_lower 20
+    -Search:precursor:mass_tolerance_upper 20
+    -Search:precursor:mass_tolerance_unit ppm
+    -Search:fragment:mass_tolerance 20
+    -Search:fragment:mass_tolerance_unit ppm
+    -Search:enzyme Trypsin/P
+    -Search:peptide:missed_cleavages 2
+    "-Search:modifications:variable" "Oxidation (M)" "Acetyl (Protein N-term)"
+    -Search:decoys
+    -Search:dia:enabled true
+    -Search:dia:max_precursor_candidates 20)
+  set_tests_properties("TOPP_ProSE_DIA" PROPERTIES TIMEOUT 600)
+
+  add_test("TOPP_FalseDiscoveryRate_ProSEDIA" ${TOPP_BIN_PATH}/FalseDiscoveryRate -test
+    -in ${TESTS_TEMP_DIR}/ProSE_DIA_out.tmp.idXML
+    -out ${TESTS_TEMP_DIR}/ProSE_DIA_fdr.tmp.idXML
+    -FDR:PSM 0.01
+    -protein false)
+  set_tests_properties("TOPP_FalseDiscoveryRate_ProSEDIA" PROPERTIES DEPENDS "TOPP_ProSE_DIA")
 endif()
 
 # FeatureFinderMetaboIdent:


### PR DESCRIPTION
## Summary

Adds DIA (Data-Independent Acquisition) support to the ProSE search engine. For DIA data, the MS2 "precursor" is just the center of a wide isolation window (10–50 Da), not a real precursor. This PR adds a preprocessing step that uses the parent MS1 survey scan to identify likely precursor candidates within each isolation window, then searches against the fragment index using those candidates as if they were DDA precursors.

## How candidates are determined

For each DIA MS2 spectrum:

1. **Find the parent MS1** survey scan (nearest preceding MS1)
2. **Extract MS1 peaks** in `[lower_mz − ext, upper_mz + ext]` where `ext = max_isopeaks / min_charge` Da gives the deisotoper enough margin to resolve envelopes straddling the isolation window edges
3. **Deisotope** with `Deisotoper::deisotopeAndSingleCharge` — collapses isotope envelopes to monoisotopic peaks and assigns charges (`keep_only_deisotoped=true` drops single-peak noise)
4. **Boundary filter** — keep a candidate envelope iff:
   - `mono ≤ upper_mz` (otherwise whole envelope is above the window)
   - `mono + C13/charge ≥ lower_mz` (at least the +1 isotope reaches the window — handles envelopes whose mono sits just outside the lower edge but whose isotopes contribute fragments through the isolation window's soft edge)
5. **Sort by intensity, take top N** (default 20)

Each candidate is a real monoisotopic peak with a determined charge — no isotope peaks polluting the top-N slots, no mis-identification of +1 isotopes as monoisotopic.

## Multi-precursor spectra (memory)

Instead of cloning each DIA MS2 into N pseudo-spectra (one per candidate), candidates are stored as N `Precursor` objects on the **same** MS2 spectrum. Fragment peak data is shared, saving ~20× memory.

`FragmentIndex::querySpectrum()` now loops over all precursors and tags each `SpectrumMatch` with a new `precursor_idx_` field so scoring knows which precursor produced the hit. The non-SNES and SNES paths both support this.

## Detection / loading

- **`dia:enabled=auto`** (default): metadata-only load (`setFillData(false)`) of MS2 spectra, check median isolation window width > `dia:min_isolation_width` Da. If DIA, reload with MS1+MS2 for precursor extraction. **DDA files never load MS1 data.**
- **`dia:enabled=true`**: skip detection, load full experiment directly
- **`dia:enabled=false`**: skip DIA processing entirely
- The DIA detect-load-expand pattern is consolidated into `loadSpectraForSearch_()` — one helper used by all three search entry points (single-file, chunked multi-file, non-chunked multi-file)

## New parameters

| Parameter | Default | Purpose |
|-----------|---------|---------|
| `dia:enabled` | `auto` | `auto` / `true` / `false` |
| `dia:max_precursor_candidates` | `20` | Top-N MS1 candidates per window |
| `dia:isotope_tolerance_ppm` | `10.0` | Deisotoper tolerance for matching isotope peaks |
| `dia:min_isolation_width` | `4.0` Da | Auto-detect threshold |

## Test plan

- [x] Unit tests for each DIA helper: auto-detection, MS2→MS1 map, MS1 candidate extraction (basic + boundary cases), pseudo-spectrum expansion
- [x] Four boundary cases tested: in-window, envelope straddling lower edge (kept), envelope far below (excluded), envelope above (excluded)
- [x] TOPP integration test using `DIA_HeLa_50ng_5_6min.d` Bruker .d dataset, gated behind `ENABLE_OPENTIMS_TESTS` + `OPENTIMS_DIA_TEST_DATA`
- [x] 1% PSM FDR filter on DIA results
- [ ] PSM count floor for DIA test (TBD after first run establishes a baseline)
- [ ] Verify multi-file DIA + DDA mixed input
- [ ] Verify DIA + open-search modification analysis

## Commit history (11 commits)

1. `feat(ProSE)`: core DIA infrastructure + 4 new parameters + 3 file-based entry points
2. `test(ProSE)`: 6 unit tests for the DIA helpers
3. `refactor(DIA)`: switch from cloned pseudo-spectra to multi-precursor (~20× memory reduction)
4. `test(ProSE)`: DIA TOPP integration test
5. `fix(DIA)`: review findings — per-hit charge propagation, SNES charge fallback, dead code removal, MS2-before-MS1 fallback, half-window false-positive guard
6. `fix(DIA)`: extract `loadSpectraForSearch_` helper, fix calibration `precursor[0]` bug
7. `fix(DIA)`: avoid loading full experiment for DDA files in auto-detect
8. `perf(DIA)`: metadata-only probe for auto-detection (no peak decoding)
9. `refactor(DIA)`: use `Deisotoper` for MS1 candidate extraction (replaces raw intensity ranking)
10. `fix(DIA)`: symmetric envelope extension for isolation window edges
11. `fix(DIA)`: keep edge-overlap envelopes as candidates (soft-edge isolation)

## Stats

```
 6 files changed, 804 insertions(+), 85 deletions(-)
```

## Not in this PR (potential follow-ups)

- Hit deduplication for overlapping DIA precursors that match the same peptide (currently each precursor produces its own PSM — useful for diagnostics, redundant for downstream)
- PSM count floor for the DIA TOPP test once a stable baseline is observed
- Memory optimization for very wide windows: share fragment peak storage via `shared_ptr` instead of full spectrum copy in `expandDIASpectra_`

🤖 Generated with Claude Code

https://claude.ai/code/session_016m1dsNTCbDVhXwczDJD4ZM