### PR TITLE
feat: add CCS/ion-mobility support to MetaboliteSpectralMatching (#8784)

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/MetaboliteSpectralMatching.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/MetaboliteSpectralMatching.h
@@ -137,6 +137,16 @@ namespace OpenMS
     /// Setter for the precursor adduct
     void setPrecursorAdduct(const String&);
 
+    /// Observed collision cross section (CCS) of the experimental precursor in Angstrom^2; -1.0 if not available
+    double getObservedCCS() const;
+    /// Setter for the observed CCS (Angstrom^2); use -1.0 to indicate "not available"
+    void setObservedCCS(const double&);
+
+    /// CCS (Angstrom^2) of the matching DB-side spectrum; -1.0 if not available
+    double getFoundCCS() const;
+    /// Setter for the DB-side CCS (Angstrom^2); use -1.0 to indicate "not available"
+    void setFoundCCS(const double&);
+
 
   private:
     double observed_precursor_mass_;   ///< Observed-side precursor mass (Da)
@@ -156,6 +166,9 @@ namespace OpenMS
     String inchi_string_;   ///< InChI string
     String smiles_string_;  ///< SMILES string
     String precursor_adduct_; ///< DB-side precursor adduct annotation
+
+    double observed_ccs_;   ///< Observed-side collision cross section (Angstrom^2); -1.0 if not available
+    double found_ccs_;      ///< DB-side collision cross section (Angstrom^2); -1.0 if not available
 
   };
 
@@ -191,10 +204,19 @@ namespace OpenMS
          single best match per spectrum according to parameter @c "report_mode" (only
          @c "top3" or @c "best" are valid values) to MzTab.
 
+    Optionally, candidates can additionally be filtered by collision cross section (CCS / ion
+    mobility): when parameter @c "ccs_error_percent" is greater than 0, a candidate is discarded
+    if the relative CCS error @c |observed - library| / library * 100 exceeds the configured
+    percentage. The experimental CCS is taken (in this order) from a CCS-unit drift time, a
+    1/K0 (VSSC) drift time converted via @ref IMTypes::oneOverK0ToCCS, or a numeric @c "CCS"
+    meta value; the library CCS is taken from the DB-side spectrum the same way. If either side
+    has no CCS, the candidate is kept (CCS does not penalise data lacking ion mobility). The
+    observed/library CCS and the relative CCS error are always exported to MzTab when available.
+
     Configuration is exposed through @ref DefaultParamHandler — see the defaults installed
     by the constructor for the supported keys (@c "prec_mass_error_value",
     @c "frag_mass_error_value", @c "mass_error_unit", @c "ionization_mode", @c "report_mode",
-    @c "merge_spectra").
+    @c "merge_spectra", @c "ccs_error_percent").
 
     @ingroup Analysis_ID
   */
@@ -294,6 +316,8 @@ namespace OpenMS
     String report_mode_;            ///< Cached value of parameter @c "report_mode"; only @c "top3" or @c "best" are valid — controls whether the top 3 or only the single best match per spectrum is exported to MzTab
 
     bool merge_spectra_;            ///< If true, merge same-precursor MS2 spectra before searching
+
+    double ccs_error_percent_;      ///< Cached value of parameter @c "ccs_error_percent"; allowed CCS error in percent for filtering candidates (0 = filtering disabled)
   };
 
 }

--- a/src/openms/include/OpenMS/IONMOBILITY/IMTypes.h
+++ b/src/openms/include/OpenMS/IONMOBILITY/IMTypes.h
@@ -140,7 +140,7 @@ namespace OpenMS
     static double oneOverK0ToCCS(double one_over_k0, double mz, int charge, double buffer_gas_mass = N2_BUFFER_GAS_MASS);
 
     /**
-      @brief Inverse of @ref oneOverK0ToCCS: convert a collision cross section (CCS) back to reduced inverse ion mobility (1/K0).
+      @brief Inverse of @ref oneOverK0ToCCS - convert a collision cross section (CCS) back to reduced inverse ion mobility (1/K0).
 
       @param[in] ccs             Collision cross section in square Angstrom (Angstrom^2); must be > 0.
       @param[in] mz              Precursor m/z of the ion; must be > 0.

--- a/src/openms/include/OpenMS/IONMOBILITY/IMTypes.h
+++ b/src/openms/include/OpenMS/IONMOBILITY/IMTypes.h
@@ -108,10 +108,10 @@ namespace OpenMS
     static IMFormat determineIMFormat(const MSSpectrum& spec);
 
     /**
-     * \brief
-     * \param from Drift unit to convert from
-     * \return A more general DIM_UNIT (or exception)
-     * \throws Exception::ConversionError if @p from has invalid value (e.g. 'NONE')
+     * @brief Convert a DriftTimeUnit to the more general DIM_UNIT.
+     * @param[in] from Drift unit to convert from
+     * @return A more general DIM_UNIT
+     * @throws Exception::ConversionError if @p from has an invalid value (e.g. 'NONE')
      */
     static DIM_UNIT fromIMUnit(const DriftTimeUnit from);
 

--- a/src/openms/include/OpenMS/IONMOBILITY/IMTypes.h
+++ b/src/openms/include/OpenMS/IONMOBILITY/IMTypes.h
@@ -108,12 +108,48 @@ namespace OpenMS
     static IMFormat determineIMFormat(const MSSpectrum& spec);
 
     /**
-     * \brief 
+     * \brief
      * \param from Drift unit to convert from
      * \return A more general DIM_UNIT (or exception)
      * \throws Exception::ConversionError if @p from has invalid value (e.g. 'NONE')
      */
     static DIM_UNIT fromIMUnit(const DriftTimeUnit from);
+
+    /// Mass of N2 (the most common drift/buffer gas) in Da; default buffer gas for the CCS conversions below.
+    /// The rounded value 28.0 is used (rather than 28.006148) to match the calibration constant below,
+    /// which was validated against the Bruker/alphatims and MaxQuant CCS values.
+    inline static constexpr double N2_BUFFER_GAS_MASS = 28.0;
+
+    /**
+      @brief Convert a reduced inverse ion mobility (1/K0) to a collision cross section (CCS) via the Mason-Schamp relation.
+
+      Uses the conventional single-temperature form
+        CCS = (C * |charge| / sqrt(mu)) * (1/K0)
+      with the Bruker calibration constant C = 1059.62245 (validated against alphatims and MaxQuant CCS
+      values for an N2 drift gas at the usual calibration temperature). @c mu is the ion-gas reduced mass
+        mu = (m_ion * m_gas) / (m_ion + m_gas),
+      with the ion mass approximated as m_ion = mz * |charge|.
+
+      @param[in] one_over_k0     Reduced inverse ion mobility 1/K0 in V*s/cm^2; must be > 0.
+      @param[in] mz              Precursor m/z of the ion; must be > 0.
+      @param[in] charge          Precursor charge; the sign is ignored (|charge| is used) and it must be non-zero.
+      @param[in] buffer_gas_mass Drift-gas mass in Da; defaults to N2 (@ref N2_BUFFER_GAS_MASS).
+      @return Collision cross section in square Angstrom (Angstrom^2).
+      @throws Exception::InvalidValue if @p one_over_k0 <= 0, @p mz <= 0, or @p charge == 0.
+    */
+    static double oneOverK0ToCCS(double one_over_k0, double mz, int charge, double buffer_gas_mass = N2_BUFFER_GAS_MASS);
+
+    /**
+      @brief Inverse of @ref oneOverK0ToCCS: convert a collision cross section (CCS) back to reduced inverse ion mobility (1/K0).
+
+      @param[in] ccs             Collision cross section in square Angstrom (Angstrom^2); must be > 0.
+      @param[in] mz              Precursor m/z of the ion; must be > 0.
+      @param[in] charge          Precursor charge; the sign is ignored (|charge| is used) and it must be non-zero.
+      @param[in] buffer_gas_mass Drift-gas mass in Da; defaults to N2 (@ref N2_BUFFER_GAS_MASS).
+      @return Reduced inverse ion mobility 1/K0 in V*s/cm^2.
+      @throws Exception::InvalidValue if @p ccs <= 0, @p mz <= 0, or @p charge == 0.
+    */
+    static double ccsToOneOverK0(double ccs, double mz, int charge, double buffer_gas_mass = N2_BUFFER_GAS_MASS);
   };
 
 };

--- a/src/openms/source/ANALYSIS/ID/MetaboliteSpectralMatching.cpp
+++ b/src/openms/source/ANALYSIS/ID/MetaboliteSpectralMatching.cpp
@@ -13,7 +13,9 @@
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/IONMOBILITY/IMTypes.h>
 
+#include <cmath>
 #include <numeric>
 #include <boost/math/special_functions/factorials.hpp>
 
@@ -42,7 +44,9 @@ namespace OpenMS
     sum_formula_(),
     inchi_string_(),
     smiles_string_(),
-    precursor_adduct_()
+    precursor_adduct_(),
+    observed_ccs_(IMTypes::DRIFTTIME_NOT_SET),
+    found_ccs_(IMTypes::DRIFTTIME_NOT_SET)
   {
   }
 
@@ -72,6 +76,8 @@ namespace OpenMS
     inchi_string_ = rhs.inchi_string_;
     smiles_string_ = rhs.smiles_string_;
     precursor_adduct_ = rhs.precursor_adduct_;
+    observed_ccs_ = rhs.observed_ccs_;
+    found_ccs_ = rhs.found_ccs_;
 
     return *this;
   }
@@ -256,6 +262,83 @@ namespace OpenMS
   }
 
 
+  double SpectralMatch::getObservedCCS() const
+  {
+    return observed_ccs_;
+  }
+
+
+  void SpectralMatch::setObservedCCS(const double& ccs)
+  {
+    observed_ccs_ = ccs;
+  }
+
+
+  double SpectralMatch::getFoundCCS() const
+  {
+    return found_ccs_;
+  }
+
+
+  void SpectralMatch::setFoundCCS(const double& ccs)
+  {
+    found_ccs_ = ccs;
+  }
+
+
+  /**
+    @brief Extract a collision cross section (CCS, Angstrom^2) for a spectrum, or -1.0 if unavailable.
+
+    Sources are tried in order: a CCS-unit drift time, a 1/K0 (VSSC) drift time converted via the
+    Mason-Schamp relation (@ref IMTypes::oneOverK0ToCCS, needs the precursor m/z and charge), and
+    finally a numeric @c "CCS" meta value. Both the spectrum-level and the first-precursor-level
+    drift time are inspected. @p mz and @p charge are only needed for the 1/K0 conversion.
+  */
+  static double extractCCS(const MSSpectrum& spectrum, double mz, int charge)
+  {
+    // (1) spectrum-level drift time, already in CCS units
+    if (spectrum.getDriftTimeUnit() == DriftTimeUnit::CCS && spectrum.getDriftTime() > 0.0)
+    {
+      return spectrum.getDriftTime();
+    }
+    // (2) spectrum-level drift time as 1/K0 -> convert to CCS (requires m/z and charge)
+    if (spectrum.getDriftTimeUnit() == DriftTimeUnit::VSSC && spectrum.getDriftTime() > 0.0 && mz > 0.0 && charge != 0)
+    {
+      return IMTypes::oneOverK0ToCCS(spectrum.getDriftTime(), mz, charge);
+    }
+
+    if (!spectrum.getPrecursors().empty())
+    {
+      const auto& prec = spectrum.getPrecursors()[0];
+      // (3) precursor-level drift time in CCS units
+      if (prec.getDriftTimeUnit() == DriftTimeUnit::CCS && prec.getDriftTime() > 0.0)
+      {
+        return prec.getDriftTime();
+      }
+      // (4) precursor-level drift time as 1/K0 -> convert to CCS
+      if (prec.getDriftTimeUnit() == DriftTimeUnit::VSSC && prec.getDriftTime() > 0.0 && mz > 0.0 && charge != 0)
+      {
+        return IMTypes::oneOverK0ToCCS(prec.getDriftTime(), mz, charge);
+      }
+    }
+
+    // (5) numeric "CCS" meta value
+    if (spectrum.metaValueExists("CCS"))
+    {
+      try
+      {
+        return String(spectrum.getMetaValue("CCS").toString()).toDouble();
+      }
+      catch (const Exception::ConversionError&)
+      {
+        // ignore non-numeric CCS meta value
+      }
+    }
+
+    return IMTypes::DRIFTTIME_NOT_SET;
+  }
+
+
   MetaboliteSpectralMatching::MetaboliteSpectralMatching() :
     DefaultParamHandler("MetaboliteSpectralMatching"), ProgressLogger()
   {
@@ -273,6 +356,13 @@ namespace OpenMS
 
     defaults_.setValue("merge_spectra", "true", "Merge MS2 spectra with the same precursor mass.");
     defaults_.setValidStrings("merge_spectra", {"true","false"});
+
+    defaults_.setValue("ccs_error_percent", 0.0, "Allowed collision cross section (CCS) error in percent for filtering candidates "
+                       "(0 = filtering disabled). The relative error |observed - library| / library * 100 must not exceed this value. "
+                       "Typical values for confident identification are 1-3%. Candidates for which the experimental or the library CCS "
+                       "is missing are kept (not filtered). Requires CCS to be present as CCS-unit drift time, 1/K0 (converted to CCS), "
+                       "or a numeric 'CCS' meta value.");
+    defaults_.setMinFloat("ccs_error_percent", 0.0);
 
     defaultsToParam_();
 
@@ -456,6 +546,10 @@ namespace OpenMS
     bool fragment_error_unit_ppm(true);
     if (mz_error_unit_ == "Da") { fragment_error_unit_ppm = false; }
 
+    // track whether any experimental CCS could be obtained, to warn if CCS filtering is enabled but inert
+    bool ccs_filtering_enabled = ccs_error_percent_ > 0.0;
+    bool any_obs_ccs_found = false;
+
     for (Size spec_idx = 0; spec_idx < msexp.size(); ++spec_idx)
     {
       OPENMS_LOG_DEBUG << "merged spectrum no. " << spec_idx << " with #fragment ions: " << msexp[spec_idx].size() << endl;
@@ -465,6 +559,11 @@ namespace OpenMS
       {
         // get precursor m/z
         double precursor_mz(msexp[spec_idx].getPrecursors()[prec_idx].getMZ());
+
+        // experimental CCS for this precursor (used for optional CCS filtering and MzTab export)
+        int obs_charge = msexp[spec_idx].getPrecursors()[prec_idx].getCharge();
+        double obs_ccs = extractCCS(msexp[spec_idx], precursor_mz, obs_charge);
+        if (obs_ccs > 0.0) { any_obs_ccs_found = true; }
 
         OPENMS_LOG_DEBUG << "precursor no. " << prec_idx << ": mz " << precursor_mz << " ";
 
@@ -533,6 +632,22 @@ namespace OpenMS
             continue;
           }
 
+          // library CCS for this candidate (also reused below for the MzTab export)
+          double lib_ccs = extractCCS(spec_db[search_idx],
+                                      spec_db[search_idx].getPrecursors()[0].getMZ(),
+                                      spec_db[search_idx].getPrecursors()[0].getCharge());
+
+          // optional CCS filtering: skip candidates outside tolerance.
+          // If either CCS is missing, the candidate is kept (CCS does not penalise non-IM data).
+          if (ccs_filtering_enabled && obs_ccs > 0.0 && lib_ccs > 0.0)
+          {
+            double ccs_error = std::abs(obs_ccs - lib_ccs) / lib_ccs * 100.0;
+            if (ccs_error > ccs_error_percent_)
+            {
+              continue;
+            }
+          }
+
           double hyperscore(computeHyperScore(fragment_mz_error_, fragment_error_unit_ppm, msexp[spec_idx], spec_db[search_idx], 0.0));
 
           OPENMS_LOG_DEBUG << " scored with " << hyperscore << endl;
@@ -589,6 +704,10 @@ namespace OpenMS
             tmp_match.setSMILESString(spec_db[search_idx].getMetaValue(Constants::UserParam::MSM_SMILES_STRING));
             tmp_match.setPrecursorAdduct(spec_db[search_idx].getMetaValue(Constants::UserParam::MSM_PRECURSOR_ADDUCT));
 
+            // CCS values for the MzTab output (already extracted above for the optional filtering)
+            tmp_match.setObservedCCS(obs_ccs);
+            tmp_match.setFoundCCS(lib_ccs);
+
             partial_results.push_back(tmp_match);
           }
         }
@@ -621,6 +740,14 @@ namespace OpenMS
       } // end precursor loop
     } // end spectra loop
 
+    // warn if CCS filtering was requested but no experimental CCS was found anywhere (filter is inert)
+    if (ccs_filtering_enabled && !any_obs_ccs_found)
+    {
+      OPENMS_LOG_WARN << "Warning: 'ccs_error_percent' is set to " << ccs_error_percent_
+                      << " but no experimental CCS could be determined for any spectrum (no CCS-unit or 1/K0 drift time "
+                      << "and no numeric 'CCS' meta value). CCS filtering had no effect." << endl;
+    }
+
     // write final results to MzTab
     exportMzTab_(matching_results, mztab_out);
   }
@@ -637,6 +764,7 @@ namespace OpenMS
     mz_error_unit_ = param_.getValue("mass_error_unit").toString();
     report_mode_ = param_.getValue("report_mode").toString();
     merge_spectra_ = (bool)param_.getValue("merge_spectra").toBool();
+    ccs_error_percent_ = (double)param_.getValue("ccs_error_percent");
   }
 
 
@@ -833,6 +961,40 @@ namespace OpenMS
       col5.first = "opt_spec_native_id";
       col5.second = spec_native_id_str;
       optionals.push_back(col5);
+
+      // CCS columns (observed, library, and relative error in percent); "null" when unavailable.
+      // CCS values are rounded to two decimals, consistent with the opt_ppm_error column above.
+      const double obs_ccs = current_id.getObservedCCS();
+      const double lib_ccs = current_id.getFoundCCS();
+
+      MzTabString obs_ccs_str;
+      obs_ccs_str.set(obs_ccs > 0.0 ? String(floor(obs_ccs * 100) / 100) : "null");
+      MzTabOptionalColumnEntry col6;
+      col6.first = "opt_observed_ccs";
+      col6.second = obs_ccs_str;
+      optionals.push_back(col6);
+
+      MzTabString lib_ccs_str;
+      lib_ccs_str.set(lib_ccs > 0.0 ? String(floor(lib_ccs * 100) / 100) : "null");
+      MzTabOptionalColumnEntry col7;
+      col7.first = "opt_library_ccs";
+      col7.second = lib_ccs_str;
+      optionals.push_back(col7);
+
+      MzTabString ccs_err_str;
+      if (obs_ccs > 0.0 && lib_ccs > 0.0)
+      {
+        double ccs_err = std::abs(obs_ccs - lib_ccs) / lib_ccs * 100.0;
+        ccs_err_str.set(String(floor(ccs_err * 100) / 100));
+      }
+      else
+      {
+        ccs_err_str.set("null");
+      }
+      MzTabOptionalColumnEntry col8;
+      col8.first = "opt_ccs_error_percent";
+      col8.second = ccs_err_str;
+      optionals.push_back(col8);
 
       mztab_row_record.opt_ = optionals;
 

--- a/src/openms/source/IONMOBILITY/IMTypes.cpp
+++ b/src/openms/source/IONMOBILITY/IMTypes.cpp
@@ -12,6 +12,9 @@
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 
+#include <cmath>
+#include <cstdlib>
+
 namespace OpenMS
 {
 
@@ -161,5 +164,44 @@ namespace OpenMS
       default:
         throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Cannot convert from " + driftTimeUnitToString(from) + " to a DIM_UNIT.");
     }
+  }
+
+  namespace
+  {
+    /// Bruker Mason-Schamp calibration constant relating 1/K0 [V*s/cm^2] and CCS [Angstrom^2] for an N2
+    /// drift gas; value confirmed against alphatims and MaxQuant CCS values (also used by OpenNuXL).
+    /// CCS = (MASON_SCHAMP_CONSTANT * |z| / sqrt(reduced_mass)) * (1/K0).
+    constexpr double MASON_SCHAMP_CONSTANT = 1059.62245;
+
+    /// Ion-gas reduced mass [Da] with the ion mass approximated as mz * |charge|.
+    double reducedMass_(double mz, int charge, double buffer_gas_mass)
+    {
+      const double ion_mass = mz * std::abs(charge);
+      return (ion_mass * buffer_gas_mass) / (ion_mass + buffer_gas_mass);
+    }
+  }
+
+  double IMTypes::oneOverK0ToCCS(double one_over_k0, double mz, int charge, double buffer_gas_mass)
+  {
+    if (one_over_k0 <= 0.0 || mz <= 0.0 || charge == 0)
+    {
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "oneOverK0ToCCS requires one_over_k0 > 0, mz > 0 and charge != 0",
+        "1/K0=" + String(one_over_k0) + ", mz=" + String(mz) + ", charge=" + String(charge));
+    }
+    const double mu = reducedMass_(mz, charge, buffer_gas_mass);
+    return MASON_SCHAMP_CONSTANT * std::abs(charge) / std::sqrt(mu) * one_over_k0;
+  }
+
+  double IMTypes::ccsToOneOverK0(double ccs, double mz, int charge, double buffer_gas_mass)
+  {
+    if (ccs <= 0.0 || mz <= 0.0 || charge == 0)
+    {
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "ccsToOneOverK0 requires ccs > 0, mz > 0 and charge != 0",
+        "CCS=" + String(ccs) + ", mz=" + String(mz) + ", charge=" + String(charge));
+    }
+    const double mu = reducedMass_(mz, charge, buffer_gas_mass);
+    return ccs * std::sqrt(mu) / (MASON_SCHAMP_CONSTANT * std::abs(charge));
   }
 }// namespace OpenMS

--- a/src/pyOpenMS/bindings/bind_analysis.cpp
+++ b/src/pyOpenMS/bindings/bind_analysis.cpp
@@ -2653,6 +2653,10 @@ params.select_transition_group = False
         .def("setSMILESString", [](OpenMS::SpectralMatch& self, const OpenMS::String& p0) { return self.setSMILESString(p0); })
         .def("getPrecursorAdduct", [](const OpenMS::SpectralMatch& self) { return self.getPrecursorAdduct(); })
         .def("setPrecursorAdduct", [](OpenMS::SpectralMatch& self, const OpenMS::String& p0) { return self.setPrecursorAdduct(p0); })
+        .def("getObservedCCS", [](const OpenMS::SpectralMatch& self) { return self.getObservedCCS(); })
+        .def("setObservedCCS", [](OpenMS::SpectralMatch& self, const double& p0) { return self.setObservedCCS(p0); })
+        .def("getFoundCCS", [](const OpenMS::SpectralMatch& self) { return self.getFoundCCS(); })
+        .def("setFoundCCS", [](OpenMS::SpectralMatch& self, const double& p0) { return self.setFoundCCS(p0); })
         ;
 
     // -----------------------------------------------------------------------

--- a/src/tests/class_tests/openms/source/IMTypes_test.cpp
+++ b/src/tests/class_tests/openms/source/IMTypes_test.cpp
@@ -197,6 +197,46 @@ START_SECTION(determineIMFormat returns IM_PEAK for centroided IM data)
 }
 END_SECTION
 
+START_SECTION(static double oneOverK0ToCCS(double one_over_k0, double mz, int charge, double buffer_gas_mass))
+{
+  // Reserpine [M+H]+ (m/z 609.28, z=1): 1/K0 ~1.196 should give a CCS near the
+  // published N2 value of ~245 Angstrom^2.
+  TOLERANCE_ABSOLUTE(0.01)
+  double ccs = IMTypes::oneOverK0ToCCS(1.196, 609.28, 1);
+  TEST_REAL_SIMILAR(ccs, 244.9402)
+
+  // charge sign must not matter (|z| is used)
+  TEST_REAL_SIMILAR(IMTypes::oneOverK0ToCCS(0.9, 300.0, -1), IMTypes::oneOverK0ToCCS(0.9, 300.0, 1))
+
+  // larger 1/K0 -> larger CCS (monotonic)
+  TEST_EQUAL(IMTypes::oneOverK0ToCCS(1.2, 300.0, 1) > IMTypes::oneOverK0ToCCS(0.9, 300.0, 1), true)
+
+  // invalid inputs throw
+  TEST_EXCEPTION(Exception::InvalidValue, IMTypes::oneOverK0ToCCS(0.0, 300.0, 1))
+  TEST_EXCEPTION(Exception::InvalidValue, IMTypes::oneOverK0ToCCS(-1.0, 300.0, 1))
+  TEST_EXCEPTION(Exception::InvalidValue, IMTypes::oneOverK0ToCCS(0.9, 0.0, 1))
+  TEST_EXCEPTION(Exception::InvalidValue, IMTypes::oneOverK0ToCCS(0.9, 300.0, 0))
+}
+END_SECTION
+
+START_SECTION(static double ccsToOneOverK0(double ccs, double mz, int charge, double buffer_gas_mass))
+{
+  // round-trip: 1/K0 -> CCS -> 1/K0 must recover the original value
+  double one_over_k0 = 0.95;
+  double ccs = IMTypes::oneOverK0ToCCS(one_over_k0, 412.5, 1);
+  TEST_REAL_SIMILAR(IMTypes::ccsToOneOverK0(ccs, 412.5, 1), one_over_k0)
+
+  // round-trip for a multiply charged ion
+  double ok0_2 = 0.62;
+  double ccs2 = IMTypes::oneOverK0ToCCS(ok0_2, 524.3, 2);
+  TEST_REAL_SIMILAR(IMTypes::ccsToOneOverK0(ccs2, 524.3, 2), ok0_2)
+
+  // invalid inputs throw
+  TEST_EXCEPTION(Exception::InvalidValue, IMTypes::ccsToOneOverK0(0.0, 300.0, 1))
+  TEST_EXCEPTION(Exception::InvalidValue, IMTypes::ccsToOneOverK0(200.0, 300.0, 0))
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST

--- a/src/tests/class_tests/openms/source/MetaboliteSpectralMatching_test.cpp
+++ b/src/tests/class_tests/openms/source/MetaboliteSpectralMatching_test.cpp
@@ -16,6 +16,7 @@
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/METADATA/Precursor.h>
 #include <OpenMS/IONMOBILITY/IMTypes.h>
+#include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/FORMAT/MzTab.h>
 
 using namespace OpenMS;
@@ -31,6 +32,13 @@ static PeakMap makeLibrary()
   lib1.setName("compound_A");
   lib1.setMetaValue("Metabolite_Name", "compound_A");
   lib1.setMetaValue("CCS", "150.0");
+  // run() reads these string meta values for every scored candidate and converts them to String,
+  // which throws for non-string/absent values - so populate them as a real MSP/GNPS library would.
+  lib1.setMetaValue("HMDB_ID", "HMDB0000001");
+  lib1.setMetaValue(Constants::UserParam::MSM_SUM_FORMULA, "C10H15N");
+  lib1.setMetaValue(Constants::UserParam::MSM_INCHI_STRING, "InChI=1S/compoundA");
+  lib1.setMetaValue(Constants::UserParam::MSM_SMILES_STRING, "CCO");
+  lib1.setMetaValue(Constants::UserParam::MSM_PRECURSOR_ADDUCT, "[M+H]+");
   Precursor p1;
   p1.setMZ(300.0);
   p1.setCharge(1);
@@ -46,6 +54,11 @@ static PeakMap makeLibrary()
   lib2.setName("compound_B");
   lib2.setMetaValue("Metabolite_Name", "compound_B");
   lib2.setMetaValue("CCS", "200.0");
+  lib2.setMetaValue("HMDB_ID", "HMDB0000002");
+  lib2.setMetaValue(Constants::UserParam::MSM_SUM_FORMULA, "C12H17N");
+  lib2.setMetaValue(Constants::UserParam::MSM_INCHI_STRING, "InChI=1S/compoundB");
+  lib2.setMetaValue(Constants::UserParam::MSM_SMILES_STRING, "CCCO");
+  lib2.setMetaValue(Constants::UserParam::MSM_PRECURSOR_ADDUCT, "[M+H]+");
   Precursor p2;
   p2.setMZ(300.1);
   p2.setCharge(1);

--- a/src/tests/class_tests/openms/source/MetaboliteSpectralMatching_test.cpp
+++ b/src/tests/class_tests/openms/source/MetaboliteSpectralMatching_test.cpp
@@ -21,60 +21,6 @@
 using namespace OpenMS;
 using namespace std;
 
-START_TEST(MetaboliteSpectralMatching, "$Id$")
-
-/////////////////////////////////////////////////////////////
-/////////////////////////////////////////////////////////////
-
-MetaboliteSpectralMatching* ptr = nullptr;
-MetaboliteSpectralMatching* null_ptr = nullptr;
-START_SECTION(MetaboliteSpectralMatching())
-{
-	ptr = new MetaboliteSpectralMatching();
-	TEST_NOT_EQUAL(ptr, null_ptr)
-}
-END_SECTION
-
-START_SECTION(~MetaboliteSpectralMatching())
-{
-	delete ptr;
-}
-END_SECTION
-
-START_SECTION(SpectralMatch CCS getters and setters)
-{
-  SpectralMatch sm;
-  // default CCS values should be "not set"
-  TEST_REAL_SIMILAR(sm.getObservedCCS(), IMTypes::DRIFTTIME_NOT_SET)
-  TEST_REAL_SIMILAR(sm.getFoundCCS(), IMTypes::DRIFTTIME_NOT_SET)
-
-  sm.setObservedCCS(167.3);
-  sm.setFoundCCS(170.1);
-  TEST_REAL_SIMILAR(sm.getObservedCCS(), 167.3)
-  TEST_REAL_SIMILAR(sm.getFoundCCS(), 170.1)
-
-  // copy constructor
-  SpectralMatch sm2(sm);
-  TEST_REAL_SIMILAR(sm2.getObservedCCS(), 167.3)
-  TEST_REAL_SIMILAR(sm2.getFoundCCS(), 170.1)
-
-  // assignment operator
-  SpectralMatch sm3;
-  sm3 = sm;
-  TEST_REAL_SIMILAR(sm3.getObservedCCS(), 167.3)
-  TEST_REAL_SIMILAR(sm3.getFoundCCS(), 170.1)
-}
-END_SECTION
-
-START_SECTION(MetaboliteSpectralMatching default parameters)
-{
-  MetaboliteSpectralMatching msm;
-  Param p = msm.getDefaults();
-  // CCS filtering is disabled by default
-  TEST_REAL_SIMILAR((double)p.getValue("ccs_error_percent"), 0.0)
-}
-END_SECTION
-
 // helper to build a small spectral library with two compounds at almost identical precursor m/z
 // but different CCS values (compound_A: 150, compound_B: 200), stored as "CCS" meta value.
 static PeakMap makeLibrary()
@@ -128,6 +74,60 @@ static Param makeParams(double ccs_error_percent)
   params.setValue("ccs_error_percent", ccs_error_percent);
   return params;
 }
+
+START_TEST(MetaboliteSpectralMatching, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+MetaboliteSpectralMatching* ptr = nullptr;
+MetaboliteSpectralMatching* null_ptr = nullptr;
+START_SECTION(MetaboliteSpectralMatching())
+{
+	ptr = new MetaboliteSpectralMatching();
+	TEST_NOT_EQUAL(ptr, null_ptr)
+}
+END_SECTION
+
+START_SECTION(~MetaboliteSpectralMatching())
+{
+	delete ptr;
+}
+END_SECTION
+
+START_SECTION(SpectralMatch CCS getters and setters)
+{
+  SpectralMatch sm;
+  // default CCS values should be "not set"
+  TEST_REAL_SIMILAR(sm.getObservedCCS(), IMTypes::DRIFTTIME_NOT_SET)
+  TEST_REAL_SIMILAR(sm.getFoundCCS(), IMTypes::DRIFTTIME_NOT_SET)
+
+  sm.setObservedCCS(167.3);
+  sm.setFoundCCS(170.1);
+  TEST_REAL_SIMILAR(sm.getObservedCCS(), 167.3)
+  TEST_REAL_SIMILAR(sm.getFoundCCS(), 170.1)
+
+  // copy constructor
+  SpectralMatch sm2(sm);
+  TEST_REAL_SIMILAR(sm2.getObservedCCS(), 167.3)
+  TEST_REAL_SIMILAR(sm2.getFoundCCS(), 170.1)
+
+  // assignment operator
+  SpectralMatch sm3;
+  sm3 = sm;
+  TEST_REAL_SIMILAR(sm3.getObservedCCS(), 167.3)
+  TEST_REAL_SIMILAR(sm3.getFoundCCS(), 170.1)
+}
+END_SECTION
+
+START_SECTION(MetaboliteSpectralMatching default parameters)
+{
+  MetaboliteSpectralMatching msm;
+  Param p = msm.getDefaults();
+  // CCS filtering is disabled by default
+  TEST_REAL_SIMILAR((double)p.getValue("ccs_error_percent"), 0.0)
+}
+END_SECTION
 
 START_SECTION(CCS filtering disabled reports all matches with CCS columns)
 {

--- a/src/tests/class_tests/openms/source/MetaboliteSpectralMatching_test.cpp
+++ b/src/tests/class_tests/openms/source/MetaboliteSpectralMatching_test.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
 // SPDX-License-Identifier: BSD-3-Clause
-// 
+//
 // --------------------------------------------------------------------------
 // $Maintainer: $
 // $Authors: $
@@ -11,6 +11,12 @@
 ///////////////////////////
 #include <OpenMS/ANALYSIS/ID/MetaboliteSpectralMatching.h>
 ///////////////////////////
+
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/METADATA/Precursor.h>
+#include <OpenMS/IONMOBILITY/IMTypes.h>
+#include <OpenMS/FORMAT/MzTab.h>
 
 using namespace OpenMS;
 using namespace std;
@@ -35,21 +41,290 @@ START_SECTION(~MetaboliteSpectralMatching())
 }
 END_SECTION
 
-START_SECTION((virtual ~MetaboliteSpectralMatching()))
+START_SECTION(SpectralMatch CCS getters and setters)
 {
-  // TODO
+  SpectralMatch sm;
+  // default CCS values should be "not set" (-1.0)
+  TEST_REAL_SIMILAR(sm.getObservedCCS(), -1.0)
+  TEST_REAL_SIMILAR(sm.getFoundCCS(), -1.0)
+
+  sm.setObservedCCS(167.3);
+  sm.setFoundCCS(170.1);
+  TEST_REAL_SIMILAR(sm.getObservedCCS(), 167.3)
+  TEST_REAL_SIMILAR(sm.getFoundCCS(), 170.1)
+
+  // copy constructor
+  SpectralMatch sm2(sm);
+  TEST_REAL_SIMILAR(sm2.getObservedCCS(), 167.3)
+  TEST_REAL_SIMILAR(sm2.getFoundCCS(), 170.1)
+
+  // assignment operator
+  SpectralMatch sm3;
+  sm3 = sm;
+  TEST_REAL_SIMILAR(sm3.getObservedCCS(), 167.3)
+  TEST_REAL_SIMILAR(sm3.getFoundCCS(), 170.1)
 }
 END_SECTION
 
-START_SECTION((double computeHyperScore(MSSpectrum, MSSpectrum, const double &, const double &)))
+START_SECTION(MetaboliteSpectralMatching default parameters)
 {
-  // TODO
+  MetaboliteSpectralMatching msm;
+  Param p = msm.getDefaults();
+  // CCS filtering is disabled by default
+  TEST_REAL_SIMILAR((double)p.getValue("ccs_error_percent"), 0.0)
 }
 END_SECTION
 
-START_SECTION((void run(PeakMap &, MzTab &)))
+// helper to build a small spectral library with two compounds at almost identical precursor m/z
+// but different CCS values (compound_A: 150, compound_B: 200), stored as "CCS" meta value.
+static PeakMap makeLibrary()
 {
-  // TODO
+  PeakMap spec_db;
+
+  MSSpectrum lib1;
+  lib1.setName("compound_A");
+  lib1.setMetaValue("Metabolite_Name", "compound_A");
+  lib1.setMetaValue("CCS", "150.0");
+  Precursor p1;
+  p1.setMZ(300.0);
+  p1.setCharge(1);
+  lib1.setPrecursors({p1});
+  lib1.push_back(Peak1D(100.0, 999.0));
+  lib1.push_back(Peak1D(150.0, 500.0));
+  lib1.push_back(Peak1D(200.0, 300.0));
+  lib1.push_back(Peak1D(250.0, 100.0));
+  lib1.setRT(0);
+  spec_db.addSpectrum(lib1);
+
+  MSSpectrum lib2;
+  lib2.setName("compound_B");
+  lib2.setMetaValue("Metabolite_Name", "compound_B");
+  lib2.setMetaValue("CCS", "200.0");
+  Precursor p2;
+  p2.setMZ(300.1);
+  p2.setCharge(1);
+  lib2.setPrecursors({p2});
+  lib2.push_back(Peak1D(100.0, 999.0));
+  lib2.push_back(Peak1D(150.0, 500.0));
+  lib2.push_back(Peak1D(200.0, 300.0));
+  lib2.push_back(Peak1D(250.0, 100.0));
+  lib2.setRT(1);
+  spec_db.addSpectrum(lib2);
+
+  return spec_db;
+}
+
+static Param makeParams(double ccs_error_percent)
+{
+  Param params;
+  params.setValue("prec_mass_error_value", 1.0, "");
+  params.setValue("frag_mass_error_value", 0.5, "");
+  params.setValue("mass_error_unit", "Da", "");
+  params.setValue("ionization_mode", "positive", "");
+  params.setValue("report_mode", "top3", "");
+  params.setValue("merge_spectra", "false", "");
+  params.setValue("ccs_error_percent", ccs_error_percent, "");
+  return params;
+}
+
+START_SECTION(CCS filtering disabled reports all matches with CCS columns)
+{
+  PeakMap spec_db = makeLibrary();
+
+  // experimental spectrum with CCS = 152.0 (as "CCS" meta value)
+  PeakMap msexp;
+  MSSpectrum exp_spec;
+  exp_spec.setMSLevel(2);
+  exp_spec.setMetaValue("CCS", "152.0");
+  Precursor exp_prec;
+  exp_prec.setMZ(300.05);
+  exp_prec.setCharge(1);
+  exp_spec.setPrecursors({exp_prec});
+  exp_spec.push_back(Peak1D(100.0, 800.0));
+  exp_spec.push_back(Peak1D(150.0, 400.0));
+  exp_spec.push_back(Peak1D(200.0, 250.0));
+  exp_spec.push_back(Peak1D(250.0, 80.0));
+  exp_spec.setRT(10.0);
+  msexp.addSpectrum(exp_spec);
+
+  MetaboliteSpectralMatching msm;
+  msm.setParameters(makeParams(0.0)); // filtering disabled
+
+  MzTab mztab;
+  String out_spectra;
+  msm.run(msexp, spec_db, mztab, out_spectra);
+
+  const auto& rows = mztab.getSmallMoleculeSectionRows();
+  TEST_EQUAL(rows.size(), 2) // both compounds match
+
+  for (const auto& row : rows)
+  {
+    bool found_obs_ccs = false, found_lib_ccs = false, found_ccs_err = false;
+    for (const auto& opt : row.opt_)
+    {
+      if (opt.first == "opt_observed_ccs")
+      {
+        TEST_EQUAL(opt.second.toCellString(), "152")
+        found_obs_ccs = true;
+      }
+      if (opt.first == "opt_library_ccs")
+      {
+        TEST_EQUAL(opt.second.toCellString() == "150" || opt.second.toCellString() == "200", true)
+        found_lib_ccs = true;
+      }
+      if (opt.first == "opt_ccs_error_percent")
+      {
+        TEST_NOT_EQUAL(opt.second.toCellString(), "null")
+        found_ccs_err = true;
+      }
+    }
+    TEST_EQUAL(found_obs_ccs, true)
+    TEST_EQUAL(found_lib_ccs, true)
+    TEST_EQUAL(found_ccs_err, true)
+  }
+}
+END_SECTION
+
+START_SECTION(CCS filtering enabled keeps only within-tolerance matches)
+{
+  PeakMap spec_db = makeLibrary();
+
+  PeakMap msexp;
+  MSSpectrum exp_spec;
+  exp_spec.setMSLevel(2);
+  exp_spec.setMetaValue("CCS", "152.0"); // within 5% of compound_A (150), far from compound_B (200)
+  Precursor exp_prec;
+  exp_prec.setMZ(300.05);
+  exp_prec.setCharge(1);
+  exp_spec.setPrecursors({exp_prec});
+  exp_spec.push_back(Peak1D(100.0, 800.0));
+  exp_spec.push_back(Peak1D(150.0, 400.0));
+  exp_spec.push_back(Peak1D(200.0, 250.0));
+  exp_spec.push_back(Peak1D(250.0, 80.0));
+  exp_spec.setRT(10.0);
+  msexp.addSpectrum(exp_spec);
+
+  MetaboliteSpectralMatching msm;
+  msm.setParameters(makeParams(5.0)); // 5% CCS tolerance
+
+  MzTab mztab;
+  String out_spectra;
+  msm.run(msexp, spec_db, mztab, out_spectra);
+
+  const auto& rows = mztab.getSmallMoleculeSectionRows();
+  TEST_EQUAL(rows.size(), 1) // only compound_A matches
+
+  for (const auto& opt : rows[0].opt_)
+  {
+    if (opt.first == "opt_library_ccs") { TEST_EQUAL(opt.second.toCellString(), "150") }
+    if (opt.first == "opt_observed_ccs") { TEST_EQUAL(opt.second.toCellString(), "152") }
+  }
+}
+END_SECTION
+
+START_SECTION(CCS filtering converts 1/K0 (VSSC) drift time to CCS)
+{
+  PeakMap spec_db = makeLibrary();
+
+  // experimental spectrum carries a 1/K0 (VSSC) drift time instead of a CCS meta value.
+  // For m/z 300.05, z=1, 1/K0 = 0.726 converts to ~152 Angstrom^2 (within 5% of compound_A only).
+  PeakMap msexp;
+  MSSpectrum exp_spec;
+  exp_spec.setMSLevel(2);
+  exp_spec.setDriftTime(0.726);
+  exp_spec.setDriftTimeUnit(DriftTimeUnit::VSSC);
+  Precursor exp_prec;
+  exp_prec.setMZ(300.05);
+  exp_prec.setCharge(1);
+  exp_spec.setPrecursors({exp_prec});
+  exp_spec.push_back(Peak1D(100.0, 800.0));
+  exp_spec.push_back(Peak1D(150.0, 400.0));
+  exp_spec.push_back(Peak1D(200.0, 250.0));
+  exp_spec.push_back(Peak1D(250.0, 80.0));
+  exp_spec.setRT(10.0);
+  msexp.addSpectrum(exp_spec);
+
+  MetaboliteSpectralMatching msm;
+  msm.setParameters(makeParams(5.0));
+
+  MzTab mztab;
+  String out_spectra;
+  msm.run(msexp, spec_db, mztab, out_spectra);
+
+  // Without the 1/K0 -> CCS conversion the observed CCS would be unknown and both compounds
+  // would pass; getting a single row proves the conversion + filtering worked.
+  const auto& rows = mztab.getSmallMoleculeSectionRows();
+  TEST_EQUAL(rows.size(), 1)
+
+  for (const auto& opt : rows[0].opt_)
+  {
+    if (opt.first == "opt_library_ccs") { TEST_EQUAL(opt.second.toCellString(), "150") }
+    if (opt.first == "opt_observed_ccs") { TEST_NOT_EQUAL(opt.second.toCellString(), "null") }
+  }
+}
+END_SECTION
+
+START_SECTION(CCS filtering keeps matches when CCS is missing)
+{
+  PeakMap spec_db = makeLibrary();
+
+  // experimental spectrum without any CCS information
+  PeakMap msexp;
+  MSSpectrum exp_spec;
+  exp_spec.setMSLevel(2);
+  Precursor exp_prec;
+  exp_prec.setMZ(300.05);
+  exp_prec.setCharge(1);
+  exp_spec.setPrecursors({exp_prec});
+  exp_spec.push_back(Peak1D(100.0, 800.0));
+  exp_spec.push_back(Peak1D(150.0, 400.0));
+  exp_spec.push_back(Peak1D(200.0, 250.0));
+  exp_spec.push_back(Peak1D(250.0, 80.0));
+  exp_spec.setRT(10.0);
+  msexp.addSpectrum(exp_spec);
+
+  MetaboliteSpectralMatching msm;
+  msm.setParameters(makeParams(5.0)); // enabled, but no experimental CCS -> not filtered
+
+  MzTab mztab;
+  String out_spectra;
+  msm.run(msexp, spec_db, mztab, out_spectra);
+
+  const auto& rows = mztab.getSmallMoleculeSectionRows();
+  TEST_EQUAL(rows.size(), 2) // both kept (CCS does not penalise non-IM data)
+
+  for (const auto& row : rows)
+  {
+    for (const auto& opt : row.opt_)
+    {
+      if (opt.first == "opt_observed_ccs") { TEST_EQUAL(opt.second.toCellString(), "null") }
+      if (opt.first == "opt_ccs_error_percent") { TEST_EQUAL(opt.second.toCellString(), "null") }
+    }
+  }
+}
+END_SECTION
+
+START_SECTION((static double computeHyperScore(double, bool, const MSSpectrum&, const MSSpectrum&, double)))
+{
+  MSSpectrum exp_spec;
+  exp_spec.push_back(Peak1D(100.0, 100.0));
+  exp_spec.push_back(Peak1D(200.0, 200.0));
+  exp_spec.push_back(Peak1D(300.0, 300.0));
+  exp_spec.push_back(Peak1D(400.0, 50.0));
+
+  MSSpectrum db_spec;
+  db_spec.push_back(Peak1D(100.0, 999.0));
+  db_spec.push_back(Peak1D(200.0, 999.0));
+  db_spec.push_back(Peak1D(300.0, 999.0));
+  db_spec.push_back(Peak1D(400.0, 999.0));
+
+  double score = MetaboliteSpectralMatching::computeHyperScore(0.5, false, exp_spec, db_spec, 0.0);
+  TEST_EQUAL(score > 0, true)
+
+  // an empty experimental spectrum scores 0
+  MSSpectrum empty_spec;
+  score = MetaboliteSpectralMatching::computeHyperScore(0.5, false, empty_spec, db_spec, 0.0);
+  TEST_REAL_SIMILAR(score, 0.0)
 }
 END_SECTION
 
@@ -57,6 +332,3 @@ END_SECTION
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST
-
-
-

--- a/src/tests/class_tests/openms/source/MetaboliteSpectralMatching_test.cpp
+++ b/src/tests/class_tests/openms/source/MetaboliteSpectralMatching_test.cpp
@@ -179,12 +179,12 @@ START_SECTION(CCS filtering disabled reports all matches with CCS columns)
     {
       if (opt.first == "opt_observed_ccs")
       {
-        TEST_EQUAL(opt.second.toCellString(), "152")
+        TEST_EQUAL(opt.second.toCellString(), "152.0")
         found_obs_ccs = true;
       }
       if (opt.first == "opt_library_ccs")
       {
-        TEST_EQUAL(opt.second.toCellString() == "150" || opt.second.toCellString() == "200", true)
+        TEST_EQUAL(opt.second.toCellString() == "150.0" || opt.second.toCellString() == "200.0", true)
         found_lib_ccs = true;
       }
       if (opt.first == "opt_ccs_error_percent")
@@ -233,8 +233,8 @@ START_SECTION(CCS filtering enabled keeps only within-tolerance matches)
   {
     for (const auto& opt : rows[0].opt_)
     {
-      if (opt.first == "opt_library_ccs") { TEST_EQUAL(opt.second.toCellString(), "150") }
-      if (opt.first == "opt_observed_ccs") { TEST_EQUAL(opt.second.toCellString(), "152") }
+      if (opt.first == "opt_library_ccs") { TEST_EQUAL(opt.second.toCellString(), "150.0") }
+      if (opt.first == "opt_observed_ccs") { TEST_EQUAL(opt.second.toCellString(), "152.0") }
     }
   }
 }
@@ -278,7 +278,7 @@ START_SECTION(CCS filtering converts 1/K0 (VSSC) drift time to CCS)
   {
     for (const auto& opt : rows[0].opt_)
     {
-      if (opt.first == "opt_library_ccs") { TEST_EQUAL(opt.second.toCellString(), "150") }
+      if (opt.first == "opt_library_ccs") { TEST_EQUAL(opt.second.toCellString(), "150.0") }
       if (opt.first == "opt_observed_ccs") { TEST_NOT_EQUAL(opt.second.toCellString(), "null") }
     }
   }

--- a/src/tests/class_tests/openms/source/MetaboliteSpectralMatching_test.cpp
+++ b/src/tests/class_tests/openms/source/MetaboliteSpectralMatching_test.cpp
@@ -44,9 +44,9 @@ END_SECTION
 START_SECTION(SpectralMatch CCS getters and setters)
 {
   SpectralMatch sm;
-  // default CCS values should be "not set" (-1.0)
-  TEST_REAL_SIMILAR(sm.getObservedCCS(), -1.0)
-  TEST_REAL_SIMILAR(sm.getFoundCCS(), -1.0)
+  // default CCS values should be "not set"
+  TEST_REAL_SIMILAR(sm.getObservedCCS(), IMTypes::DRIFTTIME_NOT_SET)
+  TEST_REAL_SIMILAR(sm.getFoundCCS(), IMTypes::DRIFTTIME_NOT_SET)
 
   sm.setObservedCCS(167.3);
   sm.setFoundCCS(170.1);
@@ -116,14 +116,16 @@ static PeakMap makeLibrary()
 
 static Param makeParams(double ccs_error_percent)
 {
-  Param params;
-  params.setValue("prec_mass_error_value", 1.0, "");
-  params.setValue("frag_mass_error_value", 0.5, "");
-  params.setValue("mass_error_unit", "Da", "");
-  params.setValue("ionization_mode", "positive", "");
-  params.setValue("report_mode", "top3", "");
-  params.setValue("merge_spectra", "false", "");
-  params.setValue("ccs_error_percent", ccs_error_percent, "");
+  // start from the algorithm defaults so the fixture inherits future parameter additions,
+  // then override only the knobs these tests rely on.
+  Param params = MetaboliteSpectralMatching().getDefaults();
+  params.setValue("prec_mass_error_value", 1.0);
+  params.setValue("frag_mass_error_value", 0.5);
+  params.setValue("mass_error_unit", "Da");
+  params.setValue("ionization_mode", "positive");
+  params.setValue("report_mode", "top3");
+  params.setValue("merge_spectra", "false");
+  params.setValue("ccs_error_percent", ccs_error_percent);
   return params;
 }
 
@@ -214,10 +216,13 @@ START_SECTION(CCS filtering enabled keeps only within-tolerance matches)
   const auto& rows = mztab.getSmallMoleculeSectionRows();
   TEST_EQUAL(rows.size(), 1) // only compound_A matches
 
-  for (const auto& opt : rows[0].opt_)
+  if (rows.size() == 1)
   {
-    if (opt.first == "opt_library_ccs") { TEST_EQUAL(opt.second.toCellString(), "150") }
-    if (opt.first == "opt_observed_ccs") { TEST_EQUAL(opt.second.toCellString(), "152") }
+    for (const auto& opt : rows[0].opt_)
+    {
+      if (opt.first == "opt_library_ccs") { TEST_EQUAL(opt.second.toCellString(), "150") }
+      if (opt.first == "opt_observed_ccs") { TEST_EQUAL(opt.second.toCellString(), "152") }
+    }
   }
 }
 END_SECTION
@@ -256,10 +261,13 @@ START_SECTION(CCS filtering converts 1/K0 (VSSC) drift time to CCS)
   const auto& rows = mztab.getSmallMoleculeSectionRows();
   TEST_EQUAL(rows.size(), 1)
 
-  for (const auto& opt : rows[0].opt_)
+  if (rows.size() == 1)
   {
-    if (opt.first == "opt_library_ccs") { TEST_EQUAL(opt.second.toCellString(), "150") }
-    if (opt.first == "opt_observed_ccs") { TEST_NOT_EQUAL(opt.second.toCellString(), "null") }
+    for (const auto& opt : rows[0].opt_)
+    {
+      if (opt.first == "opt_library_ccs") { TEST_EQUAL(opt.second.toCellString(), "150") }
+      if (opt.first == "opt_observed_ccs") { TEST_NOT_EQUAL(opt.second.toCellString(), "null") }
+    }
   }
 }
 END_SECTION

--- a/src/topp/OpenNuXL.cpp
+++ b/src/topp/OpenNuXL.cpp
@@ -13,6 +13,7 @@
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/METADATA/SpectrumSettings.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/IONMOBILITY/IMTypes.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/CONCEPT/LogStream.h>
@@ -4578,16 +4579,14 @@ static void scoreXLIons_(
   void convertVSSCToCCS(MSExperiment& spectra)
   { // confirmed values with alpha and MaxQuant
     OPENMS_LOG_INFO << "Converting 1/k0 to CCS values." << std::endl;
-    constexpr double bruker_CCS_coef = 1059.62245; // constant coefficient for Bruker in the Mason-Schamp equation
-    constexpr double IM_N2_gas_mass = 28.0; // like in alpha code
     for (auto& s : spectra)
     {
+      if (s.getPrecursors().empty()) { continue; }
       const double IM = s.getDriftTime();
       const double mz = s.getPrecursors()[0].getMZ();
-      const double charge = s.getPrecursors()[0].getCharge();
-      const double mass = mz * charge;
-      const double reduced_mass = mass * IM_N2_gas_mass / (mass + IM_N2_gas_mass);
-      const double CCS = IM * charge * bruker_CCS_coef / std::sqrt(reduced_mass); // Mason-Schamp equation
+      const int charge = s.getPrecursors()[0].getCharge();
+      if (IM <= 0.0 || mz <= 0.0 || charge == 0) { continue; } // not convertible (no IM / missing charge)
+      const double CCS = IMTypes::oneOverK0ToCCS(IM, mz, charge); // Mason-Schamp equation
       s.setDriftTime(CCS);
       s.setDriftTimeUnit(DriftTimeUnit::CCS);
     }

--- a/src/topp/OpenNuXL.cpp
+++ b/src/topp/OpenNuXL.cpp
@@ -4581,11 +4581,23 @@ static void scoreXLIons_(
     OPENMS_LOG_INFO << "Converting 1/k0 to CCS values." << std::endl;
     for (auto& s : spectra)
     {
-      if (s.getPrecursors().empty()) { continue; }
+      // spectra without convertible IM (no precursor / no IM / missing charge) get their IM cleared,
+      // so downstream code (e.g. fillSpectrumID_) never mixes raw 1/K0 with CCS values.
+      if (s.getPrecursors().empty())
+      {
+        s.setDriftTime(0.0);
+        s.setDriftTimeUnit(DriftTimeUnit::NONE);
+        continue;
+      }
       const double IM = s.getDriftTime();
       const double mz = s.getPrecursors()[0].getMZ();
       const int charge = s.getPrecursors()[0].getCharge();
-      if (IM <= 0.0 || mz <= 0.0 || charge == 0) { continue; } // not convertible (no IM / missing charge)
+      if (IM <= 0.0 || mz <= 0.0 || charge == 0)
+      {
+        s.setDriftTime(0.0);
+        s.setDriftTimeUnit(DriftTimeUnit::NONE);
+        continue;
+      }
       const double CCS = IMTypes::oneOverK0ToCCS(IM, mz, charge); // Mason-Schamp equation
       s.setDriftTime(CCS);
       s.setDriftTimeUnit(DriftTimeUnit::CCS);


### PR DESCRIPTION
Re-applies the CCS feature from #8963 on top of current `develop` (the PR head was based on a stale `develop` and conflicted) and addresses the review, grounded against how Skyline/mzMine and the CCS literature handle ion-mobility filtering. Closes #8784. Supersedes/continues #8963.

## Core feature
- New `ccs_error_percent` parameter (default `0` = disabled). Filters candidates by relative CCS error `|observed - library| / library * 100` — library as the reference denominator, matching AutoCCS and published CCS libraries.
- `SpectralMatch` gains observed/found CCS fields with Doxygen-documented accessors.
- MzTab export adds `opt_observed_ccs`, `opt_library_ccs`, `opt_ccs_error_percent`, rounded consistently with the existing `opt_ppm_error` column.
- pyOpenMS bindings for the new accessors.

## Review fixes (vs #8963)
- **Closed the scoping gap:** `extractCCS` now also converts a **1/K0 (VSSC)** drift time to CCS, so raw timsTOF data works — not only pre-computed CCS. Sources tried in order: CCS-unit drift time → 1/K0 (converted) → numeric `CCS` meta value, at both spectrum and precursor level.
- Library CCS is extracted **once** and reused for filtering and export (resolves the double-extraction discussion on the original line 684).
- **Missing-CCS = keep-not-filter** (Skyline convention; mzMine instead drops). Now documented in the parameter help, and a **warning is logged when filtering is enabled but no experimental CCS could be determined** (filter would otherwise be silently inert).
- Reuses `IMTypes::DRIFTTIME_NOT_SET` as the sentinel; consistent CCS rounding in MzTab.

## Shared Mason-Schamp conversion
- Adds `IMTypes::oneOverK0ToCCS` / `ccsToOneOverK0` (Bruker constant `1059.62245`, N2 buffer gas) — the conversion previously buried as a private static in `OpenNuXL.cpp` — and refactors `OpenNuXL::convertVSSCToCCS` to use it (with input guards, so it no longer silently produces NaN on charge-0 / missing-IM spectra). Output is identical to the previous formula for valid positive-charge data.

## Tests
- `IMTypes_test`: conversion correctness (reserpine ≈ 244.94 Å²), `|z|` handling, 1/K0→CCS→1/K0 round-trip, invalid-input exceptions.
- `MetaboliteSpectralMatching_test`: CCS accessors + copy/assign, default parameter, filtering disabled/enabled, the **1/K0→CCS conversion path**, missing-CCS kept, and `computeHyperScore`.

## Note
Not yet compiled in this environment (no contrib toolchain available here) — the conversion math is verified standalone, but CI is the first real build/test. Happy to chase any CI failures.

https://claude.ai/code/session_01LSJRu6W4ek3bie42DnBMZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSJRu6W4ek3bie42DnBMZs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional CCS/ion-mobility filtering for metabolite spectral matching with configurable error tolerance
  * Extraction, storage, and export of observed and library CCS values and per-match CCS error (new optional MzTab fields)
  * Ion-mobility ↔ CCS conversion utilities and improved conversion handling across tools (including conversion fallback/validation)
  * Python bindings expose CCS accessors for match objects

* **Tests**
  * Unit and integration tests covering CCS conversions, filtering behavior, and exports

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->