### PR TITLE
fix: optimize MzIdentML parser lookups and add 1.3 schema support (#8764)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,6 +22,7 @@ the authors tag in the respective file header.
  - Chirag Dave
  - Chris Bauer
  - Chris Bielow
+ - Christie Mathews
  - Christian Ehrlich
  - Clemens Groepl
  - Cornelia Friedle

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -59,6 +59,7 @@ General:
   - Fix: SwathMapMassCorrection: removed null-pointer dereference and memory leak in correctMZ/correctIM when fetchSpectrumSwath returns an empty spectrum; empty-spectrum iterations are now skipped cleanly via continue or a null-pointer guard (#9386)
   - Fix: SimpleSearchEngineAlgorithm: removed default(none) from the OpenMP parallel-for pragma that unconditionally listed annotated_hits_lock in its shared() clause; on macOS/Xcode where _OPENMP is not defined, this caused "use of undeclared identifier" compile errors and prevented building on those platforms (#9388)
   - New ThermoRawFile class for native reading of Thermo .raw files into MSExperiment via the openms-thermo-bridge (.NET managed DLL bridge); fetched automatically via CMake FetchContent; controlled by WITH_THERMO_RAW CMake option (ON by default, except on Linux/aarch64); registered in FileHandler and FileTypes (#9389)
+  - Optimized MzIdentML parser performance by caching CV lookups and added mzIdentML 1.3 schema support (#8764)
 
 Dependencies:
   - PyOpenMS: Autowrap/Cython replaced with nanobind; nanobind 2.10.0+ fetched automatically (#8699)

--- a/share/OpenMS/SCHEMAS/mzIdentML1.2.0.xsd
+++ b/share/OpenMS/SCHEMAS/mzIdentML1.2.0.xsd
@@ -1,0 +1,1854 @@
+﻿<!-- mzIdentML version 1.2.0
+Distributed under the Creative Commons license http://creativecommons.org/licenses/by/2.0/.
+-->
+<xsd:schema xmlns:psi-pi="http://psidev.info/psi/pi/mzIdentML/1.2" xmlns="http://psidev.info/psi/pi/mzIdentML/1.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://psidev.info/psi/pi/mzIdentML/1.2" elementFormDefault="qualified" version="1.2.0">
+	<xsd:element name="MzIdentML" type="MzIdentMLType">
+		<xsd:unique name="PK_MZIDENTML">
+			<xsd:selector xpath="."/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_SCDBSEQ">
+			<xsd:selector xpath="./psi-pi:SequenceCollection/psi-pi:DBSequence"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_SCPEP">
+			<xsd:selector xpath="./psi-pi:SequenceCollection/psi-pi:Peptide"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_SCPEPEVLIPEPEV">
+			<xsd:selector xpath="./psi-pi:SequenceCollection/psi-pi:PeptideEvidence"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_ANA">
+			<xsd:selector xpath="./psi-pi:AnalysisCollection/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_APC">
+			<xsd:selector xpath="./psi-pi:AnalysisProtocolCollection/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_APCSIPMT">
+			<xsd:selector xpath="./psi-pi:AnalysisProtocolCollection/psi-pi:SpectrumIdentificationProtocol/psi-pi:MassTable"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_APCSIPENZ">
+			<xsd:selector xpath="./psi-pi:AnalysisProtocolCollection/psi-pi:SpectrumIdentificationProtocol/psi-pi:Enzymes/psi-pi:Enzyme"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_APCSIPDTTT">
+			<xsd:selector xpath="./psi-pi:AnalysisProtocolCollection/psi-pi:SpectrumIdentificationProtocol/psi-pi:DatabaseTranslation/psi-pi:TranslationTable"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_DATAIN">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:Inputs/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_DATAAD">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_DATAADSIL">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_DATAADSILSIR">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:SpectrumIdentificationResult/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_DATAADSILSIRSII">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:SpectrumIdentificationResult/psi-pi:SpectrumIdentificationItem"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_DATAADPDL">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:ProteinDetectionList/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_DATAADPDLPAG">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:ProteinDetectionList/psi-pi:ProteinAmbiguityGroup/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_ANASW">
+			<xsd:selector xpath="./psi-pi:AnalysisSoftwareList/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_PROV">
+			<xsd:selector xpath="./Provider"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_AUDIT">
+			<xsd:selector xpath="./psi-pi:AuditCollection/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_AUDITORG">
+			<xsd:selector xpath="./psi-pi:AuditCollection/psi-pi:Organization"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_AUDITPER">
+			<xsd:selector xpath="./psi-pi:AuditCollection/psi-pi:Person"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_SAMPLE">
+			<xsd:selector xpath="./psi-pi:AnalysisSampleCollection/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_CV">
+			<xsd:selector xpath="./psi-pi:cvList/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_DATAADSILFRAGTMEAS">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:FragmentationTable/psi-pi:Measure"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_Bibref">
+			<xsd:selector xpath="./psi-pi:BibliographicReference"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_spectrumID">		
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:SpectrumIdentificationResult/psi-pi:SpectrumIdentificationItem"/>
+			<xsd:field xpath="@spectrumID"/>
+			<xsd:field xpath="@spectraData_ref"/>
+		</xsd:unique>
+		<xsd:keyref name="FK_SoftwareContact" refer="PK_AUDIT">
+			<xsd:selector xpath="./psi-pi:AnalysisSoftwareList/psi-pi:AnalysisSoftware/psi-pi:ContactRole"/>
+			<xsd:field xpath="@contact_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_AUDITPERAFF" refer="PK_AUDITORG">
+			<xsd:selector xpath="./psi-pi:AuditCollection/psi-pi:Person/psi-pi:Affiliation"/>
+			<xsd:field xpath="@organization_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_AUDITORGPAR" refer="PK_AUDITORG">
+			<xsd:selector xpath="./psi-pi:AuditCollection/psi-pi:Organization/psi-pi:Parent"/>
+			<xsd:field xpath="@organization_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_ProviderContact" refer="PK_AUDIT">
+			<xsd:selector xpath="./psi-pi:Provider/psi-pi:ContactRole"/>
+			<xsd:field xpath="@contact_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_ProviderSoftware" refer="PK_ANASW">
+			<xsd:selector xpath="./psi-pi:Provider"/>
+			<xsd:field xpath="@software_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_SampleContact" refer="PK_AUDIT">
+			<xsd:selector xpath="./psi-pi:AnalysisSampleCollection/psi-pi:Sample/psi-pi:ContactRole"/>
+			<xsd:field xpath="@contact_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_subSamples" refer="PK_SAMPLE">
+			<xsd:selector xpath="./psi-pi:AnalysisSampleCollection/psi-pi:Sample/psi-pi:SubSample"/>
+			<xsd:field xpath="@sample_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_DBSEQ_SDB" refer="PK_DATAIN">
+			<xsd:selector xpath="./psi-pi:SequenceCollection/psi-pi:DBSequence"/>
+			<xsd:field xpath="@searchDatabase_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_PEPEVID_PEP" refer="PK_SCPEP">
+			<xsd:selector xpath="./psi-pi:SequenceCollection/psi-pi:PeptideEvidence"/>
+			<xsd:field xpath="@peptide_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_PEPEVID_DBSEQ" refer="PK_SCDBSEQ">
+			<xsd:selector xpath="./psi-pi:SequenceCollection/psi-pi:PeptideEvidence"/>
+			<xsd:field xpath="@dBSequence_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_PEPEVID_TT" refer="PK_APCSIPDTTT">
+			<xsd:selector xpath="./psi-pi:SequenceCollection/psi-pi:PeptideEvidence"/>
+			<xsd:field xpath="@translationTable_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_SI_SIP" refer="PK_APC">
+			<xsd:selector xpath="./psi-pi:AnalysisCollection/psi-pi:SpectrumIdentification"/>
+			<xsd:field xpath="@spectrumIdentificationProtocol_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_SI_SILR" refer="PK_DATAAD">
+			<xsd:selector xpath="./psi-pi:AnalysisCollection/psi-pi:SpectrumIdentification"/>
+			<xsd:field xpath="@spectrumIdentificationList_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_SISDB_SDBR" refer="PK_DATAIN">
+			<xsd:selector xpath="./psi-pi:AnalysisCollection/psi-pi:SpectrumIdentification/psi-pi:SearchDatabaseRef"/>
+			<xsd:field xpath="@searchDatabase_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_SIIS_SDR" refer="PK_DATAIN">
+			<xsd:selector xpath="./psi-pi:AnalysisCollection/psi-pi:SpectrumIdentification/psi-pi:InputSpectra"/>
+			<xsd:field xpath="@spectraData_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_PD_PDP" refer="PK_APC">
+			<xsd:selector xpath="./psi-pi:AnalysisCollection/psi-pi:ProteinDetection"/>
+			<xsd:field xpath="@proteinDetectionProtocol_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_PD_PDL" refer="PK_DATAAD">
+			<xsd:selector xpath="./psi-pi:AnalysisCollection/psi-pi:ProteinDetection"/>
+			<xsd:field xpath="@proteinDetectionList_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_PDSIL_ISI" refer="PK_DATAAD">
+			<xsd:selector xpath="./psi-pi:AnalysisCollection/psi-pi:ProteinDetection/psi-pi:InputSpectrumIdentifications"/>
+			<xsd:field xpath="@spectrumIdentificationList_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_APSIP_ASW" refer="PK_ANASW">
+			<xsd:selector xpath="./psi-pi:AnalysisProtocolCollection/psi-pi:SpectrumIdentificationProtocol"/>
+			<xsd:field xpath="@analysisSoftware_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_APPDP_ASW" refer="PK_ANASW">
+			<xsd:selector xpath="./psi-pi:AnalysisProtocolCollection/psi-pi:ProteinDetectionProtocol"/>
+			<xsd:field xpath="@analysisSoftware_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_SIIPEV_PEPEVR" refer="PK_SCPEPEVLIPEPEV">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:SpectrumIdentificationResult/psi-pi:SpectrumIdentificationItem/psi-pi:PeptideEvidenceRef"/>
+			<xsd:field xpath="@peptideEvidence_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_DATAADSILSIR_SDR" refer="PK_DATAIN">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:SpectrumIdentificationResult"/>
+			<xsd:field xpath="@spectraData_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_DATAADSILSIRSII_PEP" refer="PK_SCPEP">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:SpectrumIdentificationResult/psi-pi:SpectrumIdentificationItem"/>
+			<xsd:field xpath="@peptide_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_DATAADPDLPAGPDHPH_PEPEV" refer="PK_SCPEPEVLIPEPEV">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:ProteinDetectionList/psi-pi:ProteinAmbiguityGroup/psi-pi:ProteinDetectionHypothesis/psi-pi:PeptideHypothesis"/>
+			<xsd:field xpath="@peptideEvidence_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_DATAADPDLPAGPDHPHSIIR_SII" refer="PK_DATAADSILSIRSII">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:ProteinDetectionList/psi-pi:ProteinAmbiguityGroup/psi-pi:ProteinDetectionHypothesis/psi-pi:PeptideHypothesis/psi-pi:SpectrumIdentificationItemRef"/>
+			<xsd:field xpath="@spectrumIdentificationItem_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_PDH_DBSeq" refer="PK_SCDBSEQ">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:ProteinDetectionList/psi-pi:ProteinAmbiguityGroup/psi-pi:ProteinDetectionHypothesis"/>
+			<xsd:field xpath="@dBSequence_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_DATAADSILSIRSIIFRAGIONFRAGARR" refer="PK_DATAADSILFRAGTMEAS">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:SpectrumIdentificationResult/psi-pi:SpectrumIdentificationItem/psi-pi:Fragmentation/psi-pi:IonType/psi-pi:FragmentArray"/>
+			<xsd:field xpath="@measure_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_Sample" refer="PK_SAMPLE">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:SpectrumIdentificationResult/psi-pi:SpectrumIdentificationItem"/>
+			<xsd:field xpath="@sample_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_MassTable" refer="PK_APCSIPMT">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:SpectrumIdentificationResult/SpectrumIdentificationItem"/>
+			<xsd:field xpath="@massTable_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_UnitCVlist1" refer="PK_CV">
+			<xsd:selector xpath="*"/>
+			<xsd:field xpath="@unitCvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_UnitCVlist2" refer="PK_CV">
+			<xsd:selector xpath="*/*"/>
+			<xsd:field xpath="@unitCvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_UnitCVlist3" refer="PK_CV">
+			<xsd:selector xpath="*/*/*"/>
+			<xsd:field xpath="@unitCvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_UnitCVlist4" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*"/>
+			<xsd:field xpath="@unitCvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_UnitCVlist5" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*/*"/>
+			<xsd:field xpath="@unitCvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_UnitCVlist6" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*/*/*"/>
+			<xsd:field xpath="@unitCvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_UnitCVlist7" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*/*/*/*"/>
+			<xsd:field xpath="@unitCvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_UnitCVlist8" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*/*/*/*/*"/>
+			<xsd:field xpath="@unitCvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_CVlist1" refer="PK_CV">
+			<xsd:selector xpath="*"/>
+			<xsd:field xpath="@cvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_CVlist2" refer="PK_CV">
+			<xsd:selector xpath="*/*"/>
+			<xsd:field xpath="@cvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_CVlist3" refer="PK_CV">
+			<xsd:selector xpath="*/*/*"/>
+			<xsd:field xpath="@cvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_CVlist4" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*"/>
+			<xsd:field xpath="@cvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_CVlist5" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*/*"/>
+			<xsd:field xpath="@cvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_CVlist6" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*/*/*"/>
+			<xsd:field xpath="@cvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_CVlist7" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*/*/*/*"/>
+			<xsd:field xpath="@cvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_CVlist8" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*/*/*/*/*"/>
+			<xsd:field xpath="@cvRef"/>
+		</xsd:keyref>
+	</xsd:element>
+	<xsd:complexType name="CVListType">
+		<xsd:annotation>
+			<xsd:documentation>The list of controlled vocabularies used in the file.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="cv" type="cvType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AnalysisSoftwareListType">
+		<xsd:annotation>
+			<xsd:documentation>The software packages used to perform the analyses.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="AnalysisSoftware" type="AnalysisSoftwareType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AnalysisSampleCollectionType">
+		<xsd:annotation>
+			<xsd:documentation>The samples analysed can optionally be recorded using CV terms for descriptions. If a composite sample has been analysed, the subsample association can be used to build a hierarchical description. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Sample" type="SampleType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="SequenceCollectionType">
+		<xsd:annotation>
+			<xsd:documentation>The collection of sequences (DBSequence or Peptide) identified and their relationship between each other (PeptideEvidence) to be referenced elsewhere in the results. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="DBSequence" type="DBSequenceType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="Peptide" type="PeptideType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="PeptideEvidence" type="PeptideEvidenceType" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AnalysisCollectionType">
+		<xsd:annotation>
+			<xsd:documentation>The analyses performed to get the results, which map the input and output data sets. Analyses are for example: SpectrumIdentification (resulting in peptides) or ProteinDetection (assemble proteins from peptides).</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SpectrumIdentification" type="SpectrumIdentificationType" maxOccurs="unbounded"/>
+			<xsd:element name="ProteinDetection" type="ProteinDetectionType" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AnalysisProtocolCollectionType">
+		<xsd:annotation>
+			<xsd:documentation>The collection of protocols which include the parameters and settings of the performed analyses. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SpectrumIdentificationProtocol" type="SpectrumIdentificationProtocolType" maxOccurs="unbounded"/>
+			<xsd:element name="ProteinDetectionProtocol" type="ProteinDetectionProtocolType" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="InputsType">
+		<xsd:annotation>
+			<xsd:documentation>The inputs to the analyses including the databases searched, the spectral data and the source file converted to mzIdentML. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SourceFile" type="SourceFileType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="SearchDatabase" type="SearchDatabaseType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="SpectraData" type="SpectraDataType" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AnalysisDataType">
+		<xsd:annotation>
+			<xsd:documentation>Data sets generated by the analyses, including peptide and protein lists. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SpectrumIdentificationList" type="SpectrumIdentificationListType" maxOccurs="unbounded"/>
+			<xsd:element name="ProteinDetectionList" type="ProteinDetectionListType" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DataCollectionType">
+		<xsd:annotation>
+			<xsd:documentation>The collection of input and output data sets of the analyses.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Inputs" type="InputsType"/>
+			<xsd:element name="AnalysisData" type="psi-pi:AnalysisDataType"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="MzIdentMLType">
+		<xsd:annotation>
+			<xsd:documentation>The upper-most hierarchy level of mzIdentML with sub-containers for example describing software, protocols and search results (spectrum identifications or protein detection results). </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="cvList" type="CVListType"/>
+					<xsd:element name="AnalysisSoftwareList" type="AnalysisSoftwareListType" minOccurs="0"/>
+					<xsd:element name="Provider" type="ProviderType" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>The Provider of the mzIdentML record in terms of the contact and software. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="AuditCollection" type="AuditCollectionType" minOccurs="0"/>
+					<xsd:element name="AnalysisSampleCollection" type="AnalysisSampleCollectionType" minOccurs="0"/>
+					<xsd:element name="SequenceCollection" type="SequenceCollectionType" minOccurs="0"/>
+					<xsd:element name="AnalysisCollection" type="AnalysisCollectionType"/>
+					<xsd:element name="AnalysisProtocolCollection" type="AnalysisProtocolCollectionType"/>
+					<xsd:element name="DataCollection" type="DataCollectionType"/>
+					<xsd:element name="BibliographicReference" type="BibliographicReferenceType" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Any bibliographic references associated with the file</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="creationDate" type="xsd:dateTime">
+					<xsd:annotation>
+						<xsd:documentation>The date on which the file was produced.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="version" type="versionRegex" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The version of the schema this instance document refers to, in the format x.y.z. Changes to z should not affect prevent instance documents from validating. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="SearchDatabaseType">
+		<xsd:annotation>
+			<xsd:documentation>A database for searching mass spectra. Examples include a set of amino acid sequence entries, nucleotide databases (e.g. 6 frame translated) or annotated spectra libraries. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ExternalDataType">
+				<xsd:sequence>
+					<xsd:element name="DatabaseName" type="ParamType">
+						<xsd:annotation>
+							<xsd:documentation>The database name may be given as a cvParam if it maps exactly to one of the release databases listed in the CV, otherwise a userParam should be used. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="cvParam" type="CVParamType" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="version" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The version of the database.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="releaseDate" type="xsd:dateTime">
+					<xsd:annotation>
+						<xsd:documentation>The date and time the database was released to the public; omit this attribute when the date and time are unknown or not applicable (e.g. custom databases). </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="numDatabaseSequences" type="xsd:long">
+					<xsd:annotation>
+						<xsd:documentation>The total number of sequences in the database.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="numResidues" type="xsd:long">
+					<xsd:annotation>
+						<xsd:documentation>The number of residues in the database.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="SourceFileType">
+		<xsd:annotation>
+			<xsd:documentation>A file from which this mzIdentML instance was created.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ExternalDataType">
+                <xsd:sequence>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+								<xsd:documentation>Any additional parameters description the source
+								file.</xsd:documentation>
+						</xsd:annotation>
+						</xsd:group>
+					</xsd:sequence>
+			</xsd:extension>
+
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ModificationParamsType">
+		<xsd:annotation>
+			<xsd:documentation>The specification of static/variable modifications (e.g. Oxidation of Methionine) that are to be considered in the spectra search. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SearchModification" type="SearchModificationType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="FilterType">
+		<xsd:annotation>
+			<xsd:documentation>Filters applied to the search database. The filter must include at least one of Include and Exclude. If both are used, it is assumed that inclusion is performed first. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="FilterType" type="ParamType">
+				<xsd:annotation>
+					<xsd:documentation>The type of filter e.g. database taxonomy filter, pi filter, mw filter </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Include" type="ParamListType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>All sequences fulfilling the specifed criteria are included.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Exclude" type="ParamListType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>All sequences fulfilling the specifed criteria are excluded.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DatabaseFiltersType">
+		<xsd:annotation>
+			<xsd:documentation>The specification of filters applied to the database searched.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Filter" type="FilterType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="TranslationTableType">
+		<xsd:annotation>
+			<xsd:documentation>The table used to translate codons into nucleic acids e.g. by reference to the NCBI translation table. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="cvParam" type="CVParamType" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>The details specifying this translation table are captured as cvParams, e.g. translation table, translation start codons and translation table description (see specification document and mapping file)</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="DatabaseTranslationType">
+		<xsd:annotation>
+			<xsd:documentation>A specification of how a nucleic acid sequence database was translated for searching. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="TranslationTable" type="TranslationTableType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="frames" type="listOfAllowedFrames">
+			<xsd:annotation>
+				<xsd:documentation>The frames in which the nucleic acid sequence has been translated as a space separated list </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="SpectrumIdentificationProtocolType">
+		<xsd:annotation>
+			<xsd:documentation>The parameters and settings of a SpectrumIdentification analysis.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="SearchType" type="ParamType">
+						<xsd:annotation>
+							<xsd:documentation>The type of search performed e.g. PMF, Tag searches, MS-MS </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="AdditionalSearchParams" type="ParamListType" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>The search parameters other than the modifications searched. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="ModificationParams" type="ModificationParamsType" minOccurs="0"/>
+					<xsd:element name="Enzymes" type="EnzymesType" minOccurs="0"/>
+					<xsd:element name="MassTable" type="MassTableType" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="FragmentTolerance" type="ToleranceType" minOccurs="0"/>
+					<xsd:element name="ParentTolerance" type="ToleranceType" minOccurs="0"/>
+					<xsd:element name="Threshold" type="ParamListType">
+						<xsd:annotation>
+							<xsd:documentation>The threshold(s) applied to determine that a result is significant. If multiple terms are used it is assumed that all conditions are satisfied by the passing results.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="DatabaseFilters" type="DatabaseFiltersType" minOccurs="0"/>
+					<xsd:element name="DatabaseTranslation" type="DatabaseTranslationType" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:attribute name="analysisSoftware_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The search algorithm used, given as a reference to the SoftwareCollection section. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="InputSpectraType">
+		<xsd:annotation>
+			<xsd:documentation>The attribute referencing an identifier within the SpectraData section. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="spectraData_ref" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the SpectraData element which locates the input spectra to an external file. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="SearchDatabaseRefType">
+		<xsd:annotation>
+			<xsd:documentation>One of the search databases used.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="searchDatabase_ref" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the database searched.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="SpectrumIdentificationType">
+		<xsd:annotation>
+			<xsd:documentation>An Analysis which tries to identify peptides in input spectra, referencing the database searched, the input spectra, the output results and the protocol that is run. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ProtocolApplicationType">
+				<xsd:sequence>
+					<xsd:element name="InputSpectra" type="InputSpectraType" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>One of the spectra data sets used.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="SearchDatabaseRef" type="SearchDatabaseRefType" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="spectrumIdentificationProtocol_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the search protocol used for this SpectrumIdentification. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="spectrumIdentificationList_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the SpectrumIdentificationList produced by this analysis in the DataCollection section. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="MeasureType">
+		<xsd:annotation>
+			<xsd:documentation>References to CV terms defining the measures about product ions to be reported in SpectrumIdentificationItem </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="cvParam" type="CVParamType" minOccurs="1" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="FragmentationTableType">
+		<xsd:annotation>
+			<xsd:documentation>Contains the types of measures that will be reported in generic arrays for each SpectrumIdentificationItem e.g. product ion m/z, product ion intensity, product ion m/z error </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Measure" type="MeasureType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="SpectrumIdentificationListType">
+		<xsd:annotation>
+			<xsd:documentation>Represents the set of all search results from SpectrumIdentification.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="FragmentationTable" type="FragmentationTableType" minOccurs="0"/>
+					<xsd:element name="SpectrumIdentificationResult" type="SpectrumIdentificationResultType" maxOccurs="unbounded"/>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Scores or output parameters associated with the SpectrumIdentificationList.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+				<xsd:attribute name="numSequencesSearched" type="xsd:long">
+					<xsd:annotation>
+						<xsd:documentation>The number of database sequences searched against. This value should be provided unless a de novo search has been performed.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="SpecificityRulesType">
+		<xsd:annotation>
+			<xsd:documentation>The specificity rules of the searched modification including for example the probability of a modification's presence or peptide or protein termini. Standard fixed or variable status should be provided by the attribute fixedMod.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="cvParam" type="CVParamType" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="SearchModificationType">
+		<xsd:annotation>
+			<xsd:documentation>Specification of a search modification as parameter for a spectra search. Contains the name of the modification, the mass, the specificity and whether it is a static modification. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SpecificityRules" type="SpecificityRulesType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="cvParam" type="CVParamType" minOccurs="1" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>The modification is uniquely identified by references to external CVs such as UNIMOD, see specification document and mapping file for more details.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="fixedMod" type="xsd:boolean" use="required">
+			<xsd:annotation>
+				<xsd:documentation>True, if the modification is static (i.e. occurs always).</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="massDelta" type="xsd:float" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The mass delta of the searched modification in Daltons.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="residues" type="listOfCharsOrAny" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The residue(s) searched with the specified modification. For N or C terminal modifications that can occur on any residue, the . character should be used to specify any, otherwise the list of amino acids should be provided.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="FragmentArrayType">
+		<xsd:annotation>
+			<xsd:documentation>An array of values for a given type of measure and for a particular ion type, in parallel to the index of ions identified. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="values" type="listOfFloats" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The values of this particular measure, corresponding to the index defined in ion type </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="measure_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the Measure defined in the FragmentationTable</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="IonTypeType">
+		<xsd:annotation>
+			<xsd:documentation>IonType defines the index of fragmentation ions being reported, importing a CV term for the type of ion e.g. b ion. Example: if b3 b7 b8 and b10 have been identified, the index attribute will contain 3 7 8 10, and the corresponding values will be reported in parallel arrays below </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="FragmentArray" type="FragmentArrayType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element maxOccurs="unbounded" minOccurs="0" name="userParam" type="UserParamType">
+				<xsd:annotation>
+					<xsd:documentation>In case more information about the ions annotation has to be conveyed, that has no fit in FragmentArray. Note: It is suggested that the value attribute takes the form of a list of the same size as FragmentArray values. However, there is no formal encoding and it cannot be expeceted that other software will process or impart that information properly.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="cvParam" type="CVParamType" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>The type of ion identified. In the case of neutral losses, one term should report the ion type, a second term should report the neutral loss - note: this is a change in practice from mzIdentML 1.1.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="index" type="listOfIntegers">
+			<xsd:annotation>
+				<xsd:documentation>The index of ions identified as integers, following standard notation for a-c, x-z e.g. if b3 b5 and b6 have been identified, the index would store "3 5 6". For internal ions, the index contains pairs defining the start and end point - see specification document for examples. For immonium ions, the index is the position of the identified ion within the peptide sequence - if the peptide contains the same amino acid in multiple positions that cannot be distinguished, all positions should be given. For precursor ions, including neutral losses, the index value MUST be 0. For any other ions not related to the position within the peptide sequence e.g. quantification reporter ions, the index value MUST be 0. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="charge" type="xsd:int" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The charge of the identified fragmentation ions.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="FragmentationType">
+		<xsd:annotation>
+			<xsd:documentation>The product ions identified in this result.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="IonType" type="IonTypeType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PeptideEvidenceRefType">
+		<xsd:annotation>
+			<xsd:documentation>Reference to the PeptideEvidence element identified. If a specific sequence can be assigned to multiple proteins and or positions in a protein all possible PeptideEvidence elements should be referenced here.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="peptideEvidence_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the PeptideEvidenceItem element(s).</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="SpectrumIdentificationItemType">
+		<xsd:annotation>
+			<xsd:documentation>An identification of a single (poly)peptide, resulting from querying an input spectra, along with the set of confidence values for that identification.
+PeptideEvidence elements should be given for all mappings of the corresponding Peptide sequence within protein sequences. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="PeptideEvidenceRef" type="PeptideEvidenceRefType" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="Fragmentation" type="FragmentationType" minOccurs="0"/>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Scores or attributes associated with the SpectrumIdentificationItem e.g. e-value, p-value, score.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+				<xsd:attribute name="chargeState" type="xsd:int" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The charge state of the identified peptide.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="experimentalMassToCharge" type="xsd:double" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The mass-to-charge value measured in the experiment in Daltons / charge. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="calculatedMassToCharge" type="xsd:double">
+					<xsd:annotation>
+						<xsd:documentation>The theoretical mass-to-charge value calculated for the peptide in Daltons / charge. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="calculatedPI" type="xsd:float">
+					<xsd:annotation>
+						<xsd:documentation>The calculated isoelectric point of the (poly)peptide, with relevant modifications included. Do not supply this value if the PI cannot be calcuated properly. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="peptide_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the identified (poly)peptide sequence in the Peptide element. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="rank" type="xsd:int" use="required">
+					<xsd:annotation>
+						<xsd:documentation>For an MS/MS result set, this is the rank of the identification quality as scored by the search engine. 1 is the top rank. If multiple identifications have the same top score, they should all be assigned rank =1. For PMF data, the rank attribute may be meaningless and values of rank = 0 should be given. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="passThreshold" type="xsd:boolean" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Set to true if the producers of the file has deemed that the identification has passed a given threshold or been validated as correct. If no such threshold has been set, value of true should be given for all results. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="massTable_ref" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>A reference should be given to the MassTable used to calculate the sequenceMass only if more than one MassTable has been given.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="sample_ref" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>A reference should be provided to link the SpectrumIdentificationItem to a Sample if more than one sample has been described in the AnalysisSampleCollection. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="SpectrumIdentificationResultType">
+		<xsd:annotation>
+			<xsd:documentation>All identifications made from searching one spectrum. For PMF data, all peptide identifications will be listed underneath as SpectrumIdentificationItems. For MS/MS data, there will be ranked SpectrumIdentificationItems corresponding to possible different peptide IDs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="SpectrumIdentificationItem" type="SpectrumIdentificationItemType" maxOccurs="unbounded"/>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation> Scores or parameters associated with the SpectrumIdentificationResult (i.e the set of SpectrumIdentificationItems derived from one spectrum) e.g. the number of peptide sequences within the parent tolerance for this spectrum. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+				<xsd:attribute name="spectrumID" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The locally unique id for the spectrum in the spectra data set specified by SpectraData_ref. External guidelines are provided on the use of consistent identifiers for spectra in different external formats. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="spectraData_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to a spectra data set (e.g. a spectra file).</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="InputSpectrumIdentificationsType">
+		<xsd:annotation>
+			<xsd:documentation>The lists of spectrum identifications that are input to the protein detection process. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="spectrumIdentificationList_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the list of spectrum identifications that were input to the process. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="ProteinDetectionType">
+		<xsd:annotation>
+			<xsd:documentation>An Analysis which assembles a set of peptides (e.g. from a spectra search analysis) to proteins. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ProtocolApplicationType">
+				<xsd:sequence>
+					<xsd:element name="InputSpectrumIdentifications" type="InputSpectrumIdentificationsType" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="proteinDetectionList_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the ProteinDetectionList in the DataCollection section. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="proteinDetectionProtocol_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the detection protocol used for this ProteinDetection. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ProteinDetectionProtocolType">
+		<xsd:annotation>
+			<xsd:documentation>The parameters and settings of a ProteinDetection process.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="AnalysisParams" type="ParamListType" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>The parameters and settings for the protein detection given as CV terms. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="Threshold" type="ParamListType" minOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>The threshold(s) applied to determine that a result is significant. If multiple terms are used it is assumed that all conditions are satisfied by the passing results.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="analysisSoftware_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The protein detection software used, given as a reference to the SoftwareCollection section. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ProteinDetectionListType">
+		<xsd:annotation>
+			<xsd:documentation>The protein list resulting from a protein detection process.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="ProteinAmbiguityGroup" type="ProteinAmbiguityGroupType" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Scores or output parameters associated with the whole ProteinDetectionList </xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="SpectrumIdentificationItemRefType">
+		<xsd:annotation>
+			<xsd:documentation>Reference(s) to the SpectrumIdentificationItem element(s) that support the given PeptideEvidence element. Using these references it is possible to indicate which spectra were actually accepted as evidence for this peptide identification in the given protein.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="spectrumIdentificationItem_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the SpectrumIdentificationItem element(s).</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="PeptideHypothesisType">
+		<xsd:annotation>
+			<xsd:documentation>Peptide evidence on which this ProteinHypothesis is based by reference to a PeptideEvidence element. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SpectrumIdentificationItemRef" type="SpectrumIdentificationItemRefType" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="peptideEvidence_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the PeptideEvidence element on which this hypothesis is based. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="ProteinDetectionHypothesisType">
+		<xsd:annotation>
+			<xsd:documentation>A single result of the ProteinDetection analysis (i.e. a protein).</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="PeptideHypothesis" type="PeptideHypothesisType" maxOccurs="unbounded"/>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Scores or parameters associated with this ProteinDetectionHypothesis e.g. p-value</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+				<xsd:attribute name="dBSequence_ref" type="xsd:string"  use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the corresponding DBSequence entry. Note - this attribute was optional in mzIdentML 1.1 but is now mandatory in mzIdentML 1.2. Consuming software should assume that the DBSequence entry referenced here is the definitive identifier for the protein. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="passThreshold" type="xsd:boolean" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Set to true if the producers of the file has deemed that the ProteinDetectionHypothesis has passed a given threshold or been validated as correct. If no such threshold has been set, value of true should be given for all results. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ProteinAmbiguityGroupType">
+		<xsd:annotation>
+			<xsd:documentation>A set of logically related results from a protein detection, for example to represent conflicting assignments of peptides to proteins.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="ProteinDetectionHypothesis" type="ProteinDetectionHypothesisType" maxOccurs="unbounded"/>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Scores or parameters associated with the ProteinAmbiguityGroup.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ModificationType">
+		<xsd:annotation>
+			<xsd:documentation>A molecule modification specification. If n modifications have been found on a peptide, there should be n instances of Modification. If multiple modifications are provided as cvParams, it is assumed that the modification is ambiguous i.e. one modification or another. A cvParam must be provided with the identification of the modification sourced from a suitable CV e.g. UNIMOD. If the modification is not present in the CV (and this will be checked by the semantic validator within a given tolerance window), there is a â€œunknown modificationâ€ CV term that must be used instead. A neutral loss should be defined as an additional CVParam within Modification. If more complex information should be given about neutral losses (such as presence/absence on particular product ions), this can additionally be encoded within the FragmentationArray. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="cvParam" type="CVParamType" minOccurs="1" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>CV terms capturing the modification, sourced from an appropriate controlled vocabulary.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="location" type="xsd:int">
+			<xsd:annotation>
+				<xsd:documentation>Location of the modification within the peptide - position in peptide sequence, counted from the N-terminus residue, starting at position 1. Specific modifications to the N-terminus should be given the location 0. Modification to the C-terminus should be given as peptide length + 1. If the modification location is unknown e.g. for PMF data, this attribute should be omitted.	</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="residues" type="listOfChars">
+			<xsd:annotation>
+				<xsd:documentation>Specification of the residue (amino acid) on which the modification occurs. If multiple values are given, it is assumed that the exact residue modified is unknown i.e. the modification is to ONE of the residues listed. Multiple residues would usually only be specified for PMF data.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="avgMassDelta" type="xsd:double">
+			<xsd:annotation>
+				<xsd:documentation>Atomic mass delta considering the natural distribution of isotopes in Daltons. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="monoisotopicMassDelta" type="xsd:double">
+			<xsd:annotation>
+				<xsd:documentation>Atomic mass delta when assuming only the most common isotope of elements in Daltons. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="PeptideType">
+		<xsd:annotation>
+			<xsd:documentation>One (poly)peptide (a sequence with modifications). The combination of Peptide sequence and modifications must be unique in the file.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="PeptideSequence" type="sequence">
+						<xsd:annotation>
+							<xsd:documentation>The amino acid sequence of the (poly)peptide. If a substitution modification has been found, the original sequence
+should be reported. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="Modification" type="ModificationType" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="SubstitutionModification" type="SubstitutionModificationType" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Additional descriptors of this peptide sequence</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="SubstitutionModificationType">
+		<xsd:annotation>
+			<xsd:documentation>A modification where one residue is substituted by another (amino acid change). </xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="originalResidue" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The original residue before replacement.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:pattern value="[ABCDEFGHIJKLMNOPQRSTUVWXYZ?\-]{1}"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="replacementResidue" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The residue that replaced the originalResidue.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:pattern value="[ABCDEFGHIJKLMNOPQRSTUVWXYZ?\-]{1}"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="location" type="xsd:int">
+			<xsd:annotation>
+				<xsd:documentation>Location of the modification within the peptide - position in peptide sequence, counted from the N-terminus residue, starting at position 1.
+Specific modifications to the N-terminus should be given the location 0.
+Modification to the C-terminus should be given as peptide length + 1.		</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="avgMassDelta" type="xsd:double">
+			<xsd:annotation>
+				<xsd:documentation>Atomic mass delta considering the natural distribution of isotopes in Daltons. This should only be reported if the original amino acid is known i.e. it is not "X" </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="monoisotopicMassDelta" type="xsd:double">
+			<xsd:annotation>
+				<xsd:documentation>Atomic mass delta when assuming only the most common isotope of elements in Daltons. This should only be reported if the original amino acid is known i.e. it is not "X" </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="SpectraDataType">
+		<xsd:annotation>
+			<xsd:documentation>A data set containing spectra data (consisting of one or more spectra). </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ExternalDataType">
+				<xsd:sequence>
+					<xsd:element name="SpectrumIDFormat" type="SpectrumIDFormatType"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="AnalysisSoftwareType">
+		<xsd:annotation>
+			<xsd:documentation>The software used for performing the analyses.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="ContactRole" type="ContactRoleType" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>The contact details of the organisation or person that produced the software</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="SoftwareName" type="ParamType">
+						<xsd:annotation>
+							<xsd:documentation>The name of the analysis software package, sourced from a CV if available. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="Customizations" type="xsd:string" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Any customizations to the software, such as alternative scoring mechanisms implemented, should be documented here as free text. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="version" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The version of Software used.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="uri" type="xsd:anyURI">
+					<xsd:annotation>
+						<xsd:documentation>URI of the analysis software e.g. manufacturer's website</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="EnzymeType">
+		<xsd:annotation>
+			<xsd:documentation>The details of an individual cleavage enzyme should be provided by giving a regular expression or a CV term if a "standard" enzyme cleavage has been performed. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="SiteRegexp" type="xsd:string" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Regular expression for specifying the enzyme cleavage site.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="EnzymeName" type="ParamListType" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>The name of the enzyme from a CV.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="nTermGain" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>Element formula gained at NTerm.</xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:string">
+							<xsd:pattern value="[A-Za-z0-9 ]+"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+				<xsd:attribute name="cTermGain" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>Element formula gained at CTerm.</xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:string">
+							<xsd:pattern value="[A-Za-z0-9 ]+"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+				<xsd:attribute name="semiSpecific" type="xsd:boolean" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>Set to true if the enzyme cleaves semi-specifically (i.e. one terminus must cleave according to the rules, the other can cleave at any residue), false if the enzyme cleavage is assumed to be specific to both termini (accepting for any missed cleavages). </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="missedCleavages" type="xsd:int" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>The number of missed cleavage sites allowed by the search. The attribute must be provided if an enzyme has been used.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="minDistance" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>Minimal distance for another cleavage (minimum: 1).</xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:int">
+							<xsd:minInclusive value="1"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="EnzymesType">
+		<xsd:annotation>
+			<xsd:documentation>The list of enzymes used in experiment</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Enzyme" type="EnzymeType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="independent" type="xsd:boolean">
+			<xsd:annotation>
+				<xsd:documentation>If there are multiple enzymes specified, this attribute is set to true if cleavage with different enzymes is performed independently.		</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="ResidueType">
+		<xsd:attribute name="code" type="chars" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The single letter code for the residue.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="mass" type="xsd:float" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The residue mass in Daltons (not including any fixed modifications). </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="AmbiguousResidueType">
+		<xsd:annotation>
+			<xsd:documentation>Ambiguous residues e.g. X can be specified by the Code attribute and a set of parameters for example giving the different masses that will be used in the search. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:group ref="ParamGroup" minOccurs="1" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Parameters for capturing e.g. "alternate single letter codes"</xsd:documentation>
+				</xsd:annotation>
+			</xsd:group>
+		</xsd:sequence>
+		<xsd:attribute name="code" type="chars" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The single letter code of the ambiguous residue e.g. X.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="MassTableType">
+		<xsd:annotation>
+			<xsd:documentation>The masses of residues used in the search.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="Residue" type="ResidueType" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>The specification of a single residue within the mass table. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="AmbiguousResidue" type="AmbiguousResidueType" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Additional parameters or descriptors for the MassTable.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+				<xsd:attribute name="msLevel" type="listOfIntegers" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The MS spectrum that the MassTable refers to e.g. "1" for MS1 "2" for MS2 or "1 2" for MS1 or MS2.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="PeptideEvidenceType">
+		<xsd:annotation>
+			<xsd:documentation>PeptideEvidence links a specific Peptide element to a specific position in a DBSequence. There must only be one PeptideEvidence item per Peptide-to-DBSequence-position. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Additional parameters or descriptors for the PeptideEvidence.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+				<xsd:attribute name="dBSequence_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the protein sequence in which the specified peptide has been linked. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="peptide_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the identified (poly)peptide sequence in the Peptide element. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="start" type="xsd:int">
+					<xsd:annotation>
+						<xsd:documentation>Start position of the peptide inside the protein sequence, where the first amino acid of the protein sequence is position 1. Must be provided unless this is a de novo search.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="end" type="xsd:int">
+					<xsd:annotation>
+						<xsd:documentation>The index position of the last amino acid of the peptide inside the protein sequence, where the first amino acid of the protein sequence is position 1. Must be provided unless this is a de novo search. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="pre">
+					<xsd:annotation>
+						<xsd:documentation>Previous flanking residue. If the peptide is N-terminal, pre="-" and not pre="". If for any reason it is unknown (e.g. denovo), pre="?" should be used. </xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:string">
+							<xsd:pattern value="[ABCDEFGHIJKLMNOPQRSTUVWXYZ?\-]{1}"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+				<xsd:attribute name="post">
+					<xsd:annotation>
+						<xsd:documentation>Post flanking residue. If the peptide is C-terminal, post="-" and not post="". If for any reason it is unknown (e.g. denovo), post="?" should be used. </xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:string">
+							<xsd:pattern value="[ABCDEFGHIJKLMNOPQRSTUVWXYZ?\-]{1}"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+				<xsd:attribute name="translationTable_ref" type="xsd:string" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the translation table used if this is PeptideEvidence derived from nucleic acid sequence </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="frame" type="allowed_frames" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>The translation frame of this sequence if this is PeptideEvidence derived from nucleic acid sequence </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="isDecoy" type="xsd:boolean" default="false">
+					<xsd:annotation>
+						<xsd:documentation>Set to true if the peptide is matched to a decoy sequence. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ToleranceType">
+		<xsd:annotation>
+			<xsd:documentation>The tolerance of the search given as a plus and minus value with units. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="cvParam" type="CVParamType" minOccurs="1" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>CV terms capturing the tolerance plus and minus values.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="SpectrumIDFormatType">
+		<xsd:annotation>
+			<xsd:documentation>The format of the spectrum identifier within the source file</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="cvParam" type="CVParamType">
+				<xsd:annotation>
+					<xsd:documentation>CV term capturing the type of identifier used.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DBSequenceType">
+		<xsd:annotation>
+			<xsd:documentation>A database sequence from the specified SearchDatabase (nucleic acid or amino acid). If the sequence is nucleic acid, the source nucleic acid sequence
+should be given in the seq attribute rather than a translated sequence.	</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="Seq" type="sequence" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>The actual sequence of amino acids or nucleic acid.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Additional descriptors for the sequence, such as taxon, description line etc.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+				<xsd:attribute name="length" type="xsd:int">
+					<xsd:annotation>
+						<xsd:documentation>The length of the sequence as a number of bases or residues. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="searchDatabase_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The source database of this sequence.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="accession" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The unique accession of this sequence.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="SampleType">
+		<xsd:annotation>
+			<xsd:documentation> A description of the sample analysed by mass spectrometry using CVParams or UserParams. If a composite sample has been analysed, a parent sample should be defined, which references subsamples. This represents any kind of substance used in an experimental workflow, such as whole organisms, cells, DNA, solutions, compounds and experimental substances (gels, arrays etc.).	</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="ContactRole" type="ContactRoleType" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Contact details for the Material. The association to ContactRole could specify, for example, the creator or provider of the Material. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="SubSample" type="SubSampleType" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>The characteristics of a
+Material.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="SubSampleType">
+		<xsd:annotation>
+			<xsd:documentation>References to the individual component samples within a mixed parent sample. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="sample_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the child sample.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:simpleType name="listOfIntegers">
+		<xsd:list itemType="xsd:integer"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="listOfFloats">
+		<xsd:list itemType="xsd:float"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="listOfChars">
+		<xsd:list itemType="chars"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="listOfCharsOrAny">		
+		<xsd:union>
+			<xsd:simpleType id="listOfChars">
+				<xsd:list itemType="chars"/>
+			</xsd:simpleType>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="."/>
+				</xsd:restriction>
+			</xsd:simpleType>			
+		</xsd:union>		
+	</xsd:simpleType>
+	<xsd:simpleType name="chars">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="[ABCDEFGHIJKLMNOPQRSTUVWXYZ]{1}"/>
+		</xsd:restriction>
+	</xsd:simpleType>	
+	<xsd:simpleType name="sequence">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="[ABCDEFGHIJKLMNOPQRSTUVWXYZ]*"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="allowed_frames">
+		<xsd:restriction base="xsd:int">
+			<xsd:enumeration value="3"/>
+			<xsd:enumeration value="2"/>
+			<xsd:enumeration value="1"/>
+			<xsd:enumeration value="-3"/>
+			<xsd:enumeration value="-2"/>
+			<xsd:enumeration value="-1"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="listOfAllowedFrames">
+		<xsd:list itemType="allowed_frames"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="versionRegex">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="(1\.2\.\d+)"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!-- FuGE stuff -->
+	<xsd:complexType name="ExternalDataType">
+		<xsd:annotation>
+			<xsd:documentation>Data external to the XML instance document. The location of the data file is given in the location attribute. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="ExternalFormatDocumentation" type="xsd:anyURI" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>A URI to access documentation and tools to interpret the external format of the ExternalData instance. For example, XML Schema or static libraries (APIs) to access binary formats.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="FileFormat" type="FileFormatType" minOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="location" type="xsd:anyURI" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The location of the data file.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="FileFormatType">
+		<xsd:annotation>
+			<xsd:documentation>The format of the ExternalData file, for example "tiff" for image files. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="cvParam" type="CVParamType">
+				<xsd:annotation>
+					<xsd:documentation>cvParam capturing file formats</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PersonType">
+		<xsd:annotation>
+			<xsd:documentation>A person's name and contact details. Any additional information such as the address, contact email etc. should be supplied using CV parameters or user parameters.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AbstractContactType">
+				<xsd:sequence>
+					<xsd:element name="Affiliation" type="AffiliationType" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>The organization a person belongs to.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="lastName" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The Person's last/family name.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="firstName" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The Person's first name.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="midInitials" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The Person's middle initial.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="AffiliationType">
+		<xsd:attribute name="organization_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the organization this contact belongs to.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="OrganizationType">
+		<xsd:annotation>
+			<xsd:documentation>Organizations are entities like companies, universities, government agencies. Any additional information such as the address, email etc. should be supplied either as CV parameters or as user parameters. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AbstractContactType">
+				<xsd:sequence>
+					<xsd:element name="Parent" type="ParentOrganizationType" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ParentOrganizationType">
+		<xsd:annotation>
+			<xsd:documentation>The containing organization (the university or business which a lab belongs to, etc.) </xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="organization_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the organization this contact belongs to.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="AbstractContactType" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>A contact is either a person or an organization.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Attributes of this contact such as address, email, telephone etc.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ContactRoleType">
+		<xsd:annotation>
+			<xsd:documentation>The role that a Contact plays in an organization or with respect to the associating class. A Contact may have several Roles within scope, and as such,
+associations to ContactRole allow the use of a Contact in a certain manner. Examples
+might include a provider, or a data analyst. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Role" type="RoleType"/>
+		</xsd:sequence>
+		<xsd:attribute name="contact_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>When a ContactRole is used, it specifies which Contact the role is associated with. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="RoleType">
+		<xsd:annotation>
+			<xsd:documentation>The roles (lab equipment sales, contractor, etc.) the Contact fills.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="cvParam" type="CVParamType">
+				<xsd:annotation>
+					<xsd:documentation>CV term for contact roles, such as software provider.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="BibliographicReferenceType">
+		<xsd:annotation>
+			<xsd:documentation>Represents bibliographic references. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:attribute name="authors" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The names of the authors of the reference.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="publication" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The name of the journal, book etc.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="publisher" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The publisher of the publication.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="editor" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The editor(s) of the reference.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="year" type="xsd:int">
+					<xsd:annotation>
+						<xsd:documentation>The year of publication.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="volume" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The volume name or number.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="issue" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The issue name or number.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="pages" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The page numbers.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="title" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The title of the BibliographicReference.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="doi" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The DOI of the referenced publication.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ProtocolApplicationType" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>The use of a protocol with the requisite Parameters and ParameterValues. ProtocolApplications can take Material or Data (or both) as input
+and produce Material or Data (or both) as output. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:attribute name="activityDate" type="xsd:dateTime">
+					<xsd:annotation>
+						<xsd:documentation>When the protocol was applied.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="AbstractParamType" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Abstract entity allowing either cvParam or userParam to be referenced in other schemas. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="name" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The name of the parameter.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="value" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>The user-entered value of the parameter.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="unitAccession" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>An accession number identifying the unit within the OBO foundry Unit CV. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="unitName" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>The name of the unit.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="unitCvRef" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>If a unit term is referenced, this attribute must refer to the CV 'id' attribute defined in the cvList in this file. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="UserParamType">
+		<xsd:annotation>
+			<xsd:documentation>A single user-defined parameter.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AbstractParamType">
+				<xsd:attribute name="type" type="xsd:string" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>The datatype of the parameter, where appropriate (e.g.: xsd:float).</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="CVParamType">
+		<xsd:annotation>
+			<xsd:documentation>A single entry from an ontology or a controlled
+vocabulary.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AbstractParamType">
+				<xsd:attribute name="cvRef" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the cv element from which this term originates. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="accession" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The accession or ID number of this CV term in the source CV. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="cvType">
+		<xsd:annotation>
+			<xsd:documentation>A source controlled vocabulary from which cvParams will be obtained.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="fullName" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The full name of the CV.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="version" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>The version of the CV.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="uri" type="xsd:anyURI" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The URI of the source CV.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="id" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The unique identifier of this cv within the document to be referenced by cvParam elements. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="IdentifiableType" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Other classes in the model can be specified as sub-classes, inheriting from Identifiable. Identifiable gives classes a unique identifier within the scope and a name that need not be unique.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="id" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>An identifier is an unambiguous string that is unique within the scope (i.e. a document, a set of related documents, or a repository) of its use.		</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="name" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>The potentially ambiguous common identifier, such as a human-readable name for the instance. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="AuditCollectionType">
+		<xsd:annotation>
+			<xsd:documentation>The complete set of Contacts (people and organisations) for this file. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:choice maxOccurs="unbounded">
+			<xsd:element name="Person" type="PersonType"/>
+			<xsd:element name="Organization" type="OrganizationType"/>
+		</xsd:choice>
+	</xsd:complexType>
+	<xsd:complexType name="ProviderType">
+		<xsd:annotation>
+			<xsd:documentation>The provider of the document in terms of the Contact and the software the produced the document instance. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="ContactRole" type="ContactRoleType" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>The Contact that provided the document instance.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="analysisSoftware_ref" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The Software that produced the document instance.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ParamListType">
+		<xsd:annotation>
+			<xsd:documentation>Helper type to allow multiple cvParams or userParams to be given for an element.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:group ref="ParamGroup" maxOccurs="unbounded"/>
+	</xsd:complexType>
+	<xsd:complexType name="ParamType">
+		<xsd:annotation>
+			<xsd:documentation>Helper type to allow either a cvParam or a userParam to be provided for an element.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:group ref="ParamGroup"/>
+	</xsd:complexType>
+	<xsd:group name="ParamGroup">
+		<xsd:annotation>
+			<xsd:documentation>A choice of either a cvParam or userParam.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:choice>
+			<xsd:element name="cvParam" type="CVParamType"/>
+			<xsd:element name="userParam" type="UserParamType"/>
+		</xsd:choice>
+	</xsd:group>
+</xsd:schema>

--- a/share/OpenMS/SCHEMAS/mzIdentML1.3.0.xsd
+++ b/share/OpenMS/SCHEMAS/mzIdentML1.3.0.xsd
@@ -1,0 +1,1855 @@
+﻿<!-- mzIdentML version 1.3.0
+Distributed under the Creative Commons license http://creativecommons.org/licenses/by/2.0/.
+-->
+<xsd:schema xmlns:psi-pi="http://psidev.info/psi/pi/mzIdentML/1.3" xmlns="http://psidev.info/psi/pi/mzIdentML/1.3" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://psidev.info/psi/pi/mzIdentML/1.3" elementFormDefault="qualified" version="1.3.0">
+	<xsd:element name="MzIdentML" type="MzIdentMLType">
+		<xsd:unique name="PK_MZIDENTML">
+			<xsd:selector xpath="."/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_SCDBSEQ">
+			<xsd:selector xpath="./psi-pi:SequenceCollection/psi-pi:DBSequence"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_SCPEP">
+			<xsd:selector xpath="./psi-pi:SequenceCollection/psi-pi:Peptide"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_SCPEPEVLIPEPEV">
+			<xsd:selector xpath="./psi-pi:SequenceCollection/psi-pi:PeptideEvidence"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_ANA">
+			<xsd:selector xpath="./psi-pi:AnalysisCollection/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_APC">
+			<xsd:selector xpath="./psi-pi:AnalysisProtocolCollection/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_APCSIPMT">
+			<xsd:selector xpath="./psi-pi:AnalysisProtocolCollection/psi-pi:SpectrumIdentificationProtocol/psi-pi:MassTable"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_APCSIPENZ">
+			<xsd:selector xpath="./psi-pi:AnalysisProtocolCollection/psi-pi:SpectrumIdentificationProtocol/psi-pi:Enzymes/psi-pi:Enzyme"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_APCSIPDTTT">
+			<xsd:selector xpath="./psi-pi:AnalysisProtocolCollection/psi-pi:SpectrumIdentificationProtocol/psi-pi:DatabaseTranslation/psi-pi:TranslationTable"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_DATAIN">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:Inputs/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_DATAAD">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_DATAADSIL">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_DATAADSILSIR">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:SpectrumIdentificationResult/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_DATAADSILSIRSII">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:SpectrumIdentificationResult/psi-pi:SpectrumIdentificationItem"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_DATAADPDL">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:ProteinDetectionList/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_DATAADPDLPAG">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:ProteinDetectionList/psi-pi:ProteinAmbiguityGroup/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_ANASW">
+			<xsd:selector xpath="./psi-pi:AnalysisSoftwareList/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_PROV">
+			<xsd:selector xpath="./Provider"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_AUDIT">
+			<xsd:selector xpath="./psi-pi:AuditCollection/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_AUDITORG">
+			<xsd:selector xpath="./psi-pi:AuditCollection/psi-pi:Organization"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_AUDITPER">
+			<xsd:selector xpath="./psi-pi:AuditCollection/psi-pi:Person"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_SAMPLE">
+			<xsd:selector xpath="./psi-pi:AnalysisSampleCollection/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_CV">
+			<xsd:selector xpath="./psi-pi:cvList/*"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_DATAADSILFRAGTMEAS">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:FragmentationTable/psi-pi:Measure"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_Bibref">
+			<xsd:selector xpath="./psi-pi:BibliographicReference"/>
+			<xsd:field xpath="@id"/>
+		</xsd:unique>
+		<xsd:unique name="PK_spectrumID">		
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:SpectrumIdentificationResult/psi-pi:SpectrumIdentificationItem"/>
+			<xsd:field xpath="@spectrumID"/>
+			<xsd:field xpath="@spectraData_ref"/>
+		</xsd:unique>
+		<xsd:keyref name="FK_SoftwareContact" refer="PK_AUDIT">
+			<xsd:selector xpath="./psi-pi:AnalysisSoftwareList/psi-pi:AnalysisSoftware/psi-pi:ContactRole"/>
+			<xsd:field xpath="@contact_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_AUDITPERAFF" refer="PK_AUDITORG">
+			<xsd:selector xpath="./psi-pi:AuditCollection/psi-pi:Person/psi-pi:Affiliation"/>
+			<xsd:field xpath="@organization_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_AUDITORGPAR" refer="PK_AUDITORG">
+			<xsd:selector xpath="./psi-pi:AuditCollection/psi-pi:Organization/psi-pi:Parent"/>
+			<xsd:field xpath="@organization_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_ProviderContact" refer="PK_AUDIT">
+			<xsd:selector xpath="./psi-pi:Provider/psi-pi:ContactRole"/>
+			<xsd:field xpath="@contact_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_ProviderSoftware" refer="PK_ANASW">
+			<xsd:selector xpath="./psi-pi:Provider"/>
+			<xsd:field xpath="@software_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_SampleContact" refer="PK_AUDIT">
+			<xsd:selector xpath="./psi-pi:AnalysisSampleCollection/psi-pi:Sample/psi-pi:ContactRole"/>
+			<xsd:field xpath="@contact_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_subSamples" refer="PK_SAMPLE">
+			<xsd:selector xpath="./psi-pi:AnalysisSampleCollection/psi-pi:Sample/psi-pi:SubSample"/>
+			<xsd:field xpath="@sample_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_DBSEQ_SDB" refer="PK_DATAIN">
+			<xsd:selector xpath="./psi-pi:SequenceCollection/psi-pi:DBSequence"/>
+			<xsd:field xpath="@searchDatabase_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_PEPEVID_PEP" refer="PK_SCPEP">
+			<xsd:selector xpath="./psi-pi:SequenceCollection/psi-pi:PeptideEvidence"/>
+			<xsd:field xpath="@peptide_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_PEPEVID_DBSEQ" refer="PK_SCDBSEQ">
+			<xsd:selector xpath="./psi-pi:SequenceCollection/psi-pi:PeptideEvidence"/>
+			<xsd:field xpath="@dBSequence_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_PEPEVID_TT" refer="PK_APCSIPDTTT">
+			<xsd:selector xpath="./psi-pi:SequenceCollection/psi-pi:PeptideEvidence"/>
+			<xsd:field xpath="@translationTable_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_SI_SIP" refer="PK_APC">
+			<xsd:selector xpath="./psi-pi:AnalysisCollection/psi-pi:SpectrumIdentification"/>
+			<xsd:field xpath="@spectrumIdentificationProtocol_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_SI_SILR" refer="PK_DATAAD">
+			<xsd:selector xpath="./psi-pi:AnalysisCollection/psi-pi:SpectrumIdentification"/>
+			<xsd:field xpath="@spectrumIdentificationList_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_SISDB_SDBR" refer="PK_DATAIN">
+			<xsd:selector xpath="./psi-pi:AnalysisCollection/psi-pi:SpectrumIdentification/psi-pi:SearchDatabaseRef"/>
+			<xsd:field xpath="@searchDatabase_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_SIIS_SDR" refer="PK_DATAIN">
+			<xsd:selector xpath="./psi-pi:AnalysisCollection/psi-pi:SpectrumIdentification/psi-pi:InputSpectra"/>
+			<xsd:field xpath="@spectraData_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_PD_PDP" refer="PK_APC">
+			<xsd:selector xpath="./psi-pi:AnalysisCollection/psi-pi:ProteinDetection"/>
+			<xsd:field xpath="@proteinDetectionProtocol_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_PD_PDL" refer="PK_DATAAD">
+			<xsd:selector xpath="./psi-pi:AnalysisCollection/psi-pi:ProteinDetection"/>
+			<xsd:field xpath="@proteinDetectionList_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_PDSIL_ISI" refer="PK_DATAAD">
+			<xsd:selector xpath="./psi-pi:AnalysisCollection/psi-pi:ProteinDetection/psi-pi:InputSpectrumIdentifications"/>
+			<xsd:field xpath="@spectrumIdentificationList_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_APSIP_ASW" refer="PK_ANASW">
+			<xsd:selector xpath="./psi-pi:AnalysisProtocolCollection/psi-pi:SpectrumIdentificationProtocol"/>
+			<xsd:field xpath="@analysisSoftware_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_APPDP_ASW" refer="PK_ANASW">
+			<xsd:selector xpath="./psi-pi:AnalysisProtocolCollection/psi-pi:ProteinDetectionProtocol"/>
+			<xsd:field xpath="@analysisSoftware_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_SIIPEV_PEPEVR" refer="PK_SCPEPEVLIPEPEV">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:SpectrumIdentificationResult/psi-pi:SpectrumIdentificationItem/psi-pi:PeptideEvidenceRef"/>
+			<xsd:field xpath="@peptideEvidence_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_DATAADSILSIR_SDR" refer="PK_DATAIN">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:SpectrumIdentificationResult"/>
+			<xsd:field xpath="@spectraData_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_DATAADSILSIRSII_PEP" refer="PK_SCPEP">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:SpectrumIdentificationResult/psi-pi:SpectrumIdentificationItem"/>
+			<xsd:field xpath="@peptide_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_DATAADPDLPAGPDHPH_PEPEV" refer="PK_SCPEPEVLIPEPEV">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:ProteinDetectionList/psi-pi:ProteinAmbiguityGroup/psi-pi:ProteinDetectionHypothesis/psi-pi:PeptideHypothesis"/>
+			<xsd:field xpath="@peptideEvidence_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_DATAADPDLPAGPDHPHSIIR_SII" refer="PK_DATAADSILSIRSII">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:ProteinDetectionList/psi-pi:ProteinAmbiguityGroup/psi-pi:ProteinDetectionHypothesis/psi-pi:PeptideHypothesis/psi-pi:SpectrumIdentificationItemRef"/>
+			<xsd:field xpath="@spectrumIdentificationItem_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_PDH_DBSeq" refer="PK_SCDBSEQ">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:ProteinDetectionList/psi-pi:ProteinAmbiguityGroup/psi-pi:ProteinDetectionHypothesis"/>
+			<xsd:field xpath="@dBSequence_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_DATAADSILSIRSIIFRAGIONFRAGARR" refer="PK_DATAADSILFRAGTMEAS">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:SpectrumIdentificationResult/psi-pi:SpectrumIdentificationItem/psi-pi:Fragmentation/psi-pi:IonType/psi-pi:FragmentArray"/>
+			<xsd:field xpath="@measure_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_Sample" refer="PK_SAMPLE">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:SpectrumIdentificationResult/psi-pi:SpectrumIdentificationItem"/>
+			<xsd:field xpath="@sample_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_MassTable" refer="PK_APCSIPMT">
+			<xsd:selector xpath="./psi-pi:DataCollection/psi-pi:AnalysisData/psi-pi:SpectrumIdentificationList/psi-pi:SpectrumIdentificationResult/SpectrumIdentificationItem"/>
+			<xsd:field xpath="@massTable_ref"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_UnitCVlist1" refer="PK_CV">
+			<xsd:selector xpath="*"/>
+			<xsd:field xpath="@unitCvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_UnitCVlist2" refer="PK_CV">
+			<xsd:selector xpath="*/*"/>
+			<xsd:field xpath="@unitCvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_UnitCVlist3" refer="PK_CV">
+			<xsd:selector xpath="*/*/*"/>
+			<xsd:field xpath="@unitCvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_UnitCVlist4" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*"/>
+			<xsd:field xpath="@unitCvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_UnitCVlist5" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*/*"/>
+			<xsd:field xpath="@unitCvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_UnitCVlist6" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*/*/*"/>
+			<xsd:field xpath="@unitCvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_UnitCVlist7" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*/*/*/*"/>
+			<xsd:field xpath="@unitCvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_UnitCVlist8" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*/*/*/*/*"/>
+			<xsd:field xpath="@unitCvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_CVlist1" refer="PK_CV">
+			<xsd:selector xpath="*"/>
+			<xsd:field xpath="@cvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_CVlist2" refer="PK_CV">
+			<xsd:selector xpath="*/*"/>
+			<xsd:field xpath="@cvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_CVlist3" refer="PK_CV">
+			<xsd:selector xpath="*/*/*"/>
+			<xsd:field xpath="@cvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_CVlist4" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*"/>
+			<xsd:field xpath="@cvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_CVlist5" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*/*"/>
+			<xsd:field xpath="@cvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_CVlist6" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*/*/*"/>
+			<xsd:field xpath="@cvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_CVlist7" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*/*/*/*"/>
+			<xsd:field xpath="@cvRef"/>
+		</xsd:keyref>
+		<xsd:keyref name="FK_CVlist8" refer="PK_CV">
+			<xsd:selector xpath="*/*/*/*/*/*/*/*"/>
+			<xsd:field xpath="@cvRef"/>
+		</xsd:keyref>
+	</xsd:element>
+	<xsd:complexType name="CVListType">
+		<xsd:annotation>
+			<xsd:documentation>The list of controlled vocabularies used in the file.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="cv" type="cvType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AnalysisSoftwareListType">
+		<xsd:annotation>
+			<xsd:documentation>The software packages used to perform the analyses.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="AnalysisSoftware" type="AnalysisSoftwareType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AnalysisSampleCollectionType">
+		<xsd:annotation>
+			<xsd:documentation>The samples analysed can optionally be recorded using CV terms for descriptions. If a composite sample has been analysed, the subsample association can be used to build a hierarchical description. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Sample" type="SampleType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="SequenceCollectionType">
+		<xsd:annotation>
+			<xsd:documentation>The collection of sequences (DBSequence or Peptide) identified and their relationship between each other (PeptideEvidence) to be referenced elsewhere in the results. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="DBSequence" type="DBSequenceType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="Peptide" type="PeptideType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="PeptideEvidence" type="PeptideEvidenceType" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AnalysisCollectionType">
+		<xsd:annotation>
+			<xsd:documentation>The analyses performed to get the results, which map the input and output data sets. Analyses are for example: SpectrumIdentification (resulting in peptides) or ProteinDetection (assemble proteins from peptides).</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SpectrumIdentification" type="SpectrumIdentificationType" maxOccurs="unbounded"/>
+			<xsd:element name="ProteinDetection" type="ProteinDetectionType" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AnalysisProtocolCollectionType">
+		<xsd:annotation>
+			<xsd:documentation>The collection of protocols which include the parameters and settings of the performed analyses. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SpectrumIdentificationProtocol" type="SpectrumIdentificationProtocolType" maxOccurs="unbounded"/>
+			<xsd:element name="ProteinDetectionProtocol" type="ProteinDetectionProtocolType" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="InputsType">
+		<xsd:annotation>
+			<xsd:documentation>The inputs to the analyses including the databases searched, the spectral data and the source file converted to mzIdentML. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SourceFile" type="SourceFileType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="SearchDatabase" type="SearchDatabaseType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="SpectraData" type="SpectraDataType" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AnalysisDataType">
+		<xsd:annotation>
+			<xsd:documentation>Data sets generated by the analyses, including peptide and protein lists. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SpectrumIdentificationList" type="SpectrumIdentificationListType" maxOccurs="unbounded"/>
+			<xsd:element name="ProteinDetectionList" type="ProteinDetectionListType" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DataCollectionType">
+		<xsd:annotation>
+			<xsd:documentation>The collection of input and output data sets of the analyses.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Inputs" type="InputsType"/>
+			<xsd:element name="AnalysisData" type="psi-pi:AnalysisDataType"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="MzIdentMLType">
+		<xsd:annotation>
+			<xsd:documentation>The upper-most hierarchy level of mzIdentML with sub-containers for example describing software, protocols and search results (spectrum identifications or protein detection results). </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="cvList" type="CVListType"/>
+					<xsd:element name="cvParam" type="CVParamType" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="AnalysisSoftwareList" type="AnalysisSoftwareListType" minOccurs="0"/>
+					<xsd:element name="Provider" type="ProviderType" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>The Provider of the mzIdentML record in terms of the contact and software. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="AuditCollection" type="AuditCollectionType" minOccurs="0"/>
+					<xsd:element name="AnalysisSampleCollection" type="AnalysisSampleCollectionType" minOccurs="0"/>
+					<xsd:element name="SequenceCollection" type="SequenceCollectionType" minOccurs="0"/>
+					<xsd:element name="AnalysisCollection" type="AnalysisCollectionType"/>
+					<xsd:element name="AnalysisProtocolCollection" type="AnalysisProtocolCollectionType"/>
+					<xsd:element name="DataCollection" type="DataCollectionType"/>
+					<xsd:element name="BibliographicReference" type="BibliographicReferenceType" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Any bibliographic references associated with the file</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="creationDate" type="xsd:dateTime">
+					<xsd:annotation>
+						<xsd:documentation>The date on which the file was produced.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="version" type="versionRegex" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The version of the schema this instance document refers to, in the format x.y.z. Changes to z should not affect prevent instance documents from validating. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="SearchDatabaseType">
+		<xsd:annotation>
+			<xsd:documentation>A database for searching mass spectra. Examples include a set of amino acid sequence entries, nucleotide databases (e.g. 6 frame translated) or annotated spectra libraries. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ExternalDataType">
+				<xsd:sequence>
+					<xsd:element name="DatabaseName" type="ParamType">
+						<xsd:annotation>
+							<xsd:documentation>The database name may be given as a cvParam if it maps exactly to one of the release databases listed in the CV, otherwise a userParam should be used. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="cvParam" type="CVParamType" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="version" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The version of the database.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="releaseDate" type="xsd:dateTime">
+					<xsd:annotation>
+						<xsd:documentation>The date and time the database was released to the public; omit this attribute when the date and time are unknown or not applicable (e.g. custom databases). </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="numDatabaseSequences" type="xsd:long">
+					<xsd:annotation>
+						<xsd:documentation>The total number of sequences in the database.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="numResidues" type="xsd:long">
+					<xsd:annotation>
+						<xsd:documentation>The number of residues in the database.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="SourceFileType">
+		<xsd:annotation>
+			<xsd:documentation>A file from which this mzIdentML instance was created.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ExternalDataType">
+                <xsd:sequence>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+								<xsd:documentation>Any additional parameters description the source
+								file.</xsd:documentation>
+						</xsd:annotation>
+						</xsd:group>
+					</xsd:sequence>
+			</xsd:extension>
+
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ModificationParamsType">
+		<xsd:annotation>
+			<xsd:documentation>The specification of static/variable modifications (e.g. Oxidation of Methionine) that are to be considered in the spectra search. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SearchModification" type="SearchModificationType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="FilterType">
+		<xsd:annotation>
+			<xsd:documentation>Filters applied to the search database. The filter must include at least one of Include and Exclude. If both are used, it is assumed that inclusion is performed first. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="FilterType" type="ParamType">
+				<xsd:annotation>
+					<xsd:documentation>The type of filter e.g. database taxonomy filter, pi filter, mw filter </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Include" type="ParamListType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>All sequences fulfilling the specifed criteria are included.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Exclude" type="ParamListType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>All sequences fulfilling the specifed criteria are excluded.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DatabaseFiltersType">
+		<xsd:annotation>
+			<xsd:documentation>The specification of filters applied to the database searched.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Filter" type="FilterType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="TranslationTableType">
+		<xsd:annotation>
+			<xsd:documentation>The table used to translate codons into nucleic acids e.g. by reference to the NCBI translation table. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="cvParam" type="CVParamType" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>The details specifying this translation table are captured as cvParams, e.g. translation table, translation start codons and translation table description (see specification document and mapping file)</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="DatabaseTranslationType">
+		<xsd:annotation>
+			<xsd:documentation>A specification of how a nucleic acid sequence database was translated for searching. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="TranslationTable" type="TranslationTableType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="frames" type="listOfAllowedFrames">
+			<xsd:annotation>
+				<xsd:documentation>The frames in which the nucleic acid sequence has been translated as a space separated list </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="SpectrumIdentificationProtocolType">
+		<xsd:annotation>
+			<xsd:documentation>The parameters and settings of a SpectrumIdentification analysis.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="SearchType" type="ParamType">
+						<xsd:annotation>
+							<xsd:documentation>The type of search performed e.g. PMF, Tag searches, MS-MS </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="AdditionalSearchParams" type="ParamListType" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>The search parameters other than the modifications searched. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="ModificationParams" type="ModificationParamsType" minOccurs="0"/>
+					<xsd:element name="Enzymes" type="EnzymesType" minOccurs="0"/>
+					<xsd:element name="MassTable" type="MassTableType" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="FragmentTolerance" type="ToleranceType" minOccurs="0"/>
+					<xsd:element name="ParentTolerance" type="ToleranceType" minOccurs="0"/>
+					<xsd:element name="Threshold" type="ParamListType">
+						<xsd:annotation>
+							<xsd:documentation>The threshold(s) applied to determine that a result is significant. If multiple terms are used it is assumed that all conditions are satisfied by the passing results.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="DatabaseFilters" type="DatabaseFiltersType" minOccurs="0"/>
+					<xsd:element name="DatabaseTranslation" type="DatabaseTranslationType" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:attribute name="analysisSoftware_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The search algorithm used, given as a reference to the SoftwareCollection section. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="InputSpectraType">
+		<xsd:annotation>
+			<xsd:documentation>The attribute referencing an identifier within the SpectraData section. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="spectraData_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the SpectraData element which locates the input spectra to an external file. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="SearchDatabaseRefType">
+		<xsd:annotation>
+			<xsd:documentation>One of the search databases used.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="searchDatabase_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the database searched.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="SpectrumIdentificationType">
+		<xsd:annotation>
+			<xsd:documentation>An Analysis which tries to identify peptides in input spectra, referencing the database searched, the input spectra, the output results and the protocol that is run. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ProtocolApplicationType">
+				<xsd:sequence>
+					<xsd:element name="InputSpectra" type="InputSpectraType" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>One of the spectra data sets used.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="SearchDatabaseRef" type="SearchDatabaseRefType" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="spectrumIdentificationProtocol_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the search protocol used for this SpectrumIdentification. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="spectrumIdentificationList_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the SpectrumIdentificationList produced by this analysis in the DataCollection section. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="MeasureType">
+		<xsd:annotation>
+			<xsd:documentation>References to CV terms defining the measures about product ions to be reported in SpectrumIdentificationItem </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="cvParam" type="CVParamType" minOccurs="1" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="FragmentationTableType">
+		<xsd:annotation>
+			<xsd:documentation>Contains the types of measures that will be reported in generic arrays for each SpectrumIdentificationItem e.g. product ion m/z, product ion intensity, product ion m/z error </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Measure" type="MeasureType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="SpectrumIdentificationListType">
+		<xsd:annotation>
+			<xsd:documentation>Represents the set of all search results from SpectrumIdentification.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="FragmentationTable" type="FragmentationTableType" minOccurs="0"/>
+					<xsd:element name="SpectrumIdentificationResult" type="SpectrumIdentificationResultType" maxOccurs="unbounded"/>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Scores or output parameters associated with the SpectrumIdentificationList.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+				<xsd:attribute name="numSequencesSearched" type="xsd:long">
+					<xsd:annotation>
+						<xsd:documentation>The number of database sequences searched against. This value should be provided unless a de novo search has been performed.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="SpecificityRulesType">
+		<xsd:annotation>
+			<xsd:documentation>The specificity rules of the searched modification including for example the probability of a modification's presence or peptide or protein termini. Standard fixed or variable status should be provided by the attribute fixedMod.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="cvParam" type="CVParamType" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="SearchModificationType">
+		<xsd:annotation>
+			<xsd:documentation>Specification of a search modification as parameter for a spectra search. Contains the name of the modification, the mass, the specificity and whether it is a static modification. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SpecificityRules" type="SpecificityRulesType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="cvParam" type="CVParamType" minOccurs="1" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>The modification is uniquely identified by references to external CVs such as UNIMOD, see specification document and mapping file for more details.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="fixedMod" type="xsd:boolean" use="required">
+			<xsd:annotation>
+				<xsd:documentation>True, if the modification is static (i.e. occurs always).</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="massDelta" type="xsd:float" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The mass delta of the searched modification in Daltons.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="residues" type="listOfCharsOrAny" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The residue(s) searched with the specified modification. For N or C terminal modifications that can occur on any residue, the . character should be used to specify any, otherwise the list of amino acids should be provided.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="FragmentArrayType">
+		<xsd:annotation>
+			<xsd:documentation>An array of values for a given type of measure and for a particular ion type, in parallel to the index of ions identified. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="values" type="listOfFloats" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The values of this particular measure, corresponding to the index defined in ion type </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="measure_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the Measure defined in the FragmentationTable</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="IonTypeType">
+		<xsd:annotation>
+			<xsd:documentation>IonType defines the index of fragmentation ions being reported, importing a CV term for the type of ion e.g. b ion. Example: if b3 b7 b8 and b10 have been identified, the index attribute will contain 3 7 8 10, and the corresponding values will be reported in parallel arrays below </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="FragmentArray" type="FragmentArrayType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element maxOccurs="unbounded" minOccurs="0" name="userParam" type="UserParamType">
+				<xsd:annotation>
+					<xsd:documentation>In case more information about the ions annotation has to be conveyed, that has no fit in FragmentArray. Note: It is suggested that the value attribute takes the form of a list of the same size as FragmentArray values. However, there is no formal encoding and it cannot be expeceted that other software will process or impart that information properly.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="cvParam" type="CVParamType" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>The type of ion identified. In the case of neutral losses, one term should report the ion type, a second term should report the neutral loss - note: this is a change in practice from mzIdentML 1.1.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="index" type="listOfIntegers">
+			<xsd:annotation>
+				<xsd:documentation>The index of ions identified as integers, following standard notation for a-c, x-z e.g. if b3 b5 and b6 have been identified, the index would store "3 5 6". For internal ions, the index contains pairs defining the start and end point - see specification document for examples. For immonium ions, the index is the position of the identified ion within the peptide sequence - if the peptide contains the same amino acid in multiple positions that cannot be distinguished, all positions should be given. For precursor ions, including neutral losses, the index value MUST be 0. For any other ions not related to the position within the peptide sequence e.g. quantification reporter ions, the index value MUST be 0. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="charge" type="xsd:int" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The charge of the identified fragmentation ions.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="FragmentationType">
+		<xsd:annotation>
+			<xsd:documentation>The product ions identified in this result.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="IonType" type="IonTypeType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PeptideEvidenceRefType">
+		<xsd:annotation>
+			<xsd:documentation>Reference to the PeptideEvidence element identified. If a specific sequence can be assigned to multiple proteins and or positions in a protein all possible PeptideEvidence elements should be referenced here.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="peptideEvidence_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the PeptideEvidenceItem element(s).</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="SpectrumIdentificationItemType">
+		<xsd:annotation>
+			<xsd:documentation>An identification of a single (poly)peptide, resulting from querying an input spectra, along with the set of confidence values for that identification.
+PeptideEvidence elements should be given for all mappings of the corresponding Peptide sequence within protein sequences. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="PeptideEvidenceRef" type="PeptideEvidenceRefType" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="Fragmentation" type="FragmentationType" minOccurs="0"/>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Scores or attributes associated with the SpectrumIdentificationItem e.g. e-value, p-value, score.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+				<xsd:attribute name="chargeState" type="xsd:int" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The charge state of the identified peptide.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="experimentalMassToCharge" type="xsd:double" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The mass-to-charge value measured in the experiment in Daltons / charge. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="calculatedMassToCharge" type="xsd:double">
+					<xsd:annotation>
+						<xsd:documentation>The theoretical mass-to-charge value calculated for the peptide in Daltons / charge. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="calculatedPI" type="xsd:float">
+					<xsd:annotation>
+						<xsd:documentation>The calculated isoelectric point of the (poly)peptide, with relevant modifications included. Do not supply this value if the PI cannot be calcuated properly. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="peptide_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the identified (poly)peptide sequence in the Peptide element. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="rank" type="xsd:int" use="required">
+					<xsd:annotation>
+						<xsd:documentation>For an MS/MS result set, this is the rank of the identification quality as scored by the search engine. 1 is the top rank. If multiple identifications have the same top score, they should all be assigned rank =1. For PMF data, the rank attribute may be meaningless and values of rank = 0 should be given. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="passThreshold" type="xsd:boolean" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Set to true if the producers of the file has deemed that the identification has passed a given threshold or been validated as correct. If no such threshold has been set, value of true should be given for all results. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="massTable_ref" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>A reference should be given to the MassTable used to calculate the sequenceMass only if more than one MassTable has been given.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="sample_ref" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>A reference should be provided to link the SpectrumIdentificationItem to a Sample if more than one sample has been described in the AnalysisSampleCollection. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="SpectrumIdentificationResultType">
+		<xsd:annotation>
+			<xsd:documentation>All identifications made from searching one spectrum. For PMF data, all peptide identifications will be listed underneath as SpectrumIdentificationItems. For MS/MS data, there will be ranked SpectrumIdentificationItems corresponding to possible different peptide IDs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="SpectrumIdentificationItem" type="SpectrumIdentificationItemType" maxOccurs="unbounded"/>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation> Scores or parameters associated with the SpectrumIdentificationResult (i.e the set of SpectrumIdentificationItems derived from one spectrum) e.g. the number of peptide sequences within the parent tolerance for this spectrum. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+				<xsd:attribute name="spectrumID" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The locally unique id for the spectrum in the spectra data set specified by SpectraData_ref. External guidelines are provided on the use of consistent identifiers for spectra in different external formats. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="spectraData_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to a spectra data set (e.g. a spectra file).</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="InputSpectrumIdentificationsType">
+		<xsd:annotation>
+			<xsd:documentation>The lists of spectrum identifications that are input to the protein detection process. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="spectrumIdentificationList_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the list of spectrum identifications that were input to the process. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="ProteinDetectionType">
+		<xsd:annotation>
+			<xsd:documentation>An Analysis which assembles a set of peptides (e.g. from a spectra search analysis) to proteins. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ProtocolApplicationType">
+				<xsd:sequence>
+					<xsd:element name="InputSpectrumIdentifications" type="InputSpectrumIdentificationsType" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="proteinDetectionList_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the ProteinDetectionList in the DataCollection section. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="proteinDetectionProtocol_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the detection protocol used for this ProteinDetection. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ProteinDetectionProtocolType">
+		<xsd:annotation>
+			<xsd:documentation>The parameters and settings of a ProteinDetection process.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="AnalysisParams" type="ParamListType" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>The parameters and settings for the protein detection given as CV terms. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="Threshold" type="ParamListType" minOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>The threshold(s) applied to determine that a result is significant. If multiple terms are used it is assumed that all conditions are satisfied by the passing results.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="analysisSoftware_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The protein detection software used, given as a reference to the SoftwareCollection section. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ProteinDetectionListType">
+		<xsd:annotation>
+			<xsd:documentation>The protein list resulting from a protein detection process.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="ProteinAmbiguityGroup" type="ProteinAmbiguityGroupType" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Scores or output parameters associated with the whole ProteinDetectionList </xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="SpectrumIdentificationItemRefType">
+		<xsd:annotation>
+			<xsd:documentation>Reference(s) to the SpectrumIdentificationItem element(s) that support the given PeptideEvidence element. Using these references it is possible to indicate which spectra were actually accepted as evidence for this peptide identification in the given protein.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="spectrumIdentificationItem_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the SpectrumIdentificationItem element(s).</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="PeptideHypothesisType">
+		<xsd:annotation>
+			<xsd:documentation>Peptide evidence on which this ProteinHypothesis is based by reference to a PeptideEvidence element. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SpectrumIdentificationItemRef" type="SpectrumIdentificationItemRefType" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="peptideEvidence_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the PeptideEvidence element on which this hypothesis is based. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="ProteinDetectionHypothesisType">
+		<xsd:annotation>
+			<xsd:documentation>A single result of the ProteinDetection analysis (i.e. a protein).</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="PeptideHypothesis" type="PeptideHypothesisType" maxOccurs="unbounded"/>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Scores or parameters associated with this ProteinDetectionHypothesis e.g. p-value</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+				<xsd:attribute name="dBSequence_ref" type="xsd:string"  use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the corresponding DBSequence entry. Note - this attribute was optional in mzIdentML 1.1 but is now mandatory in mzIdentML 1.2. Consuming software should assume that the DBSequence entry referenced here is the definitive identifier for the protein. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="passThreshold" type="xsd:boolean" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Set to true if the producers of the file has deemed that the ProteinDetectionHypothesis has passed a given threshold or been validated as correct. If no such threshold has been set, value of true should be given for all results. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ProteinAmbiguityGroupType">
+		<xsd:annotation>
+			<xsd:documentation>A set of logically related results from a protein detection, for example to represent conflicting assignments of peptides to proteins.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="ProteinDetectionHypothesis" type="ProteinDetectionHypothesisType" maxOccurs="unbounded"/>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Scores or parameters associated with the ProteinAmbiguityGroup.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ModificationType">
+		<xsd:annotation>
+			<xsd:documentation>A molecule modification specification. If n modifications have been found on a peptide, there should be n instances of Modification. If multiple modifications are provided as cvParams, it is assumed that the modification is ambiguous i.e. one modification or another. A cvParam must be provided with the identification of the modification sourced from a suitable CV e.g. UNIMOD. If the modification is not present in the CV (and this will be checked by the semantic validator within a given tolerance window), there is a "unknown modification" CV term that must be used instead. A neutral loss should be defined as an additional CVParam within Modification. If more complex information should be given about neutral losses (such as presence/absence on particular product ions), this can additionally be encoded within the FragmentationArray. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="cvParam" type="CVParamType" minOccurs="1" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>CV terms capturing the modification, sourced from an appropriate controlled vocabulary.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="location" type="xsd:int">
+			<xsd:annotation>
+				<xsd:documentation>Location of the modification within the peptide - position in peptide sequence, counted from the N-terminus residue, starting at position 1. Specific modifications to the N-terminus should be given the location 0. Modification to the C-terminus should be given as peptide length + 1. If the modification location is unknown e.g. for PMF data, this attribute should be omitted.	</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="residues" type="listOfChars">
+			<xsd:annotation>
+				<xsd:documentation>Specification of the residue (amino acid) on which the modification occurs. If multiple values are given, it is assumed that the exact residue modified is unknown i.e. the modification is to ONE of the residues listed. Multiple residues would usually only be specified for PMF data.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="avgMassDelta" type="xsd:double">
+			<xsd:annotation>
+				<xsd:documentation>Atomic mass delta considering the natural distribution of isotopes in Daltons. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="monoisotopicMassDelta" type="xsd:double">
+			<xsd:annotation>
+				<xsd:documentation>Atomic mass delta when assuming only the most common isotope of elements in Daltons. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="PeptideType">
+		<xsd:annotation>
+			<xsd:documentation>One (poly)peptide (a sequence with modifications). The combination of Peptide sequence and modifications must be unique in the file.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="PeptideSequence" type="sequence">
+						<xsd:annotation>
+							<xsd:documentation>The amino acid sequence of the (poly)peptide. If a substitution modification has been found, the original sequence
+should be reported. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="Modification" type="ModificationType" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="SubstitutionModification" type="SubstitutionModificationType" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Additional descriptors of this peptide sequence</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="SubstitutionModificationType">
+		<xsd:annotation>
+			<xsd:documentation>A modification where one residue is substituted by another (amino acid change). </xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="originalResidue" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The original residue before replacement.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:pattern value="[ABCDEFGHIJKLMNOPQRSTUVWXYZ?\-]{1}"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="replacementResidue" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The residue that replaced the originalResidue.</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:pattern value="[ABCDEFGHIJKLMNOPQRSTUVWXYZ?\-]{1}"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="location" type="xsd:int">
+			<xsd:annotation>
+				<xsd:documentation>Location of the modification within the peptide - position in peptide sequence, counted from the N-terminus residue, starting at position 1.
+Specific modifications to the N-terminus should be given the location 0.
+Modification to the C-terminus should be given as peptide length + 1.		</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="avgMassDelta" type="xsd:double">
+			<xsd:annotation>
+				<xsd:documentation>Atomic mass delta considering the natural distribution of isotopes in Daltons. This should only be reported if the original amino acid is known i.e. it is not "X" </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="monoisotopicMassDelta" type="xsd:double">
+			<xsd:annotation>
+				<xsd:documentation>Atomic mass delta when assuming only the most common isotope of elements in Daltons. This should only be reported if the original amino acid is known i.e. it is not "X" </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="SpectraDataType">
+		<xsd:annotation>
+			<xsd:documentation>A data set containing spectra data (consisting of one or more spectra). </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ExternalDataType">
+				<xsd:sequence>
+					<xsd:element name="SpectrumIDFormat" type="SpectrumIDFormatType"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="AnalysisSoftwareType">
+		<xsd:annotation>
+			<xsd:documentation>The software used for performing the analyses.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="ContactRole" type="ContactRoleType" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>The contact details of the organisation or person that produced the software</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="SoftwareName" type="ParamType">
+						<xsd:annotation>
+							<xsd:documentation>The name of the analysis software package, sourced from a CV if available. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="Customizations" type="xsd:string" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Any customizations to the software, such as alternative scoring mechanisms implemented, should be documented here as free text. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="version" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The version of Software used.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="uri" type="xsd:anyURI">
+					<xsd:annotation>
+						<xsd:documentation>URI of the analysis software e.g. manufacturer's website</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="EnzymeType">
+		<xsd:annotation>
+			<xsd:documentation>The details of an individual cleavage enzyme should be provided by giving a regular expression or a CV term if a "standard" enzyme cleavage has been performed. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="SiteRegexp" type="xsd:string" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Regular expression for specifying the enzyme cleavage site.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="EnzymeName" type="ParamListType" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>The name of the enzyme from a CV.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="nTermGain" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>Element formula gained at NTerm.</xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:string">
+							<xsd:pattern value="[A-Za-z0-9 ]+"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+				<xsd:attribute name="cTermGain" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>Element formula gained at CTerm.</xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:string">
+							<xsd:pattern value="[A-Za-z0-9 ]+"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+				<xsd:attribute name="semiSpecific" type="xsd:boolean" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>Set to true if the enzyme cleaves semi-specifically (i.e. one terminus must cleave according to the rules, the other can cleave at any residue), false if the enzyme cleavage is assumed to be specific to both termini (accepting for any missed cleavages). </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="missedCleavages" type="xsd:int" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>The number of missed cleavage sites allowed by the search. The attribute must be provided if an enzyme has been used.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="minDistance" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>Minimal distance for another cleavage (minimum: 1).</xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:int">
+							<xsd:minInclusive value="1"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="EnzymesType">
+		<xsd:annotation>
+			<xsd:documentation>The list of enzymes used in experiment</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Enzyme" type="EnzymeType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="independent" type="xsd:boolean">
+			<xsd:annotation>
+				<xsd:documentation>If there are multiple enzymes specified, this attribute is set to true if cleavage with different enzymes is performed independently.		</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="ResidueType">
+		<xsd:attribute name="code" type="chars" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The single letter code for the residue.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="mass" type="xsd:float" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The residue mass in Daltons (not including any fixed modifications). </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="AmbiguousResidueType">
+		<xsd:annotation>
+			<xsd:documentation>Ambiguous residues e.g. X can be specified by the Code attribute and a set of parameters for example giving the different masses that will be used in the search. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:group ref="ParamGroup" minOccurs="1" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Parameters for capturing e.g. "alternate single letter codes"</xsd:documentation>
+				</xsd:annotation>
+			</xsd:group>
+		</xsd:sequence>
+		<xsd:attribute name="code" type="chars" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The single letter code of the ambiguous residue e.g. X.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="MassTableType">
+		<xsd:annotation>
+			<xsd:documentation>The masses of residues used in the search.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="Residue" type="ResidueType" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>The specification of a single residue within the mass table. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="AmbiguousResidue" type="AmbiguousResidueType" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Additional parameters or descriptors for the MassTable.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+				<xsd:attribute name="msLevel" type="listOfIntegers" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The MS spectrum that the MassTable refers to e.g. "1" for MS1 "2" for MS2 or "1 2" for MS1 or MS2.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="PeptideEvidenceType">
+		<xsd:annotation>
+			<xsd:documentation>PeptideEvidence links a specific Peptide element to a specific position in a DBSequence. There must only be one PeptideEvidence item per Peptide-to-DBSequence-position. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Additional parameters or descriptors for the PeptideEvidence.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+				<xsd:attribute name="dBSequence_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the protein sequence in which the specified peptide has been linked. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="peptide_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the identified (poly)peptide sequence in the Peptide element. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="start" type="xsd:int">
+					<xsd:annotation>
+						<xsd:documentation>Start position of the peptide inside the protein sequence, where the first amino acid of the protein sequence is position 1. Must be provided unless this is a de novo search.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="end" type="xsd:int">
+					<xsd:annotation>
+						<xsd:documentation>The index position of the last amino acid of the peptide inside the protein sequence, where the first amino acid of the protein sequence is position 1. Must be provided unless this is a de novo search. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="pre">
+					<xsd:annotation>
+						<xsd:documentation>Previous flanking residue. If the peptide is N-terminal, pre="-" and not pre="". If for any reason it is unknown (e.g. denovo), pre="?" should be used. </xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:string">
+							<xsd:pattern value="[ABCDEFGHIJKLMNOPQRSTUVWXYZ?\-]{1}"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+				<xsd:attribute name="post">
+					<xsd:annotation>
+						<xsd:documentation>Post flanking residue. If the peptide is C-terminal, post="-" and not post="". If for any reason it is unknown (e.g. denovo), post="?" should be used. </xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:string">
+							<xsd:pattern value="[ABCDEFGHIJKLMNOPQRSTUVWXYZ?\-]{1}"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+				<xsd:attribute name="translationTable_ref" type="xsd:string" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the translation table used if this is PeptideEvidence derived from nucleic acid sequence </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="frame" type="allowed_frames" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>The translation frame of this sequence if this is PeptideEvidence derived from nucleic acid sequence </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="isDecoy" type="xsd:boolean" default="false">
+					<xsd:annotation>
+						<xsd:documentation>Set to true if the peptide is matched to a decoy sequence. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ToleranceType">
+		<xsd:annotation>
+			<xsd:documentation>The tolerance of the search given as a plus and minus value with units. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="cvParam" type="CVParamType" minOccurs="1" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>CV terms capturing the tolerance plus and minus values.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="SpectrumIDFormatType">
+		<xsd:annotation>
+			<xsd:documentation>The format of the spectrum identifier within the source file</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="cvParam" type="CVParamType">
+				<xsd:annotation>
+					<xsd:documentation>CV term capturing the type of identifier used.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DBSequenceType">
+		<xsd:annotation>
+			<xsd:documentation>A database sequence from the specified SearchDatabase (nucleic acid or amino acid). If the sequence is nucleic acid, the source nucleic acid sequence
+should be given in the seq attribute rather than a translated sequence.	</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="Seq" type="sequence" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>The actual sequence of amino acids or nucleic acid.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Additional descriptors for the sequence, such as taxon, description line etc.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+				<xsd:attribute name="length" type="xsd:int">
+					<xsd:annotation>
+						<xsd:documentation>The length of the sequence as a number of bases or residues. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="searchDatabase_ref" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The source database of this sequence.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="accession" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The unique accession of this sequence.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="SampleType">
+		<xsd:annotation>
+			<xsd:documentation> A description of the sample analysed by mass spectrometry using CVParams or UserParams. If a composite sample has been analysed, a parent sample should be defined, which references subsamples. This represents any kind of substance used in an experimental workflow, such as whole organisms, cells, DNA, solutions, compounds and experimental substances (gels, arrays etc.).	</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="ContactRole" type="ContactRoleType" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Contact details for the Material. The association to ContactRole could specify, for example, the creator or provider of the Material. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="SubSample" type="SubSampleType" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>The characteristics of a
+Material.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="SubSampleType">
+		<xsd:annotation>
+			<xsd:documentation>References to the individual component samples within a mixed parent sample. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="sample_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the child sample.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:simpleType name="listOfIntegers">
+		<xsd:list itemType="xsd:integer"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="listOfFloats">
+		<xsd:list itemType="xsd:float"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="listOfChars">
+		<xsd:list itemType="chars"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="listOfCharsOrAny">		
+		<xsd:union>
+			<xsd:simpleType id="listOfChars">
+				<xsd:list itemType="chars"/>
+			</xsd:simpleType>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="."/>
+				</xsd:restriction>
+			</xsd:simpleType>			
+		</xsd:union>		
+	</xsd:simpleType>
+	<xsd:simpleType name="chars">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="[ABCDEFGHIJKLMNOPQRSTUVWXYZ]{1}"/>
+		</xsd:restriction>
+	</xsd:simpleType>	
+	<xsd:simpleType name="sequence">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="[ABCDEFGHIJKLMNOPQRSTUVWXYZ]*"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="allowed_frames">
+		<xsd:restriction base="xsd:int">
+			<xsd:enumeration value="3"/>
+			<xsd:enumeration value="2"/>
+			<xsd:enumeration value="1"/>
+			<xsd:enumeration value="-3"/>
+			<xsd:enumeration value="-2"/>
+			<xsd:enumeration value="-1"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="listOfAllowedFrames">
+		<xsd:list itemType="allowed_frames"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="versionRegex">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="(1\.3\.\d+)"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!-- FuGE stuff -->
+	<xsd:complexType name="ExternalDataType">
+		<xsd:annotation>
+			<xsd:documentation>Data external to the XML instance document. The location of the data file is given in the location attribute. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="ExternalFormatDocumentation" type="xsd:anyURI" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>A URI to access documentation and tools to interpret the external format of the ExternalData instance. For example, XML Schema or static libraries (APIs) to access binary formats.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="FileFormat" type="FileFormatType" minOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="location" type="xsd:anyURI" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The location of the data file.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="FileFormatType">
+		<xsd:annotation>
+			<xsd:documentation>The format of the ExternalData file, for example "tiff" for image files. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="cvParam" type="CVParamType">
+				<xsd:annotation>
+					<xsd:documentation>cvParam capturing file formats</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PersonType">
+		<xsd:annotation>
+			<xsd:documentation>A person's name and contact details. Any additional information such as the address, contact email etc. should be supplied using CV parameters or user parameters.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AbstractContactType">
+				<xsd:sequence>
+					<xsd:element name="Affiliation" type="AffiliationType" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>The organization a person belongs to.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="lastName" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The Person's last/family name.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="firstName" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The Person's first name.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="midInitials" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The Person's middle initial.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="AffiliationType">
+		<xsd:attribute name="organization_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the organization this contact belongs to.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="OrganizationType">
+		<xsd:annotation>
+			<xsd:documentation>Organizations are entities like companies, universities, government agencies. Any additional information such as the address, email etc. should be supplied either as CV parameters or as user parameters. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AbstractContactType">
+				<xsd:sequence>
+					<xsd:element name="Parent" type="ParentOrganizationType" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ParentOrganizationType">
+		<xsd:annotation>
+			<xsd:documentation>The containing organization (the university or business which a lab belongs to, etc.) </xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="organization_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>A reference to the organization this contact belongs to.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="AbstractContactType" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>A contact is either a person or an organization.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:group ref="ParamGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Attributes of this contact such as address, email, telephone etc.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ContactRoleType">
+		<xsd:annotation>
+			<xsd:documentation>The role that a Contact plays in an organization or with respect to the associating class. A Contact may have several Roles within scope, and as such,
+associations to ContactRole allow the use of a Contact in a certain manner. Examples
+might include a provider, or a data analyst. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Role" type="RoleType"/>
+		</xsd:sequence>
+		<xsd:attribute name="contact_ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>When a ContactRole is used, it specifies which Contact the role is associated with. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="RoleType">
+		<xsd:annotation>
+			<xsd:documentation>The roles (lab equipment sales, contractor, etc.) the Contact fills.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="cvParam" type="CVParamType">
+				<xsd:annotation>
+					<xsd:documentation>CV term for contact roles, such as software provider.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="BibliographicReferenceType">
+		<xsd:annotation>
+			<xsd:documentation>Represents bibliographic references. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:attribute name="authors" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The names of the authors of the reference.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="publication" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The name of the journal, book etc.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="publisher" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The publisher of the publication.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="editor" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The editor(s) of the reference.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="year" type="xsd:int">
+					<xsd:annotation>
+						<xsd:documentation>The year of publication.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="volume" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The volume name or number.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="issue" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The issue name or number.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="pages" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The page numbers.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="title" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The title of the BibliographicReference.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="doi" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The DOI of the referenced publication.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ProtocolApplicationType" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>The use of a protocol with the requisite Parameters and ParameterValues. ProtocolApplications can take Material or Data (or both) as input
+and produce Material or Data (or both) as output. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:attribute name="activityDate" type="xsd:dateTime">
+					<xsd:annotation>
+						<xsd:documentation>When the protocol was applied.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="AbstractParamType" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Abstract entity allowing either cvParam or userParam to be referenced in other schemas. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="name" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The name of the parameter.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="value" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>The user-entered value of the parameter.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="unitAccession" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>An accession number identifying the unit within the OBO foundry Unit CV. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="unitName" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>The name of the unit.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="unitCvRef" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>If a unit term is referenced, this attribute must refer to the CV 'id' attribute defined in the cvList in this file. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="UserParamType">
+		<xsd:annotation>
+			<xsd:documentation>A single user-defined parameter.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AbstractParamType">
+				<xsd:attribute name="type" type="xsd:string" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>The datatype of the parameter, where appropriate (e.g.: xsd:float).</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="CVParamType">
+		<xsd:annotation>
+			<xsd:documentation>A single entry from an ontology or a controlled
+vocabulary.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AbstractParamType">
+				<xsd:attribute name="cvRef" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>A reference to the cv element from which this term originates. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="accession" type="xsd:string" use="required">
+					<xsd:annotation>
+						<xsd:documentation>The accession or ID number of this CV term in the source CV. </xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="cvType">
+		<xsd:annotation>
+			<xsd:documentation>A source controlled vocabulary from which cvParams will be obtained.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="fullName" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The full name of the CV.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="version" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>The version of the CV.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="uri" type="xsd:anyURI" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The URI of the source CV.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="id" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>The unique identifier of this cv within the document to be referenced by cvParam elements. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="IdentifiableType" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Other classes in the model can be specified as sub-classes, inheriting from Identifiable. Identifiable gives classes a unique identifier within the scope and a name that need not be unique.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="id" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>An identifier is an unambiguous string that is unique within the scope (i.e. a document, a set of related documents, or a repository) of its use.		</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="name" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>The potentially ambiguous common identifier, such as a human-readable name for the instance. </xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="AuditCollectionType">
+		<xsd:annotation>
+			<xsd:documentation>The complete set of Contacts (people and organisations) for this file. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:choice maxOccurs="unbounded">
+			<xsd:element name="Person" type="PersonType"/>
+			<xsd:element name="Organization" type="OrganizationType"/>
+		</xsd:choice>
+	</xsd:complexType>
+	<xsd:complexType name="ProviderType">
+		<xsd:annotation>
+			<xsd:documentation>The provider of the document in terms of the Contact and the software the produced the document instance. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="IdentifiableType">
+				<xsd:sequence>
+					<xsd:element name="ContactRole" type="ContactRoleType" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>The Contact that provided the document instance.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="analysisSoftware_ref" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>The Software that produced the document instance.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ParamListType">
+		<xsd:annotation>
+			<xsd:documentation>Helper type to allow multiple cvParams or userParams to be given for an element.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:group ref="ParamGroup" maxOccurs="unbounded"/>
+	</xsd:complexType>
+	<xsd:complexType name="ParamType">
+		<xsd:annotation>
+			<xsd:documentation>Helper type to allow either a cvParam or a userParam to be provided for an element.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:group ref="ParamGroup"/>
+	</xsd:complexType>
+	<xsd:group name="ParamGroup">
+		<xsd:annotation>
+			<xsd:documentation>A choice of either a cvParam or userParam.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:choice>
+			<xsd:element name="cvParam" type="CVParamType"/>
+			<xsd:element name="userParam" type="UserParamType"/>
+		</xsd:choice>
+	</xsd:group>
+</xsd:schema>

--- a/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
+++ b/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
@@ -161,6 +161,16 @@ public:
     void getAllChildTerms(std::set<String>& terms, const String& parent_id) const;
 
     /**
+        @brief Writes the parent term and all descendant term IDs into @p terms
+
+        @param[in,out] terms Output set extended with @p parent_id and all descendants
+        @param[in] parent_id The parent term ID
+
+        @exception Exception::InvalidValue is thrown if the term is not present
+    */
+    void addAllChildTerms(std::set<String>& terms, const String& parent_id) const;
+
+    /**
         @brief Iterates over all children (incl. subchildren etc) of parent recursively, i.e. the whole subtree.
 
         @param[in] parent_id Id of parent (to be passed to getTerm(), to obtain its children).

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzIdentMLDOMHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzIdentMLDOMHandler.h
@@ -113,6 +113,9 @@ protected:
       /// Looks up a child CV term of @p parent_accession with the name @p name. If no such term is found, an empty term is returned.
       ControlledVocabulary::CVTerm getChildWithName_(const String& parent_accession, const String& name) const;
 
+      /// Precompute the CV child-term sets used per PSM (constant across a file); shared by both constructors.
+      void initScoreTermCaches_();
+
       /**@name Helper functions to build the internal id structures from the DOM tree */
       //@{
 

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzIdentMLDOMHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzIdentMLDOMHandler.h
@@ -38,6 +38,7 @@
 
 #include <list>
 #include <map>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -261,6 +262,10 @@ private:
       std::map<String, double> xl_mass_map_; ///< mapping Peptide id -> cross-link mass
       std::map<String, String> xl_mod_map_; ///< mapping peptide id -> cross-linking reagent name
 
+      /// cached CV child term sets (computed once, reused per PSM)
+      std::set<String> q_score_child_terms_;
+      std::set<String> e_score_child_terms_;
+      std::set<String> specific_score_child_terms_;
     };
   } // namespace Internal
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzIdentMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzIdentMLHandler.h
@@ -352,6 +352,9 @@ protected:
 
 private:
       MzIdentMLHandler();
+
+      /// Load CVs and precompute the cached CV child-term set; shared by both constructors.
+      void initCvCaches_();
       MzIdentMLHandler(const MzIdentMLHandler& rhs);
       MzIdentMLHandler& operator=(const MzIdentMLHandler& rhs);
       std::map<String, AASequence> pep_sequences_;

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzIdentMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzIdentMLHandler.h
@@ -21,6 +21,7 @@
 
 #include <vector>
 #include <map>
+#include <set>
 
 namespace OpenMS
 {
@@ -362,6 +363,9 @@ private:
       AASequence actual_peptide_;
       Int current_mod_location_;
       ProteinHit actual_protein_;
+
+      /// cached CV child terms for "MS:1001143"
+      std::set<String> peptide_result_details_;
 
     };
   } // namespace Internal

--- a/src/openms/include/OpenMS/FORMAT/MzIdentMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MzIdentMLFile.h
@@ -74,6 +74,31 @@ public:
     */
     bool isSemanticallyValid(const String& filename, StringList& errors, StringList& warnings);
 
+    /**
+        @brief Checks if a file validates against the mzIdentML schema that matches its declared version.
+
+        Unlike the base-class @ref Internal::XMLFile::isValid (which always validates against the schema
+        the file adapter was constructed with), this overload first detects the mzIdentML version declared
+        in @p filename and validates against the corresponding schema (1.1.0, 1.2.0 or 1.3.0). This keeps
+        older, still-valid mzIdentML files from being reported as invalid just because OpenMS now writes
+        1.3.0. The schema version actually used is returned via @p used_version.
+
+        @param[in]     filename     File name of the file to be checked.
+        @param[in,out] os           Error-message sink for validation errors.
+        @param[out]    used_version Receives the schema version the file was validated against.
+
+        @exception Exception::FileNotFound is thrown if the file could not be opened
+    */
+    bool isValid(const String& filename, std::ostream& os, String& used_version);
+
+    /**
+        @brief Detect the mzIdentML version declared in @p filename (e.g. "1.1.0").
+
+        Reads the @c version attribute / target namespace from the document header. Falls back to the
+        adapter's default version (1.3.0) if no version can be determined or no matching schema exists.
+    */
+    String detectVersion(const String& filename) const;
+
 private:
 
   };

--- a/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
@@ -964,6 +964,10 @@ namespace OpenMS
       if (id.getHits().empty()) continue;
 
       PeptideHit& ph_alpha = id.getHits()[0];
+
+      // skip non-crosslinked PeptideIdentifications that were parsed and don't have crosslink MetaValues
+      if (!ph_alpha.metaValueExists(Constants::UserParam::OPENPEPXL_XL_POS1)) continue;
+
       String prot1_pos;
 
       // cross-link position in Protein (alpha)

--- a/src/openms/source/FORMAT/ControlledVocabulary.cpp
+++ b/src/openms/source/FORMAT/ControlledVocabulary.cpp
@@ -541,6 +541,12 @@ namespace OpenMS
     }
   }
 
+  void ControlledVocabulary::addAllChildTerms(set<String>& terms, const String& parent) const
+  {
+    terms.insert(parent);
+    getAllChildTerms(terms, parent);
+  }
+
   const ControlledVocabulary::CVTerm& ControlledVocabulary::getTermByName(const String& name, const String& desc) const
   {
     //slow, but Vocabulary is very finite and this method will be called only a few times during write of a ML file using a CV

--- a/src/openms/source/FORMAT/ControlledVocabulary.cpp
+++ b/src/openms/source/FORMAT/ControlledVocabulary.cpp
@@ -543,6 +543,7 @@ namespace OpenMS
 
   void ControlledVocabulary::addAllChildTerms(set<String>& terms, const String& parent) const
   {
+    getTerm(parent); // validate before mutating caller-owned output (throws if parent is unknown)
     terms.insert(parent);
     getAllChildTerms(terms, parent);
   }

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -191,6 +191,12 @@ namespace OpenMS::Internal
       // we adopt/own the document so we can free it in case this DOMHandler is reused on another file.
       xercesc::DOMDocument* xmlDoc = mzid_parser_.adoptDocument();
 
+      // parse() failures above are only logged, so guard against a null document instead of crashing on malformed input.
+      if (xmlDoc == nullptr)
+      {
+        throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, mzid_file, "Failed to parse mzIdentML file (no document produced).");
+      }
+
       try
       {
         // Catch special case: Cross-Linking MS
@@ -1442,6 +1448,10 @@ namespace OpenMS::Internal
         double exp_mz =StringManager::convert(cl_sii->getAttribute(CONST_XMLCH("experimentalMassToCharge"))).toDouble();
         exp_mzs.push_back(exp_mz);
 
+        // collect one RT entry per SII so RTs stays index-aligned with peptides/exp_mzs even when some SIIs lack MS:1000894
+        double rt = 0.0;
+        bool has_rt = false;
+
         if (rank == 0)
         {
           rank = StringManager::convert(cl_sii->getAttribute(CONST_XMLCH("rank"))).toInt();
@@ -1487,8 +1497,8 @@ namespace OpenMS::Internal
           }
           else if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("accession")), CONST_XMLCH("MS:1000894"))) // retention time
           {
-            double RT = StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))).toDouble();
-            RTs.push_back(RT);
+            rt = StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))).toDouble();
+            has_rt = true;
           }
         }
 
@@ -1509,6 +1519,12 @@ namespace OpenMS::Internal
         userParamNameLists.push_back(userParamNames);
         userParamValueLists.push_back(userParamValues);
         userParamUnitLists.push_back(userParamUnits);
+
+        RTs.push_back(rt);
+        if (!has_rt)
+        {
+          OPENMS_LOG_WARN << "No retention time found for cross-linked SpectrumIdentificationItem in '" << spectrumID << "'." << endl;
+        }
 
         // Fragmentation, does not matter where to get them. Look for them as long as the vector is empty
         if (frag_annotations.empty())
@@ -1678,11 +1694,7 @@ namespace OpenMS::Internal
       }
 
       // Generate and fill PeptideIdentification
-      if (RTs.empty())
-      {
-        RTs.resize(exp_mzs.size(), 0.0);
-        OPENMS_LOG_WARN << "No retention time found for cross-linked SpectrumIdentificationItems in '" << spectrumID << "'." << endl;
-      }
+      // RTs is now collected one entry per SII (see loop above), so it stays aligned with exp_mzs/peptides.
 
       vector<String> spectrumIDs;
       spectrumID.split(",", spectrumIDs);
@@ -1745,42 +1757,19 @@ namespace OpenMS::Internal
         current_pep_id.setMetaValue(Constants::UserParam::SPECTRUM_REFERENCE, spectrumID);
         current_pep_id.setHigherScoreBetter(false);
 
-        for (Size i = 0; i < peptides.size(); ++i)
+        // Reuse the regular SII parser so per-SII score type/userParams/passThreshold/calcMZ handling and
+        // pro_id_ protein-hit population behave exactly like the normal non-XL path.
+        DOMElement* reg_sii = element_res->getFirstElementChild();
+        while (reg_sii)
         {
-          PeptideHit ph;
-          ph.setSequence(pep_map_[peptides[i]]);
-          ph.setCharge(charge);
-          ph.setScore(score);
-          ph.setRank(rank - 1);
-
-          // connect with PeptideEvidences and DBSequences
-          pair<multimap<String, String>::iterator, multimap<String, String>::iterator> pev_its;
-          pev_its = p_pv_map_.equal_range(peptides[i]);
-          for (multimap<String, String>::iterator pev_it = pev_its.first; pev_it != pev_its.second; ++pev_it)
+          if (XMLString::equals(reg_sii->getTagName(), CONST_XMLCH("SpectrumIdentificationItem")))
           {
-            OpenMS::PeptideEvidence pev;
-            if (pe_ev_map_.find(pev_it->second) != pe_ev_map_.end())
-            {
-              MzIdentMLDOMHandler::PeptideEvidence& pv = pe_ev_map_[pev_it->second];
-              if (pv.pre != '-') pev.setAABefore(pv.pre);
-              if (pv.post != '-') pev.setAAAfter(pv.post);
-              if (pv.start != OpenMS::PeptideEvidence::UNKNOWN_POSITION && pv.stop != OpenMS::PeptideEvidence::UNKNOWN_POSITION)
-              {
-                pev.setStart(pv.start);
-                pev.setEnd(pv.stop);
-              }
-            }
-            if (pv_db_map_.find(pev_it->second) != pv_db_map_.end())
-            {
-              String& dpv = pv_db_map_[pev_it->second];
-              DBSequence& db = db_sq_map_[dpv];
-              pev.setProteinAccession(db.accession);
-            }
-            ph.addPeptideEvidence(pev);
+            parseSpectrumIdentificationItemElement_(reg_sii, current_pep_id, sil);
           }
-          current_pep_id.insertHit(ph);
+          reg_sii = reg_sii->getNextElementSibling();
         }
         current_pep_id.setIdentifier(pro_id_->at(si_pro_map_[sil]).getIdentifier());
+        current_pep_id.sort();
         pep_id_->push_back(current_pep_id);
         return;
       }
@@ -2112,7 +2101,8 @@ namespace OpenMS::Internal
             break;
           }
         }
-        else if (specific_score_child_terms_.find(scoreit->first) != specific_score_child_terms_.end())
+        else if (scoreit->first != "MS:1001143" && // the parent term itself has no numeric value; handled in the special case below
+                 specific_score_child_terms_.find(scoreit->first) != specific_score_child_terms_.end())
         {
           score = scoreit->second.front().getValue().toString().toDouble(); // cast fix needed as DataValue is init with XercesString
           spectrum_identification.setHigherScoreBetter(ControlledVocabulary::CVTerm::isHigherBetterScore(cv_.getTerm(scoreit->first)));

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -1482,35 +1482,35 @@ namespace OpenMS::Internal
           DOMElement* element_sii_cvp = dynamic_cast<xercesc::DOMElement*>(sii_cvp->item(i));
           if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("accession")), CONST_XMLCH("MS:1002681"))) // OpenXQuest:combined score
           {
-            score = StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))).toDouble();
+            score = toDoubleOrNaN_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
           }
           else if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("accession")), CONST_XMLCH("MS:1002682"))) // OpenXQuest: xcorr common
           {
-            xcorrx = StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))).toDouble();
+            xcorrx = toDoubleOrNaN_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
           }
           else if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("accession")), CONST_XMLCH("MS:1002683"))) // OpenXQuest: xcorr xlink
           {
-            xcorrc = StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))).toDouble();
+            xcorrc = toDoubleOrNaN_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
           }
           else if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("accession")), CONST_XMLCH("MS:1002684"))) // OpenXQuest: match-odds
           {
-            matchodds = StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))).toDouble();
+            matchodds = toDoubleOrNaN_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
           }
           else if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("accession")), CONST_XMLCH("MS:1002685"))) // OpenXQuest: intsum
           {
-            intsum = StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))).toDouble();
+            intsum = toDoubleOrNaN_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
           }
           else if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("accession")), CONST_XMLCH("MS:1002686"))) // OpenXQuest: wTIC
           {
-            wTIC = StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))).toDouble();
+            wTIC = toDoubleOrNaN_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
           }
           else if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("accession")), CONST_XMLCH("MS:1003024"))) // OpenPepXL:score
           {
-            score = StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))).toDouble();
+            score = toDoubleOrNaN_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
           }
           else if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("accession")), CONST_XMLCH("MS:1000894"))) // retention time
           {
-            rt = StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))).toDouble();
+            rt = toDoubleOrNaN_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
             if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("unitAccession")), CONST_XMLCH("UO:0000031"))) // minutes -> seconds (mirror non-XL path)
             {
               rt *= 60.0;
@@ -1700,8 +1700,8 @@ namespace OpenMS::Internal
 
                 PeptideHit::PeakAnnotation frag_anno;
                 frag_anno.charge = ion_charge;
-                frag_anno.mz = positions[s].toDouble();
-                frag_anno.intensity = intensities[s].toDouble();
+                frag_anno.mz = positions[s].empty() ? 0.0 : positions[s].toDouble();
+                frag_anno.intensity = intensities[s].empty() ? 0.0 : intensities[s].toDouble();
                 frag_anno.annotation = annotation;
                 frag_annotations.push_back(frag_anno);
               }

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -31,12 +31,21 @@ namespace OpenMS::Internal
 
   namespace
   {
-    // (experimental|calculated)MassToCharge are optional mzIdentML attributes; a missing attribute is
-    // returned by Xerces as an empty string. Convert tolerantly so an absent value becomes NaN instead
-    // of throwing Exception::ConversionError while parsing (e.g. on store/load round-trips).
+    // (experimental|calculated)MassToCharge and retention time are optional mzIdentML attributes/values; a
+    // missing one is returned by Xerces as an empty string. For these position-like fields convert tolerantly
+    // so an absent value becomes NaN instead of throwing Exception::ConversionError while parsing (e.g. on
+    // store/load round-trips); NaN is the OpenMS sentinel for "no RT/MZ" (cf. PeptideIdentification::hasRT()).
     inline double toDoubleOrNaN_(const String& s)
     {
       return s.empty() ? std::numeric_limits<double>::quiet_NaN() : s.toDouble();
+    }
+
+    // For score values an empty value must NOT become NaN: PeptideHit has no "hasScore()" and defaults the
+    // score to 0.0, and a NaN score silently breaks sorting/FDR/IDFilter (every NaN comparison is false).
+    // Default to 0.0 to match PeptideHit's contract and the other identification parsers.
+    inline double toDoubleOrZero_(const String& s)
+    {
+      return s.empty() ? 0.0 : s.toDouble();
     }
   }
 
@@ -1483,31 +1492,31 @@ namespace OpenMS::Internal
           DOMElement* element_sii_cvp = dynamic_cast<xercesc::DOMElement*>(sii_cvp->item(i));
           if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("accession")), CONST_XMLCH("MS:1002681"))) // OpenXQuest:combined score
           {
-            score = toDoubleOrNaN_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
+            score = toDoubleOrZero_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
           }
           else if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("accession")), CONST_XMLCH("MS:1002682"))) // OpenXQuest: xcorr common
           {
-            xcorrx = toDoubleOrNaN_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
+            xcorrx = toDoubleOrZero_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
           }
           else if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("accession")), CONST_XMLCH("MS:1002683"))) // OpenXQuest: xcorr xlink
           {
-            xcorrc = toDoubleOrNaN_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
+            xcorrc = toDoubleOrZero_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
           }
           else if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("accession")), CONST_XMLCH("MS:1002684"))) // OpenXQuest: match-odds
           {
-            matchodds = toDoubleOrNaN_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
+            matchodds = toDoubleOrZero_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
           }
           else if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("accession")), CONST_XMLCH("MS:1002685"))) // OpenXQuest: intsum
           {
-            intsum = toDoubleOrNaN_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
+            intsum = toDoubleOrZero_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
           }
           else if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("accession")), CONST_XMLCH("MS:1002686"))) // OpenXQuest: wTIC
           {
-            wTIC = toDoubleOrNaN_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
+            wTIC = toDoubleOrZero_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
           }
           else if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("accession")), CONST_XMLCH("MS:1003024"))) // OpenPepXL:score
           {
-            score = toDoubleOrNaN_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
+            score = toDoubleOrZero_(StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))));
           }
           else if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("accession")), CONST_XMLCH("MS:1000894"))) // retention time
           {
@@ -2123,7 +2132,7 @@ namespace OpenMS::Internal
         {
           if (scoreit->first != "MS:1002055") // do not use peptide-level q-values for now
           {
-            score = toDoubleOrNaN_(scoreit->second.front().getValue().toString()); // cast fix needed as DataValue is init with XercesString
+            score = toDoubleOrZero_(scoreit->second.front().getValue().toString()); // cast fix needed as DataValue is init with XercesString
             spectrum_identification.setHigherScoreBetter(false);
             spectrum_identification.setScoreType("q-value"); //higherIsBetter = false
             scoretype = true;
@@ -2133,7 +2142,7 @@ namespace OpenMS::Internal
         else if (scoreit->first != "MS:1001143" && // the parent term itself has no numeric value; handled in the special case below
                  specific_score_child_terms_.find(scoreit->first) != specific_score_child_terms_.end())
         {
-          score = toDoubleOrNaN_(scoreit->second.front().getValue().toString()); // cast fix needed as DataValue is init with XercesString
+          score = toDoubleOrZero_(scoreit->second.front().getValue().toString()); // cast fix needed as DataValue is init with XercesString
           spectrum_identification.setHigherScoreBetter(ControlledVocabulary::CVTerm::isHigherBetterScore(cv_.getTerm(scoreit->first)));
           spectrum_identification.setScoreType(scoreit->second.front().getName());
           scoretype = true;
@@ -2141,7 +2150,7 @@ namespace OpenMS::Internal
         }
         else if (e_score_child_terms_.find(scoreit->first) != e_score_child_terms_.end())
         {
-          score = toDoubleOrNaN_(scoreit->second.front().getValue().toString()); // cast fix needed as DataValue is init with XercesString
+          score = toDoubleOrZero_(scoreit->second.front().getValue().toString()); // cast fix needed as DataValue is init with XercesString
           spectrum_identification.setHigherScoreBetter(false);
           spectrum_identification.setScoreType("E-value"); //higherIsBetter = false
           scoretype = true;

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -72,11 +72,7 @@ namespace OpenMS::Internal
       xml_cvparam_tag_ptr_ = XMLString::transcode("cvParam");
       xml_name_attr_ptr_ = XMLString::transcode("option_a");
 
-      // precompute CV child term sets, used per PSM, but constant across the file
-      cv_.addAllChildTerms(q_score_child_terms_, "MS:1002354");
-      cv_.addAllChildTerms(e_score_child_terms_, "MS:1001872");
-      cv_.addAllChildTerms(e_score_child_terms_, "MS:1002353");
-      cv_.addAllChildTerms(specific_score_child_terms_, "MS:1001143");
+      initScoreTermCaches_();
     }
 
     MzIdentMLDOMHandler::MzIdentMLDOMHandler(vector<ProteinIdentification>& pro_id, PeptideIdentificationList& pep_id, const String& version, const ProgressLogger& logger) :
@@ -108,6 +104,11 @@ namespace OpenMS::Internal
       xml_cvparam_tag_ptr_ = XMLString::transcode("cvParam");
       xml_name_attr_ptr_ = XMLString::transcode("name");
 
+      initScoreTermCaches_();
+    }
+
+    void MzIdentMLDOMHandler::initScoreTermCaches_()
+    {
       // precompute CV child term sets, used per PSM, but constant across the file
       cv_.addAllChildTerms(q_score_child_terms_, "MS:1002354");
       cv_.addAllChildTerms(e_score_child_terms_, "MS:1001872");
@@ -1729,7 +1730,10 @@ namespace OpenMS::Internal
       double MZ_light = *std::min_element(exp_mzs.begin(), exp_mzs.end());
       double MZ_heavy = *std::max_element(exp_mzs.begin(), exp_mzs.end());
 
-      // are the cross-links labeled?
+      // Are the cross-links labeled? A labeled (light/heavy) cross-link is reported as a light and a heavy
+      // SII whose experimental m/z differ AND that reference two distinct spectra (comma-separated spectrumID).
+      // Requiring >1 spectrum avoids misclassifying a single spectrum whose SIIs merely happen to have
+      // differing experimental m/z as a labeled pair.
       bool labeled = MZ_light != MZ_heavy && spectrumIDs.size() > 1;
 
       for (Size i = 0; i < exp_mzs.size(); ++i)

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -1498,6 +1498,10 @@ namespace OpenMS::Internal
           else if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("accession")), CONST_XMLCH("MS:1000894"))) // retention time
           {
             rt = StringManager::convert(element_sii_cvp->getAttribute(CONST_XMLCH("value"))).toDouble();
+            if (XMLString::equals(element_sii_cvp->getAttribute(CONST_XMLCH("unitAccession")), CONST_XMLCH("UO:0000031"))) // minutes -> seconds (mirror non-XL path)
+            {
+              rt *= 60.0;
+            }
             has_rt = true;
           }
         }

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -2119,7 +2119,7 @@ namespace OpenMS::Internal
         {
           if (scoreit->first != "MS:1002055") // do not use peptide-level q-values for now
           {
-            score = scoreit->second.front().getValue().toString().toDouble(); // cast fix needed as DataValue is init with XercesString
+            score = toDoubleOrNaN_(scoreit->second.front().getValue().toString()); // cast fix needed as DataValue is init with XercesString
             spectrum_identification.setHigherScoreBetter(false);
             spectrum_identification.setScoreType("q-value"); //higherIsBetter = false
             scoretype = true;
@@ -2129,7 +2129,7 @@ namespace OpenMS::Internal
         else if (scoreit->first != "MS:1001143" && // the parent term itself has no numeric value; handled in the special case below
                  specific_score_child_terms_.find(scoreit->first) != specific_score_child_terms_.end())
         {
-          score = scoreit->second.front().getValue().toString().toDouble(); // cast fix needed as DataValue is init with XercesString
+          score = toDoubleOrNaN_(scoreit->second.front().getValue().toString()); // cast fix needed as DataValue is init with XercesString
           spectrum_identification.setHigherScoreBetter(ControlledVocabulary::CVTerm::isHigherBetterScore(cv_.getTerm(scoreit->first)));
           spectrum_identification.setScoreType(scoreit->second.front().getName());
           scoretype = true;
@@ -2137,7 +2137,7 @@ namespace OpenMS::Internal
         }
         else if (e_score_child_terms_.find(scoreit->first) != e_score_child_terms_.end())
         {
-          score = scoreit->second.front().getValue().toString().toDouble(); // cast fix needed as DataValue is init with XercesString
+          score = toDoubleOrNaN_(scoreit->second.front().getValue().toString()); // cast fix needed as DataValue is init with XercesString
           spectrum_identification.setHigherScoreBetter(false);
           spectrum_identification.setScoreType("E-value"); //higherIsBetter = false
           scoretype = true;

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -29,6 +29,17 @@ using namespace xercesc;
 namespace OpenMS::Internal
 {
 
+  namespace
+  {
+    // (experimental|calculated)MassToCharge are optional mzIdentML attributes; a missing attribute is
+    // returned by Xerces as an empty string. Convert tolerantly so an absent value becomes NaN instead
+    // of throwing Exception::ConversionError while parsing (e.g. on store/load round-trips).
+    inline double toDoubleOrNaN_(const String& s)
+    {
+      return s.empty() ? std::numeric_limits<double>::quiet_NaN() : s.toDouble();
+    }
+  }
+
     //TODO remodel CVTermList
     //TODO extend CVTermlist with CVCollection functionality for complete replacement??
     //TODO general id openms struct for overall parameter for one id run
@@ -1446,7 +1457,7 @@ namespace OpenMS::Internal
         // Attributes
         String peptide = StringManager::convert(cl_sii->getAttribute(CONST_XMLCH("peptide_ref")));
         peptides.push_back(peptide);
-        double exp_mz =StringManager::convert(cl_sii->getAttribute(CONST_XMLCH("experimentalMassToCharge"))).toDouble();
+        double exp_mz = toDoubleOrNaN_(StringManager::convert(cl_sii->getAttribute(CONST_XMLCH("experimentalMassToCharge"))));
         exp_mzs.push_back(exp_mz);
 
         // collect one RT entry per SII so RTs stays index-aligned with peptides/exp_mzs even when some SIIs lack MS:1000894;
@@ -2056,7 +2067,7 @@ namespace OpenMS::Internal
       String id = StringManager::convert(spectrumIdentificationItemElement->getAttribute(CONST_XMLCH("id")));
       String name = StringManager::convert(spectrumIdentificationItemElement->getAttribute(CONST_XMLCH("name")));
 
-      long double calculatedMassToCharge = StringManager::convert(spectrumIdentificationItemElement->getAttribute(CONST_XMLCH("calculatedMassToCharge"))).toDouble();
+      long double calculatedMassToCharge = toDoubleOrNaN_(StringManager::convert(spectrumIdentificationItemElement->getAttribute(CONST_XMLCH("calculatedMassToCharge"))));
 //      long double calculatedPI = StringManager::convert(spectrumIdentificationItemElement->getAttribute(CONST_XMLCH("calculatedPI"))).toDouble();
       int chargeState = 0;
       try
@@ -2067,7 +2078,7 @@ namespace OpenMS::Internal
       {
         OPENMS_LOG_WARN << "Found unreadable 'chargeState'." << endl;
       }
-      long double experimentalMassToCharge = StringManager::convert(spectrumIdentificationItemElement->getAttribute(CONST_XMLCH("experimentalMassToCharge"))).toDouble();
+      long double experimentalMassToCharge = toDoubleOrNaN_(StringManager::convert(spectrumIdentificationItemElement->getAttribute(CONST_XMLCH("experimentalMassToCharge"))));
       int rank = 0;
       try
       {
@@ -2449,7 +2460,7 @@ namespace OpenMS::Internal
                   String donor_val = StringManager::convert(cvp->getAttribute(CONST_XMLCH("value")));
                   xl_id_donor_map_.insert(make_pair(pep_id, donor_val));
                   String massdelta = StringManager::convert(element_sib->getAttribute(CONST_XMLCH("monoisotopicMassDelta")));
-                  double monoisotopicMassDelta = massdelta.toDouble();
+                  double monoisotopicMassDelta = massdelta.empty() ? 0.0 : massdelta.toDouble();
                   xl_mass_map_.insert(make_pair(pep_id, monoisotopicMassDelta));
                   xl_donor_pos_map_.insert(make_pair(donor_val, index-1));
 

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -21,6 +21,7 @@
 
 #include <sys/stat.h>
 #include <cerrno>
+#include <limits>
 
 using namespace std;
 using namespace xercesc;
@@ -1448,8 +1449,9 @@ namespace OpenMS::Internal
         double exp_mz =StringManager::convert(cl_sii->getAttribute(CONST_XMLCH("experimentalMassToCharge"))).toDouble();
         exp_mzs.push_back(exp_mz);
 
-        // collect one RT entry per SII so RTs stays index-aligned with peptides/exp_mzs even when some SIIs lack MS:1000894
-        double rt = 0.0;
+        // collect one RT entry per SII so RTs stays index-aligned with peptides/exp_mzs even when some SIIs lack MS:1000894;
+        // a missing RT stays NaN (mirrors the non-XL path and PeptideIdentification::hasRT()) so it is not confused with a real 0 s RT
+        double rt = std::numeric_limits<double>::quiet_NaN();
         bool has_rt = false;
 
         if (rank == 0)

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -60,6 +60,11 @@ namespace OpenMS::Internal
       xml_cvparam_tag_ptr_ = XMLString::transcode("cvParam");
       xml_name_attr_ptr_ = XMLString::transcode("option_a");
 
+      // precompute CV child term sets, used per PSM, but constant across the file
+      cv_.addAllChildTerms(q_score_child_terms_, "MS:1002354");
+      cv_.addAllChildTerms(e_score_child_terms_, "MS:1001872");
+      cv_.addAllChildTerms(e_score_child_terms_, "MS:1002353");
+      cv_.addAllChildTerms(specific_score_child_terms_, "MS:1001143");
     }
 
     MzIdentMLDOMHandler::MzIdentMLDOMHandler(vector<ProteinIdentification>& pro_id, PeptideIdentificationList& pep_id, const String& version, const ProgressLogger& logger) :
@@ -90,6 +95,12 @@ namespace OpenMS::Internal
       xml_root_tag_ptr_ = XMLString::transcode("MzIdentML");
       xml_cvparam_tag_ptr_ = XMLString::transcode("cvParam");
       xml_name_attr_ptr_ = XMLString::transcode("name");
+
+      // precompute CV child term sets, used per PSM, but constant across the file
+      cv_.addAllChildTerms(q_score_child_terms_, "MS:1002354");
+      cv_.addAllChildTerms(e_score_child_terms_, "MS:1001872");
+      cv_.addAllChildTerms(e_score_child_terms_, "MS:1002353");
+      cv_.addAllChildTerms(specific_score_child_terms_, "MS:1001143");
     }
 
     /*
@@ -940,12 +951,28 @@ namespace OpenMS::Internal
                 {
                   if (XMLString::equals(sub->getTagName(), CONST_XMLCH("cvParam")))
                   {
-                    mname = StringManager::convert(sub->getAttribute(CONST_XMLCH("name")));
-                   if (mname == "unknown modification")
-                   {
-                     // e.g. <cvParam cvRef="MS" accession="MS:1001460" name="unknown modification" value="N-Glycan"/>
-                     mname = StringManager::convert(sub->getAttribute(CONST_XMLCH("value")));
-                   }
+                    // In v1.3, SearchModification may have multiple cvParams: the actual modification
+                    // plus PSI-MS annotations (MS:1003392 "search modification id",
+                    // MS:1003347 "UNIMOD derivative code", MS:1002509/MS:1002510 donor/acceptor)
+                    String cvref = StringManager::convert(sub->getAttribute(CONST_XMLCH("cvRef")));
+                    if (cvref == "UNIMOD" || cvref == "XLMOD")
+                    {
+                      mname = StringManager::convert(sub->getAttribute(CONST_XMLCH("name")));
+                      if (mname == "unknown modification")
+                      {
+                        // e.g. <cvParam cvRef="MS" accession="MS:1001460" name="unknown modification" value="N-Glycan"/>
+                        mname = StringManager::convert(sub->getAttribute(CONST_XMLCH("value")));
+                      }
+                    }
+                    else if (mname.empty())
+                    {
+                      // fallback for files that may not specify cvRef
+                      mname = StringManager::convert(sub->getAttribute(CONST_XMLCH("name")));
+                      if (mname == "unknown modification")
+                      {
+                        mname = StringManager::convert(sub->getAttribute(CONST_XMLCH("value")));
+                      }
+                    }
                   }
                   else if (XMLString::equals(sub->getTagName(), CONST_XMLCH("SpecificityRules")))
                   {
@@ -964,43 +991,51 @@ namespace OpenMS::Internal
                   String mod;
                   String r = (residues != ".") ? residues : "";
 
-                  if (!specificity_rules.empty())
+                  try
                   {
-                    for (map<String, vector<CVTerm> >::const_iterator spci = specificity_rules.getCVTerms().begin(); spci != specificity_rules.getCVTerms().end(); ++spci)
+                    if (!specificity_rules.empty())
                     {
-                      if (spci->second.front().getAccession() == "MS:1001189")  // nterm
+                      for (map<String, vector<CVTerm> >::const_iterator spci = specificity_rules.getCVTerms().begin(); spci != specificity_rules.getCVTerms().end(); ++spci)
                       {
-                        const ResidueModification* m = ModificationsDB::getInstance()->getModification(mname, r, ResidueModification::N_TERM);
-                        mod = m->getFullId();
-                      }
-                      else if (spci->second.front().getAccession() == "MS:1001190")  // cterm
-                      {
-                        const ResidueModification* m = ModificationsDB::getInstance()->getModification(mname, r, ResidueModification::C_TERM);
-                        mod = m->getFullId();
-                      }
-                      else if (spci->second.front().getAccession() == "MS:1002057")  // protein nterm
-                      {
-                        const ResidueModification* m = ModificationsDB::getInstance()->getModification(mname,  r, ResidueModification::PROTEIN_N_TERM);
-                        mod = m->getFullId();
-                      }
-                      else if (spci->second.front().getAccession() == "MS:1002058")  // protein cterm
-                      {
-                        const ResidueModification* m = ModificationsDB::getInstance()->getModification(mname,  r, ResidueModification::PROTEIN_C_TERM);
-                        mod = m->getFullId();
+                        if (spci->second.front().getAccession() == "MS:1001189")  // nterm
+                        {
+                          const ResidueModification* m = ModificationsDB::getInstance()->getModification(mname, r, ResidueModification::N_TERM);
+                          mod = m->getFullId();
+                        }
+                        else if (spci->second.front().getAccession() == "MS:1001190")  // cterm
+                        {
+                          const ResidueModification* m = ModificationsDB::getInstance()->getModification(mname, r, ResidueModification::C_TERM);
+                          mod = m->getFullId();
+                        }
+                        else if (spci->second.front().getAccession() == "MS:1002057")  // protein nterm
+                        {
+                          const ResidueModification* m = ModificationsDB::getInstance()->getModification(mname,  r, ResidueModification::PROTEIN_N_TERM);
+                          mod = m->getFullId();
+                        }
+                        else if (spci->second.front().getAccession() == "MS:1002058")  // protein cterm
+                        {
+                          const ResidueModification* m = ModificationsDB::getInstance()->getModification(mname,  r, ResidueModification::PROTEIN_C_TERM);
+                          mod = m->getFullId();
+                        }
                       }
                     }
+                    else  // anywhere
+                    {
+                      const ResidueModification* m = ModificationsDB::getInstance()->getModification(mname, r);
+                      mod = m->getFullId();
+                    }
                   }
-                  else  // anywhere
+                  catch (Exception::BaseException& e)
                   {
-                    const ResidueModification* m = ModificationsDB::getInstance()->getModification(mname, r);
-                    mod = m->getFullId();
+                    OPENMS_LOG_WARN << "SearchModification '" << mname << "' not found in ModificationsDB"
+                                    << e.what() << endl;
                   }
 
-                  if (fixedMod)
+                  if (!mod.empty() && fixedMod)
                   {
                     fix.push_back(mod);
                   }
-                  else
+                  else if (!mod.empty())
                   {
                     var.push_back(mod);
                   }
@@ -1148,14 +1183,15 @@ namespace OpenMS::Internal
 //              String identi = search_engine+"_"+si_pro_map_[si_it->second.spectrum_identification_list_ref]->getDateTime().getDate()+"T"
 //                      +si_pro_map_[si_it->second.spectrum_identification_list_ref]->getDateTime().getTime();
 //              pro_id_->at(si_pro_map_[si_it->second.spectrum_identification_list_ref]).setIdentifier(identi);
-              pro_id_->at(si_pro_map_[si_it->second.spectrum_identification_list_ref]).setSearchEngine(search_engine);
-              pro_id_->at(si_pro_map_[si_it->second.spectrum_identification_list_ref]).setSearchEngineVersion(search_engine_version);
-              sp.db = pro_id_->at(si_pro_map_[si_it->second.spectrum_identification_list_ref]).getSearchParameters().db; // was previously set, but main parts of sp are set here
-              sp.db_version = pro_id_->at(si_pro_map_[si_it->second.spectrum_identification_list_ref]).getSearchParameters().db_version; // was previously set, but main parts of sp are set here
-              pro_id_->at(si_pro_map_[si_it->second.spectrum_identification_list_ref]).setSearchParameters(sp);
+              auto& pro = pro_id_->at(si_pro_map_[si_it->second.spectrum_identification_list_ref]);
+              pro.setSearchEngine(search_engine);
+              pro.setSearchEngineVersion(search_engine_version);
+              sp.db = pro.getSearchParameters().db; // was previously set, but main parts of sp are set here
+              sp.db_version = pro.getSearchParameters().db_version; // was previously set, but main parts of sp are set here
+              pro.setSearchParameters(sp);
               if (use_thresh)
               {
-                pro_id_->at(si_pro_map_[si_it->second.spectrum_identification_list_ref]).setSignificanceThreshold(thresh);
+                pro.setSignificanceThreshold(thresh);
               }
             }
           }
@@ -1642,13 +1678,22 @@ namespace OpenMS::Internal
       }
 
       // Generate and fill PeptideIdentification
+      if (RTs.empty())
+      {
+        RTs.resize(exp_mzs.size(), 0.0);
+        OPENMS_LOG_WARN << "No retention time found for cross-linked SpectrumIdentificationItems in '" << spectrumID << "'." << endl;
+      }
+
+      vector<String> spectrumIDs;
+      spectrumID.split(",", spectrumIDs);
+
       vector<Size> light;
       vector<Size> heavy;
       double MZ_light = *std::min_element(exp_mzs.begin(), exp_mzs.end());
       double MZ_heavy = *std::max_element(exp_mzs.begin(), exp_mzs.end());
 
       // are the cross-links labeled?
-      bool labeled = MZ_light != MZ_heavy;
+      bool labeled = MZ_light != MZ_heavy && spectrumIDs.size() > 1;
 
       for (Size i = 0; i < exp_mzs.size(); ++i)
       {
@@ -1685,9 +1730,62 @@ namespace OpenMS::Internal
       }
       String xl_type = "mono-link";
 
+      // If no crosslink donors were found fall back to parsing each SII as a regular peptide identification
+      if (alpha.empty())
+      {
+        OPENMS_LOG_WARN << "No crosslink donor found for SIIs in '" << spectrumID
+                        << "'; parsing as regular (non-XLMS) peptide identifications." << endl;
+
+        DOMElement* parent = dynamic_cast<xercesc::DOMElement*>(element_res->getParentNode());
+        String sil = StringManager::convert(parent->getAttribute(CONST_XMLCH("id")));
+
+        PeptideIdentification current_pep_id;
+        current_pep_id.setRT(RTs.empty() ? 0.0 : RTs[0]);
+        current_pep_id.setMZ(exp_mzs.empty() ? 0.0 : exp_mzs[0]);
+        current_pep_id.setMetaValue(Constants::UserParam::SPECTRUM_REFERENCE, spectrumID);
+        current_pep_id.setHigherScoreBetter(false);
+
+        for (Size i = 0; i < peptides.size(); ++i)
+        {
+          PeptideHit ph;
+          ph.setSequence(pep_map_[peptides[i]]);
+          ph.setCharge(charge);
+          ph.setScore(score);
+          ph.setRank(rank - 1);
+
+          // connect with PeptideEvidences and DBSequences
+          pair<multimap<String, String>::iterator, multimap<String, String>::iterator> pev_its;
+          pev_its = p_pv_map_.equal_range(peptides[i]);
+          for (multimap<String, String>::iterator pev_it = pev_its.first; pev_it != pev_its.second; ++pev_it)
+          {
+            OpenMS::PeptideEvidence pev;
+            if (pe_ev_map_.find(pev_it->second) != pe_ev_map_.end())
+            {
+              MzIdentMLDOMHandler::PeptideEvidence& pv = pe_ev_map_[pev_it->second];
+              if (pv.pre != '-') pev.setAABefore(pv.pre);
+              if (pv.post != '-') pev.setAAAfter(pv.post);
+              if (pv.start != OpenMS::PeptideEvidence::UNKNOWN_POSITION && pv.stop != OpenMS::PeptideEvidence::UNKNOWN_POSITION)
+              {
+                pev.setStart(pv.start);
+                pev.setEnd(pv.stop);
+              }
+            }
+            if (pv_db_map_.find(pev_it->second) != pv_db_map_.end())
+            {
+              String& dpv = pv_db_map_[pev_it->second];
+              DBSequence& db = db_sq_map_[dpv];
+              pev.setProteinAccession(db.accession);
+            }
+            ph.addPeptideEvidence(pev);
+          }
+          current_pep_id.insertHit(ph);
+        }
+        current_pep_id.setIdentifier(pro_id_->at(si_pro_map_[sil]).getIdentifier());
+        pep_id_->push_back(current_pep_id);
+        return;
+      }
+
       SignedSize alpha_pos = xl_donor_pos_map_.at(xl_id_donor_map_.at(peptides[alpha[0]]));
-      vector<String> spectrumIDs;
-      spectrumID.split(",", spectrumIDs);
 
       if (alpha.size() == beta.size()) // if a beta exists at all, it must be cross-link. But they should also each have the same number of SIIs in the mzid
       {
@@ -2000,18 +2098,10 @@ namespace OpenMS::Internal
 
       long double score = 0;
       const auto& [param_cv, param_user] = parseParamGroup_(spectrumIdentificationItemElement->getChildNodes());
-      set<String> q_score_terms;
-      set<String> e_score_terms,e_score_tmp;
-      set<String> specific_score_terms;
-      cv_.getAllChildTerms(q_score_terms, "MS:1002354"); //q-value for peptides
-      cv_.getAllChildTerms(e_score_terms, "MS:1001872");
-      cv_.getAllChildTerms(e_score_tmp, "MS:1002353");
-      e_score_terms.insert(e_score_tmp.begin(),e_score_tmp.end()); //E-value for peptides
-      cv_.getAllChildTerms(specific_score_terms, "MS:1001143"); //search engine specific score for PSMs
       bool scoretype = false;
       for (map<String, vector<OpenMS::CVTerm>>::const_iterator scoreit = param_cv.getCVTerms().begin(); scoreit != param_cv.getCVTerms().end(); ++scoreit)
       {
-        if (q_score_terms.find(scoreit->first) != q_score_terms.end() || scoreit->first == "MS:1002354")
+        if (q_score_child_terms_.find(scoreit->first) != q_score_child_terms_.end() || scoreit->first == "MS:1002354")
         {
           if (scoreit->first != "MS:1002055") // do not use peptide-level q-values for now
           {
@@ -2022,7 +2112,7 @@ namespace OpenMS::Internal
             break;
           }
         }
-        else if (specific_score_terms.find(scoreit->first) != specific_score_terms.end())
+        else if (specific_score_child_terms_.find(scoreit->first) != specific_score_child_terms_.end())
         {
           score = scoreit->second.front().getValue().toString().toDouble(); // cast fix needed as DataValue is init with XercesString
           spectrum_identification.setHigherScoreBetter(ControlledVocabulary::CVTerm::isHigherBetterScore(cv_.getTerm(scoreit->first)));
@@ -2030,7 +2120,7 @@ namespace OpenMS::Internal
           scoretype = true;
           break;
         }
-        else if (e_score_terms.find(scoreit->first) != e_score_terms.end())
+        else if (e_score_child_terms_.find(scoreit->first) != e_score_child_terms_.end())
         {
           score = scoreit->second.front().getValue().toString().toDouble(); // cast fix needed as DataValue is init with XercesString
           spectrum_identification.setHigherScoreBetter(false);
@@ -2359,8 +2449,24 @@ namespace OpenMS::Internal
                   xl_mass_map_.insert(make_pair(pep_id, monoisotopicMassDelta));
                   xl_donor_pos_map_.insert(make_pair(donor_val, index-1));
 
+                  // Find the actual modification name from UNIMOD/XLMOD cvParam
+                  String xl_mod_name;
                   DOMElement* cvp1 = element_sib->getFirstElementChild();
-                  String xl_mod_name = StringManager::convert(cvp1->getAttribute(CONST_XMLCH("name")));
+                  while (cvp1)
+                  {
+                    String cvref = StringManager::convert(cvp1->getAttribute(CONST_XMLCH("cvRef")));
+                    if (cvref == "UNIMOD" || cvref == "XLMOD")
+                    {
+                      xl_mod_name = StringManager::convert(cvp1->getAttribute(CONST_XMLCH("name")));
+                      break;
+                    }
+                    cvp1 = cvp1->getNextElementSibling();
+                  }
+                  if (xl_mod_name.empty())
+                  {
+                    // fallback
+                    xl_mod_name = StringManager::convert(element_sib->getFirstElementChild()->getAttribute(CONST_XMLCH("name")));
+                  }
                   xl_mod_map_.insert(make_pair(pep_id, xl_mod_name));
                   donor_acceptor_found = true;
                 }

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -1696,6 +1696,14 @@ namespace OpenMS::Internal
       // Generate and fill PeptideIdentification
       // RTs is now collected one entry per SII (see loop above), so it stays aligned with exp_mzs/peptides.
 
+      // Guard against a SpectrumIdentificationResult without any SpectrumIdentificationItems: the
+      // min/max_element and light[0]/heavy[0] accesses below assume at least one experimental m/z.
+      if (exp_mzs.empty())
+      {
+        OPENMS_LOG_WARN << "SpectrumIdentificationResult '" << spectrumID << "' has no SpectrumIdentificationItems; skipping." << endl;
+        return;
+      }
+
       vector<String> spectrumIDs;
       spectrumID.split(",", spectrumIDs);
 

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -1541,14 +1541,14 @@ namespace OpenMS::Internal
         MetaInfoInterface copy_hit = hit;
         String st(it->getScoreType()); //scoretype
 
-        if (cv_.hasTermWithName(st))
+        // Only consume the score type here if it maps to a PSM-level search-engine statistic (MS:1001143 subtree).
+        // Otherwise fall through to the dedicated alias branches below (e.g. Mascot/OMSSA), which would
+        // otherwise be unreachable for score types that happen to be valid (non-score) PSI-MS term names.
+        if (const auto* term = cv_.checkAndGetTermByName(st);
+            term != nullptr && peptide_result_details_.find(term->id) != peptide_result_details_.end())
         {
-          const auto& term = cv_.getTermByName(st);
-          if (peptide_result_details_.find(term.id) != peptide_result_details_.end())
-          {
-            (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);
-            copy_hit.removeMetaValue(term.id);
-          }
+          (sii_tmp += "\t\t\t\t\t") += term->toXMLString(cv_ns, sc);
+          copy_hit.removeMetaValue(term->id);
         }
         else if (cv_.exists(st) && peptide_result_details_.find(st) != peptide_result_details_.end())
         {
@@ -2187,14 +2187,13 @@ namespace OpenMS::Internal
       MetaInfoInterface copy_hit = hit;
       String st(it->getScoreType()); //scoretype
 
-      if (cv_.hasTermWithName(st))
+      // Only consume the score type here if it maps to a PSM-level search-engine statistic (MS:1001143 subtree);
+      // otherwise fall through to the dedicated alias branches below.
+      if (const auto* term = cv_.checkAndGetTermByName(st);
+          term != nullptr && peptide_result_details_.find(term->id) != peptide_result_details_.end())
       {
-        const auto& term = cv_.getTermByName(st);
-        if (peptide_result_details_.find(term.id) != peptide_result_details_.end())
-        {
-          (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);
-          copy_hit.removeMetaValue(term.id);
-        }
+        (sii_tmp += "\t\t\t\t\t") += term->toXMLString(cv_ns, sc);
+        copy_hit.removeMetaValue(term->id);
       }
       else if (cv_.exists(st) && peptide_result_details_.find(st) != peptide_result_details_.end())
       {

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -880,7 +880,9 @@ namespace OpenMS::Internal
         if (is_ppxl)
         {
           ProteinIdentification::SearchParameters search_params = cpro_id_->front().getSearchParameters();
-          ppxl_crosslink_mass = String(search_params.getMetaValue("cross_link:mass")).toDouble();
+          // use a default so a missing/empty cross_link:mass meta value does not throw a ConversionError
+          // (e.g. on a store after a load where the search parameter was not preserved)
+          ppxl_crosslink_mass = String(search_params.getMetaValue("cross_link:mass", "0")).toDouble();
         }
 
         for (std::vector<PeptideHit>::const_iterator jt = it->getHits().begin(); jt != it->getHits().end(); ++jt)
@@ -2282,7 +2284,8 @@ namespace OpenMS::Internal
         sii_tmp = sii_tmp.substitute("value=\"" + ert, "value=\"" + String(hit.getMetaValue(Constants::UserParam::OPENPEPXL_HEAVY_SPEC_RT)));
 
         ProteinIdentification::SearchParameters search_params = cpro_id_->front().getSearchParameters();
-        double iso_shift = String(search_params.getMetaValue("cross_link:mass_isoshift")).toDouble();
+        // default avoids a ConversionError when the isoshift meta value is absent/empty
+        double iso_shift = String(search_params.getMetaValue("cross_link:mass_isoshift", "0")).toDouble();
         double cmz_heavy = cmz.toDouble() + (iso_shift / hit.getCharge());
 
         sii_tmp = sii_tmp.substitute(String("calculatedMassToCharge=\"") + String(cmz),

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -198,11 +198,7 @@ namespace OpenMS::Internal
       cpro_id_(&pro_id),
       cpep_id_(&pep_id)
     {
-      cv_.loadFromOBO("PSI-MS", File::find("/CV/psi-ms.obo"));
-      unimod_.loadFromOBO("PSI-MS", File::find("/CV/unimod.obo"));
-      // descendants only: the parent term MS:1001143 ("PSM-level search engine specific statistic")
-      // is non-numeric and must not be serialized as a scored cvParam (it is handled via the userParam fallback)
-      cv_.getAllChildTerms(peptide_result_details_, "MS:1001143");
+      initCvCaches_();
     }
 
     MzIdentMLHandler::MzIdentMLHandler(std::vector<ProteinIdentification>& pro_id, PeptideIdentificationList& pep_id, const String& filename, const String& version, const ProgressLogger& logger) :
@@ -213,6 +209,11 @@ namespace OpenMS::Internal
       pep_id_(&pep_id),
       cpro_id_(nullptr),
       cpep_id_(nullptr)
+    {
+      initCvCaches_();
+    }
+
+    void MzIdentMLHandler::initCvCaches_()
     {
       cv_.loadFromOBO("PSI-MS", File::find("/CV/psi-ms.obo"));
       unimod_.loadFromOBO("PSI-MS", File::find("/CV/unimod.obo"));
@@ -965,7 +966,8 @@ namespace OpenMS::Internal
       // XML header
       //--------------------------------------------------------------------------------------------
       String v_s = "1.3.0";
-      String v_short = v_s.substr(0, v_s.size() - 2);
+      // namespace uses only major.minor (e.g. "1.3" from "1.3.0"); derive it by dropping the patch component
+      String v_short = v_s.prefix(v_s.rfind('.'));
       os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
          << "<MzIdentML xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
          << "\txsi:schemaLocation=\"http://psidev.info/psi/pi/mzIdentML/" << v_short << " "

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -200,6 +200,7 @@ namespace OpenMS::Internal
     {
       cv_.loadFromOBO("PSI-MS", File::find("/CV/psi-ms.obo"));
       unimod_.loadFromOBO("PSI-MS", File::find("/CV/unimod.obo"));
+      cv_.addAllChildTerms(peptide_result_details_, "MS:1001143");
     }
 
     MzIdentMLHandler::MzIdentMLHandler(std::vector<ProteinIdentification>& pro_id, PeptideIdentificationList& pep_id, const String& filename, const String& version, const ProgressLogger& logger) :
@@ -213,6 +214,7 @@ namespace OpenMS::Internal
     {
       cv_.loadFromOBO("PSI-MS", File::find("/CV/psi-ms.obo"));
       unimod_.loadFromOBO("PSI-MS", File::find("/CV/unimod.obo"));
+      cv_.addAllChildTerms(peptide_result_details_, "MS:1001143");
     }
 
     //~ TODO create MzIdentML instances from MSExperiment which contains much of the information yet needed
@@ -956,16 +958,13 @@ namespace OpenMS::Internal
       //--------------------------------------------------------------------------------------------
       // XML header
       //--------------------------------------------------------------------------------------------
-      String v_s = "1.1.0";
-      if (is_ppxl)
-      {
-         v_s = "1.2.0";
-      }
+      String v_s = "1.3.0";
+      String v_short = v_s.substr(0, v_s.size() - 2);
       os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
          << "<MzIdentML xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
-         << "\txsi:schemaLocation=\"http://psidev.info/psi/pi/mzIdentML/"<< v_s.substr(0,v_s.size()-2) <<" "
-         << "https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML"<< v_s <<".xsd\"\n"
-         << "\txmlns=\"http://psidev.info/psi/pi/mzIdentML/"<< v_s.substr(0,v_s.size()-2) <<"\"\n"
+         << "\txsi:schemaLocation=\"http://psidev.info/psi/pi/mzIdentML/" << v_short << " "
+         << "https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML" << v_s << ".xsd\"\n"
+         << "\txmlns=\"http://psidev.info/psi/pi/mzIdentML/" << v_short << "\"\n"
          << "\tversion=\"" << v_s << "\"\n";
       os << "\tid=\"OpenMS_" << String(UniqueIdGenerator::getUniqueId()) << "\"\n"
          << "\tcreationDate=\"" << DateTime::now().getDate() << "T" << DateTime::now().getTime() << "\">\n";
@@ -1230,28 +1229,26 @@ namespace OpenMS::Internal
         {
           lt += " - "+loss;
         }
-        if (annotation_map.find(pep.charge) == annotation_map.end())
+        auto& charge_map = annotation_map[pep.charge];
+        auto& lt_vec = charge_map[lt];
+        if (lt_vec.empty())
         {
-          annotation_map[pep.charge] = std::map<String, std::vector<StringList> >();
-        }
-        if (annotation_map[pep.charge].find(lt) == annotation_map[pep.charge].end())
-        {
-          annotation_map[pep.charge][lt] = std::vector<StringList> (3);
+          lt_vec.resize(3);
           if (is_ppxl)
           {
-            annotation_map[pep.charge][lt].emplace_back();  // alpha|beta
-            annotation_map[pep.charge][lt].emplace_back();  // ci|xi
+            lt_vec.push_back(StringList());
+            lt_vec.push_back(StringList());
           }
         }
-        annotation_map[pep.charge][lt][0].push_back(ionseries_index);
-        annotation_map[pep.charge][lt][1].emplace_back(pep.mz);
-        annotation_map[pep.charge][lt][2].emplace_back(pep.intensity);
+        lt_vec[0].push_back(ionseries_index);
+        lt_vec[1].emplace_back(pep.mz);
+        lt_vec[2].emplace_back(pep.intensity);
         if (is_ppxl)
         {
           String ab = ListUtils::contains<String>(extra ,String("alpha")) ? String("alpha"):String("beta");
           String cx = ListUtils::contains<String>(extra ,String("ci")) ? String("ci"):String("xi");
-          annotation_map[pep.charge][lt][3].push_back(ab);
-          annotation_map[pep.charge][lt][4].push_back(cx);
+          lt_vec[3].push_back(ab);
+          lt_vec[4].push_back(cx);
         }
       }
 
@@ -1501,15 +1498,19 @@ namespace OpenMS::Internal
         {
           pte = boost::lexical_cast<std::string>(hit.getMetaValue("pass_threshold"));
         }
-        else if (pp_identifier_2_thresh.find(it->getIdentifier())!= pp_identifier_2_thresh.end() && pp_identifier_2_thresh.find(it->getIdentifier())->second != 0.0)
-        {
-          double th = pp_identifier_2_thresh.find(it->getIdentifier())->second;
-          //threshold was 'set' in proteinIdentification (!= default value of member, now check pass
-          pte = boost::lexical_cast<std::string>(it->isHigherScoreBetter() ? hit.getScore() > th : hit.getScore() < th); //passThreshold-eval
-        }
         else
         {
-          pte = true;
+          auto thresh_it = pp_identifier_2_thresh.find(it->getIdentifier());
+          if (thresh_it != pp_identifier_2_thresh.end() && thresh_it->second != 0.0)
+          {
+            double th = thresh_it->second;
+            //threshold was 'set' in proteinIdentification (!= default value of member, now check pass
+            pte = boost::lexical_cast<std::string>(it->isHigherScoreBetter() ? hit.getScore() > th : hit.getScore() < th); //passThreshold-eval
+          }
+          else
+          {
+            pte = true;
+          }
         }
 
         //write SpectrumIdentificationItem elements
@@ -1537,60 +1538,71 @@ namespace OpenMS::Internal
           writeFragmentAnnotations_(sii_tmp, hit.getPeakAnnotations(), 5, false);
         }
 
-        std::set<String> peptide_result_details;
-        cv_.getAllChildTerms(peptide_result_details, "MS:1001143"); // search engine specific score for PSMs
         MetaInfoInterface copy_hit = hit;
         String st(it->getScoreType()); //scoretype
 
-        if (cv_.hasTermWithName(st) && peptide_result_details.find(cv_.getTermByName(st).id) != peptide_result_details.end())
+        if (cv_.hasTermWithName(st))
         {
-          sii_tmp +=  "\t\t\t\t\t" + cv_.getTermByName(st).toXMLString(cv_ns, sc);
-          copy_hit.removeMetaValue(cv_.getTermByName(st).id);
+          const auto& term = cv_.getTermByName(st);
+          if (peptide_result_details_.find(term.id) != peptide_result_details_.end())
+          {
+            (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);
+            copy_hit.removeMetaValue(term.id);
+          }
         }
-        else if (cv_.exists(st) && peptide_result_details.find(st) != peptide_result_details.end())
+        else if (cv_.exists(st) && peptide_result_details_.find(st) != peptide_result_details_.end())
         {
-          sii_tmp +=  "\t\t\t\t\t" + cv_.getTerm(st).toXMLString(cv_ns, sc);
-          copy_hit.removeMetaValue(cv_.getTerm(st).id);
+          const auto& term = cv_.getTerm(st);
+          (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);
+          copy_hit.removeMetaValue(term.id);
         }
         else if (st == "q-value" || st == "FDR")
         {
-          sii_tmp +=  "\t\t\t\t\t" + cv_.getTermByName("PSM-level q-value").toXMLString(cv_ns, sc);
-          copy_hit.removeMetaValue(cv_.getTermByName("PSM-level q-value").id);
+          const auto& term = cv_.getTermByName("PSM-level q-value");
+          (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);
+          copy_hit.removeMetaValue(term.id);
         }
         else if (st == "Posterior Error Probability")
         {
-          sii_tmp +=  "\t\t\t\t\t" + cv_.getTermByName("percolator:PEP").toXMLString(cv_ns, sc); // 'percolaror' was not a typo in the code but in the cv.
-          copy_hit.removeMetaValue(cv_.getTermByName("percolator:PEP").id);
+          const auto& term = cv_.getTermByName("percolator:PEP"); // 'percolaror' was not a typo in the code but in the cv.
+          (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);
+          copy_hit.removeMetaValue(term.id);
         }
         else if (st == "OMSSA")
         {
-          sii_tmp +=  "\t\t\t\t\t" + cv_.getTermByName("OMSSA:evalue").toXMLString(cv_ns, sc);
-          copy_hit.removeMetaValue(cv_.getTermByName("OMSSA:evalue").id);
+          const auto& term = cv_.getTermByName("OMSSA:evalue");
+          (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);
+          copy_hit.removeMetaValue(term.id);
         }
         else if (st == "Mascot")
         {
-          sii_tmp +=  "\t\t\t\t\t" + cv_.getTermByName("Mascot:score").toXMLString(cv_ns, sc);
-          copy_hit.removeMetaValue(cv_.getTermByName("Mascot:score").id);
+          const auto& term = cv_.getTermByName("Mascot:score");
+          (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);
+          copy_hit.removeMetaValue(term.id);
         }
         else if (st == "XTandem")
         {
-          sii_tmp +=  "\t\t\t\t\t" + cv_.getTermByName("X\\!Tandem:hyperscore").toXMLString(cv_ns, sc);
-          copy_hit.removeMetaValue(cv_.getTermByName("X\\!Tandem:hyperscore").id);
+          const auto& term = cv_.getTermByName("X\\!Tandem:hyperscore");
+          (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);
+          copy_hit.removeMetaValue(term.id);
         }
         else if (st == "SEQUEST")
         {
-          sii_tmp +=  "\t\t\t\t\t" + cv_.getTermByName("Sequest:xcorr").toXMLString(cv_ns, sc);
-          copy_hit.removeMetaValue(cv_.getTermByName("Sequest:xcorr").id);
+          const auto& term = cv_.getTermByName("Sequest:xcorr");
+          (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);
+          copy_hit.removeMetaValue(term.id);
         }
         else if (st == "MS-GF+")
         {
-          sii_tmp +=  "\t\t\t\t\t" + cv_.getTermByName("MS-GF:RawScore").toXMLString(cv_ns, sc);
-          copy_hit.removeMetaValue(cv_.getTermByName("MS-GF:RawScore").id);
+          const auto& term = cv_.getTermByName("MS-GF:RawScore");
+          (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);
+          copy_hit.removeMetaValue(term.id);
         }
         else if (st == Constants::UserParam::OPENPEPXL_SCORE)
         {
-          sii_tmp +=  "\t\t\t\t\t" + cv_.getTermByName(st).toXMLString(cv_ns, sc);
-          copy_hit.removeMetaValue(cv_.getTermByName(st).id);
+          const auto& term = cv_.getTermByName(st);
+          (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);
+          copy_hit.removeMetaValue(term.id);
         }
         else
         {
@@ -2131,15 +2143,19 @@ namespace OpenMS::Internal
       {
         pte = boost::lexical_cast<std::string>(hit.getMetaValue("pass_threshold"));
       }
-      else if (pp_identifier_2_thresh.find(it->getIdentifier())!= pp_identifier_2_thresh.end() && pp_identifier_2_thresh.find(it->getIdentifier())->second != 0.0)
-      {
-        double th = pp_identifier_2_thresh.find(it->getIdentifier())->second;
-        //threshold was 'set' in proteinIdentification (!= default value of member, now check pass
-        pte = boost::lexical_cast<std::string>(it->isHigherScoreBetter() ? hit.getScore() > th : hit.getScore() < th); //passThreshold-eval
-      }
       else
       {
-        pte = true;
+        auto thresh_it = pp_identifier_2_thresh.find(it->getIdentifier());
+        if (thresh_it != pp_identifier_2_thresh.end() && thresh_it->second != 0.0)
+        {
+          double th = thresh_it->second;
+          //threshold was 'set' in proteinIdentification (!= default value of member, now check pass
+          pte = boost::lexical_cast<std::string>(it->isHigherScoreBetter() ? hit.getScore() > th : hit.getScore() < th); //passThreshold-eval
+        }
+        else
+        {
+          pte = true;
+        }
       }
 
       //write SpectrumIdentificationItem elements
@@ -2168,35 +2184,41 @@ namespace OpenMS::Internal
         writeFragmentAnnotations_(sii_tmp, hit.getPeakAnnotations(), 5, true);
       }
 
-      std::set<String> peptide_result_details;
-      cv_.getAllChildTerms(peptide_result_details, "MS:1001143"); // search engine specific score for PSMs
       MetaInfoInterface copy_hit = hit;
       String st(it->getScoreType()); //scoretype
 
-      if (cv_.hasTermWithName(st) && peptide_result_details.find(cv_.getTermByName(st).id) != peptide_result_details.end())
+      if (cv_.hasTermWithName(st))
       {
-        sii_tmp +=  "\t\t\t\t\t" + cv_.getTermByName(st).toXMLString(cv_ns, sc);
-        copy_hit.removeMetaValue(cv_.getTermByName(st).id);
+        const auto& term = cv_.getTermByName(st);
+        if (peptide_result_details_.find(term.id) != peptide_result_details_.end())
+        {
+          (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);
+          copy_hit.removeMetaValue(term.id);
+        }
       }
-      else if (cv_.exists(st) && peptide_result_details.find(st) != peptide_result_details.end())
+      else if (cv_.exists(st) && peptide_result_details_.find(st) != peptide_result_details_.end())
       {
-        sii_tmp +=  "\t\t\t\t\t" + cv_.getTerm(st).toXMLString(cv_ns, sc);
-        copy_hit.removeMetaValue(cv_.getTerm(st).id);
+        const auto& term = cv_.getTerm(st);
+        (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);
+        copy_hit.removeMetaValue(term.id);
       }
       else if (st == "q-value" || st == "FDR")
       {
-        sii_tmp +=  "\t\t\t\t\t" + cv_.getTermByName("PSM-level q-value").toXMLString(cv_ns, sc);
-        copy_hit.removeMetaValue(cv_.getTermByName("PSM-level q-value").id);
+        const auto& term = cv_.getTermByName("PSM-level q-value");
+        (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);
+        copy_hit.removeMetaValue(term.id);
       }
       else if (st == "Posterior Error Probability")
       {
-        sii_tmp +=  "\t\t\t\t\t" + cv_.getTermByName("percolator:PEP").toXMLString(cv_ns, sc); // 'percolaror' was not a typo in the code but in the cv.
-        copy_hit.removeMetaValue(cv_.getTermByName("percolator:PEP").id);
+        const auto& term = cv_.getTermByName("percolator:PEP"); // 'percolaror' was not a typo in the code but in the cv.
+        (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);
+        copy_hit.removeMetaValue(term.id);
       }
       else if (st == Constants::UserParam::OPENPEPXL_SCORE)
       {
-        sii_tmp +=  "\t\t\t\t\t" + cv_.getTermByName(st).toXMLString(cv_ns, sc);
-        copy_hit.removeMetaValue(cv_.getTermByName(st).id);
+        const auto& term = cv_.getTermByName(st);
+        (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);
+        copy_hit.removeMetaValue(term.id);
       }
       else
       {

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -200,7 +200,9 @@ namespace OpenMS::Internal
     {
       cv_.loadFromOBO("PSI-MS", File::find("/CV/psi-ms.obo"));
       unimod_.loadFromOBO("PSI-MS", File::find("/CV/unimod.obo"));
-      cv_.addAllChildTerms(peptide_result_details_, "MS:1001143");
+      // descendants only: the parent term MS:1001143 ("PSM-level search engine specific statistic")
+      // is non-numeric and must not be serialized as a scored cvParam (it is handled via the userParam fallback)
+      cv_.getAllChildTerms(peptide_result_details_, "MS:1001143");
     }
 
     MzIdentMLHandler::MzIdentMLHandler(std::vector<ProteinIdentification>& pro_id, PeptideIdentificationList& pep_id, const String& filename, const String& version, const ProgressLogger& logger) :
@@ -214,7 +216,9 @@ namespace OpenMS::Internal
     {
       cv_.loadFromOBO("PSI-MS", File::find("/CV/psi-ms.obo"));
       unimod_.loadFromOBO("PSI-MS", File::find("/CV/unimod.obo"));
-      cv_.addAllChildTerms(peptide_result_details_, "MS:1001143");
+      // descendants only: the parent term MS:1001143 ("PSM-level search engine specific statistic")
+      // is non-numeric and must not be serialized as a scored cvParam (it is handled via the userParam fallback)
+      cv_.getAllChildTerms(peptide_result_details_, "MS:1001143");
     }
 
     //~ TODO create MzIdentML instances from MSExperiment which contains much of the information yet needed

--- a/src/openms/source/FORMAT/MzIdentMLFile.cpp
+++ b/src/openms/source/FORMAT/MzIdentMLFile.cpp
@@ -21,7 +21,7 @@ namespace OpenMS
 {
 
   MzIdentMLFile::MzIdentMLFile() :
-    XMLFile("/SCHEMAS/mzIdentML1.1.0.xsd", "1.1.0")
+    XMLFile("/SCHEMAS/mzIdentML1.3.0.xsd", "1.3.0")
   {
   }
 

--- a/src/openms/source/FORMAT/MzIdentMLFile.cpp
+++ b/src/openms/source/FORMAT/MzIdentMLFile.cpp
@@ -14,6 +14,8 @@
 #include <OpenMS/FORMAT/CVMappingFile.h>
 #include <OpenMS/FORMAT/HANDLERS/MzIdentMLHandler.h>
 #include <OpenMS/FORMAT/HANDLERS/MzIdentMLDOMHandler.h>
+#include <OpenMS/FORMAT/TextFile.h>
+#include <OpenMS/FORMAT/VALIDATORS/XMLValidator.h>
 #include <OpenMS/SYSTEM/File.h>
 
 
@@ -44,6 +46,54 @@ namespace OpenMS
     save_(filename, &handler);
 //    Internal::MzIdentMLDOMHandler handler(poid, peid, schema_version_, *this);
 //    handler.writeMzIdentMLFile(filename);
+  }
+
+  String MzIdentMLFile::detectVersion(const String& filename) const
+  {
+    // Read the first few lines of the header and look for the mzIdentML version. The version is
+    // declared both as a 'version="x.y.z"' attribute on the <MzIdentML> root and in the target
+    // namespace ('.../mzIdentML/x.y'). We prefer the explicit version attribute and fall back to
+    // the namespace; if neither maps to a bundled schema we keep the adapter default (1.3.0).
+    TextFile file(filename, true, 15);
+    String header;
+    header.concatenate(file.begin(), file.end(), " ");
+
+    // candidate versions we ship schemas for, newest first
+    static const std::vector<String> known_versions = {"1.3.0", "1.2.0", "1.1.0", "1.0.0"};
+
+    // 1) explicit version attribute, e.g. version="1.1.0"
+    for (const String& v : known_versions)
+    {
+      if (header.hasSubstring(String("version=\"") + v + "\""))
+      {
+        return v;
+      }
+    }
+    // 2) target namespace, e.g. http://psidev.info/psi/pi/mzIdentML/1.1
+    for (const String& v : known_versions)
+    {
+      // namespace carries only major.minor (e.g. "1.1"), so match on that prefix
+      String ns_version = v.prefix(v.rfind('.')); // "1.1.0" -> "1.1"
+      if (header.hasSubstring(String("mzIdentML/") + ns_version))
+      {
+        return v;
+      }
+    }
+    // 3) fall back to the adapter default
+    return schema_version_;
+  }
+
+  bool MzIdentMLFile::isValid(const String& filename, std::ostream& os, String& used_version)
+  {
+    used_version = detectVersion(filename);
+    // map the detected version to its schema; fall back to the default schema if not bundled
+    String schema = "/SCHEMAS/mzIdentML" + used_version + ".xsd";
+    if (!File::exists(File::getOpenMSDataPath() + schema))
+    {
+      schema = schema_location_;
+      used_version = schema_version_;
+    }
+    return XMLValidator().isValid(filename, File::find(schema), os);
   }
 
   bool MzIdentMLFile::isSemanticallyValid(const String& filename, StringList& errors, StringList& warnings)

--- a/src/tests/class_tests/openms/data/MzIdentML_v1.3_crosslinking.mzid
+++ b/src/tests/class_tests/openms/data/MzIdentML_v1.3_crosslinking.mzid
@@ -1,0 +1,480 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MzIdentML id="12345" version="1.3.0" xmlns="http://psidev.info/psi/pi/mzIdentML/1.3"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.3 http://www.psidev.info/files/mzIdentML1.3.0.xsd"
+           creationDate="2023-02-02T11:55:34">
+    <cvList>
+        <cv fullName="PSI-MS" version="4.0.0"
+            uri="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo" id="PSI-MS"/>
+        <cv fullName="XLMOD" uri="resource:///XLMOD.obo" id="XLMOD"/>
+        <cv fullName="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo" id="UNIMOD"/>
+        <cv fullName="UNIT-ONTOLOGY"
+            uri="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo" id="UO"/>
+    </cvList>
+    <cvParam cvRef="PSI-MS" accession="MS:1003385" name="mzIdentML crosslinking extension document version"
+             value="1.0.0"/>
+    <AnalysisSoftwareList>
+        <AnalysisSoftware id="xi_id" name="xi">
+            <SoftwareName>
+                <cvParam cvRef="PSI-MS" accession="MS:1002544" name="xi"/>
+            </SoftwareName>
+        </AnalysisSoftware>
+        <AnalysisSoftware version="2.2.beta6" id="xiFDR_id" name="XiFDR">
+            <SoftwareName>
+                <cvParam cvRef="PSI-MS" accession="MS:1002543" name="xiFDR"/>
+            </SoftwareName>
+        </AnalysisSoftware>
+    </AnalysisSoftwareList>
+    <Provider id="PROVIDER">
+        <ContactRole contact_ref="PERSON_DOC_OWNER">
+            <Role>
+                <cvParam cvRef="PSI-MS" accession="MS:1001271" name="researcher"/>
+            </Role>
+        </ContactRole>
+    </Provider>
+    <AuditCollection>
+        <Person lastName="Fischer" firstName="Lutz" id="PERSON_DOC_OWNER">
+            <cvParam cvRef="PSI-MS" accession="MS:1000587" name="contact address" value="TIB Gebäude 17,
+Etage 4, Raum 474
+Gustav-Meyer-Allee 25
+13355 Berlin"/>
+            <cvParam cvRef="PSI-MS" accession="MS:1000589" name="contact email" value="lutz.fischer@tu-berlin.de"/>
+            <Affiliation organization_ref="ORG_DOC_OWNER"/>
+        </Person>
+        <Organization id="ORG_DOC_OWNER" name="TU Berlin">
+            <cvParam cvRef="PSI-MS" accession="MS:1000586" name="contact name" value="TU Berlin"/>
+        </Organization>
+    </AuditCollection>
+    <SequenceCollection>
+        <DBSequence length="1338" searchDatabase_ref="SDB_17022_2120" accession="ggFANCI" id="dbseq_ggFANCI_target"
+                    name=" ggFANCI">
+            <Seq>MAQRILQLAAEGSPERLQEALQGLTEGELGDMVTRQALRGRETAALLKGIFKGSPCSQQSGVLRRLQVYKHCVSLVESGDLHVGKVSEIIGLLMLEARQLPGHALAELATLFVEVIKRGSLSNGKSLELFSTVLTALSNSKESLAYGKGELNGEEFKKQLINTLCSSKWDPQCVIHLANMFRDIPLSGEELQFVVEKVLRMFSKLDLQEIPPLVYQLLLLSAKGSKKTVLEGIISFFNQLDKRQKEEQRVPQSADLEVATVPLDQLRHVEGTVILHIVSAINLDQDIGEELIKHLKTEQQKDPGKALCPFSVSLLLSTAVKHRLQEQIFDFLKTSITRSCKDLQILQASKFLQDLCPQQYDVTAVILEVVKNSAFGWDHVTQGLVDLGFSLMESYEPKKSFGGKAAETNLGLSKMPAQQACKLGASILLETFKVHEPIRSDILEQVLNRVLTKAASPVSHFIDLLSNIVVSAPLVLQNSSSRVTETFDNLSFLPIDTVQGLLRAVQPLLKVSMSVRDSLILVLQKAIFSRQLDARKAAVAGFLLLLRNFKILGSLTSSQCSQAIGATQVQADVHACYNSAANEAFCLEILGSLRRCLSQQADVRLMLYEGFYDVLRRNSQLASSIMETLLSQIKQYYLPQQDLLPPLKLEGCIMAQGDQIFLQEPLAHLLCCIQHCLAWYKSTVHLCKGAEDEEEEEDVGFEQNFEEMLESVTRRMIKSELEDFELDKSADFSPSSGVGVKNNIYAIQVMGICEVLIEYNFKIGNFSKNKFEDVLGLFTCYNKLSEILKEKAGKNKSTLGNRIARSFLSMGFVSTLLTALFRDNAQSHEESLAVLRSSTEFMRYAVSVALQKVQQLEEMGQTDGPDGQNPEKMFQNLCKITRVLLWRYTSIPTAVEESGKKKGKSISLLCLEGLLRIFNTMQQLYAARIPQFLQALDITDGDAEEADINVTEKAAFQIRQFQRSLVNQLSSAEDDFNSKETQLLITILSTLSKLLDPGSQQFLQFLTWTVKICKENALEDLSCCKGLLTLLFSLHVLYKSPVSLLRELAQDIHACLGDIDQDVEIESRSHFAIVNVKTAAPTVCLLVLGQADKVLEEVDWLIKRLTILGSDTSEDSTQASNQTQALEKGVILQLGTLLTVFHELVQTALPAGSCVDSLLRSLSKTYAILTSLIKHYIQACRSTSNTVPGRLEKLVKLSGSHLTPQCYSFITYVQNIHSESLSFAEEKKKKKKEDETAVVSTVMAKVLRDTKPIPNLIFAIEQYEKFLIHLSKKSKVNLMQYMKLSTSRDFRINASMLDSVLQEQNTEDAENEPDNNQSGTAEQPDENQEPQKKRRRKK</Seq>
+            <cvParam cvRef="PSI-MS" accession="MS:1001088" name="protein description" value=" ggFANCI"/>
+        </DBSequence>
+        <DBSequence length="1439" searchDatabase_ref="SDB_17022_2120" accession="ggFANCD2" id="dbseq_ggFANCD2_target"
+                    name=" ggFANCD2">
+            <Seq>MVSKRKLSKIDAAEESSKTDLQSRCPETKRSRISDKRAPSQGGLENEGVFEELLRTSGIILKVGEGQNEIAVDQTAFQKKLRVALEKHPSYPGVVNEFISGLESHIKDRSQFKNCLLPCTPARTEGSRTLVHSYCESLIKLLLGIKILQPAVVTLLLEKIPEFFFDVVGTFGTNFPRLIVNQFKWLDGLLDSQDLVKKLMQMLSVSPVPIQHDIITSLPEILEDSQQNEVARELSCLLKQGRRLTVPILDALSRLDLDAELLAKVRQSAMTIVPSVKLEDLPVVIKFILHNVKAADAVEVISDLRKSLDLSSCVLPLQLLGSQRKLKSQAQASSSMSQVTTSQNCVKLLFDVIKLAVRFQKDVSEAWIKAIENSTSVSDHKVLDLIVLLLIHSTNSKNRKQTEKVLRSKIRLGCMPEQLMQNAFQNHSMVIKDFFPSILSLAQTFLHSAHPAVVSFGSCMYKQAFAVFDSYCQQEVVCALVTHVCSGNETELDISLDVLTDLVILHPSLLLRYATFVKTILDSMQKLNPCQIRKLFYILSTLAFSQRQEGSYIQDDMHMVIRKWLSSSVPNHKQMGIIGAVTMMGSVALKRNEADGGLLERPELSIECDGQLSTLLDLVGFCCEQTPEVLALYYDELANLIEKQKGNLDLQLLDKFGKSLVEDFPNDFVVDLSPTVDGSFLFPVKSLYNLDEDETQGAIAINLLPLVSQSEPGRVADEMSNSRKRVVSPICLSPCFRLLRLYTGEQNNGSLEEIDALLGCPLYLTDLEVEGKLDSLSKQEREFLCSLLFYALNWFREVVNAFCQQQDAEMKGKVLTRLQNITELQNVLGKCLAATPGYVPPPATFDSEAPEGVPSINAGGPVRKKNGKKRKSDSSKACSAERTQADESSDGNQPDTELSELEKSAAEKETGNPLAQLQSYRPYFRELDLEVFSVLHCGLLTKSILDTEMHTEASEVVQLGPAELCFLLDDMCWKLEHVLTPGSTRRVPFLKERGNKDVGFSHLCQRSPKEVAVCVVKLLKPLCNHMENMHNYFQTVIPNQGVVDESGLNIQEYQLMSSCYHQLLLAFRLLFAWSGFSQHENSNLLRSALQVLADRLKPGETEFLPLEELISESFQYLLNFQASIPSFQCAFILTQVLMAISEKPMTGWKREKMASLAKQFLCQSWMKPGGDREKGSHFNSALHTLLCVYLEHTDNILKAIEEISSVGVPELINSAKDGCSSTYPTLSRQTFPVFFRVMMAQLESSVKSIPAGKPSDSGEVQLEKLLKWNIAVRNFHILINLVKVFDSRPVLSICLKYGRLFVEAFLKLAMPLLDHSFKKHRDDVQSLLKTLQLSTRQLHHMCGHSKIHQDLGLTNHVPLLKKSLEQFVYRVKAMLAFNHCQEAFWVGVLKNRDLQGEEILSQASAAPEEDSAEGSEEDTEDSAAEEPDGTDSDSGGAGR</Seq>
+            <cvParam cvRef="PSI-MS" accession="MS:1001088" name="protein description" value=" ggFANCD2"/>
+        </DBSequence>
+        <Peptide id="16734061838_ISDKRAPSQGGLENEGVFEELLR_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_4_9_p1">
+            <PeptideSequence>GAEDEEEEEDVGFEQNFEEMLESVTR</PeptideSequence>
+            <Modification location="9" monoisotopicMassDelta="0.0">
+                <cvParam cvRef="PSI-MS" accession="MS:1003393" name="search modification id ref"
+                         value="SDA_crosslink_acceptor"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink acceptor" value="1"/>
+            </Modification>
+        </Peptide>
+        <Peptide id="16734061838_ISDKRAPSQGGLENEGVFEELLR_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_4_9_p0">
+            <PeptideSequence>ISDKRAPSQGGLENEGVFEELLR</PeptideSequence>
+            <Modification location="4" monoisotopicMassDelta="82.04186">
+                <cvParam cvRef="PSI-MS" accession="MS:1003393" name="search modification id ref"
+                         value="SDA_crosslink_donor"/>
+                <cvParam accession="UNIMOD:2000" name="Xlink:SDA" cvRef="UNIMOD"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1002509" name="crosslink donor" value="1"/>
+            </Modification>
+        </Peptide>
+        <Peptide id="16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_16734057553_SCcmKDLQILQASK_18_1_p1">
+            <PeptideSequence>SCKDLQILQASK</PeptideSequence>
+            <Modification location="2" residues="C" monoisotopicMassDelta="57.02147">
+                <cvParam cvRef="PSI-MS" accession="MS:1003393" name="search modification id ref" value="cm"/>
+                <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+            </Modification>
+            <Modification location="1" monoisotopicMassDelta="0.0">
+                <cvParam cvRef="PSI-MS" accession="MS:1003393" name="search modification id ref"
+                         value="SDA_crosslink_acceptor"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink acceptor" value="2"/>
+            </Modification>
+        </Peptide>
+        <Peptide id="16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_16734057553_SCcmKDLQILQASK_18_1_p0">
+            <PeptideSequence>TAAPTVCLLVLGQADKVLEEVDWLIKR</PeptideSequence>
+            <Modification location="7" residues="C" monoisotopicMassDelta="57.02147">
+                <cvParam cvRef="PSI-MS" accession="MS:1003393" name="search modification id ref" value="cm"/>
+                <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+            </Modification>
+            <Modification location="18" monoisotopicMassDelta="82.04186">
+                <cvParam cvRef="PSI-MS" accession="MS:1003393" name="search modification id ref"
+                         value="SDA_crosslink_donor"/>
+                <cvParam accession="UNIMOD:2000" name="Xlink:SDA" cvRef="UNIMOD"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1002509" name="crosslink donor" value="2"/>
+            </Modification>
+        </Peptide>
+        <PeptideEvidence dBSequence_ref="dbseq_ggFANCI_target"
+                         peptide_ref="16734061838_ISDKRAPSQGGLENEGVFEELLR_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_4_9_p1"
+                         start="689" end="714" isDecoy="false"
+                         id="pepevid_pep_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_protggFANCI_target_689_pepkey_1_16734061838_ISDKRAPSQGGLENEGVFEELLR_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_4_9_p0_16734061838_ISDKRAPSQGGLENEGVFEELLR_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_4_9_p1"/>
+        <PeptideEvidence dBSequence_ref="dbseq_ggFANCD2_target"
+                         peptide_ref="16734061838_ISDKRAPSQGGLENEGVFEELLR_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_4_9_p0"
+                         start="33" end="55" isDecoy="false"
+                         id="pepevid_pep_16734061838_ISDKRAPSQGGLENEGVFEELLR_protggFANCD2_target_33_pepkey_0_16734061838_ISDKRAPSQGGLENEGVFEELLR_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_4_9_p0_16734061838_ISDKRAPSQGGLENEGVFEELLR_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_4_9_p1"/>
+        <PeptideEvidence dBSequence_ref="dbseq_ggFANCI_target"
+                         peptide_ref="16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_16734057553_SCcmKDLQILQASK_18_1_p1"
+                         start="339" end="350" isDecoy="false"
+                         id="pepevid_pep_16734057553_SCcmKDLQILQASK_protggFANCI_target_339_pepkey_1_16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_16734057553_SCcmKDLQILQASK_18_1_p0_16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_16734057553_SCcmKDLQILQASK_18_1_p1"/>
+        <PeptideEvidence dBSequence_ref="dbseq_ggFANCI_target"
+                         peptide_ref="16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_16734057553_SCcmKDLQILQASK_18_1_p0"
+                         start="1078" end="1104" isDecoy="false"
+                         id="pepevid_pep_16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_protggFANCI_target_1078_pepkey_0_16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_16734057553_SCcmKDLQILQASK_18_1_p0_16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_16734057553_SCcmKDLQILQASK_18_1_p1"/>
+    </SequenceCollection>
+    <AnalysisCollection>
+        <SpectrumIdentification spectrumIdentificationProtocol_ref="SearchProtocol_1_17022"
+                                spectrumIdentificationList_ref="SII_LIST_1_1" id="SpecIdent_1">
+            <InputSpectra spectraData_ref="SD_17022_recal_B210619_02_Lumos_ZC_CO_190_D2I_SDA-WT1.mgf"/>
+            <InputSpectra spectraData_ref="SD_17022_recal_B210619_04_Lumos_ZC_CO_190_D2I_SDA-WT3.mgf"/>
+            <SearchDatabaseRef searchDatabase_ref="SDB_17022_2120"/>
+        </SpectrumIdentification>
+    </AnalysisCollection>
+    <AnalysisProtocolCollection>
+        <SpectrumIdentificationProtocol analysisSoftware_ref="xiFDR_id" id="SearchProtocol_1_17022">
+            <SearchType>
+                <cvParam cvRef="PSI-MS" accession="MS:1001083" name="ms-ms search"/>
+            </SearchType>
+            <AdditionalSearchParams>
+                <cvParam cvRef="PSI-MS" accession="MS:1001211" name="parent mass type mono"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1002494" name="crosslinking search"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001256" name="fragment mass type mono"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1002490" name="peptide-level scoring"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1002496" name="group PSMs by sequence"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1003343"
+                         name="FDR applied separately to self crosslinks and protein heteromeric crosslinks"/>
+                <cvParam accession="MS:1001118" name="param: b ion" cvRef="PSI-MS"/>
+                <cvParam accession="MS:1001262" name="param: y ion" cvRef="PSI-MS"/>
+            </AdditionalSearchParams>
+            <ModificationParams>
+
+                <SearchModification fixedMod="false" massDelta="100.05243" residues="K S T Y">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392"
+                             name="search modification id" value="SDA_monolink_W"/>
+                    <cvParam accession="UNIMOD:2000" cvRef="UNIMOD" name="Xlink:SDA"/>
+                    <cvParam accession="MS:1003347" name="UNIMOD derivative code"
+                             value="W" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="100.05243" residues=".">
+                    <SpecificityRules>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002057"
+                                 name="modification specificity protein N-term"/>
+                    </SpecificityRules>
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392"
+                             name="search modification id" value="SDA_monolink_W_n_term"/>
+                    <cvParam accession="UNIMOD:2000" cvRef="UNIMOD" name="Xlink:SDA"/>
+                    <cvParam accession="MS:1003347" name="UNIMOD derivative code"
+                             value="W" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="82.041865" residues="K S T Y">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392"
+                             name="search modification id" value="SDA_crosslink_donor"/>
+                    <cvParam accession="UNIMOD:2000" name="Xlink:DSSO" cvRef="UNIMOD"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002509" name="crosslink donor"
+                             value="2"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics" value="S:82.041865:O"
+                             cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="82.041865" residues=".">
+                    <SpecificityRules>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002057"
+                                 name="modification specificity protein N-term"/>
+                    </SpecificityRules>
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392"
+                             name="search modification id" value="SDA_crosslink_donor_n_term"/>
+                    <cvParam accession="UNIMOD:1842" name="Xlink:DSSO" cvRef="UNIMOD"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink donor"
+                             value="2"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics" value="S:82.041865:O"
+                             cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="0.0" residues=".">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392"
+                             name="search modification id" value="SDA_crosslink_acceptor"/>
+                    <cvParam accession="UNIMOD:2000" name="Xlink:SDA" cvRef="UNIMOD"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink acceptor"
+                             value="2"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="O:0:S" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="0.0" residues=".">
+                    <SpecificityRules>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002057"
+                                 name="modification specificity protein N-term"/>
+                    </SpecificityRules>
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392"
+                             name="search modification id"
+                             value="SDA_crosslink_acceptor_n_term"/>
+                    <cvParam accession="UNIMOD:2000" name="Xlink:SDA" cvRef="UNIMOD"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink acceptor"
+                             value="2"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="O:0:S" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="15.99491" residues="M">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392" name="search modification id"
+                             value="ox"/>
+                    <cvParam cvRef="UNIMOD" accession="UNIMOD:35" name="Oxidation"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="57.021465" residues="C">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392" name="search modification id"
+                             value="cm"/>
+                    <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+                </SearchModification>
+
+            </ModificationParams>
+            <Enzymes independent="false">
+                <Enzyme nTermGain="H" cTermGain="OH" semiSpecific="false" missedCleavages="2" id="Trypsin_0">
+                    <EnzymeName>
+                        <cvParam cvRef="PSI-MS" accession="MS:1001251" name="Trypsin"/>
+                    </EnzymeName>
+                </Enzyme>
+            </Enzymes>
+            <FragmentTolerance>
+                <cvParam cvRef="PSI-MS" accession="MS:1001412" name="search tolerance plus value" value="5.0"
+                         unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001413" name="search tolerance minus value" value="5.0"
+                         unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+            </FragmentTolerance>
+            <ParentTolerance>
+                <cvParam cvRef="PSI-MS" accession="MS:1001412" name="search tolerance plus value" value="3.0"
+                         unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001413" name="search tolerance minus value" value="3.0"
+                         unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+            </ParentTolerance>
+            <Threshold>
+                <cvParam cvRef="PSI-MS" accession="MS:1003337" name="crosslinked PSM-level global FDR" value="0.05"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1003338" name="peptide-pair sequence-level global FDR"
+                         value="0.05"/>
+            </Threshold>
+        </SpectrumIdentificationProtocol>
+        <ProteinDetectionProtocol analysisSoftware_ref="xiFDR_id" id="pdp1">
+            <Threshold>
+                <cvParam cvRef="PSI-MS" accession="MS:1002677" name="residue-pair-level global FDR" value="0.05"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1002676" name="protein-pair-level global FDR" value="0.05"/>
+            </Threshold>
+        </ProteinDetectionProtocol>
+    </AnalysisProtocolCollection>
+    <DataCollection>
+        <Inputs>
+            <SearchDatabase location="D2I_WT.fasta" id="SDB_17022_2120">
+                <FileFormat>
+                    <cvParam cvRef="PSI-MS" accession="MS:1001348" name="FASTA format"/>
+                </FileFormat>
+                <DatabaseName>
+                    <userParam name="D2I_WT.fasta"/>
+                </DatabaseName>
+            </SearchDatabase>
+            <SpectraData location="recal_B210619_02_Lumos_ZC_CO_190_D2I_SDA-WT1.mgf"
+                         id="SD_17022_recal_B210619_02_Lumos_ZC_CO_190_D2I_SDA-WT1.mgf">
+                <FileFormat>
+                    <cvParam cvRef="PSI-MS" accession="MS:1001062" name="Mascot MGF format"/>
+                </FileFormat>
+                <SpectrumIDFormat>
+                    <cvParam cvRef="PSI-MS" accession="MS:1000774" name="multiple peak list nativeID format"/>
+                </SpectrumIDFormat>
+            </SpectraData>
+            <SpectraData location="recal_B210619_04_Lumos_ZC_CO_190_D2I_SDA-WT3.mgf"
+                         id="SD_17022_recal_B210619_04_Lumos_ZC_CO_190_D2I_SDA-WT3.mgf">
+                <FileFormat>
+                    <cvParam cvRef="PSI-MS" accession="MS:1001062" name="Mascot MGF format"/>
+                </FileFormat>
+                <SpectrumIDFormat>
+                    <cvParam cvRef="PSI-MS" accession="MS:1000774" name="multiple peak list nativeID format"/>
+                </SpectrumIDFormat>
+            </SpectraData>
+        </Inputs>
+        <AnalysisData>
+            <SpectrumIdentificationList id="SII_LIST_1_1">
+                <SpectrumIdentificationResult spectrumID="index=26630"
+                                              spectraData_ref="SD_17022_recal_B210619_02_Lumos_ZC_CO_190_D2I_SDA-WT1.mgf"
+                                              id="SIR_1">
+                    <SpectrumIdentificationItem chargeState="5" experimentalMassToCharge="1135.3259479607323"
+                                                calculatedMassToCharge="1135.3254335427703"
+                                                peptide_ref="16734061838_ISDKRAPSQGGLENEGVFEELLR_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_4_9_p1"
+                                                rank="1" passThreshold="false" id="SII_1_1">
+                        <PeptideEvidenceRef
+                                peptideEvidence_ref="pepevid_pep_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_protggFANCI_target_689_pepkey_1_16734061838_ISDKRAPSQGGLENEGVFEELLR_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_4_9_p0_16734061838_ISDKRAPSQGGLENEGVFEELLR_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_4_9_p1"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002511" name="crosslink spectrum identification item"
+                                 value="1"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002545" name="xi:score" value="25.929927957127177"/>
+
+                        <!-- crosslinked PSM level global FDR -->
+                        <cvParam cvRef="PSI-MS" accession="MS:1003337" name="crosslinked PSM-level global FDR"
+                                 value="0.06"/>
+
+                        <!-- peptide pair global FDR -->
+                        <cvParam cvRef="PSI-MS" accession="MS:1002520"
+                                 value="GAEDEEEEEDVGFEQNFEEMLESVTR-ISDKRAPSQGGLENEGVFEELLR" name="peptide group ID"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003338" name="peptide-pair sequence-level global FDR"
+                                 value="0.06"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003339" name="peptide-pair passes threshold"
+                                 value="false"/>
+
+                        <!-- residue pair ref value="1.b" -->
+                        <cvParam cvRef="PSI-MS" accession="MS:1003344" value="11.b" name="residue-pair ref"/>
+
+                    </SpectrumIdentificationItem>
+                    <SpectrumIdentificationItem chargeState="5" experimentalMassToCharge="1135.3259479607323"
+                                                calculatedMassToCharge="1135.3254335427703"
+                                                peptide_ref="16734061838_ISDKRAPSQGGLENEGVFEELLR_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_4_9_p0"
+                                                rank="1" passThreshold="false" id="SII_1_2">
+                        <PeptideEvidenceRef
+                                peptideEvidence_ref="pepevid_pep_16734061838_ISDKRAPSQGGLENEGVFEELLR_protggFANCD2_target_33_pepkey_0_16734061838_ISDKRAPSQGGLENEGVFEELLR_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_4_9_p0_16734061838_ISDKRAPSQGGLENEGVFEELLR_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_4_9_p1"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002511" name="crosslink spectrum identification item"
+                                 value="1"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002545" name="xi:score" value="25.929927957127177"/>
+
+                        <!-- crosslinked PSM level global FDR -->
+                        <cvParam cvRef="PSI-MS" accession="MS:1003337" name="crosslinked PSM-level global FDR"
+                                 value="0.06"/>
+
+                        <!-- peptide pair global FDR -->
+                        <cvParam cvRef="PSI-MS" accession="MS:1002520"
+                                 value="GAEDEEEEEDVGFEQNFEEMLESVTR-ISDKRAPSQGGLENEGVFEELLR" name="peptide group ID"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003338" name="peptide-pair sequence-level global FDR"
+                                 value="0.06"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003339" name="peptide-pair passes threshold"
+                                 value="false"/>
+
+                        <!-- residue pair ref value="11.a" -->
+                        <cvParam cvRef="PSI-MS" accession="MS:XXXXXXX" value="11.a" name="Residue-pair ref"/>
+
+                    </SpectrumIdentificationItem>
+                    <cvParam cvRef="PSI-MS" accession="MS:1000797" name="peak list scans" value="40560"/>
+                </SpectrumIdentificationResult>
+                <SpectrumIdentificationResult spectrumID="index=23414"
+                                              spectraData_ref="SD_17022_recal_B210619_04_Lumos_ZC_CO_190_D2I_SDA-WT3.mgf"
+                                              id="SIR_2">
+                    <SpectrumIdentificationItem chargeState="6" experimentalMassToCharge="752.7466713415814"
+                                                calculatedMassToCharge="752.41371619677"
+                                                peptide_ref="16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_16734057553_SCcmKDLQILQASK_18_1_p1"
+                                                rank="1" passThreshold="true" id="SII_2_1">
+                        <PeptideEvidenceRef
+                                peptideEvidence_ref="pepevid_pep_16734057553_SCcmKDLQILQASK_protggFANCI_target_339_pepkey_1_16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_16734057553_SCcmKDLQILQASK_18_1_p0_16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_16734057553_SCcmKDLQILQASK_18_1_p1"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002511" name="crosslink spectrum identification item"
+                                 value="2"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002545" name="xi:score" value="21.55734182309742"/>
+
+                        <!-- crosslinked PSM level global FDR -->
+                        <cvParam cvRef="PSI-MS" accession="MS:1003337" name="crosslinked PSM-level global FDR"
+                                 value="0.03"/>
+
+                        <!-- peptide pair global FDR -->
+                        <cvParam cvRef="PSI-MS" accession="MS:1002520" value="SCKDLQILQASK-TAAPTVCLLVLGQADKVLEEVDWLIKR"
+                                 name="peptide group ID"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003338" name="peptide-pair sequence-level global FDR"
+                                 value="0.03"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003339" name="peptide-pair passes threshold"
+                                 value="true"/>
+
+                        <!-- residue pair ref value="22.b" -->
+                        <cvParam cvRef="PSI-MS" accession="MS:1003344" value="22.b" name="Residue-pair ref"/>
+                    </SpectrumIdentificationItem>
+                    <SpectrumIdentificationItem chargeState="6" experimentalMassToCharge="752.7466713415814"
+                                                calculatedMassToCharge="752.41371619677"
+                                                peptide_ref="16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_16734057553_SCcmKDLQILQASK_18_1_p0"
+                                                rank="1" passThreshold="true" id="SII_2_2">
+                        <PeptideEvidenceRef
+                                peptideEvidence_ref="pepevid_pep_16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_protggFANCI_target_1078_pepkey_0_16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_16734057553_SCcmKDLQILQASK_18_1_p0_16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_16734057553_SCcmKDLQILQASK_18_1_p1"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002511" name="crosslink spectrum identification item"
+                                 value="2"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002545" name="xi:score" value="21.55734182309742"/>
+
+                        <!-- crosslinked PSM level global FDR -->
+                        <cvParam cvRef="PSI-MS" accession="MS:1003337" name="crosslinked PSM-level global FDR"
+                                 value="0.03"/>
+
+                        <!-- peptide pair global FDR -->
+                        <cvParam cvRef="PSI-MS" accession="MS:1002520" value="SCKDLQILQASK-TAAPTVCLLVLGQADKVLEEVDWLIKR"
+                                 name="peptide group ID"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003338" name="peptide-pair sequence-level global FDR"
+                                 value="0.03"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003339" name="peptide-pair passes threshold"
+                                 value="true"/>
+
+                        <!-- residue pair ref value="22.a" -->
+                        <cvParam cvRef="PSI-MS" accession="MS:1003344" value="22.a" name="Residue-pair ref"/>
+                    </SpectrumIdentificationItem>
+                    <cvParam cvRef="PSI-MS" accession="MS:1000797" name="peak list scans" value="38065"/>
+                </SpectrumIdentificationResult>
+            </SpectrumIdentificationList>
+            <ProteinDetectionList id="PDL_1">
+                <ProteinAmbiguityGroup id="PAG_0">
+                    <ProteinDetectionHypothesis dBSequence_ref="dbseq_ggFANCI_target" passThreshold="true"
+                                                id="PAG_0_PDH_0">
+                        <PeptideHypothesis
+                                peptideEvidence_ref="pepevid_pep_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_protggFANCI_target_689_pepkey_1_16734061838_ISDKRAPSQGGLENEGVFEELLR_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_4_9_p0_16734061838_ISDKRAPSQGGLENEGVFEELLR_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_4_9_p1">
+                            <SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SII_1_1"/>
+                        </PeptideHypothesis>
+                        <PeptideHypothesis
+                                peptideEvidence_ref="pepevid_pep_16734057553_SCcmKDLQILQASK_protggFANCI_target_339_pepkey_1_16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_16734057553_SCcmKDLQILQASK_18_1_p0_16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_16734057553_SCcmKDLQILQASK_18_1_p1">
+                            <SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SII_2_1"/>
+                        </PeptideHypothesis>
+                        <PeptideHypothesis
+                                peptideEvidence_ref="pepevid_pep_16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_protggFANCI_target_1078_pepkey_0_16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_16734057553_SCcmKDLQILQASK_18_1_p0_16734068348_TAAPTVCcmLLVLGQADKVLEEVDWLIKR_16734057553_SCcmKDLQILQASK_18_1_p1">
+                            <SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SII_2_2"/>
+                        </PeptideHypothesis>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002403" name="group representative"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1001593"
+                                 name="group member with undefined relationship OR ortholog protein"/>
+
+                        <!-- forms a protein heteromeric PPI with its partner 10.a in PAG_1_PDH_0 -->
+                        <cvParam cvRef="PSI-MS" accession="MS:1002676" name="protein-pair-level global FDR"
+                                 value="10.b:null:0.059:false"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003341"
+                                 name="protein-protein interaction passes threshold" value="10:false"/>
+
+                        <!-- forms a self PPI with its partner 20.b in PAG_0_PDH_0 -->
+                        <cvParam cvRef="PSI-MS" accession="MS:1002676" name="protein-pair-level global FDR"
+                                 value="20.a:null:0.030:true"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002676" name="protein-pair-level global FDR"
+                                 value="20.b:null:0.030:true"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003341"
+                                 name="protein-protein interaction passes threshold" value="20:true"/>
+
+                        <!-- forms a protein heteromeric crosslink with its partner 11.a in PAG_1_PDH_0 -->
+                        <cvParam cvRef="PSI-MS" accession="MS:1002677" name="residue-pair-level global FDR"
+                                 value="11.b:697:0.06:false"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003340" name="residue-pair passes threshold"
+                                 value="11:false"/>
+
+                        <!-- forms a self crosslink with its partner 22.b in PAG_0_PDH_0 -->
+                        <cvParam cvRef="PSI-MS" accession="MS:1002677" name="residue-pair-level global FDR"
+                                 value="22.a:1095:0.01:true"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002677" name="residue-pair-level global FDR"
+                                 value="22.b:339:0.01:true"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003340" name="residue-pair passes threshold"
+                                 value="22:true"/>
+                    </ProteinDetectionHypothesis>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002415" name="protein group passes threshold" value="true"/>
+                </ProteinAmbiguityGroup>
+                <ProteinAmbiguityGroup id="PAG_1">
+                    <ProteinDetectionHypothesis dBSequence_ref="dbseq_ggFANCD2_target" passThreshold="true"
+                                                id="PAG_1_PDH_0">
+                        <PeptideHypothesis
+                                peptideEvidence_ref="pepevid_pep_16734061838_ISDKRAPSQGGLENEGVFEELLR_protggFANCD2_target_33_pepkey_0_16734061838_ISDKRAPSQGGLENEGVFEELLR_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_4_9_p0_16734061838_ISDKRAPSQGGLENEGVFEELLR_16734063165_GAEDEEEEEDVGFEQNFEEMLESVTR_4_9_p1">
+                            <SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SII_1_2"/>
+                        </PeptideHypothesis>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002403" name="group representative"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1001593"
+                                 name="group member with undefined relationship OR ortholog protein"/>
+
+                        <cvParam cvRef="PSI-MS" accession="MS:1002676" name="protein-pair-level global FDR"
+                                 value="10.a:null:059:false"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003341"
+                                 name="protein-protein interaction passes threshold" value="10:false"/>
+
+                        <cvParam cvRef="PSI-MS" accession="MS:1002677" name="residue-pair-level global FDR"
+                                 value="11.a:36:0.06:false"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003340" name="residue-pair passes threshold"
+                                 value="11:false"/>
+
+                    </ProteinDetectionHypothesis>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002415" name="protein group passes threshold" value="true"/>
+                </ProteinAmbiguityGroup>
+                <cvParam cvRef="PSI-MS" accession="MS:1002404" name="count of identified proteins" value="2"/>
+            </ProteinDetectionList>
+        </AnalysisData>
+    </DataCollection>
+</MzIdentML>

--- a/src/tests/class_tests/openms/data/MzIdentML_v1.3_crosslinking.mzid
+++ b/src/tests/class_tests/openms/data/MzIdentML_v1.3_crosslinking.mzid
@@ -338,7 +338,7 @@ Gustav-Meyer-Allee 25
                                  value="false"/>
 
                         <!-- residue pair ref value="11.a" -->
-                        <cvParam cvRef="PSI-MS" accession="MS:XXXXXXX" value="11.a" name="Residue-pair ref"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003344" value="11.a" name="residue-pair ref"/>
 
                     </SpectrumIdentificationItem>
                     <cvParam cvRef="PSI-MS" accession="MS:1000797" name="peak list scans" value="40560"/>
@@ -461,7 +461,7 @@ Gustav-Meyer-Allee 25
                                  name="group member with undefined relationship OR ortholog protein"/>
 
                         <cvParam cvRef="PSI-MS" accession="MS:1002676" name="protein-pair-level global FDR"
-                                 value="10.a:null:059:false"/>
+                                 value="10.a:null:0.059:false"/>
                         <cvParam cvRef="PSI-MS" accession="MS:1003341"
                                  name="protein-protein interaction passes threshold" value="10:false"/>
 

--- a/src/tests/class_tests/openms/data/MzIdentML_v1.3_multi_spectra.mzid
+++ b/src/tests/class_tests/openms/data/MzIdentML_v1.3_multi_spectra.mzid
@@ -1,0 +1,647 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MzIdentML id="12345" version="1.3.0" xmlns="http://psidev.info/psi/pi/mzIdentML/1.3"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.3 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.3.0.xsd"
+           creationDate="2022-05-02T12:24:29">
+
+    <cvList>
+        <cv fullName="PSI-MS" uri="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo" id="PSI-MS"/>
+        <cv fullName="XLMOD" uri="https://raw.githubusercontent.com/HUPO-PSI/xlmod-CV/main/XLMOD.obo" id="XLMOD"/>
+        <cv fullName="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo" id="UNIMOD"/>
+        <cv fullName="UNIT-ONTOLOGY"
+            uri="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"
+            id="UO"/>
+    </cvList>
+
+    <cvParam cvRef="PSI-MS" accession="MS:1003385" name="mzIdentML crosslinking extension document version"
+             value="1.0.0"/>
+
+    <AnalysisSoftwareList>
+        <AnalysisSoftware id="fdr_prog_id">
+            <SoftwareName>
+                <cvParam name="software" cvRef="PSI-MS" accession="MS:1000531"/>
+            </SoftwareName>
+        </AnalysisSoftware>
+    </AnalysisSoftwareList>
+
+    <SequenceCollection>
+        <DBSequence length="14" searchDatabase_ref="database_id" accession="PA" id="protein_A"
+                    name="Protein A">
+            <Seq>MKVLVIGNGKPEPK</Seq>
+        </DBSequence>
+        <DBSequence length="25" searchDatabase_ref="database_id" accession="PB" id="protein_B"
+                    name="Protein B">
+            <Seq>DAHKSEVAHRFKDLGEENFKTIDEK</Seq>
+        </DBSequence>
+
+        <Peptide id="p1">
+            <PeptideSequence>PEPK</PeptideSequence>
+            <!-- this part doesn’t change, donor has full crosslinker modMass -->
+            <Modification location="4" monoisotopicMassDelta="158.003765">
+                <cvParam cvRef="PSI-MS" accession="MS:1003393" name="search modification id ref"
+                         value="DSSO_crosslink_donor"/>
+                <cvParam accession="UNIMOD:1842" cvRef="UNIMOD" name="Xlink:DSSO"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1002509" name="crosslink donor" value="1"/>
+            </Modification>
+        </Peptide>
+
+        <Peptide id="p2">
+            <PeptideSequence>TIDEK</PeptideSequence>
+            <!-- this part doesn’t change, acceptor has 0 mass -->
+            <Modification location="1" monoisotopicMassDelta="0">
+                <cvParam cvRef="PSI-MS" accession="MS:1003393" name="search modification id ref"
+                         value="DSSO_crosslink_acceptor"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink acceptor" value="1"/>
+            </Modification>
+        </Peptide>
+
+        <!-- MS3 peptides are separately listed, as they are linear stub modified peptides -->
+        <Peptide id="p1_a">
+            <PeptideSequence>PEPK</PeptideSequence>
+            <Modification location="4" monoisotopicMassDelta="54.010565">
+                <cvParam cvRef="PSI-MS" accession="MS:1003393" name="search modification id ref"
+                         value="DSSO_crosslink_stub_a"/>
+                <cvParam accession="UNIMOD:1842" cvRef="UNIMOD" name="Xlink:DSSO"/>
+            </Modification>
+        </Peptide>
+
+        <Peptide id="p1_t">
+            <PeptideSequence>PEPK</PeptideSequence>
+            <Modification location="4" monoisotopicMassDelta="85.982635">
+                <cvParam cvRef="PSI-MS" accession="MS:1003393" name="search modification id ref"
+                         value="DSSO_crosslink_stub_t"/>
+                <cvParam accession="UNIMOD:1842" cvRef="UNIMOD" name="Xlink:DSSO"/>
+            </Modification>
+        </Peptide>
+
+        <Peptide id="p2_a">
+            <PeptideSequence>TIDEK</PeptideSequence>
+            <Modification location="1" monoisotopicMassDelta="54.010565">
+                <cvParam cvRef="PSI-MS" accession="MS:1003393" name="search modification id ref"
+                         value="DSSO_crosslink_stub_a"/>
+                <cvParam accession="UNIMOD:1842" cvRef="UNIMOD" name="Xlink:DSSO"/>
+            </Modification>
+        </Peptide>
+
+        <Peptide id="p2_t">
+            <PeptideSequence>TIDEK</PeptideSequence>
+            <Modification location="1" monoisotopicMassDelta="85.982635">
+                <cvParam cvRef="PSI-MS" accession="MS:1003393" name="search modification id ref"
+                         value="DSSO_crosslink_stub_t"/>
+                <cvParam accession="UNIMOD:1842" cvRef="UNIMOD" name="Xlink:DSSO"/>
+            </Modification>
+        </Peptide>
+
+
+        <PeptideEvidence id="pepevid_p1" dBSequence_ref="protein_A" peptide_ref="p1" start="11"/>
+        <PeptideEvidence id="pepevid_p2" dBSequence_ref="protein_B" peptide_ref="p2" start="21"/>
+        <PeptideEvidence id="pepevid_p1_a" dBSequence_ref="protein_A" peptide_ref="p1_a" start="11"/>
+        <PeptideEvidence id="pepevid_p1_t" dBSequence_ref="protein_A" peptide_ref="p1_t" start="11"/>
+        <PeptideEvidence id="pepevid_p2_a" dBSequence_ref="protein_B" peptide_ref="p2_a" start="21"/>
+        <PeptideEvidence id="pepevid_p2_t" dBSequence_ref="protein_B" peptide_ref="p2_t" start="21"/>
+    </SequenceCollection>
+
+    <AnalysisCollection>
+        <SpectrumIdentification spectrumIdentificationProtocol_ref="SearchProtocol_HCD"
+                                spectrumIdentificationList_ref="sil_HCD" id="SpecIdent_HCD">
+            <InputSpectra spectraData_ref="peaklist_id"/>
+            <SearchDatabaseRef searchDatabase_ref="database_id"/>
+        </SpectrumIdentification>
+        <SpectrumIdentification spectrumIdentificationProtocol_ref="SearchProtocol_ETD"
+                                spectrumIdentificationList_ref="sil_ETD" id="SpecIdent_ETD">
+            <InputSpectra spectraData_ref="peaklist_id"/>
+            <SearchDatabaseRef searchDatabase_ref="database_id"/>
+        </SpectrumIdentification>
+        <SpectrumIdentification spectrumIdentificationProtocol_ref="SearchProtocol_MS3"
+                                spectrumIdentificationList_ref="sil_MS3" id="SpecIdent_MS3">
+            <InputSpectra spectraData_ref="peaklist_id"/>
+            <SearchDatabaseRef searchDatabase_ref="database_id"/>
+        </SpectrumIdentification>
+    </AnalysisCollection>
+
+    <AnalysisProtocolCollection>
+
+        <SpectrumIdentificationProtocol analysisSoftware_ref="fdr_prog_id" id="SearchProtocol_HCD">
+            <!-- somewhere here come the b and y ion cv-terms, 10ppm -->
+            <SearchType>
+                <cvParam cvRef="PSI-MS" accession="MS:1001083" name="ms-ms search"/>
+            </SearchType>
+            <AdditionalSearchParams>
+                <cvParam cvRef="PSI-MS" accession="MS:1001211" name="parent mass type mono"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001256" name="fragment mass type mono"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1002494" name="crosslinking search"/>
+                <!-- are these meant to be changed to children of MS:1002307 (fragmentation ion type)  -->
+                <cvParam cvRef="PSI-MS" accession="MS:1001118" name="param: b ion"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001262" name="param: y ion"/>
+                <!-- these are the current non-deprecated ways of encoding losses?  -->
+                <cvParam name="neutral loss" cvRef="PSI-MS" accession="MS:1000336" value="H2O"/>
+                <cvParam name="neutral loss" cvRef="PSI-MS" accession="MS:1000336" value="NH3"/>
+            </AdditionalSearchParams>
+            <ModificationParams>
+
+                <SearchModification fixedMod="false" massDelta="175.030314" residues="K S T Y">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392" name="search modification id"
+                             value="DSSO_monolink_M"/>
+                    <cvParam accession="UNIMOD:1842" cvRef="UNIMOD" name="Xlink:DSSO"/>
+                    <cvParam accession="MS:1003347" name="UNIMOD derivative code"
+                             value="M" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="176.01433" residues="K S T Y">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392" name="search modification id"
+                             value="DSSO_monolink_W"/>
+                    <cvParam accession="UNIMOD:1842" cvRef="UNIMOD" name="Xlink:DSSO"/>
+                    <cvParam accession="MS:1003347" name="UNIMOD derivative code"
+                             value="W" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="175.030314" residues=".">
+                    <SpecificityRules>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002057"
+                                 name="modification specificity protein N-term"/>
+                    </SpecificityRules>
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392"
+                             name="search modification id" value="DSSO_monolink_M_n_term"/>
+                    <cvParam accession="UNIMOD:1842" cvRef="UNIMOD" name="Xlink:DSSO"/>
+                    <cvParam accession="MS:1003347" name="UNIMOD derivative code"
+                             value="M" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="176.01433" residues=".">
+                    <SpecificityRules>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002057" name="modification specificity protein N-term"/>
+                    </SpecificityRules>
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392"
+                             name="search modification id" value="DSSO_monolink_W_n_term"/>
+                    <cvParam accession="UNIMOD:1842" cvRef="UNIMOD" name="Xlink:DSSO"/>
+                    <cvParam accession="MS:1003347" name="UNIMOD derivative code"
+                             value="W" cvRef="PSI-MS"/>
+                </SearchModification>
+
+
+                <SearchModification fixedMod="false" massDelta="158.003765" residues="K S T Y">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392" name="search modification id"
+                             value="DSSO_crosslink_donor"/>
+                    <cvParam accession="UNIMOD:1842" name="Xlink:DSSO" cvRef="UNIMOD"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002509" name="crosslink donor"
+                             value="3"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="A:54.0105647:ST" cvRef="PSI-MS"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="S:103.9932001:A" cvRef="PSI-MS"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="T:85.9826354:A" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="158.003765" residues=".">
+                    <SpecificityRules>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002057"
+                                 name="modification specificity protein N-term"/>
+                    </SpecificityRules>
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392" name="search modification id"
+                             value="DSSO_crosslink_donor_n_term"/>
+                    <cvParam accession="UNIMOD:1842" name="Xlink:DSSO" cvRef="UNIMOD"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink donor"
+                             value="3"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="A:54.0105647:ST" cvRef="PSI-MS"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="S:103.9932001:A" cvRef="PSI-MS"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="T:85.9826354:A" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="0.0" residues="K S T Y">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392" name="search modification id"
+                             value="DSSO_crosslink_acceptor"/>
+                    <cvParam accession="UNIMOD:1842" name="Xlink:DSSO" cvRef="UNIMOD"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink acceptor" value="3"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="A:54.0105647:ST" cvRef="PSI-MS"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="S:103.9932001:A" cvRef="PSI-MS"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="T:85.9826354:A" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="0.0" residues=".">
+                    <SpecificityRules>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002057"
+                                 name="modification specificity protein N-term"/>
+                    </SpecificityRules>
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392" name="search modification id"
+                             value="DSSO_crosslink_acceptor_n_term"/>
+                    <cvParam accession="UNIMOD:1842" name="Xlink:DSSO" cvRef="UNIMOD"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink acceptor"
+                             value="3"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="A:54.0105647:ST" cvRef="PSI-MS"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="S:103.9932001:A" cvRef="PSI-MS"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="T:85.9826354:A" cvRef="PSI-MS"/>
+                </SearchModification>
+
+            </ModificationParams>
+            <FragmentTolerance>
+                <cvParam cvRef="PSI-MS" accession="MS:1001412" name="search tolerance plus value" value="10.0"
+                         unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001413" name="search tolerance minus value" value="10.0"
+                         unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+            </FragmentTolerance>
+            <ParentTolerance>
+                <cvParam cvRef="PSI-MS" accession="MS:1001412" name="search tolerance plus value" value="3.0"
+                         unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001413" name="search tolerance minus value" value="3.0"
+                         unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+            </ParentTolerance>
+            <Threshold>
+                <cvParam cvRef="PSI-MS" accession="MS:1001494" name="no threshold"/>
+            </Threshold>
+        </SpectrumIdentificationProtocol>
+
+        <SpectrumIdentificationProtocol analysisSoftware_ref="fdr_prog_id" id="SearchProtocol_ETD">
+            <SearchType>
+                <cvParam cvRef="PSI-MS" accession="MS:1001083" name="ms-ms search"/>
+            </SearchType>
+            <AdditionalSearchParams>
+                <cvParam cvRef="PSI-MS" accession="MS:1001211" name="parent mass type mono"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001256" name="fragment mass type mono"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1002494" name="crosslinking search"/>
+                <!-- are these meant to be changed to children of MS:1002307 (fragmentation ion type)  -->
+                <cvParam cvRef="PSI-MS" accession="MS:1001119" name="param: c ion"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001263" name="param: z ion"/>
+                <!-- these are the current non-deprecated ways of encoding losses?  -->
+                <cvParam name="neutral loss" cvRef="PSI-MS" accession="MS:1000336" value="H2O"/>
+                <cvParam name="neutral loss" cvRef="PSI-MS" accession="MS:1000336" value="NH3"/>
+            </AdditionalSearchParams>
+            <ModificationParams>
+
+                <SearchModification fixedMod="false" massDelta="175.030314" residues="K S T Y">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392" name="search modification id"
+                             value="DSSO_monolink_M"/>
+                    <cvParam accession="UNIMOD:1842" cvRef="UNIMOD" name="Xlink:DSSO"/>
+                    <cvParam accession="MS:1003347" name="UNIMOD derivative code"
+                             value="M" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="176.01433" residues="K S T Y">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392" name="search modification id"
+                             value="DSSO_monolink_W"/>
+                    <cvParam accession="UNIMOD:1842" cvRef="UNIMOD" name="Xlink:DSSO"/>
+                    <cvParam accession="MS:1003347" name="UNIMOD derivative code"
+                             value="W" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="175.030314" residues=".">
+                    <SpecificityRules>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002057" name="modification specificity protein N-term"/>
+                    </SpecificityRules>
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392" name="search modification id"
+                             value="DSSO_monolink_M_n_term"/>
+                    <cvParam accession="UNIMOD:1842" cvRef="UNIMOD" name="Xlink:DSSO"/>
+                    <cvParam accession="MS:1003347" name="UNIMOD derivative code"
+                             value="M" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="176.01433" residues=".">
+                    <SpecificityRules>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002057" name="modification specificity protein N-term"/>
+                    </SpecificityRules>
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392"
+                             name="search modification id" value="DSSO_monolink_W_n_term"/>
+                    <cvParam accession="UNIMOD:1842" cvRef="UNIMOD" name="Xlink:DSSO"/>
+                    <cvParam accession="MS:1003347" name="UNIMOD derivative code"
+                             value="W" cvRef="PSI-MS"/>
+                </SearchModification>
+
+
+                <SearchModification fixedMod="false" massDelta="158.003765" residues="K S T Y">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392"
+                             name="search modification id" value="DSSO_crosslink_donor"/>
+                    <cvParam accession="UNIMOD:1842" name="Xlink:DSSO" cvRef="UNIMOD"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002509" name="crosslink donor" value="3"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="A:54.0105647:ST" cvRef="PSI-MS"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="S:103.9932001:A" cvRef="PSI-MS"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="T:85.9826354:A" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="158.003765" residues=".">
+                    <SpecificityRules>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002057" name="modification specificity protein N-term"/>
+                    </SpecificityRules>
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392"
+                             name="search modification id" value="DSSO_crosslink_donor_n_term"/>
+                    <cvParam accession="UNIMOD:1842" name="Xlink:DSSO" cvRef="UNIMOD"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink donor" value="3"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="A:54.0105647:ST" cvRef="PSI-MS"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="S:103.9932001:A" cvRef="PSI-MS"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="T:85.9826354:A" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="0.0" residues="K S T Y">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392" name="search modification id"
+                             value="DSSO_crosslink_acceptor"/>
+                    <cvParam accession="UNIMOD:1842" name="Xlink:DSSO" cvRef="UNIMOD"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink acceptor" value="3"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="A:54.0105647:ST" cvRef="PSI-MS"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="S:103.9932001:A" cvRef="PSI-MS"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="T:85.9826354:A" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="0.0" residues=".">
+                    <SpecificityRules>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002057" name="modification specificity protein N-term"/>
+                    </SpecificityRules>
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392" name="search modification id"
+                             value="DSSO_crosslink_acceptor_n_term"/>
+                    <cvParam accession="UNIMOD:1842" name="Xlink:DSSO" cvRef="UNIMOD"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink acceptor" value="3"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="A:54.0105647:ST" cvRef="PSI-MS"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="S:103.9932001:A" cvRef="PSI-MS"/>
+                    <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
+                             value="T:85.9826354:A" cvRef="PSI-MS"/>
+                </SearchModification>
+
+            </ModificationParams>
+
+            <FragmentTolerance>
+                <cvParam cvRef="PSI-MS" accession="MS:1001412" name="search tolerance plus value" value="10.0"
+                         unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001413" name="search tolerance minus value" value="10.0"
+                         unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+            </FragmentTolerance>
+            <ParentTolerance>
+                <cvParam cvRef="PSI-MS" accession="MS:1001412" name="search tolerance plus value" value="3.0"
+                         unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001413" name="search tolerance minus value" value="3.0"
+                         unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+            </ParentTolerance>
+            <Threshold>
+                <cvParam cvRef="PSI-MS" accession="MS:1001494" name="no threshold"/>
+            </Threshold>
+        </SpectrumIdentificationProtocol>
+
+        <!-- if the MS3 has different search params, e.g. mass tolerance it needs a separate
+        protocol -->
+        <SpectrumIdentificationProtocol analysisSoftware_ref="fdr_prog_id" id="SearchProtocol_MS3">
+            <SearchType>
+                <cvParam cvRef="PSI-MS" accession="MS:1001083"
+                         name="ms-ms search"/> <!-- new CV term for ms3 search? -->
+            </SearchType>
+            <AdditionalSearchParams>
+                <cvParam cvRef="PSI-MS" accession="MS:1001211" name="parent mass type mono"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001256" name="fragment mass type mono"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1002494" name="crosslinking search"/>
+                <!-- are these meant to be changed to children of MS:1002307 (fragmentation ion type)  -->
+                <cvParam cvRef="PSI-MS" accession="MS:1001118" name="param: b ion"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001262" name="param: y ion"/>
+                <!-- these are the current non-deprecated ways of encoding losses?  -->
+                <cvParam name="neutral loss" cvRef="PSI-MS" accession="MS:1000336" value="H2O"/>
+                <cvParam name="neutral loss" cvRef="PSI-MS" accession="MS:1000336" value="NH3"/>
+            </AdditionalSearchParams>
+            <ModificationParams>
+
+                <SearchModification fixedMod="false" massDelta="175.030314" residues="K S T Y">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392" name="search modification id"
+                             value="DSSO_monolink_M"/>
+                    <cvParam accession="UNIMOD:1842" cvRef="UNIMOD" name="Xlink:DSSO"/>
+                    <cvParam accession="MS:1003347" name="UNIMOD derivative code"
+                             value="M" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="176.01433" residues="K S T Y">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392"
+                             name="search modification id" value="DSSO_monolink_W"/>
+                    <cvParam accession="UNIMOD:1842" cvRef="UNIMOD" name="Xlink:DSSO"/>
+                    <cvParam accession="MS:1003347" name="UNIMOD derivative code"
+                             value="W" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="175.030314" residues=".">
+                    <SpecificityRules>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002057"
+                                 name="modification specificity protein N-term"/>
+                    </SpecificityRules>
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392"
+                             name="search modification id" value="DSSO_monolink_M_n_term"/>
+                    <cvParam accession="UNIMOD:1842" cvRef="UNIMOD" name="Xlink:DSSO"/>
+                    <cvParam accession="MS:1003347" name="UNIMOD derivative code"
+                             value="M" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="176.01433" residues=".">
+                    <SpecificityRules>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002057"
+                                 name="modification specificity protein N-term"/>
+                    </SpecificityRules>
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392"
+                             name="search modification id" value="DSSO_monolink_W_n_term"/>
+                    <cvParam accession="UNIMOD:1842" cvRef="UNIMOD" name="Xlink:DSSO"/>
+                    <cvParam accession="MS:1003347" name="UNIMOD derivative code"
+                             value="W" cvRef="PSI-MS"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="54.010565" residues="K S T Y">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392"
+                             name="search modification id" value="DSSO_crosslink_stub_a"/>
+                    <cvParam accession="UNIMOD:1842" name="Xlink:DSSO" cvRef="UNIMOD"/>
+                    <cvParam accession="MS:1003347" name="UNIMOD derivative code"
+                             value="A" cvRef="PSI-MS"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1003346" name="cleavable crosslinker stub"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="85.982636" residues="K S T Y">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392"
+                             name="search modification id" value="DSSO_crosslink_stub_t"/>
+                    <cvParam accession="UNIMOD:1842" name="Xlink:DSSO" cvRef="UNIMOD"/>
+                    <cvParam accession="MS:1003347" name="UNIMOD derivative code"
+                             value="T" cvRef="PSI-MS"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1003346" name="cleavable crosslinker stub"/>
+                </SearchModification>
+
+                <SearchModification fixedMod="false" massDelta="103.9932" residues="K S T Y">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392"
+                             name="search modification id" value="DSSO_crosslink_stub_s"/>
+                    <cvParam accession="UNIMOD:1842" name="Xlink:DSSO" cvRef="UNIMOD"/>
+                    <cvParam accession="MS:1003347" name="UNIMOD derivative code"
+                             value="S" cvRef="PSI-MS"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1003346" name="cleavable crosslinker stub"/>
+                </SearchModification>
+
+            </ModificationParams>
+            <FragmentTolerance>
+                <cvParam cvRef="PSI-MS" accession="MS:1001412" name="search tolerance plus value" value="1.4"
+                         unitAccession="UO:0000221" unitName="dalton" unitCvRef="UO"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001413" name="search tolerance minus value" value="1.4"
+                         unitAccession="UO:0000221" unitName="dalton" unitCvRef="UO"/>
+            </FragmentTolerance>
+            <ParentTolerance>
+                <cvParam cvRef="PSI-MS" accession="MS:1001412" name="search tolerance plus value" value="10.0"
+                         unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001413" name="search tolerance minus value" value="10.0"
+                         unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+            </ParentTolerance>
+            <Threshold>
+                <cvParam cvRef="PSI-MS" accession="MS:1001494" name="no threshold"/>
+            </Threshold>
+            <!-- somewhere here come the cv terms for MS3 b, y, 1.4 dalton-->
+        </SpectrumIdentificationProtocol>
+    </AnalysisProtocolCollection>
+
+    <DataCollection>
+
+        <Inputs>
+            <SearchDatabase location="sequences.fasta" id="database_id">
+                <FileFormat>
+                    <cvParam cvRef="PSI-MS" accession="MS:1001348" name="FASTA format"/>
+                </FileFormat>
+                <DatabaseName>
+                    <userParam name="sequences"/>
+                </DatabaseName>
+            </SearchDatabase>
+            <SpectraData id="peaklist_id" location="path.mzml">
+                <FileFormat>
+                    <cvParam cvRef="PSI-MS" accession="MS:1000584" name="mzML format"/>
+                </FileFormat>
+                <SpectrumIDFormat>
+                    <cvParam cvRef="PSI-MS" accession="MS:1001530" name="mzML unique identifier"/>
+                </SpectrumIDFormat>
+            </SpectraData>
+        </Inputs>
+
+        <AnalysisData>
+
+            <SpectrumIdentificationList id="sil_HCD">
+                <!--  HCD MS2 match defined basically the same as in a non-cleavable case -->
+                <SpectrumIdentificationResult spectrumID="index=1" spectraData_ref="peaklist_id" id="SIR_1">
+                    <SpectrumIdentificationItem chargeState="3" experimentalMassToCharge="210.093" peptide_ref="p1" rank="1"
+                                                passThreshold="true" id="HCD_SII_0">
+                        <PeptideEvidenceRef peptideEvidence_ref="pepevid_p1"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002511" name="crosslink spectrum identification item"
+                                 value="1"/>
+                        <!-- this flags it as part of the crosslinked identification '1234' -->
+                        <cvParam accession="MS:1003332" cvRef="PSI-MS" value="1234:P"
+                                 name="identification based on multiple spectra"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003336"
+                                 name="Posterior Error Probability for an identification based on multiple spectra"
+                                 value="1234:1E-08"/>
+                    </SpectrumIdentificationItem>
+                    <SpectrumIdentificationItem chargeState="3" experimentalMassToCharge="202.443" peptide_ref="p2" rank="1"
+                                                passThreshold="true" id="HCD_SII_1">
+                        <PeptideEvidenceRef peptideEvidence_ref="pepevid_p2"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002511" name="crosslink spectrum identification item"
+                                 value="1"/>
+                        <!-- this flags it as part of the crosslinked identification '1234' -->
+                        <cvParam accession="MS:1003332" cvRef="PSI-MS" value="1234:P"
+                                 name="identification based on multiple spectra"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003336"
+                                 name="Posterior Error Probability for an identification based on multiple spectra"
+                                 value="1234:1E-08"/>
+                    </SpectrumIdentificationItem>
+                </SpectrumIdentificationResult>
+            </SpectrumIdentificationList>
+
+            <!-- if the ETD should be correctly identified - it needs to go into a separate list -->
+            <SpectrumIdentificationList id="sil_ETD">
+                <SpectrumIdentificationResult spectrumID="index=2" spectraData_ref="peaklist_id" id="SIR_2">
+                    <SpectrumIdentificationItem chargeState="3" experimentalMassToCharge="210.093" peptide_ref="p1" rank="1"
+                                                passThreshold="true" id="ETD_SII_0">
+                        <PeptideEvidenceRef peptideEvidence_ref="pepevid_p1"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002511" name="crosslink spectrum identification item"
+                                 value="1"/>
+                        <!-- this flags it as part of the crosslinked identification '1234' -->
+                        <cvParam accession="MS:1003332" cvRef="PSI-MS" value="1234:P"
+                                 name="identification based on multiple spectra"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003336"
+                                 name="Posterior Error Probability for an identification based on multiple spectra"
+                                 value="1234:1E-08"/>
+                    </SpectrumIdentificationItem>
+                    <SpectrumIdentificationItem chargeState="3" experimentalMassToCharge="202.443" peptide_ref="p2" rank="1"
+                                                passThreshold="true" id="ETD_SII_1">
+                        <PeptideEvidenceRef peptideEvidence_ref="pepevid_p2"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002511" name="crosslink spectrum identification item"
+                                 value="1"/>
+                        <!-- this flags it as part of the crosslinked identification '1234' -->
+                        <cvParam accession="MS:1003332" cvRef="PSI-MS" value="1234:P"
+                                 name="identification based on multiple spectra"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003336"
+                                 name="Posterior Error Probability for an identification based on multiple spectra"
+                                 value="1234:1E-08"/>
+                    </SpectrumIdentificationItem>
+                </SpectrumIdentificationResult>
+            </SpectrumIdentificationList>
+            <!-- if the MS3 has different search params, e.g. mass tolerance they need to go into a separate list -->
+
+            <SpectrumIdentificationList id="sil_MS3">
+                <!--  HCD MS3 match peptide 1 A-->
+                <SpectrumIdentificationResult spectrumID="index=3" spectraData_ref="peaklist_id" id="SIR_3">
+                    <SpectrumIdentificationItem chargeState="3" experimentalMassToCharge="175.429" peptide_ref="p1_a"
+                                                rank="1" passThreshold="true" id="MS3_SII_0">
+                        <PeptideEvidenceRef peptideEvidence_ref="pepevid_p1_a"/>
+                        <!-- this flags it as part of the crosslinked identification '1234' -->
+                        <cvParam accession="MS:1003332" cvRef="PSI-MS" value="1234:C"
+                                 name="identification based on multiple spectra"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003336"
+                                 name="Posterior Error Probability for an identification based on multiple spectra"
+                                 value="1234:1E-08"/>
+                    </SpectrumIdentificationItem>
+                </SpectrumIdentificationResult>
+
+                <!--  HCD MS3 match peptide 2 T-->
+                <SpectrumIdentificationResult spectrumID="index=4" spectraData_ref="peaklist_id" id="SIR_4">
+                    <SpectrumIdentificationItem chargeState="3" experimentalMassToCharge="230.432" peptide_ref="p2_t"
+                                                rank="1" passThreshold="true" id="MS3_SII_1">
+                        <PeptideEvidenceRef peptideEvidence_ref="pepevid_p2_t"/>
+                        <!-- this flags it as part of the crosslinked identification '1234' -->
+                        <cvParam accession="MS:1003332" cvRef="PSI-MS" value="1234:C"
+                                 name="identification based on multiple spectra"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003336"
+                                 name="Posterior Error Probability for an identification based on multiple spectra"
+                                 value="1234:1E-08"/>
+                    </SpectrumIdentificationItem>
+                </SpectrumIdentificationResult>
+
+                <!--  HCD MS3 match peptide 1 T-->
+                <SpectrumIdentificationResult spectrumID="index=5" spectraData_ref="peaklist_id" id="SIR_5">
+                    <SpectrumIdentificationItem chargeState="3" experimentalMassToCharge="186.086" peptide_ref="p1_t"
+                                                rank="1" passThreshold="true" id="MS3_SII_2">
+                        <PeptideEvidenceRef peptideEvidence_ref="pepevid_p1_t"/>
+                        <!-- this flags it as part of the crosslinked identification '1234' -->
+                        <cvParam accession="MS:1003332" cvRef="PSI-MS" value="1234:C"
+                                 name="identification based on multiple spectra"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003336"
+                                 name="Posterior Error Probability for an identification based on multiple spectra"
+                                 value="1234:1E-08"/>
+                    </SpectrumIdentificationItem>
+                </SpectrumIdentificationResult>
+
+                <!--  HCD MS3 match peptide 2 A-->
+                <SpectrumIdentificationResult spectrumID="index=6" spectraData_ref="peaklist_id" id="SIR_6">
+                    <SpectrumIdentificationItem chargeState="3" experimentalMassToCharge="219.775" peptide_ref="p2_a"
+                                                rank="1" passThreshold="true" id="MS3_SII_3">
+                        <PeptideEvidenceRef peptideEvidence_ref="pepevid_p2_a"/>
+                        <!-- this flags it as part of the crosslinked identification '1234' -->
+                        <cvParam accession="MS:1003332" cvRef="PSI-MS" value="1234:C"
+                                 name="identification based on multiple spectra"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003336"
+                                 name="Posterior Error Probability for an identification based on multiple spectra"
+                                 value="1234:1E-08"/>
+                    </SpectrumIdentificationItem>
+                </SpectrumIdentificationResult>
+
+            </SpectrumIdentificationList>
+        </AnalysisData>
+    </DataCollection>
+</MzIdentML>

--- a/src/tests/class_tests/openms/data/MzIdentML_v1.3_multi_spectra.mzid
+++ b/src/tests/class_tests/openms/data/MzIdentML_v1.3_multi_spectra.mzid
@@ -201,7 +201,7 @@
                     <cvParam cvRef="PSI-MS" accession="MS:1003392" name="search modification id"
                              value="DSSO_crosslink_donor_n_term"/>
                     <cvParam accession="UNIMOD:1842" name="Xlink:DSSO" cvRef="UNIMOD"/>
-                    <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink donor"
+                    <cvParam cvRef="PSI-MS" accession="MS:1002509" name="crosslink donor"
                              value="3"/>
                     <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
                              value="A:54.0105647:ST" cvRef="PSI-MS"/>
@@ -336,7 +336,7 @@
                     <cvParam cvRef="PSI-MS" accession="MS:1003392"
                              name="search modification id" value="DSSO_crosslink_donor_n_term"/>
                     <cvParam accession="UNIMOD:1842" name="Xlink:DSSO" cvRef="UNIMOD"/>
-                    <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink donor" value="3"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002509" name="crosslink donor" value="3"/>
                     <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"
                              value="A:54.0105647:ST" cvRef="PSI-MS"/>
                     <cvParam accession="MS:1003390" name="crosslinker cleavage characteristics"

--- a/src/tests/class_tests/openms/data/MzIdentML_v1.3_noncov_assoc.mzid
+++ b/src/tests/class_tests/openms/data/MzIdentML_v1.3_noncov_assoc.mzid
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MzIdentML id="12345" version="1.3.0" xmlns="http://psidev.info/psi/pi/mzIdentML/1.3"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.3 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.3.0.xsd"
+           creationDate="2022-05-02T12:24:29">
+    <cvList>
+        <cv fullName="PSI-MS" uri="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo" id="PSI-MS"/>
+        <cv fullName="XLMOD" uri="https://raw.githubusercontent.com/HUPO-PSI/xlmod-CV/main/XLMOD.obo" id="XLMOD"/>
+        <cv fullName="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo" id="UNIMOD"/>
+        <cv fullName="UNIT-ONTOLOGY"
+            uri="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"
+            id="UO"/>
+    </cvList>
+    <cvParam cvRef="PSI-MS" accession="MS:1003385" name="mzIdentML crosslinking extension document version"
+             value="1.0.0"/>
+    <AnalysisSoftwareList>
+        <AnalysisSoftware id="xi_id" name="xi">
+            <SoftwareName>
+                <cvParam cvRef="PSI-MS" accession="MS:1002544" name="xi"/>
+            </SoftwareName>
+        </AnalysisSoftware>
+        <AnalysisSoftware version="2.2.beta" id="xiFDR_id" name="XiFDR">
+            <SoftwareName>
+                <cvParam cvRef="PSI-MS" accession="MS:1002543" name="xiFDR"/>
+            </SoftwareName>
+        </AnalysisSoftware>
+    </AnalysisSoftwareList>
+    <Provider id="PROVIDER">
+        <ContactRole contact_ref="PERSON_DOC_OWNER">
+            <Role>
+                <cvParam cvRef="PSI-MS" accession="MS:1001271" name="researcher"/>
+            </Role>
+        </ContactRole>
+    </Provider>
+    <AuditCollection>
+        <Person lastName="Fischer" firstName="Lutz" id="PERSON_DOC_OWNER">
+            <cvParam cvRef="PSI-MS" accession="MS:1000587" name="contact address" value="TIB Gebäude 17,
+Etage 4, Raum 474
+Gustav-Meyer-Allee 25
+13355 Berlin"/>
+            <cvParam cvRef="PSI-MS" accession="MS:1000589" name="contact email"
+                     value="lutz.fischer@tu-berlin.de"/>
+            <Affiliation organization_ref="ORG_DOC_OWNER"/>
+        </Person>
+        <Organization id="ORG_DOC_OWNER" name="TU Berlin">
+            <cvParam cvRef="PSI-MS" accession="MS:1000586" name="contact name" value="TU Berlin"/>
+        </Organization>
+    </AuditCollection>
+    <SequenceCollection>
+        <DBSequence length="429" searchDatabase_ref="SDB_16441_1534" accession="P15640" id="dbseq_P15640_target"
+                    name="PUR2_ECOLI Phosphoribosylamine--glycine ligase OS=Escherichia coli (strain K12) OX=83333 GN=purD PE=1 SV=2">
+            <Seq>
+                MKVLVIGNGGREHALAWKAAQSPLVETVFVAPGNAGTALEPALQNVAIGVTDIPALLDFAQNEKIDLTIVGPEAPLVKGVVDTFRAAGLKIFGPTAGAAQLEGSKAFTKDFLARHKIPTAEYQNFTEVEPALAYLREKGAPIVIKADGLAAGKGVIVAMTLEEAEAAVHDMLAGNAFGDAGHRIVIEEFLDGEEASFIVMVDGEHVLPMATSQDHKRVGDKDTGPNTGGMGAYSPAPVVTDDVHQRTMERIIWPTVKGMAAEGNTYTGFLYAGLMIDKQGNPKVIEFNCRFGDPETQPIMLRMKSDLVELCLAACESKLDEKTSEWDERASLGVVMAAGGYPGDYRTGDVIHGLPLEEVAGGKVFHAGTKLADDEQVVTNGGRVLCVTALGHTVAEAQKRAYALMTDIHWDDCFCRKDIGWRAIEREQN
+            </Seq>
+            <cvParam cvRef="PSI-MS" accession="MS:1001088" name="protein description"
+                     value="PUR2_ECOLI Phosphoribosylamine--glycine ligase OS=Escherichia coli (strain K12) OX=83333 GN=purD PE=1 SV=2"/>
+        </DBSequence>
+        <DBSequence length="585" searchDatabase_ref="SDB_16441_1534" accession="P02768-A" id="dbseq_P02768-A_target"
+                    name="ALBU_HUMAN Serum albumin active OS=Homo sapiens GN=ALB PE=1 SV=2">
+            <Seq>
+                DAHKSEVAHRFKDLGEENFKALVLIAFAQYLQQCPFEDHVKLVNEVTEFAKTCVADESAENCDKSLHTLFGDKLCTVATLRETYGEMADCCAKQEPERNECFLQHKDDNPNLPRLVRPEVDVMCTAFHDNEETFLKKYLYEIARRHPYFYAPELLFFAKRYKAAFTECCQAADKAACLLPKLDELRDEGKASSAKQRLKCASLQKFGERAFKAWAVARLSQRFPKAEFAEVSKLVTDLTKVHTECCHGDLLECADDRADLAKYICENQDSISSKLKECCEKPLLEKSHCIAEVENDEMPADLPSLAADFVESKDVCKNYAEAKDVFLGMFLYEYARRHPDYSVVLLLRLAKTYETTLEKCCAAADPHECYAKVFDEFKPLVEEPQNLIKQNCELFEQLGEYKFQNALLVRYTKKVPQVSTPTLVEVSRNLGKVGSKCCKHPEAKRMPCAEDYLSVVLNQLCVLHEKTPVSDRVTKCCTESLVNRRPCFSALEVDETYVPKEFNAETFTFHADICTLSEKERQIKKQTALVELVKHKPKATKEQLKAVMDDFAAFVEKCCKADDKETCFAEEGKKLVAASQAALGL
+            </Seq>
+            <cvParam cvRef="PSI-MS" accession="MS:1001088" name="protein description"
+                     value="ALBU_HUMAN Serum albumin active OS=Homo sapiens GN=ALB PE=1 SV=2"/>
+        </DBSequence>
+        <Peptide id="p1">
+            <PeptideSequence>AYALMTDIHWDDCFCR</PeptideSequence>
+            <Modification location="5" residues="M" monoisotopicMassDelta="15.99491">
+                <cvParam cvRef="PSI-MS" accession="MS:1003393" name="search modification id ref" value="ox"/>
+                <cvParam cvRef="UNIMOD" accession="UNIMOD:35" name="Oxidation"/>
+            </Modification>
+            <Modification location="13" residues="C" monoisotopicMassDelta="57.02147">
+                <cvParam cvRef="PSI-MS" accession="MS:1003393" name="search modification id ref" value="cm"/>
+                <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+            </Modification>
+            <Modification location="15" residues="C" monoisotopicMassDelta="57.02147">
+                <cvParam cvRef="PSI-MS" accession="MS:1003393" name="search modification id ref" value="cm"/>
+                <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+            </Modification>
+        </Peptide>
+        <Peptide id="p2">
+            <PeptideSequence>VHTECCHGDLLECADDR</PeptideSequence>
+            <Modification location="5" residues="C" monoisotopicMassDelta="57.02147">
+                <cvParam cvRef="PSI-MS" accession="MS:1003393" name="search modification id ref" value="cm"/>
+                <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+            </Modification>
+            <Modification location="6" residues="C" monoisotopicMassDelta="57.02147">
+                <cvParam cvRef="PSI-MS" accession="MS:1003393" name="search modification id ref" value="cm"/>
+                <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+            </Modification>
+            <Modification location="13" residues="C" monoisotopicMassDelta="57.02147">
+                <cvParam cvRef="PSI-MS" accession="MS:1003393" name="search modification id ref" value="cm"/>
+                <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+            </Modification>
+        </Peptide>
+        <PeptideEvidence dBSequence_ref="dbseq_P15640_target"
+                         peptide_ref="p1"
+                         start="401" end="416" isDecoy="false"
+                         id="pepevid_p1"/>
+        <PeptideEvidence dBSequence_ref="dbseq_P02768-A_target"
+                         peptide_ref="p2"
+                         start="241" end="257" isDecoy="false"
+                         id="pepevid_p2"/>
+    </SequenceCollection>
+    <AnalysisCollection>
+        <SpectrumIdentification spectrumIdentificationProtocol_ref="SearchProtocol_1_16441"
+                                spectrumIdentificationList_ref="SII_LIST_1_1_16441_recal_E151023_06_Lumos_CS_AB_IN_190_HCD_HSA_SDA_2.mgf"
+                                id="SpecIdent__16441_recal_E151023_06_Lumos_CS_AB_IN_190_HCD_HSA_SDA_2.mgf">
+            <InputSpectra
+                    spectraData_ref="SD_16441_recal_E151023_06_Lumos_CS_AB_IN_190_HCD_HSA_SDA_2.mgf"/>
+            <SearchDatabaseRef searchDatabase_ref="SDB_16441_1534"/>
+        </SpectrumIdentification>
+    </AnalysisCollection>
+    <AnalysisProtocolCollection>
+        <SpectrumIdentificationProtocol analysisSoftware_ref="xiFDR_id" id="SearchProtocol_1_16441">
+            <SearchType>
+                <cvParam cvRef="PSI-MS" accession="MS:1001083" name="ms-ms search"/>
+            </SearchType>
+            <AdditionalSearchParams>
+                <cvParam cvRef="PSI-MS" accession="MS:1001211" name="parent mass type mono"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001256" name="fragment mass type mono"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1002494" name="crosslinking search"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1003330" name="noncovalently associated peptides search"/>
+
+                <!-- are these meant to be changed to children of MS:1002307 (fragmentation ion type)  -->
+                <cvParam cvRef="PSI-MS" accession="MS:1001118" name="param: b ion"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001262" name="param: y ion"/>
+
+                <!-- these are the current non-deprecated ways of encoding losses?  -->
+                <cvParam name="neutral loss" cvRef="PSI-MS" accession="MS:1000336" value="H2O"/>
+                <cvParam name="neutral loss" cvRef="PSI-MS" accession="MS:1000336" value="NH3"/>
+
+            </AdditionalSearchParams>
+            <ModificationParams>
+                <SearchModification fixedMod="false" massDelta="15.99491" residues="M">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392" name="search modification id"
+                             value="ox"/>
+                    <cvParam cvRef="UNIMOD" accession="UNIMOD:35" name="Oxidation"/>
+                </SearchModification>
+                <SearchModification fixedMod="false" massDelta="57.021465" residues="C">
+                    <cvParam cvRef="PSI-MS" accession="MS:1003392" name="search modification id"
+                             value="cm"/>
+                    <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+                </SearchModification>
+            </ModificationParams>
+            <Enzymes independent="false">
+                <Enzyme nTermGain="H" cTermGain="OH" semiSpecific="false" missedCleavages="3" id="Trypsin_0">
+                    <EnzymeName>
+                        <cvParam cvRef="PSI-MS" accession="MS:1001251" name="Trypsin"/>
+                    </EnzymeName>
+                </Enzyme>
+            </Enzymes>
+            <FragmentTolerance>
+                <cvParam cvRef="PSI-MS" accession="MS:1001412" name="search tolerance plus value" value="20.0"
+                         unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001413" name="search tolerance minus value" value="20.0"
+                         unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+            </FragmentTolerance>
+            <ParentTolerance>
+                <cvParam cvRef="PSI-MS" accession="MS:1001412" name="search tolerance plus value" value="3.0"
+                         unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+                <cvParam cvRef="PSI-MS" accession="MS:1001413" name="search tolerance minus value" value="3.0"
+                         unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+            </ParentTolerance>
+            <Threshold>
+                <cvParam cvRef="PSI-MS" accession="MS:1001494" name="no threshold"/>
+            </Threshold>
+        </SpectrumIdentificationProtocol>
+    </AnalysisProtocolCollection>
+    <DataCollection>
+        <Inputs>
+            <SearchDatabase location="HSA_first200_Ecoli.fasta" id="SDB_16441_1534">
+                <FileFormat>
+                    <cvParam cvRef="PSI-MS" accession="MS:1001348" name="FASTA format"/>
+                </FileFormat>
+                <DatabaseName>
+                    <userParam name="HSA_first200_Ecoli.fasta"/>
+                </DatabaseName>
+            </SearchDatabase>
+            <SpectraData location="recal_E151023_06_Lumos_CS_AB_IN_190_HCD_HSA_SDA_2.mgf"
+                         id="SD_16441_recal_E151023_06_Lumos_CS_AB_IN_190_HCD_HSA_SDA_2.mgf">
+                <FileFormat>
+                    <cvParam cvRef="PSI-MS" accession="MS:1001062" name="Mascot MGF format"/>
+                </FileFormat>
+                <SpectrumIDFormat>
+                    <cvParam cvRef="PSI-MS" accession="MS:1000774" name="multiple peak list nativeID format"/>
+                </SpectrumIDFormat>
+            </SpectraData>
+        </Inputs>
+        <AnalysisData>
+            <SpectrumIdentificationList id="SII_LIST_1_1_16441_recal_E151023_06_Lumos_CS_AB_IN_190_HCD_HSA_SDA_2.mgf">
+                <SpectrumIdentificationResult spectrumID="index=4630"
+                                              spectraData_ref="SD_16441_recal_E151023_06_Lumos_CS_AB_IN_190_HCD_HSA_SDA_2.mgf"
+                                              id="SIR_1">
+                    <SpectrumIdentificationItem chargeState="3" experimentalMassToCharge="1392.897440641436"
+                                                calculatedMassToCharge="1392.567094980103"
+                                                peptide_ref="p1"
+                                                rank="1" passThreshold="true" id="SII_1_1">
+                        <PeptideEvidenceRef
+                                peptideEvidence_ref="pepevid_p1"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003331"
+                                 name="noncovalently associated peptides spectrum identification item"
+                                 value="1"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002545" name="xi:score"
+                                 value="13.456698034492756"/>
+                    </SpectrumIdentificationItem>
+                    <SpectrumIdentificationItem chargeState="3" experimentalMassToCharge="1392.897440641436"
+                                                calculatedMassToCharge="1392.567094980103"
+                                                peptide_ref="p2"
+                                                rank="1" passThreshold="true" id="SII_1_2">
+                        <PeptideEvidenceRef
+                                peptideEvidence_ref="pepevid_p2"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1003331"
+                                 name="noncovalently associated peptides spectrum identification item"
+                                 value="1"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002545" name="xi:score"
+                                 value="13.456698034492756"/>
+                    </SpectrumIdentificationItem>
+                    <cvParam cvRef="PSI-MS" accession="MS:1000797" name="peak list scans" value="13773"/>
+                </SpectrumIdentificationResult>
+            </SpectrumIdentificationList>
+            <ProteinDetectionList id="PDL_1">
+                <ProteinAmbiguityGroup id="PAG_0">
+                    <ProteinDetectionHypothesis dBSequence_ref="dbseq_P15640_target" passThreshold="false"
+                                                id="PAG_0_PDH_0">
+                        <PeptideHypothesis
+                                peptideEvidence_ref="pepevid_p1">
+                            <SpectrumIdentificationItemRef
+                                    spectrumIdentificationItem_ref="SII_1_1"/>
+                        </PeptideHypothesis>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002403" name="group representative"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1001593"
+                                 name="group member with undefined relationship OR ortholog protein"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002676" name="protein-pair-level global FDR"
+                                 value="10.b:null:0.0:true"/>
+                    </ProteinDetectionHypothesis>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002415" name="protein group passes threshold"
+                             value="true"/>
+                </ProteinAmbiguityGroup>
+                <ProteinAmbiguityGroup id="PAG_1">
+                    <ProteinDetectionHypothesis dBSequence_ref="dbseq_P02768-A_target" passThreshold="false"
+                                                id="PAG_1_PDH_0">
+                        <PeptideHypothesis
+                                peptideEvidence_ref="pepevid_p2">
+                            <SpectrumIdentificationItemRef
+                                    spectrumIdentificationItem_ref="SII_1_2"/>
+                        </PeptideHypothesis>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002403" name="group representative"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1001593"
+                                 name="group member with undefined relationship OR ortholog protein"/>
+                        <cvParam cvRef="PSI-MS" accession="MS:1002676" name="protein-pair-level global FDR"
+                                 value="10.a:null:0.0:true"/>
+                    </ProteinDetectionHypothesis>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002415" name="protein group passes threshold"
+                             value="true"/>
+                </ProteinAmbiguityGroup>
+                <cvParam cvRef="PSI-MS" accession="MS:1002404" name="count of identified proteins" value="2"/>
+            </ProteinDetectionList>
+        </AnalysisData>
+    </DataCollection>
+</MzIdentML>

--- a/src/tests/class_tests/openms/data/MzIdentML_v1.3_noncov_assoc.mzid
+++ b/src/tests/class_tests/openms/data/MzIdentML_v1.3_noncov_assoc.mzid
@@ -33,17 +33,15 @@
         </ContactRole>
     </Provider>
     <AuditCollection>
-        <Person lastName="Fischer" firstName="Lutz" id="PERSON_DOC_OWNER">
-            <cvParam cvRef="PSI-MS" accession="MS:1000587" name="contact address" value="TIB Gebäude 17,
-Etage 4, Raum 474
-Gustav-Meyer-Allee 25
-13355 Berlin"/>
+        <Person lastName="Doe" firstName="Jane" id="PERSON_DOC_OWNER">
+            <cvParam cvRef="PSI-MS" accession="MS:1000587" name="contact address" value="123 Example Street
+00000 Example City"/>
             <cvParam cvRef="PSI-MS" accession="MS:1000589" name="contact email"
-                     value="lutz.fischer@tu-berlin.de"/>
+                     value="contact@example.org"/>
             <Affiliation organization_ref="ORG_DOC_OWNER"/>
         </Person>
-        <Organization id="ORG_DOC_OWNER" name="TU Berlin">
-            <cvParam cvRef="PSI-MS" accession="MS:1000586" name="contact name" value="TU Berlin"/>
+        <Organization id="ORG_DOC_OWNER" name="Example Organization">
+            <cvParam cvRef="PSI-MS" accession="MS:1000586" name="contact name" value="Example Organization"/>
         </Organization>
     </AuditCollection>
     <SequenceCollection>

--- a/src/tests/class_tests/openms/data/MzIdentML_v1.3_xlink_edc.mzid
+++ b/src/tests/class_tests/openms/data/MzIdentML_v1.3_xlink_edc.mzid
@@ -1,0 +1,1578 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MzIdentML id="report" version="1.3.0"
+             xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.3 http://localhost/mascot_2_8_1xy/xmlns/schema/mzIdentML/mzIdentML1.3.0.xsd"
+             xmlns="http://psidev.info/psi/pi/mzIdentML/1.3"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             creationDate="2022-04-11T15:36:24">
+  <cvList>
+    <cv id="PSI-MS" fullName="Proteomics Standards Initiative Mass Spectrometry Vocabularies"   uri="http://psidev.cvs.sourceforge.net/viewvc/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo" version="4.1.69"></cv>
+    <cv id="UNIMOD" fullName="UNIMOD"        uri="http://www.unimod.org/obo/unimod.obo"></cv>
+    <cv id="UO"     fullName="UNIT-ONTOLOGY" uri="http://bioportal.bioontology.org/ontologies/UO?p=classes&amp;conceptid=root"></cv>
+  </cvList>
+  <cvParam cvRef="PSI-MS" accession="MS:1003385" name="mzIdentML crosslinking extension document version" value="1.0.0"/>
+  <AnalysisSoftwareList>
+    <AnalysisSoftware id="AS_mascot_server" name="Mascot Server" version="2.8.1" uri="http://www.matrixscience.com/search_form_select.html">
+      <ContactRole contact_ref="ORG_MSL">
+        <Role>
+          <cvParam accession="MS:1001267" name="software vendor" cvRef="PSI-MS" />
+        </Role>
+      </ContactRole>
+      <SoftwareName>
+        <cvParam accession="MS:1001207" name="Mascot" cvRef="PSI-MS" />
+      </SoftwareName>
+      <Customizations>
+        No customisations
+      </Customizations>
+    </AnalysisSoftware>
+    <AnalysisSoftware id="AS_mascot_parser" name="Mascot Parser" version="2.8.1.0" uri="http://www.matrixscience.com/msparser.html">
+      <ContactRole contact_ref="ORG_MSL">
+        <Role>
+          <cvParam accession="MS:1001267" name="software vendor" cvRef="PSI-MS" />
+        </Role>
+      </ContactRole>
+      <SoftwareName>
+        <cvParam accession="MS:1001478" name="Mascot Parser" cvRef="PSI-MS" />
+      </SoftwareName>
+      <Customizations>
+        No customisations
+      </Customizations>
+    </AnalysisSoftware>
+  </AnalysisSoftwareList>
+  <Provider id="PROVIDER">
+    <ContactRole contact_ref="PERSON_DOC_OWNER">
+      <Role>
+        <cvParam accession="MS:1001271" name="researcher" cvRef="PSI-MS" />
+      </Role>
+    </ContactRole>
+  </Provider>
+  <AuditCollection>
+    <Person id="PERSON_MSL">
+      <Affiliation organization_ref="ORG_MSL" />
+    </Person>
+    <Person id="PERSON_DOC_OWNER" name="">
+      <Affiliation organization_ref="ORG_DOC_OWNER" />
+    </Person>
+    <Organization id="ORG_MSL" name="Matrix Science Limited">
+      <cvParam accession="MS:1000589" name="contact email" value="support@matrixscience.com" cvRef="PSI-MS" />
+      <cvParam accession="MS:1000587" name="contact address" value="64 Baker Street, London W1U 7GB, UK" cvRef="PSI-MS" />
+      <cvParam accession="MS:1001755" name="contact phone number" value="+44 (0)20 7486 1050" cvRef="PSI-MS" />
+      <cvParam accession="MS:1001756" name="contact fax number" value="+44 (0)20 7224 1344" cvRef="PSI-MS" />
+      <cvParam accession="MS:1000588" name="contact URL" value="http://www.matrixscience.com" cvRef="PSI-MS" />
+    </Organization>
+    <Organization id="ORG_DOC_OWNER" />
+  </AuditCollection>
+  <SequenceCollection>
+    <DBSequence id="DBSeq_2_MND1_ARATH" searchDatabase_ref="SDB_PXD001538" accession="MND1_ARATH" >
+      <Seq>MSKKRGLSLEEKREKMLQIFYESQDFFLLKELEKMGPKKGVISQSVKDVIQSLVDDDLVAKDKIGISIYFWSLPSCAGNQLRSVRQKLESDLQGSNKRLAELVDQCEALKKGREESEERTEALTQLKDIEKKHKDLKNEMVQFADNDPATLEAKRNAIEVAHQSANRWTDNIFTLRQWCSNNFPQAKEQLEHLYTEAGITEDFDYIELSSFPLSSSHEADTAKQLVQDEA</Seq>
+      <cvParam accession="MS:1001088" name="protein description" cvRef="PSI-MS" value="Meiotic nuclear division protein 1 homolog OS=Arabidopsis t" />
+    </DBSequence>
+    <DBSequence id="DBSeq_2_HOP2_ARATH" searchDatabase_ref="SDB_PXD001538" accession="HOP2_ARATH" >
+      <Seq>MAPKSDNTEAIVLNFVNEQNKPLNTQNAADALQKFNLKKTAVQKALDSLADAGKITFKEYGKQKIYIARQDQFEIPNSEELAQMKEDNAKLQEQLQEKKKTISDVESEIKSLQSNLTLEEIQEKDAKLRKEVKEMEEKLVKLREGITLVRPEDKKAVEDMYADKINQWRKRKRMFRDIWDTVTENSPKDVKELKEELGIEYDEDVGLSFQAYADLIQHGKKRPRGQ</Seq>
+      <cvParam accession="MS:1001088" name="protein description" cvRef="PSI-MS" value="Homologous-pairing protein 2 homolog OS=Arabidopsis thalian" />
+    </DBSequence>
+    <Peptide id="peptide_1_1">
+      <PeptideSequence>QLVQDEA</PeptideSequence>
+    </Peptide>
+    <Peptide id="peptide_2_1">
+      <PeptideSequence>ALDSLADAGK</PeptideSequence>
+    </Peptide>
+    <Peptide id="peptide_3_1">
+      <PeptideSequence>WTDNIFTLR</PeptideSequence>
+    </Peptide>
+    <Peptide id="peptide_4_1">
+      <PeptideSequence>LESDLQGSNKR</PeptideSequence>
+    </Peptide>
+    <Peptide id="peptide_5_1">
+      <PeptideSequence>KTISDVESEIK</PeptideSequence>
+    </Peptide>
+    <Peptide id="peptide_7_1">
+      <PeptideSequence>DVIQSLVDDDLVAK</PeptideSequence>
+      <Modification location="10" residues="D" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="100" />
+      </Modification>
+      <Modification location="14" residues="K" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink acceptor" value="100" />
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_7_2">
+      <PeptideSequence>DVIQSLVDDDLVAK</PeptideSequence>
+      <Modification location="9" residues="D" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="101" />
+      </Modification>
+      <Modification location="14" residues="K" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink acceptor" value="101" />
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_7_3">
+      <PeptideSequence>DVIQSLVDDDLVAK</PeptideSequence>
+      <Modification location="8" residues="D" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="102" />
+      </Modification>
+      <Modification location="14" residues="K" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink acceptor" value="102" />
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_8_1">
+      <PeptideSequence>TEALTQLKDIEKK</PeptideSequence>
+    </Peptide>
+    <Peptide id="peptide_8_2_p1">
+      <PeptideSequence>TEALTQLK</PeptideSequence>
+      <Modification location="8" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="1"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_8_2_p2">
+      <PeptideSequence>DIEKK</PeptideSequence>
+      <Modification location="1" residues="D" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="1"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_8_3_p1">
+      <PeptideSequence>TEALTQLK</PeptideSequence>
+      <Modification location="8" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="2"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_8_3_p2">
+      <PeptideSequence>DIEKK</PeptideSequence>
+      <Modification location="3" residues="E" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="2"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_9_1">
+      <PeptideSequence>TEALTQLKDIEKK</PeptideSequence>
+    </Peptide>
+    <Peptide id="peptide_9_2_p1">
+      <PeptideSequence>TEALTQLK</PeptideSequence>
+      <Modification location="8" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="3"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_9_2_p2">
+      <PeptideSequence>DIEKK</PeptideSequence>
+      <Modification location="1" residues="D" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="3"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_9_3_p1">
+      <PeptideSequence>TEALTQLK</PeptideSequence>
+      <Modification location="8" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="4"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_9_3_p2">
+      <PeptideSequence>DIEKK</PeptideSequence>
+      <Modification location="3" residues="E" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="4"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_10_1">
+      <PeptideSequence>DVIQSLVDDDLVAK</PeptideSequence>
+    </Peptide>
+    <Peptide id="peptide_11_1">
+      <PeptideSequence>NEMVQFADNDPATLEAKR</PeptideSequence>
+      <Modification location="3" residues="M" monoisotopicMassDelta="15.994915">
+        <cvParam accession="UNIMOD:35" name="Oxidation" cvRef="UNIMOD" />
+        <cvParam accession="MS:1001524" name="fragment neutral loss" cvRef="PSI-MS" value="0" unitAccession="UO:0000221" unitName="dalton" unitCvRef="UO" />
+      </Modification>
+      <Modification location="15" residues="E" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="103" />
+      </Modification>
+      <Modification location="17" residues="K" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink acceptor" value="103" />
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_11_2">
+      <PeptideSequence>NEMVQFADNDPATLEAKR</PeptideSequence>
+      <Modification location="3" residues="M" monoisotopicMassDelta="15.994915">
+        <cvParam accession="UNIMOD:35" name="Oxidation" cvRef="UNIMOD" />
+        <cvParam accession="MS:1001524" name="fragment neutral loss" cvRef="PSI-MS" value="0" unitAccession="UO:0000221" unitName="dalton" unitCvRef="UO" />
+      </Modification>
+      <Modification location="10" residues="D" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="104" />
+      </Modification>
+      <Modification location="17" residues="K" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink acceptor" value="104" />
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_12_1">
+      <PeptideSequence>NEMVQFADNDPATLEAKR</PeptideSequence>
+    </Peptide>
+    <Peptide id="peptide_13_1_p1">
+      <PeptideSequence>KTISDVESEIK</PeptideSequence>
+      <Modification location="1" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="5"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_13_1_p2">
+      <PeptideSequence>TEALTQLK</PeptideSequence>
+      <Modification location="2" residues="E" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="5"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_13_2_p1">
+      <PeptideSequence>KKTISDVESEIK</PeptideSequence>
+      <Modification location="1" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="6"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_13_2_p2">
+      <PeptideSequence>GLSLEEK</PeptideSequence>
+      <Modification location="6" residues="E" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="6"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_13_3_p1">
+      <PeptideSequence>KKTISDVESEIK</PeptideSequence>
+      <Modification location="1" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="7"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_13_3_p2">
+      <PeptideSequence>GLSLEEK</PeptideSequence>
+      <Modification location="5" residues="E" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="7"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_13_4_p1">
+      <PeptideSequence>KKTISDVESEIK</PeptideSequence>
+      <Modification location="2" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="8"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_13_4_p2">
+      <PeptideSequence>GLSLEEK</PeptideSequence>
+      <Modification location="6" residues="E" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="8"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_13_5_p1">
+      <PeptideSequence>KKTISDVESEIK</PeptideSequence>
+      <Modification location="2" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="9"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_13_5_p2">
+      <PeptideSequence>GLSLEEK</PeptideSequence>
+      <Modification location="5" residues="E" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="9"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_13_6_p1">
+      <PeptideSequence>KTISDVESEIK</PeptideSequence>
+      <Modification location="11" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="10"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_13_6_p2">
+      <PeptideSequence>TEALTQLK</PeptideSequence>
+      <Modification location="2" residues="E" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="10"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_14_1_p1">
+      <PeptideSequence>LESDLQGSNKR</PeptideSequence>
+      <Modification location="10" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="11"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_14_1_p2">
+      <PeptideSequence>ALDSLADAGK</PeptideSequence>
+      <Modification location="7" residues="D" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="11"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_14_2_p1">
+      <PeptideSequence>LESDLQGSNKR</PeptideSequence>
+      <Modification location="4" residues="D" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="12"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_14_2_p2">
+      <PeptideSequence>ALDSLADAGK</PeptideSequence>
+      <Modification location="10" residues="K" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="12"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_14_3_p1">
+      <PeptideSequence>LESDLQGSNKR</PeptideSequence>
+      <Modification location="10" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="13"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_14_3_p2">
+      <PeptideSequence>ALDSLADAGK</PeptideSequence>
+      <Modification location="3" residues="D" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="13"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_14_4_p1">
+      <PeptideSequence>LESDLQGSNKR</PeptideSequence>
+      <Modification location="2" residues="E" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="14"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_14_4_p2">
+      <PeptideSequence>ALDSLADAGK</PeptideSequence>
+      <Modification location="10" residues="K" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="14"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_15_1_p1">
+      <PeptideSequence>LESDLQGSNKR</PeptideSequence>
+      <Modification location="10" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="15"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_15_1_p2">
+      <PeptideSequence>WTDNIFTLR</PeptideSequence>
+      <Modification location="3" residues="D" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="15"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_16_1">
+      <PeptideSequence>HKDLKNEMVQFADNDPATLEAK</PeptideSequence>
+    </Peptide>
+    <Peptide id="peptide_16_2_p1">
+      <PeptideSequence>NEMVQFADNDPATLEAK</PeptideSequence>
+      <Modification location="2" residues="E" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="16"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_16_2_p2">
+      <PeptideSequence>HKDLK</PeptideSequence>
+      <Modification location="5" residues="K" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="16"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_16_3_p1">
+      <PeptideSequence>NEMVQFADNDPATLEAK</PeptideSequence>
+      <Modification location="2" residues="E" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="17"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_16_3_p2">
+      <PeptideSequence>HKDLK</PeptideSequence>
+      <Modification location="2" residues="K" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="17"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_16_4_p1">
+      <PeptideSequence>NEMVQFADNDPATLEAK</PeptideSequence>
+      <Modification location="8" residues="D" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="18"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_16_4_p2">
+      <PeptideSequence>HKDLK</PeptideSequence>
+      <Modification location="5" residues="K" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="18"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_16_5_p1">
+      <PeptideSequence>NEMVQFADNDPATLEAK</PeptideSequence>
+      <Modification location="8" residues="D" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="19"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_16_5_p2">
+      <PeptideSequence>HKDLK</PeptideSequence>
+      <Modification location="2" residues="K" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="19"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_16_6_p1">
+      <PeptideSequence>NEMVQFADNDPATLEAK</PeptideSequence>
+      <Modification location="10" residues="D" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="20"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_16_6_p2">
+      <PeptideSequence>HKDLK</PeptideSequence>
+      <Modification location="5" residues="K" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="20"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_16_7_p1">
+      <PeptideSequence>NEMVQFADNDPATLEAK</PeptideSequence>
+      <Modification location="10" residues="D" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="21"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_16_7_p2">
+      <PeptideSequence>HKDLK</PeptideSequence>
+      <Modification location="2" residues="K" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="21"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_17_1_p1">
+      <PeptideSequence>HKDLKNEMVQFADNDPATLEAK</PeptideSequence>
+      <Modification location="5" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="22"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_17_1_p2">
+      <PeptideSequence>QLVQDEA</PeptideSequence>
+      <Modification location="8" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="22"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_17_2_p1">
+      <PeptideSequence>HKDLKNEMVQFADNDPATLEAK</PeptideSequence>
+      <Modification location="2" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="23"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_17_2_p2">
+      <PeptideSequence>QLVQDEA</PeptideSequence>
+      <Modification location="8" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="23"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_17_3_p1">
+      <PeptideSequence>HKDLKNEMVQFADNDPATLEAK</PeptideSequence>
+      <Modification location="5" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="24"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_17_3_p2">
+      <PeptideSequence>QLVQDEA</PeptideSequence>
+      <Modification location="6" residues="E" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="24"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_17_4_p1">
+      <PeptideSequence>HKDLKNEMVQFADNDPATLEAK</PeptideSequence>
+      <Modification location="2" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="25"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_17_4_p2">
+      <PeptideSequence>QLVQDEA</PeptideSequence>
+      <Modification location="6" residues="E" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="25"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_17_5_p1">
+      <PeptideSequence>HKDLKNEMVQFADNDPATLEAK</PeptideSequence>
+      <Modification location="5" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="26"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_17_5_p2">
+      <PeptideSequence>QLVQDEA</PeptideSequence>
+      <Modification location="5" residues="D" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="26"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_17_6_p1">
+      <PeptideSequence>HKDLKNEMVQFADNDPATLEAK</PeptideSequence>
+      <Modification location="2" residues="K" monoisotopicMassDelta="-18.010565">
+        <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+        <cvParam accession="MS:1002509" cvRef="PSI-MS" name="crosslink donor" value="27"/>
+      </Modification>
+    </Peptide>
+    <Peptide id="peptide_17_6_p2">
+      <PeptideSequence>QLVQDEA</PeptideSequence>
+      <Modification location="5" residues="D" monoisotopicMassDelta="0.0">
+        <cvParam accession="MS:1002510" cvRef="PSI-MS" name="crosslink receiver" value="27"/>
+      </Modification>
+    </Peptide>
+    <PeptideEvidence id="PE_1_1_2_MND1_ARATH_0_224_230" start="224" end="230" pre="K" post="-" peptide_ref="peptide_1_1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_2_1_2_HOP2_ARATH_0_45_54" start="45" end="54" pre="K" post="I" peptide_ref="peptide_2_1" isDecoy="false" dBSequence_ref="DBSeq_2_HOP2_ARATH" />
+    <PeptideEvidence id="PE_3_1_2_MND1_ARATH_0_168_176" start="168" end="176" pre="R" post="Q" peptide_ref="peptide_3_1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_4_1_2_MND1_ARATH_0_88_98" start="88" end="98" pre="K" post="L" peptide_ref="peptide_4_1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_5_1_2_HOP2_ARATH_0_100_110" start="100" end="110" pre="K" post="S" peptide_ref="peptide_5_1" isDecoy="false" dBSequence_ref="DBSeq_2_HOP2_ARATH" />
+    <PeptideEvidence id="PE_7_1_2_MND1_ARATH_0_48_61" start="48" end="61" pre="K" post="D" peptide_ref="peptide_7_1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_7_2_2_MND1_ARATH_0_48_61" start="48" end="61" pre="K" post="D" peptide_ref="peptide_7_2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_7_3_2_MND1_ARATH_0_48_61" start="48" end="61" pre="K" post="D" peptide_ref="peptide_7_3" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_8_1_2_MND1_ARATH_0_120_132" start="120" end="132" pre="R" post="H" peptide_ref="peptide_8_1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_8_2_1_2_MND1_ARATH_0_120_127" start="120" end="127" pre="R" post="D" peptide_ref="peptide_8_2_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_8_2_2_2_MND1_ARATH_0_128_132" start="128" end="132" pre="K" post="H" peptide_ref="peptide_8_2_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_8_3_1_2_MND1_ARATH_0_120_127" start="120" end="127" pre="R" post="D" peptide_ref="peptide_8_3_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_8_3_2_2_MND1_ARATH_0_128_132" start="128" end="132" pre="K" post="H" peptide_ref="peptide_8_3_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_9_1_2_MND1_ARATH_0_120_132" start="120" end="132" pre="R" post="H" peptide_ref="peptide_9_1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_9_2_1_2_MND1_ARATH_0_120_127" start="120" end="127" pre="R" post="D" peptide_ref="peptide_9_2_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_9_2_2_2_MND1_ARATH_0_128_132" start="128" end="132" pre="K" post="H" peptide_ref="peptide_9_2_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_9_3_1_2_MND1_ARATH_0_120_127" start="120" end="127" pre="R" post="D" peptide_ref="peptide_9_3_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_9_3_2_2_MND1_ARATH_0_128_132" start="128" end="132" pre="K" post="H" peptide_ref="peptide_9_3_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_10_1_2_MND1_ARATH_0_48_61" start="48" end="61" pre="K" post="D" peptide_ref="peptide_10_1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_11_1_2_MND1_ARATH_0_138_155" start="138" end="155" pre="K" post="N" peptide_ref="peptide_11_1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_11_2_2_MND1_ARATH_0_138_155" start="138" end="155" pre="K" post="N" peptide_ref="peptide_11_2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_12_1_2_MND1_ARATH_0_138_155" start="138" end="155" pre="K" post="N" peptide_ref="peptide_12_1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_13_1_1_2_HOP2_ARATH_0_100_110" start="100" end="110" pre="K" post="S" peptide_ref="peptide_13_1_p1" isDecoy="false" dBSequence_ref="DBSeq_2_HOP2_ARATH" />
+    <PeptideEvidence id="PE_13_1_2_2_MND1_ARATH_0_120_127" start="120" end="127" pre="R" post="D" peptide_ref="peptide_13_1_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_13_2_1_2_HOP2_ARATH_0_99_110" start="99" end="110" pre="K" post="S" peptide_ref="peptide_13_2_p1" isDecoy="false" dBSequence_ref="DBSeq_2_HOP2_ARATH" />
+    <PeptideEvidence id="PE_13_2_2_2_MND1_ARATH_0_6_12" start="6" end="12" pre="R" post="R" peptide_ref="peptide_13_2_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_13_3_1_2_HOP2_ARATH_0_99_110" start="99" end="110" pre="K" post="S" peptide_ref="peptide_13_3_p1" isDecoy="false" dBSequence_ref="DBSeq_2_HOP2_ARATH" />
+    <PeptideEvidence id="PE_13_3_2_2_MND1_ARATH_0_6_12" start="6" end="12" pre="R" post="R" peptide_ref="peptide_13_3_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_13_4_1_2_HOP2_ARATH_0_99_110" start="99" end="110" pre="K" post="S" peptide_ref="peptide_13_4_p1" isDecoy="false" dBSequence_ref="DBSeq_2_HOP2_ARATH" />
+    <PeptideEvidence id="PE_13_4_2_2_MND1_ARATH_0_6_12" start="6" end="12" pre="R" post="R" peptide_ref="peptide_13_4_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_13_5_1_2_HOP2_ARATH_0_99_110" start="99" end="110" pre="K" post="S" peptide_ref="peptide_13_5_p1" isDecoy="false" dBSequence_ref="DBSeq_2_HOP2_ARATH" />
+    <PeptideEvidence id="PE_13_5_2_2_MND1_ARATH_0_6_12" start="6" end="12" pre="R" post="R" peptide_ref="peptide_13_5_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_13_6_1_2_HOP2_ARATH_0_100_110" start="100" end="110" pre="K" post="S" peptide_ref="peptide_13_6_p1" isDecoy="false" dBSequence_ref="DBSeq_2_HOP2_ARATH" />
+    <PeptideEvidence id="PE_13_6_2_2_MND1_ARATH_0_120_127" start="120" end="127" pre="R" post="D" peptide_ref="peptide_13_6_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_14_1_1_2_MND1_ARATH_0_88_98" start="88" end="98" pre="K" post="L" peptide_ref="peptide_14_1_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_14_1_2_2_HOP2_ARATH_0_45_54" start="45" end="54" pre="K" post="I" peptide_ref="peptide_14_1_p2" isDecoy="false" dBSequence_ref="DBSeq_2_HOP2_ARATH" />
+    <PeptideEvidence id="PE_14_2_1_2_MND1_ARATH_0_88_98" start="88" end="98" pre="K" post="L" peptide_ref="peptide_14_2_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_14_2_2_2_HOP2_ARATH_0_45_54" start="45" end="54" pre="K" post="I" peptide_ref="peptide_14_2_p2" isDecoy="false" dBSequence_ref="DBSeq_2_HOP2_ARATH" />
+    <PeptideEvidence id="PE_14_3_1_2_MND1_ARATH_0_88_98" start="88" end="98" pre="K" post="L" peptide_ref="peptide_14_3_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_14_3_2_2_HOP2_ARATH_0_45_54" start="45" end="54" pre="K" post="I" peptide_ref="peptide_14_3_p2" isDecoy="false" dBSequence_ref="DBSeq_2_HOP2_ARATH" />
+    <PeptideEvidence id="PE_14_4_1_2_MND1_ARATH_0_88_98" start="88" end="98" pre="K" post="L" peptide_ref="peptide_14_4_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_14_4_2_2_HOP2_ARATH_0_45_54" start="45" end="54" pre="K" post="I" peptide_ref="peptide_14_4_p2" isDecoy="false" dBSequence_ref="DBSeq_2_HOP2_ARATH" />
+    <PeptideEvidence id="PE_15_1_1_2_MND1_ARATH_0_88_98" start="88" end="98" pre="K" post="L" peptide_ref="peptide_15_1_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_15_1_2_2_MND1_ARATH_0_168_176" start="168" end="176" pre="R" post="Q" peptide_ref="peptide_15_1_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_16_1_2_MND1_ARATH_0_133_154" start="133" end="154" pre="K" post="R" peptide_ref="peptide_16_1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_16_2_1_2_MND1_ARATH_0_138_154" start="138" end="154" pre="K" post="R" peptide_ref="peptide_16_2_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_16_2_2_2_MND1_ARATH_0_133_137" start="133" end="137" pre="K" post="N" peptide_ref="peptide_16_2_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_16_3_1_2_MND1_ARATH_0_138_154" start="138" end="154" pre="K" post="R" peptide_ref="peptide_16_3_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_16_3_2_2_MND1_ARATH_0_133_137" start="133" end="137" pre="K" post="N" peptide_ref="peptide_16_3_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_16_4_1_2_MND1_ARATH_0_138_154" start="138" end="154" pre="K" post="R" peptide_ref="peptide_16_4_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_16_4_2_2_MND1_ARATH_0_133_137" start="133" end="137" pre="K" post="N" peptide_ref="peptide_16_4_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_16_5_1_2_MND1_ARATH_0_138_154" start="138" end="154" pre="K" post="R" peptide_ref="peptide_16_5_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_16_5_2_2_MND1_ARATH_0_133_137" start="133" end="137" pre="K" post="N" peptide_ref="peptide_16_5_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_16_6_1_2_MND1_ARATH_0_138_154" start="138" end="154" pre="K" post="R" peptide_ref="peptide_16_6_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_16_6_2_2_MND1_ARATH_0_133_137" start="133" end="137" pre="K" post="N" peptide_ref="peptide_16_6_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_16_7_1_2_MND1_ARATH_0_138_154" start="138" end="154" pre="K" post="R" peptide_ref="peptide_16_7_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_16_7_2_2_MND1_ARATH_0_133_137" start="133" end="137" pre="K" post="N" peptide_ref="peptide_16_7_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_17_1_1_2_MND1_ARATH_0_133_154" start="133" end="154" pre="K" post="R" peptide_ref="peptide_17_1_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_17_1_2_2_MND1_ARATH_0_224_230" start="224" end="230" pre="K" post="-" peptide_ref="peptide_17_1_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_17_2_1_2_MND1_ARATH_0_133_154" start="133" end="154" pre="K" post="R" peptide_ref="peptide_17_2_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_17_2_2_2_MND1_ARATH_0_224_230" start="224" end="230" pre="K" post="-" peptide_ref="peptide_17_2_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_17_3_1_2_MND1_ARATH_0_133_154" start="133" end="154" pre="K" post="R" peptide_ref="peptide_17_3_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_17_3_2_2_MND1_ARATH_0_224_230" start="224" end="230" pre="K" post="-" peptide_ref="peptide_17_3_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_17_4_1_2_MND1_ARATH_0_133_154" start="133" end="154" pre="K" post="R" peptide_ref="peptide_17_4_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_17_4_2_2_MND1_ARATH_0_224_230" start="224" end="230" pre="K" post="-" peptide_ref="peptide_17_4_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_17_5_1_2_MND1_ARATH_0_133_154" start="133" end="154" pre="K" post="R" peptide_ref="peptide_17_5_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_17_5_2_2_MND1_ARATH_0_224_230" start="224" end="230" pre="K" post="-" peptide_ref="peptide_17_5_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_17_6_1_2_MND1_ARATH_0_133_154" start="133" end="154" pre="K" post="R" peptide_ref="peptide_17_6_p1" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+    <PeptideEvidence id="PE_17_6_2_2_MND1_ARATH_0_224_230" start="224" end="230" pre="K" post="-" peptide_ref="peptide_17_6_p2" isDecoy="false" dBSequence_ref="DBSeq_2_MND1_ARATH" />
+  </SequenceCollection>
+  <AnalysisCollection>
+    <SpectrumIdentification id="SI" spectrumIdentificationProtocol_ref="SIP"  spectrumIdentificationList_ref="SIL_1" activityDate="2022-04-11T15:27:43">
+      <InputSpectra spectraData_ref="SD_1" />
+      <SearchDatabaseRef searchDatabase_ref="SDB_contaminants" />
+      <SearchDatabaseRef searchDatabase_ref="SDB_PXD001538" />
+      <SearchDatabaseRef searchDatabase_ref="SDB_SwissProt" />
+    </SpectrumIdentification>
+    <ProteinDetection id="PD_1" proteinDetectionProtocol_ref="PDP_MascotParser_1" proteinDetectionList_ref="PDL_1" activityDate="2022-04-11T15:36:24">
+      <InputSpectrumIdentifications spectrumIdentificationList_ref="SIL_1" />
+    </ProteinDetection>
+  </AnalysisCollection>
+  <AnalysisProtocolCollection>
+    <SpectrumIdentificationProtocol id="SIP" analysisSoftware_ref="AS_mascot_server">
+      <SearchType>
+        <cvParam accession="MS:1001083" name="ms-ms search" cvRef="PSI-MS" value="" />
+      </SearchType>
+      <AdditionalSearchParams>
+        <userParam name="Mascot User Comment" value="PXD001538 EDC MH+" />
+        <userParam name="Mascot Instrument Name" value="ESI-TRAP" />
+        <cvParam accession="MS:1001211" name="parent mass type mono"    cvRef="PSI-MS" />
+        <cvParam accession="MS:1001118" name="param: b ion" cvRef="PSI-MS" />
+        <cvParam accession="MS:1001149" name="param: b ion-NH3" cvRef="PSI-MS" />
+        <cvParam accession="MS:1001150" name="param: b ion-H2O" cvRef="PSI-MS" />
+        <cvParam accession="MS:1001262" name="param: y ion" cvRef="PSI-MS" />
+        <cvParam accession="MS:1001151" name="param: y ion-NH3" cvRef="PSI-MS" /> <!-- deprecated? -->
+        <cvParam accession="MS:1001152" name="param: y ion-H2O" cvRef="PSI-MS" /> <!-- deprecated? -->
+        <cvParam accession="MS:1002494" name="crosslinking search" cvRef="PSI-MS"/>
+      </AdditionalSearchParams>
+      <ModificationParams>
+        <SearchModification fixedMod="true" massDelta="57.021464" residues="C">
+          <cvParam accession="UNIMOD:4" name="Carbamidomethyl" cvRef="UNIMOD" />
+        </SearchModification>
+        <SearchModification fixedMod="false" massDelta="15.994915" residues="M">
+          <cvParam accession="UNIMOD:35" name="Oxidation" cvRef="UNIMOD" />
+        </SearchModification>
+
+        <!-- replace with more succinct definition of EDC for sake of example?        -->
+        <SearchModification fixedMod="false" massDelta="-18.010565" residues="K">
+          <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+          <cvParam cvRef="PSI-MS" accession="MS:1002509" name="crosslink donor" value="1" />
+        </SearchModification>
+        <SearchModification fixedMod="false" massDelta="0.0" residues="D E">
+          <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+          <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink acceptor" value="1" />
+        </SearchModification>
+        <SearchModification fixedMod="false" massDelta="0.0" residues=".">
+          <SpecificityRules>
+            <cvParam cvRef="PSI-MS" accession="MS:1002058" name="modification specificity protein C-term"/>
+          </SpecificityRules>
+          <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+          <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink acceptor" value="1" />
+        </SearchModification>
+
+        <SearchModification fixedMod="false" massDelta="-18.010565" residues="D E">
+          <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+          <cvParam cvRef="PSI-MS" accession="MS:1002509" name="crosslink donor" value="2" />
+        </SearchModification>
+        <SearchModification fixedMod="false" massDelta="0.0" residues="K">
+          <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+          <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink acceptor" value="2" />
+        </SearchModification>
+        <SearchModification fixedMod="false" massDelta="0.0" residues=".">
+          <SpecificityRules>
+            <cvParam cvRef="PSI-MS" accession="MS:1002057" name="modification specificity protein N-term"/>
+          </SpecificityRules>
+          <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+          <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink acceptor" value="2" />
+        </SearchModification>
+
+        <SearchModification fixedMod="false" massDelta="-18.010565" residues=".">
+          <SpecificityRules>
+            <cvParam cvRef="PSI-MS" accession="MS:1002057" name="modification specificity protein N-term"/>
+          </SpecificityRules>
+          <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+          <cvParam cvRef="PSI-MS" accession="MS:1002509" name="crosslink donor" value="3" />
+        </SearchModification>
+        <SearchModification fixedMod="false" massDelta="0.0" residues="D E">
+          <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+          <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink acceptor" value="3" />
+        </SearchModification>
+        <SearchModification fixedMod="false" massDelta="0.0" residues=".">
+          <SpecificityRules>
+            <cvParam cvRef="PSI-MS" accession="MS:1002058" name="modification specificity protein C-term"/>
+          </SpecificityRules>
+          <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+          <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink acceptor" value="3" />
+        </SearchModification>
+
+        <SearchModification fixedMod="false" massDelta="-18.010565" residues=".">
+          <SpecificityRules>
+            <cvParam cvRef="PSI-MS" accession="MS:1002058" name="modification specificity protein C-term"/>
+          </SpecificityRules>
+          <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+          <cvParam cvRef="PSI-MS" accession="MS:1002509" name="crosslink donor" value="4" />
+        </SearchModification>
+        <SearchModification fixedMod="false" massDelta="0.0" residues="K">
+          <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+          <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink acceptor" value="4" />
+        </SearchModification>
+        <SearchModification fixedMod="false" massDelta="0.0" residues=".">
+          <SpecificityRules>
+            <cvParam cvRef="PSI-MS" accession="MS:1002057" name="modification specificity protein N-term"/>
+          </SpecificityRules>
+          <cvParam accession="UNIMOD:2018" name="Xlink:EDC" cvRef="UNIMOD" />
+          <cvParam cvRef="PSI-MS" accession="MS:1002510" name="crosslink acceptor" value="4" />
+        </SearchModification>
+
+      </ModificationParams>
+      <Enzymes>
+        <Enzyme id="ENZ_0" cTermGain="OH" nTermGain="H" missedCleavages="4" semiSpecific="0">
+          <SiteRegexp><![CDATA[(?<=[KR])]]></SiteRegexp>
+          <EnzymeName>
+            <cvParam accession="MS:1001313" name="Trypsin/P" cvRef="PSI-MS" />
+          </EnzymeName>
+        </Enzyme>
+      </Enzymes>
+      <MassTable id="MT_1" msLevel="1 2">
+        <Residue code="A" mass="71.037114" />
+        <Residue code="C" mass="103.009185" />
+        <Residue code="D" mass="115.026943" />
+        <Residue code="E" mass="129.042593" />
+        <Residue code="F" mass="147.068414" />
+        <Residue code="G" mass="57.021464" />
+        <Residue code="H" mass="137.058912" />
+        <Residue code="I" mass="113.084064" />
+        <Residue code="J" mass="113.084064" />
+        <Residue code="K" mass="128.094963" />
+        <Residue code="L" mass="113.084064" />
+        <Residue code="M" mass="131.040485" />
+        <Residue code="N" mass="114.042927" />
+        <Residue code="O" mass="237.147727" />
+        <Residue code="P" mass="97.052764" />
+        <Residue code="Q" mass="128.058578" />
+        <Residue code="R" mass="156.101111" />
+        <Residue code="S" mass="87.032028" />
+        <Residue code="T" mass="101.047679" />
+        <Residue code="U" mass="150.953633" />
+        <Residue code="V" mass="99.068414" />
+        <Residue code="W" mass="186.079313" />
+        <Residue code="Y" mass="163.063329" />
+        <AmbiguousResidue code="B">
+          <cvParam accession="MS:1001360" name="alternate single letter codes" cvRef="PSI-MS" value="D N" />
+        </AmbiguousResidue>
+        <AmbiguousResidue code="Z">
+          <cvParam accession="MS:1001360" name="alternate single letter codes" cvRef="PSI-MS" value="E Q" />
+        </AmbiguousResidue>
+        <AmbiguousResidue code="X">
+          <cvParam accession="MS:1001360" name="alternate single letter codes" cvRef="PSI-MS" value="A C D E F G H I K L M N O P Q R S T U V W Y" />
+        </AmbiguousResidue>
+      </MassTable>
+      <FragmentTolerance>
+        <cvParam accession="MS:1001412" name="search tolerance plus value" value="0.03" cvRef="PSI-MS" unitAccession="UO:0000221" unitName="dalton" unitCvRef="UO" />
+        <cvParam accession="MS:1001413" name="search tolerance minus value" value="0.03" cvRef="PSI-MS" unitAccession="UO:0000221" unitName="dalton" unitCvRef="UO" />
+      </FragmentTolerance>
+      <ParentTolerance>
+        <cvParam accession="MS:1001412" name="search tolerance plus value" value="10" cvRef="PSI-MS" unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO" />
+        <cvParam accession="MS:1001413" name="search tolerance minus value" value="10" cvRef="PSI-MS" unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO" />
+      </ParentTolerance>
+      <Threshold>
+        <cvParam accession="MS:1001316" name="Mascot:SigThreshold" cvRef="PSI-MS" value="0.05" />
+        <cvParam accession="MS:1001758" name="Mascot:SigThresholdType" cvRef="PSI-MS" value="homology" />
+      </Threshold>
+      <DatabaseFilters>
+        <Filter>
+          <FilterType>
+            <cvParam accession="MS:1001020" name="DB filter taxonomy" cvRef="PSI-MS" />
+          </FilterType>
+          <Include>
+            <cvParam accession="MS:1001467" name="taxonomy: NCBI TaxID" cvRef="PSI-MS" value="562" />
+          </Include>
+        </Filter>
+      </DatabaseFilters>
+    </SpectrumIdentificationProtocol>
+    <ProteinDetectionProtocol id="PDP_MascotParser_1"  analysisSoftware_ref="AS_mascot_parser">
+      <AnalysisParams>
+        <cvParam accession="MS:1001316" name="Mascot:SigThreshold"                               cvRef="PSI-MS" value="0.05" />
+        <cvParam accession="MS:1001317" name="Mascot:MaxProteinHits"                             cvRef="PSI-MS" value="Auto" />
+        <cvParam accession="MS:1001318" name="Mascot:ProteinScoringMethod"                       cvRef="PSI-MS" value="MudPIT" />
+        <cvParam accession="MS:1001319" name="Mascot:MinMSMSThreshold"                           cvRef="PSI-MS" value="-1" />
+        <cvParam accession="MS:1001758" name="Mascot:SigThresholdType"                           cvRef="PSI-MS" value="homology" />
+        <cvParam accession="MS:1001759" name="Mascot:ProteinGrouping"                            cvRef="PSI-MS" value="family clustering" />
+        <cvParam accession="MS:1003030" name="Mascot:MinNumSigUniqueSeqs"                        cvRef="PSI-MS" value="1" />
+        <cvParam accession="MS:1001320" name="Mascot:ShowHomologousProteinsWithSamePeptides"     cvRef="PSI-MS" value="0" />
+        <cvParam accession="MS:1001321" name="Mascot:ShowHomologousProteinsWithSubsetOfPeptides" cvRef="PSI-MS" value="1" />
+        <cvParam accession="MS:1001322" name="Mascot:RequireBoldRed"                             cvRef="PSI-MS" value="0" />
+        <cvParam accession="MS:1001323" name="Mascot:UseUnigeneClustering"                       cvRef="PSI-MS" value="1" />
+        <cvParam accession="MS:1001324" name="Mascot:IncludeErrorTolerantMatches"                cvRef="PSI-MS" value="1" />
+        <cvParam accession="MS:1001325" name="Mascot:ShowDecoyMatches"                           cvRef="PSI-MS" value="0" />
+      </AnalysisParams>
+      <Threshold>
+        <cvParam accession="MS:1001494" name="no threshold" cvRef="PSI-MS" />
+      </Threshold>
+    </ProteinDetectionProtocol>
+  </AnalysisProtocolCollection>
+  <DataCollection>
+    <Inputs>
+      <SourceFile location="file:///../data/20220411/F001386.dat" id="SF_1" >
+        <FileFormat>
+          <cvParam accession="MS:1001199" name="Mascot DAT format" cvRef="PSI-MS" />
+        </FileFormat>
+      </SourceFile>
+      <SearchDatabase location="file:///C:/inetpub/mascot_2_8_1xy/sequence/contaminants/current/contaminants_20160129.fasta" id="SDB_contaminants" name="contaminants" numDatabaseSequences="247" numResidues="128130" version="contaminants_20160129.fasta">
+        <FileFormat>
+          <cvParam accession="MS:1001348" name="FASTA format" cvRef="PSI-MS" />
+        </FileFormat>
+        <DatabaseName>
+          <userParam name="contaminants_20160129.fasta" />
+        </DatabaseName>
+        <cvParam accession="MS:1001073" name="database type amino acid" cvRef="PSI-MS" />
+      </SearchDatabase>
+      <SearchDatabase location="file:///C:/inetpub/mascot_2_8_1xy/sequence/PXD001538/current/PXD001538_20190829.fasta" id="SDB_PXD001538" name="PXD001538" numDatabaseSequences="2" numResidues="456" version="PXD001538_20190829.fasta">
+        <FileFormat>
+          <cvParam accession="MS:1001348" name="FASTA format" cvRef="PSI-MS" />
+        </FileFormat>
+        <DatabaseName>
+          <userParam name="PXD001538_20190829.fasta" />
+        </DatabaseName>
+        <cvParam accession="MS:1001073" name="database type amino acid" cvRef="PSI-MS" />
+      </SearchDatabase>
+      <SearchDatabase location="file:///C:/inetpub/mascot_2_8_1xy/sequence/SwissProt/current/SwissProt_2021_03.fasta" id="SDB_SwissProt" name="SwissProt" numDatabaseSequences="565254" numResidues="203850821" version="SwissProt_2021_03.fasta">
+        <FileFormat>
+          <cvParam accession="MS:1001348" name="FASTA format" cvRef="PSI-MS" />
+        </FileFormat>
+        <DatabaseName>
+          <userParam name="SwissProt_2021_03.fasta" />
+        </DatabaseName>
+        <cvParam accession="MS:1001073" name="database type amino acid" cvRef="PSI-MS" />
+      </SearchDatabase>
+      <SpectraData location="file:///F001386.mgf" id="SD_1" name="EDCMES12_mh+.mgf">
+        <FileFormat>
+          <cvParam accession="MS:1001062" name="Mascot MGF format" cvRef="PSI-MS" />
+        </FileFormat>
+        <SpectrumIDFormat>
+          <cvParam accession="MS:1000775" name="single peak list nativeID format" cvRef="PSI-MS" />
+        </SpectrumIDFormat>
+      </SpectraData>
+    </Inputs>
+    <AnalysisData>
+      <SpectrumIdentificationList id="SIL_1" numSequencesSearched="23427">
+        <FragmentationTable>
+          <Measure id="m_mz">
+            <cvParam cvRef="PSI-MS" accession="MS:1001225" name="product ion m/z" unitCvRef="PSI-MS" unitAccession="MS:1000040" unitName="m/z" />
+          </Measure>
+          <Measure id="m_intensity">
+            <cvParam cvRef="PSI-MS" accession="MS:1001226" name="product ion intensity" unitCvRef="PSI-MS" unitAccession="MS:1000131" unitName="number of counts" />
+          </Measure>
+          <Measure id="m_error">
+            <cvParam cvRef="PSI-MS" accession="MS:1001227" name="product ion m/z error" unitAccession="MS:1000040" unitName="m/z" unitCvRef="PSI-MS" />
+          </Measure>
+        </FragmentationTable>
+        <SpectrumIdentificationResult id="SIR_1" spectrumID="index=7483" spectraData_ref="SD_1">
+          <SpectrumIdentificationItem id="SII_1_1"  calculatedMassToCharge="802.394117" chargeState="1" experimentalMassToCharge="802.3919" peptide_ref="peptide_1_1" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_1_1_2_MND1_ARATH_0_224_230" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="38.80" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.00023" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <cvParam accession="MS:1001371" name="Mascot:identity threshold"  cvRef="PSI-MS" value="23" />
+          <cvParam accession="MS:1001370" name="Mascot:homology threshold"  cvRef="PSI-MS" value="15" />
+          <cvParam accession="MS:1001030" name="number of peptide seqs compared to each spectrum"  cvRef="PSI-MS" value="230" />
+          <cvParam accession="MS:1000797" name="peak list scans"  cvRef="PSI-MS" value="8699" />
+          <cvParam accession="MS:1000016" name="scan start time"  cvRef="PSI-MS" value="2581.1577" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+          <cvParam accession="MS:1000796" name="spectrum title"  cvRef="PSI-MS" value="7484: Scan 8699 (rt=2581.16) [C:\Users\johnc\Downloads\xlink help page\20140603_QEx3_RSLC4_Rampler_Mechtler_IMP_shotgun_EDCMES12.raw]" />
+        </SpectrumIdentificationResult>
+        <SpectrumIdentificationResult id="SIR_2" spectrumID="index=8922" spectraData_ref="SD_1">
+          <SpectrumIdentificationItem id="SII_2_1"  calculatedMassToCharge="480.7534535" chargeState="2" experimentalMassToCharge="480.75447" peptide_ref="peptide_2_1" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_2_1_2_HOP2_ARATH_0_45_54" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="75.36" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="3.9e-07" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <cvParam accession="MS:1001371" name="Mascot:identity threshold"  cvRef="PSI-MS" value="24" />
+          <cvParam accession="MS:1001030" name="number of peptide seqs compared to each spectrum"  cvRef="PSI-MS" value="265" />
+          <cvParam accession="MS:1000797" name="peak list scans"  cvRef="PSI-MS" value="10041" />
+          <cvParam accession="MS:1000016" name="scan start time"  cvRef="PSI-MS" value="2956.2748" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+          <cvParam accession="MS:1000796" name="spectrum title"  cvRef="PSI-MS" value="8923: Scan 10041 (rt=2956.27) [C:\Users\johnc\Downloads\xlink help page\20140603_QEx3_RSLC4_Rampler_Mechtler_IMP_shotgun_EDCMES12.raw]" />
+        </SpectrumIdentificationResult>
+        <SpectrumIdentificationResult id="SIR_3" spectrumID="index=21081" spectraData_ref="SD_1">
+          <SpectrumIdentificationItem id="SII_3_1"  calculatedMassToCharge="583.303655" chargeState="2" experimentalMassToCharge="583.30488" peptide_ref="peptide_3_1" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_3_1_2_MND1_ARATH_0_168_176" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="63.67" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="1.1e-06" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <cvParam accession="MS:1001371" name="Mascot:identity threshold"  cvRef="PSI-MS" value="26" />
+          <cvParam accession="MS:1001370" name="Mascot:homology threshold"  cvRef="PSI-MS" value="16" />
+          <cvParam accession="MS:1001030" name="number of peptide seqs compared to each spectrum"  cvRef="PSI-MS" value="482" />
+          <cvParam accession="MS:1000797" name="peak list scans"  cvRef="PSI-MS" value="20510" />
+          <cvParam accession="MS:1000016" name="scan start time"  cvRef="PSI-MS" value="5930.5912" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+          <cvParam accession="MS:1000796" name="spectrum title"  cvRef="PSI-MS" value="21082: Scan 20510 (rt=5930.59) [C:\Users\johnc\Downloads\xlink help page\20140603_QEx3_RSLC4_Rampler_Mechtler_IMP_shotgun_EDCMES12.raw]" />
+        </SpectrumIdentificationResult>
+        <SpectrumIdentificationResult id="SIR_4" spectrumID="index=2980" spectraData_ref="SD_1">
+          <SpectrumIdentificationItem id="SII_4_1"  calculatedMassToCharge="416.21771" chargeState="3" experimentalMassToCharge="416.21674" peptide_ref="peptide_4_1" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_4_1_2_MND1_ARATH_0_88_98" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="89.68" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="3.8e-08" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <cvParam accession="MS:1001371" name="Mascot:identity threshold"  cvRef="PSI-MS" value="28" />
+          <cvParam accession="MS:1001030" name="number of peptide seqs compared to each spectrum"  cvRef="PSI-MS" value="712" />
+          <cvParam accession="MS:1000797" name="peak list scans"  cvRef="PSI-MS" value="4391" />
+          <cvParam accession="MS:1000016" name="scan start time"  cvRef="PSI-MS" value="1380.8912" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+          <cvParam accession="MS:1000796" name="spectrum title"  cvRef="PSI-MS" value="2981: Scan 4391 (rt=1380.89) [C:\Users\johnc\Downloads\xlink help page\20140603_QEx3_RSLC4_Rampler_Mechtler_IMP_shotgun_EDCMES12.raw]" />
+        </SpectrumIdentificationResult>
+        <SpectrumIdentificationResult id="SIR_5" spectrumID="index=9332" spectraData_ref="SD_1">
+          <SpectrumIdentificationItem id="SII_5_1"  calculatedMassToCharge="624.8377125" chargeState="2" experimentalMassToCharge="624.83768" peptide_ref="peptide_5_1" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_5_1_2_HOP2_ARATH_0_100_110" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="90.73" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="3.1e-09" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <cvParam accession="MS:1001371" name="Mascot:identity threshold"  cvRef="PSI-MS" value="23" />
+          <cvParam accession="MS:1001370" name="Mascot:homology threshold"  cvRef="PSI-MS" value="18" />
+          <cvParam accession="MS:1001030" name="number of peptide seqs compared to each spectrum"  cvRef="PSI-MS" value="229" />
+          <cvParam accession="MS:1000797" name="peak list scans"  cvRef="PSI-MS" value="10367" />
+          <cvParam accession="MS:1000016" name="scan start time"  cvRef="PSI-MS" value="3039.6382" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+          <cvParam accession="MS:1000796" name="spectrum title"  cvRef="PSI-MS" value="9333: Scan 10367 (rt=3039.64) [C:\Users\johnc\Downloads\xlink help page\20140603_QEx3_RSLC4_Rampler_Mechtler_IMP_shotgun_EDCMES12.raw]" />
+        </SpectrumIdentificationResult>
+        <SpectrumIdentificationResult id="SIR_7" spectrumID="index=24337" spectraData_ref="SD_1">
+          <SpectrumIdentificationItem id="SII_7_1"  calculatedMassToCharge="756.401235" chargeState="2" experimentalMassToCharge="756.4018" peptide_ref="peptide_7_1" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_7_1_2_MND1_ARATH_0_48_61" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="54.87" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="7.2e-06" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+            <cvParam accession="MS:1003329" cvRef="PSI-MS" name="looplink spectrum identification item"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_7_2"  calculatedMassToCharge="756.401235" chargeState="2" experimentalMassToCharge="756.4018" peptide_ref="peptide_7_2" rank="3" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_7_2_2_MND1_ARATH_0_48_61" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="41.72" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.00015" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+            <cvParam accession="MS:1003329" cvRef="PSI-MS" name="looplink spectrum identification item"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_7_3"  calculatedMassToCharge="756.401235" chargeState="2" experimentalMassToCharge="756.4018" peptide_ref="peptide_7_3" rank="4" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_7_3_2_MND1_ARATH_0_48_61" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="29.82" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.0023" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+            <cvParam accession="MS:1003329" cvRef="PSI-MS" name="looplink spectrum identification item"/>
+          </SpectrumIdentificationItem>
+          <cvParam accession="MS:1001371" name="Mascot:identity threshold"  cvRef="PSI-MS" value="27" />
+          <cvParam accession="MS:1001370" name="Mascot:homology threshold"  cvRef="PSI-MS" value="16" />
+          <cvParam accession="MS:1001030" name="number of peptide seqs compared to each spectrum"  cvRef="PSI-MS" value="532" />
+          <cvParam accession="MS:1000797" name="peak list scans"  cvRef="PSI-MS" value="23132" />
+          <cvParam accession="MS:1000016" name="scan start time"  cvRef="PSI-MS" value="6762.9084" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+          <cvParam accession="MS:1000796" name="spectrum title"  cvRef="PSI-MS" value="24338: Scan 23132 (rt=6762.91) [C:\Users\johnc\Downloads\xlink help page\20140603_QEx3_RSLC4_Rampler_Mechtler_IMP_shotgun_EDCMES12.raw]" />
+        </SpectrumIdentificationResult>
+        <SpectrumIdentificationResult id="SIR_8" spectrumID="index=9159" spectraData_ref="SD_1">
+          <SpectrumIdentificationItem id="SII_8_1"  calculatedMassToCharge="506.290870666667" chargeState="3" experimentalMassToCharge="506.29079" peptide_ref="peptide_8_1" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_8_1_2_MND1_ARATH_0_120_132" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="95.77" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="1e-09" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_8_2_p1"  calculatedMassToCharge="506.290862333333" chargeState="3" experimentalMassToCharge="506.29079" peptide_ref="peptide_8_2_p1" rank="2" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_8_2_1_2_MND1_ARATH_0_120_127" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="76.94" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="8e-08" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="2" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_8_2_p2"  calculatedMassToCharge="506.290862333333" chargeState="3" experimentalMassToCharge="506.29079" peptide_ref="peptide_8_2_p2" rank="2" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_8_2_2_2_MND1_ARATH_0_128_132" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="76.94" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="8e-08" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="2" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_8_3_p1"  calculatedMassToCharge="506.290862333333" chargeState="3" experimentalMassToCharge="506.29079" peptide_ref="peptide_8_3_p1" rank="3" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_8_3_1_2_MND1_ARATH_0_120_127" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="49.77" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="4.2e-05" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="3" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_8_3_p2"  calculatedMassToCharge="506.290862333333" chargeState="3" experimentalMassToCharge="506.29079" peptide_ref="peptide_8_3_p2" rank="3" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_8_3_2_2_MND1_ARATH_0_128_132" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="49.77" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="4.2e-05" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="3" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <cvParam accession="MS:1001371" name="Mascot:identity threshold"  cvRef="PSI-MS" value="28" />
+          <cvParam accession="MS:1001370" name="Mascot:homology threshold"  cvRef="PSI-MS" value="18" />
+          <cvParam accession="MS:1001030" name="number of peptide seqs compared to each spectrum"  cvRef="PSI-MS" value="469" />
+          <cvParam accession="MS:1000797" name="peak list scans"  cvRef="PSI-MS" value="10192" />
+          <cvParam accession="MS:1000016" name="scan start time"  cvRef="PSI-MS" value="2993.6498" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+          <cvParam accession="MS:1000796" name="spectrum title"  cvRef="PSI-MS" value="9160: Scan 10192 (rt=2993.65) [C:\Users\johnc\Downloads\xlink help page\20140603_QEx3_RSLC4_Rampler_Mechtler_IMP_shotgun_EDCMES12.raw]" />
+        </SpectrumIdentificationResult>
+        <SpectrumIdentificationResult id="SIR_9" spectrumID="index=9162" spectraData_ref="SD_1">
+          <SpectrumIdentificationItem id="SII_9_1"  calculatedMassToCharge="758.932668" chargeState="2" experimentalMassToCharge="758.93268" peptide_ref="peptide_9_1" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_9_1_2_MND1_ARATH_0_120_132" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="62.68" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="1.3e-06" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_9_2_p1"  calculatedMassToCharge="758.9326555" chargeState="2" experimentalMassToCharge="758.93268" peptide_ref="peptide_9_2_p1" rank="2" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_9_2_1_2_MND1_ARATH_0_120_127" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="49.03" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="3.1e-05" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="2" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_9_2_p2"  calculatedMassToCharge="758.9326555" chargeState="2" experimentalMassToCharge="758.93268" peptide_ref="peptide_9_2_p2" rank="2" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_9_2_2_2_MND1_ARATH_0_128_132" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="49.03" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="3.1e-05" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="2" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_9_3_p1"  calculatedMassToCharge="758.9326555" chargeState="2" experimentalMassToCharge="758.93268" peptide_ref="peptide_9_3_p1" rank="3" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_9_3_1_2_MND1_ARATH_0_120_127" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="28.40" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.0036" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="3" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_9_3_p2"  calculatedMassToCharge="758.9326555" chargeState="2" experimentalMassToCharge="758.93268" peptide_ref="peptide_9_3_p2" rank="3" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_9_3_2_2_MND1_ARATH_0_128_132" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="28.40" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.0036" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="3" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <cvParam accession="MS:1001371" name="Mascot:identity threshold"  cvRef="PSI-MS" value="28" />
+          <cvParam accession="MS:1001370" name="Mascot:homology threshold"  cvRef="PSI-MS" value="16" />
+          <cvParam accession="MS:1001030" name="number of peptide seqs compared to each spectrum"  cvRef="PSI-MS" value="469" />
+          <cvParam accession="MS:1000797" name="peak list scans"  cvRef="PSI-MS" value="10195" />
+          <cvParam accession="MS:1000016" name="scan start time"  cvRef="PSI-MS" value="2994.373" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+          <cvParam accession="MS:1000796" name="spectrum title"  cvRef="PSI-MS" value="9163: Scan 10195 (rt=2994.37) [C:\Users\johnc\Downloads\xlink help page\20140603_QEx3_RSLC4_Rampler_Mechtler_IMP_shotgun_EDCMES12.raw]" />
+        </SpectrumIdentificationResult>
+        <SpectrumIdentificationResult id="SIR_10" spectrumID="index=24018" spectraData_ref="SD_1">
+          <SpectrumIdentificationItem id="SII_10_1"  calculatedMassToCharge="765.406507" chargeState="2" experimentalMassToCharge="765.40684" peptide_ref="peptide_10_1" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_10_1_2_MND1_ARATH_0_48_61" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="95.97" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="1e-09" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <cvParam accession="MS:1001371" name="Mascot:identity threshold"  cvRef="PSI-MS" value="28" />
+          <cvParam accession="MS:1001370" name="Mascot:homology threshold"  cvRef="PSI-MS" value="18" />
+          <cvParam accession="MS:1001030" name="number of peptide seqs compared to each spectrum"  cvRef="PSI-MS" value="657" />
+          <cvParam accession="MS:1000797" name="peak list scans"  cvRef="PSI-MS" value="22868" />
+          <cvParam accession="MS:1000016" name="scan start time"  cvRef="PSI-MS" value="6675.2202" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+          <cvParam accession="MS:1000796" name="spectrum title"  cvRef="PSI-MS" value="24019: Scan 22868 (rt=6675.22) [C:\Users\johnc\Downloads\xlink help page\20140603_QEx3_RSLC4_Rampler_Mechtler_IMP_shotgun_EDCMES12.raw]" />
+        </SpectrumIdentificationResult>
+        <SpectrumIdentificationResult id="SIR_11" spectrumID="index=17323" spectraData_ref="SD_1">
+          <SpectrumIdentificationItem id="SII_11_1"  calculatedMassToCharge="682.989825" chargeState="3" experimentalMassToCharge="682.99096" peptide_ref="peptide_11_1" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_11_1_2_MND1_ARATH_0_138_155" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="63.32" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="1.2e-06" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+            <cvParam accession="MS:1003329" cvRef="PSI-MS" name="looplink spectrum identification item"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_11_2"  calculatedMassToCharge="682.989825" chargeState="3" experimentalMassToCharge="682.99096" peptide_ref="peptide_11_2" rank="2" passThreshold="false">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_11_2_2_MND1_ARATH_0_138_155" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="5.43" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.71" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="false" name="peptide passes threshold"/>
+            <cvParam accession="MS:1003329" cvRef="PSI-MS" name="looplink spectrum identification item"/>
+          </SpectrumIdentificationItem>
+          <cvParam accession="MS:1001371" name="Mascot:identity threshold"  cvRef="PSI-MS" value="25" />
+          <cvParam accession="MS:1001370" name="Mascot:homology threshold"  cvRef="PSI-MS" value="16" />
+          <cvParam accession="MS:1001030" name="number of peptide seqs compared to each spectrum"  cvRef="PSI-MS" value="347" />
+          <cvParam accession="MS:1000797" name="peak list scans"  cvRef="PSI-MS" value="17479" />
+          <cvParam accession="MS:1000016" name="scan start time"  cvRef="PSI-MS" value="5039.6412" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+          <cvParam accession="MS:1000796" name="spectrum title"  cvRef="PSI-MS" value="17324: Scan 17479 (rt=5039.64) [C:\Users\johnc\Downloads\xlink help page\20140603_QEx3_RSLC4_Rampler_Mechtler_IMP_shotgun_EDCMES12.raw]" />
+        </SpectrumIdentificationResult>
+        <SpectrumIdentificationResult id="SIR_12" spectrumID="index=13891" spectraData_ref="SD_1">
+          <SpectrumIdentificationItem id="SII_12_1"  calculatedMassToCharge="683.6617" chargeState="3" experimentalMassToCharge="683.66145" peptide_ref="peptide_12_1" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_12_1_2_MND1_ARATH_0_138_155" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="106.13" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="1.1e-10" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <cvParam accession="MS:1001371" name="Mascot:identity threshold"  cvRef="PSI-MS" value="26" />
+          <cvParam accession="MS:1001370" name="Mascot:homology threshold"  cvRef="PSI-MS" value="19" />
+          <cvParam accession="MS:1001030" name="number of peptide seqs compared to each spectrum"  cvRef="PSI-MS" value="453" />
+          <cvParam accession="MS:1000797" name="peak list scans"  cvRef="PSI-MS" value="14546" />
+          <cvParam accession="MS:1000016" name="scan start time"  cvRef="PSI-MS" value="4239.4456" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+          <cvParam accession="MS:1000796" name="spectrum title"  cvRef="PSI-MS" value="13892: Scan 14546 (rt=4239.45) [C:\Users\johnc\Downloads\xlink help page\20140603_QEx3_RSLC4_Rampler_Mechtler_IMP_shotgun_EDCMES12.raw]" />
+        </SpectrumIdentificationResult>
+        <SpectrumIdentificationResult id="SIR_13" spectrumID="index=15122" spectraData_ref="SD_1">
+          <SpectrumIdentificationItem id="SII_13_1_p1"  calculatedMassToCharge="711.726465333333" chargeState="3" experimentalMassToCharge="711.72693" peptide_ref="peptide_13_1_p1" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_13_1_1_2_HOP2_ARATH_0_100_110" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="77.19" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="2.1e-06" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="1" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_13_1_p2"  calculatedMassToCharge="711.726465333333" chargeState="3" experimentalMassToCharge="711.72693" peptide_ref="peptide_13_1_p2" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_13_1_2_2_MND1_ARATH_0_120_127" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="77.19" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="2.1e-06" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="1" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_13_2_p1"  calculatedMassToCharge="711.72646" chargeState="3" experimentalMassToCharge="711.72693" peptide_ref="peptide_13_2_p1" rank="2" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_13_2_1_2_HOP2_ARATH_0_99_110" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="37.42" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.02" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="2" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_13_2_p2"  calculatedMassToCharge="711.72646" chargeState="3" experimentalMassToCharge="711.72693" peptide_ref="peptide_13_2_p2" rank="2" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_13_2_2_2_MND1_ARATH_0_6_12" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="37.42" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.02" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="2" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_13_3_p1"  calculatedMassToCharge="711.72646" chargeState="3" experimentalMassToCharge="711.72693" peptide_ref="peptide_13_3_p1" rank="3" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_13_3_1_2_HOP2_ARATH_0_99_110" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="37.42" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.02" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="3" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_13_3_p2"  calculatedMassToCharge="711.72646" chargeState="3" experimentalMassToCharge="711.72693" peptide_ref="peptide_13_3_p2" rank="3" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_13_3_2_2_MND1_ARATH_0_6_12" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="37.42" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.02" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="3" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_13_4_p1"  calculatedMassToCharge="711.72646" chargeState="3" experimentalMassToCharge="711.72693" peptide_ref="peptide_13_4_p1" rank="4" passThreshold="false">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_13_4_1_2_HOP2_ARATH_0_99_110" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="32.94" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.057" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="4" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="false" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_13_4_p2"  calculatedMassToCharge="711.72646" chargeState="3" experimentalMassToCharge="711.72693" peptide_ref="peptide_13_4_p2" rank="4" passThreshold="false">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_13_4_2_2_MND1_ARATH_0_6_12" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="32.94" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.057" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="4" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="false" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_13_5_p1"  calculatedMassToCharge="711.72646" chargeState="3" experimentalMassToCharge="711.72693" peptide_ref="peptide_13_5_p1" rank="5" passThreshold="false">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_13_5_1_2_HOP2_ARATH_0_99_110" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="32.94" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.057" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="5" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="false" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_13_5_p2"  calculatedMassToCharge="711.72646" chargeState="3" experimentalMassToCharge="711.72693" peptide_ref="peptide_13_5_p2" rank="5" passThreshold="false">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_13_5_2_2_MND1_ARATH_0_6_12" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="32.94" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.057" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="5" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="false" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_13_6_p1"  calculatedMassToCharge="711.726465333333" chargeState="3" experimentalMassToCharge="711.72693" peptide_ref="peptide_13_6_p1" rank="6" passThreshold="false">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_13_6_1_2_HOP2_ARATH_0_100_110" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="2.41" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="65" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="6" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="false" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_13_6_p2"  calculatedMassToCharge="711.726465333333" chargeState="3" experimentalMassToCharge="711.72693" peptide_ref="peptide_13_6_p2" rank="6" passThreshold="false">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_13_6_2_2_MND1_ARATH_0_120_127" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="2.41" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="65" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="6" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="false" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <cvParam accession="MS:1001371" name="Mascot:identity threshold"  cvRef="PSI-MS" value="33" />
+          <cvParam accession="MS:1001030" name="number of peptide seqs compared to each spectrum"  cvRef="PSI-MS" value="961" />
+          <cvParam accession="MS:1000797" name="peak list scans"  cvRef="PSI-MS" value="15677" />
+          <cvParam accession="MS:1000016" name="scan start time"  cvRef="PSI-MS" value="4553.5907" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+          <cvParam accession="MS:1000796" name="spectrum title"  cvRef="PSI-MS" value="15123: Scan 15677 (rt=4553.59) [C:\Users\johnc\Downloads\xlink help page\20140603_QEx3_RSLC4_Rampler_Mechtler_IMP_shotgun_EDCMES12.raw]" />
+        </SpectrumIdentificationResult>
+        <SpectrumIdentificationResult id="SIR_14" spectrumID="index=9463" spectraData_ref="SD_1">
+          <SpectrumIdentificationItem id="SII_14_1_p1"  calculatedMassToCharge="730.044967" chargeState="3" experimentalMassToCharge="730.04462" peptide_ref="peptide_14_1_p1" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_14_1_1_2_MND1_ARATH_0_88_98" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="79.86" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="3.3e-08" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="1" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_14_1_p2"  calculatedMassToCharge="730.044967" chargeState="3" experimentalMassToCharge="730.04462" peptide_ref="peptide_14_1_p2" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_14_1_2_2_HOP2_ARATH_0_45_54" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="79.86" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="3.3e-08" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="1" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_14_2_p1"  calculatedMassToCharge="730.044967" chargeState="3" experimentalMassToCharge="730.04462" peptide_ref="peptide_14_2_p1" rank="2" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_14_2_1_2_MND1_ARATH_0_88_98" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="45.91" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="8.1e-05" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="2" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_14_2_p2"  calculatedMassToCharge="730.044967" chargeState="3" experimentalMassToCharge="730.04462" peptide_ref="peptide_14_2_p2" rank="2" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_14_2_2_2_HOP2_ARATH_0_45_54" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="45.91" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="8.1e-05" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="2" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_14_3_p1"  calculatedMassToCharge="730.044967" chargeState="3" experimentalMassToCharge="730.04462" peptide_ref="peptide_14_3_p1" rank="3" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_14_3_1_2_MND1_ARATH_0_88_98" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="32.95" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.0016" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="3" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_14_3_p2"  calculatedMassToCharge="730.044967" chargeState="3" experimentalMassToCharge="730.04462" peptide_ref="peptide_14_3_p2" rank="3" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_14_3_2_2_HOP2_ARATH_0_45_54" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="32.95" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.0016" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="3" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_14_4_p1"  calculatedMassToCharge="730.044967" chargeState="3" experimentalMassToCharge="730.04462" peptide_ref="peptide_14_4_p1" rank="4" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_14_4_1_2_MND1_ARATH_0_88_98" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="32.15" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.0019" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="4" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_14_4_p2"  calculatedMassToCharge="730.044967" chargeState="3" experimentalMassToCharge="730.04462" peptide_ref="peptide_14_4_p2" rank="4" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_14_4_2_2_HOP2_ARATH_0_45_54" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="32.15" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.0019" />
+            <cvParam accession="MS:1001175" name="peptide shared in multiple proteins" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="4" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <cvParam accession="MS:1001371" name="Mascot:identity threshold"  cvRef="PSI-MS" value="31" />
+          <cvParam accession="MS:1001370" name="Mascot:homology threshold"  cvRef="PSI-MS" value="17" />
+          <cvParam accession="MS:1001030" name="number of peptide seqs compared to each spectrum"  cvRef="PSI-MS" value="1213" />
+          <cvParam accession="MS:1000797" name="peak list scans"  cvRef="PSI-MS" value="10489" />
+          <cvParam accession="MS:1000016" name="scan start time"  cvRef="PSI-MS" value="3071.5836" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+          <cvParam accession="MS:1000796" name="spectrum title"  cvRef="PSI-MS" value="9464: Scan 10489 (rt=3071.58) [C:\Users\johnc\Downloads\xlink help page\20140603_QEx3_RSLC4_Rampler_Mechtler_IMP_shotgun_EDCMES12.raw]" />
+        </SpectrumIdentificationResult>
+        <SpectrumIdentificationResult id="SIR_15" spectrumID="index=16116" spectraData_ref="SD_1">
+          <SpectrumIdentificationItem id="SII_15_1_p1"  calculatedMassToCharge="798.411768" chargeState="3" experimentalMassToCharge="798.41246" peptide_ref="peptide_15_1_p1" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_15_1_1_2_MND1_ARATH_0_88_98" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="112.89" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="2.6e-11" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="1" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_15_1_p2"  calculatedMassToCharge="798.411768" chargeState="3" experimentalMassToCharge="798.41246" peptide_ref="peptide_15_1_p2" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_15_1_2_2_MND1_ARATH_0_168_176" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="112.89" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="2.6e-11" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="1" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <cvParam accession="MS:1001371" name="Mascot:identity threshold"  cvRef="PSI-MS" value="31" />
+          <cvParam accession="MS:1001370" name="Mascot:homology threshold"  cvRef="PSI-MS" value="20" />
+          <cvParam accession="MS:1001030" name="number of peptide seqs compared to each spectrum"  cvRef="PSI-MS" value="1064" />
+          <cvParam accession="MS:1000797" name="peak list scans"  cvRef="PSI-MS" value="16470" />
+          <cvParam accession="MS:1000016" name="scan start time"  cvRef="PSI-MS" value="4758.7506" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+          <cvParam accession="MS:1000796" name="spectrum title"  cvRef="PSI-MS" value="16117: Scan 16470 (rt=4758.75) [C:\Users\johnc\Downloads\xlink help page\20140603_QEx3_RSLC4_Rampler_Mechtler_IMP_shotgun_EDCMES12.raw]" />
+        </SpectrumIdentificationResult>
+        <SpectrumIdentificationResult id="SIR_16" spectrumID="index=13328" spectraData_ref="SD_1">
+          <SpectrumIdentificationItem id="SII_16_1"  calculatedMassToCharge="838.747942666667" chargeState="3" experimentalMassToCharge="838.74764" peptide_ref="peptide_16_1" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_16_1_2_MND1_ARATH_0_133_154" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="89.40" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="1.2e-07" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_16_2_p1"  calculatedMassToCharge="838.747934333333" chargeState="3" experimentalMassToCharge="838.74764" peptide_ref="peptide_16_2_p1" rank="2" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_16_2_1_2_MND1_ARATH_0_138_154" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="89.40" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="1.2e-07" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="2" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_16_2_p2"  calculatedMassToCharge="838.747934333333" chargeState="3" experimentalMassToCharge="838.74764" peptide_ref="peptide_16_2_p2" rank="2" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_16_2_2_2_MND1_ARATH_0_133_137" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="89.40" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="1.2e-07" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="2" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_16_3_p1"  calculatedMassToCharge="838.747934333333" chargeState="3" experimentalMassToCharge="838.74764" peptide_ref="peptide_16_3_p1" rank="3" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_16_3_1_2_MND1_ARATH_0_138_154" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="73.15" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="5.1e-06" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="3" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_16_3_p2"  calculatedMassToCharge="838.747934333333" chargeState="3" experimentalMassToCharge="838.74764" peptide_ref="peptide_16_3_p2" rank="3" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_16_3_2_2_MND1_ARATH_0_133_137" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="73.15" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="5.1e-06" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="3" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_16_4_p1"  calculatedMassToCharge="838.747934333333" chargeState="3" experimentalMassToCharge="838.74764" peptide_ref="peptide_16_4_p1" rank="4" passThreshold="false">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_16_4_1_2_MND1_ARATH_0_138_154" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="28.70" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.14" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="4" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="false" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_16_4_p2"  calculatedMassToCharge="838.747934333333" chargeState="3" experimentalMassToCharge="838.74764" peptide_ref="peptide_16_4_p2" rank="4" passThreshold="false">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_16_4_2_2_MND1_ARATH_0_133_137" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="28.70" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.14" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="4" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="false" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_16_5_p1"  calculatedMassToCharge="838.747934333333" chargeState="3" experimentalMassToCharge="838.74764" peptide_ref="peptide_16_5_p1" rank="5" passThreshold="false">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_16_5_1_2_MND1_ARATH_0_138_154" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="21.45" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.75" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="5" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="false" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_16_5_p2"  calculatedMassToCharge="838.747934333333" chargeState="3" experimentalMassToCharge="838.74764" peptide_ref="peptide_16_5_p2" rank="5" passThreshold="false">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_16_5_2_2_MND1_ARATH_0_133_137" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="21.45" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.75" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="5" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="false" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_16_6_p1"  calculatedMassToCharge="838.747934333333" chargeState="3" experimentalMassToCharge="838.74764" peptide_ref="peptide_16_6_p1" rank="6" passThreshold="false">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_16_6_1_2_MND1_ARATH_0_138_154" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="15.79" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="2.8" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="6" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="false" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_16_6_p2"  calculatedMassToCharge="838.747934333333" chargeState="3" experimentalMassToCharge="838.74764" peptide_ref="peptide_16_6_p2" rank="6" passThreshold="false">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_16_6_2_2_MND1_ARATH_0_133_137" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="15.79" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="2.8" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="6" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="false" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_16_7_p1"  calculatedMassToCharge="838.747934333333" chargeState="3" experimentalMassToCharge="838.74764" peptide_ref="peptide_16_7_p1" rank="7" passThreshold="false">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_16_7_1_2_MND1_ARATH_0_138_154" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="6.50" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="23" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="7" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="false" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_16_7_p2"  calculatedMassToCharge="838.747934333333" chargeState="3" experimentalMassToCharge="838.74764" peptide_ref="peptide_16_7_p2" rank="7" passThreshold="false">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_16_7_2_2_MND1_ARATH_0_133_137" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="6.50" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="23" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="7" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="false" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <cvParam accession="MS:1001371" name="Mascot:identity threshold"  cvRef="PSI-MS" value="33" />
+          <cvParam accession="MS:1001030" name="number of peptide seqs compared to each spectrum"  cvRef="PSI-MS" value="1105" />
+          <cvParam accession="MS:1000797" name="peak list scans"  cvRef="PSI-MS" value="14092" />
+          <cvParam accession="MS:1000016" name="scan start time"  cvRef="PSI-MS" value="4120.2851" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+          <cvParam accession="MS:1000796" name="spectrum title"  cvRef="PSI-MS" value="13329: Scan 14092 (rt=4120.29) [C:\Users\johnc\Downloads\xlink help page\20140603_QEx3_RSLC4_Rampler_Mechtler_IMP_shotgun_EDCMES12.raw]" />
+        </SpectrumIdentificationResult>
+        <SpectrumIdentificationResult id="SIR_17" spectrumID="index=17847" spectraData_ref="SD_1">
+          <SpectrumIdentificationItem id="SII_17_1_p1"  calculatedMassToCharge="825.15684" chargeState="4" experimentalMassToCharge="825.15557" peptide_ref="peptide_17_1_p1" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_17_1_1_2_MND1_ARATH_0_133_154" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="53.51" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.00064" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="1" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_17_1_p2"  calculatedMassToCharge="825.15684" chargeState="4" experimentalMassToCharge="825.15557" peptide_ref="peptide_17_1_p2" rank="1" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_17_1_2_2_MND1_ARATH_0_224_230" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="53.51" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.00064" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="1" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_17_2_p1"  calculatedMassToCharge="825.15684" chargeState="4" experimentalMassToCharge="825.15557" peptide_ref="peptide_17_2_p1" rank="2" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_17_2_1_2_MND1_ARATH_0_133_154" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="52.29" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.00085" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="2" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_17_2_p2"  calculatedMassToCharge="825.15684" chargeState="4" experimentalMassToCharge="825.15557" peptide_ref="peptide_17_2_p2" rank="2" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_17_2_2_2_MND1_ARATH_0_224_230" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="52.29" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.00085" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="2" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_17_3_p1"  calculatedMassToCharge="825.15684" chargeState="4" experimentalMassToCharge="825.15557" peptide_ref="peptide_17_3_p1" rank="3" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_17_3_1_2_MND1_ARATH_0_133_154" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="49.10" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.0018" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="3" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_17_3_p2"  calculatedMassToCharge="825.15684" chargeState="4" experimentalMassToCharge="825.15557" peptide_ref="peptide_17_3_p2" rank="3" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_17_3_2_2_MND1_ARATH_0_224_230" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="49.10" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.0018" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="3" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_17_4_p1"  calculatedMassToCharge="825.15684" chargeState="4" experimentalMassToCharge="825.15557" peptide_ref="peptide_17_4_p1" rank="4" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_17_4_1_2_MND1_ARATH_0_133_154" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="47.65" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.0025" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="4" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_17_4_p2"  calculatedMassToCharge="825.15684" chargeState="4" experimentalMassToCharge="825.15557" peptide_ref="peptide_17_4_p2" rank="4" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_17_4_2_2_MND1_ARATH_0_224_230" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="47.65" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.0025" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="4" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_17_5_p1"  calculatedMassToCharge="825.15684" chargeState="4" experimentalMassToCharge="825.15557" peptide_ref="peptide_17_5_p1" rank="5" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_17_5_1_2_MND1_ARATH_0_133_154" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="47.59" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.0025" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="5" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_17_5_p2"  calculatedMassToCharge="825.15684" chargeState="4" experimentalMassToCharge="825.15557" peptide_ref="peptide_17_5_p2" rank="5" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_17_5_2_2_MND1_ARATH_0_224_230" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="47.59" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.0025" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="5" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_17_6_p1"  calculatedMassToCharge="825.15684" chargeState="4" experimentalMassToCharge="825.15557" peptide_ref="peptide_17_6_p1" rank="6" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_17_6_1_2_MND1_ARATH_0_133_154" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="46.14" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.0035" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="6" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <SpectrumIdentificationItem id="SII_17_6_p2"  calculatedMassToCharge="825.15684" chargeState="4" experimentalMassToCharge="825.15557" peptide_ref="peptide_17_6_p2" rank="6" passThreshold="true">
+            <PeptideEvidenceRef peptideEvidence_ref="PE_17_6_2_2_MND1_ARATH_0_224_230" />
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="46.14" />
+            <cvParam accession="MS:1001172" name="Mascot:expectation value" cvRef="PSI-MS" value="0.0035" />
+            <cvParam accession="MS:1001363" name="peptide unique to one protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002511" cvRef="PSI-MS" value="6" name="crosslink spectrum identification item"/>
+            <cvParam accession="MS:1002500" cvRef="PSI-MS" value="true" name="peptide passes threshold"/>
+          </SpectrumIdentificationItem>
+          <cvParam accession="MS:1001371" name="Mascot:identity threshold"  cvRef="PSI-MS" value="34" />
+          <cvParam accession="MS:1001030" name="number of peptide seqs compared to each spectrum"  cvRef="PSI-MS" value="1121" />
+          <cvParam accession="MS:1000797" name="peak list scans"  cvRef="PSI-MS" value="17887" />
+          <cvParam accession="MS:1000016" name="scan start time"  cvRef="PSI-MS" value="5146.8317" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+          <cvParam accession="MS:1000796" name="spectrum title"  cvRef="PSI-MS" value="17848: Scan 17887 (rt=5146.83) [C:\Users\johnc\Downloads\xlink help page\20140603_QEx3_RSLC4_Rampler_Mechtler_IMP_shotgun_EDCMES12.raw]" />
+        </SpectrumIdentificationResult>
+      </SpectrumIdentificationList>
+      <ProteinDetectionList id="PDL_1">
+        <ProteinAmbiguityGroup id="PAG_hit_1" >
+          <ProteinDetectionHypothesis id="PDH_MND1_ARATH_0" dBSequence_ref="DBSeq_2_MND1_ARATH"  passThreshold="true">
+            <PeptideHypothesis peptideEvidence_ref="PE_1_1_2_MND1_ARATH_0_224_230">
+              <SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SII_1_1" />
+            </PeptideHypothesis>
+            <PeptideHypothesis peptideEvidence_ref="PE_3_1_2_MND1_ARATH_0_168_176">
+              <SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SII_3_1" />
+            </PeptideHypothesis>
+            <PeptideHypothesis peptideEvidence_ref="PE_4_1_2_MND1_ARATH_0_88_98">
+              <SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SII_4_1" />
+            </PeptideHypothesis>
+            <PeptideHypothesis peptideEvidence_ref="PE_7_1_2_MND1_ARATH_0_48_61">
+              <SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SII_7_1" />
+            </PeptideHypothesis>
+            <PeptideHypothesis peptideEvidence_ref="PE_7_2_2_MND1_ARATH_0_48_61">
+              <SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SII_7_2" />
+            </PeptideHypothesis>
+            <PeptideHypothesis peptideEvidence_ref="PE_7_3_2_MND1_ARATH_0_48_61">
+              <SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SII_7_3" />
+            </PeptideHypothesis>
+            <PeptideHypothesis peptideEvidence_ref="PE_8_1_2_MND1_ARATH_0_120_132">
+              <SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SII_8_1" />
+            </PeptideHypothesis>
+            <PeptideHypothesis peptideEvidence_ref="PE_9_1_2_MND1_ARATH_0_120_132">
+              <SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SII_9_1" />
+            </PeptideHypothesis>
+            <PeptideHypothesis peptideEvidence_ref="PE_10_1_2_MND1_ARATH_0_48_61">
+              <SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SII_10_1" />
+            </PeptideHypothesis>
+            <PeptideHypothesis peptideEvidence_ref="PE_11_1_2_MND1_ARATH_0_138_155">
+              <SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SII_11_1" />
+            </PeptideHypothesis>
+            <PeptideHypothesis peptideEvidence_ref="PE_12_1_2_MND1_ARATH_0_138_155">
+              <SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SII_12_1" />
+            </PeptideHypothesis>
+            <PeptideHypothesis peptideEvidence_ref="PE_16_1_2_MND1_ARATH_0_133_154">
+              <SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SII_16_1" />
+            </PeptideHypothesis>
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="806.097142857143" />
+            <cvParam accession="MS:1001097" name="distinct peptide sequences" cvRef="PSI-MS" value="12" />
+            <cvParam accession="MS:1002401" name="leading protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002403" name="group representative" cvRef="PSI-MS" />
+          </ProteinDetectionHypothesis>
+          <cvParam accession="MS:1002415" name="protein group passes threshold" cvRef="PSI-MS" value="true" />
+          <cvParam accession="MS:1002407" name="cluster identifier" cvRef="PSI-MS" value="1" />
+        </ProteinAmbiguityGroup>
+        <ProteinAmbiguityGroup id="PAG_hit_2" >
+          <ProteinDetectionHypothesis id="PDH_HOP2_ARATH_0" dBSequence_ref="DBSeq_2_HOP2_ARATH"  passThreshold="true">
+            <PeptideHypothesis peptideEvidence_ref="PE_2_1_2_HOP2_ARATH_0_45_54">
+              <SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SII_2_1" />
+            </PeptideHypothesis>
+            <PeptideHypothesis peptideEvidence_ref="PE_5_1_2_HOP2_ARATH_0_100_110">
+              <SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SII_5_1" />
+            </PeptideHypothesis>
+            <cvParam accession="MS:1001171" name="Mascot:score" cvRef="PSI-MS" value="254.14" />
+            <cvParam accession="MS:1001097" name="distinct peptide sequences" cvRef="PSI-MS" value="5" />
+            <cvParam accession="MS:1002401" name="leading protein" cvRef="PSI-MS" />
+            <cvParam accession="MS:1002403" name="group representative" cvRef="PSI-MS" />
+          </ProteinDetectionHypothesis>
+          <cvParam accession="MS:1002415" name="protein group passes threshold" cvRef="PSI-MS" value="true" />
+          <cvParam accession="MS:1002407" name="cluster identifier" cvRef="PSI-MS" value="2" />
+        </ProteinAmbiguityGroup>
+            <cvParam accession="MS:1002404" name="count of identified proteins" cvRef="PSI-MS" value="2" />
+      </ProteinDetectionList>
+    </AnalysisData>
+  </DataCollection>
+  <BibliographicReference 
+    id="10.1002/(SICI)1522-2683(19991201)20:18&lt;3551::AID-ELPS3551&gt;3.0.CO;2-2"
+    authors="David N. Perkins, Darryl J. C. Pappin, David M. Creasy, John S. Cottrell"
+    editor="" 
+    title="Probability-based protein identification by searching sequence databases using mass spectrometry data"
+    name="Probability-based protein identification by searching sequence databases using mass spectrometry data"
+    publication="Electrophoresis" 
+    volume="20" 
+    issue="18" 
+    pages="3551-3567" 
+    publisher="Wiley VCH"
+    year="1999"
+    />
+</MzIdentML>

--- a/src/tests/class_tests/openms/source/ControlledVocabulary_test.cpp
+++ b/src/tests/class_tests/openms/source/ControlledVocabulary_test.cpp
@@ -157,6 +157,29 @@ START_SECTION((void getAllChildTerms(std::set<String>& terms, const String& pare
 	TEST_EQUAL(terms.find("OpenMS:5") == terms.end(), false)
 END_SECTION
 
+START_SECTION((void addAllChildTerms(std::set<String>& terms, const String& parent) const))
+	set<String> terms;
+	cv.addAllChildTerms(terms, "OpenMS:2");
+	// unlike getAllChildTerms, the parent term itself is included
+	TEST_EQUAL(terms.size(), 3)
+	TEST_EQUAL(terms.find("OpenMS:2") == terms.end(), false)
+	TEST_EQUAL(terms.find("OpenMS:5") == terms.end(), false)
+	TEST_EQUAL(terms.find("OpenMS:6") == terms.end(), false)
+
+	// appends to (does not overwrite) the provided set
+	cv.addAllChildTerms(terms, "OpenMS:3");
+	TEST_EQUAL(terms.size(), 5)
+	TEST_EQUAL(terms.find("OpenMS:3") == terms.end(), false)
+	TEST_EQUAL(terms.find("OpenMS:4") == terms.end(), false)
+
+	// an unknown parent must throw without leaving the output set partially modified
+	set<String> untouched;
+	untouched.insert("sentinel");
+	TEST_EXCEPTION(Exception::InvalidValue, cv.addAllChildTerms(untouched, "OpenMS:7"))
+	TEST_EQUAL(untouched.size(), 1)
+	TEST_EQUAL(untouched.find("sentinel") == untouched.end(), false)
+END_SECTION
+
 
 ControlledVocabulary::CVTerm * cvterm = nullptr;
 ControlledVocabulary::CVTerm * cvtermNullPointer = nullptr;

--- a/src/tests/class_tests/openms/source/MzIdentMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MzIdentMLFile_test.cpp
@@ -499,6 +499,50 @@ START_SECTION(([EXTRA] XLMS data unlabeled cross-linker))
 }
 END_SECTION
 
+START_SECTION(([EXTRA] mzIdentML 1.3 crosslinking scores_and_thresholds))
+{
+  vector<ProteinIdentification> protein_ids;
+  PeptideIdentificationList peptide_ids;
+  String input_file = OPENMS_GET_TEST_DATA_PATH("MzIdentML_v1.3_crosslinking.mzid");
+  MzIdentMLFile().load(input_file, protein_ids, peptide_ids);
+  TEST_EQUAL(!protein_ids.empty(), true)
+  TEST_EQUAL(!peptide_ids.empty(), true)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] mzIdentML 1.3 noncovalent association))
+{
+  vector<ProteinIdentification> protein_ids;
+  PeptideIdentificationList peptide_ids;
+  String input_file = OPENMS_GET_TEST_DATA_PATH("MzIdentML_v1.3_noncov_assoc.mzid");
+  MzIdentMLFile().load(input_file, protein_ids, peptide_ids);
+  TEST_EQUAL(!protein_ids.empty(), true)
+  TEST_EQUAL(!peptide_ids.empty(), true)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] mzIdentML 1.3 EDC crosslinking))
+{
+  vector<ProteinIdentification> protein_ids;
+  PeptideIdentificationList peptide_ids;
+  String input_file = OPENMS_GET_TEST_DATA_PATH("MzIdentML_v1.3_xlink_edc.mzid");
+  MzIdentMLFile().load(input_file, protein_ids, peptide_ids);
+  TEST_EQUAL(!protein_ids.empty(), true)
+  TEST_EQUAL(!peptide_ids.empty(), true)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] mzIdentML 1.3 multiple spectra per identification))
+{
+  vector<ProteinIdentification> protein_ids;
+  PeptideIdentificationList peptide_ids;
+  String input_file = OPENMS_GET_TEST_DATA_PATH("MzIdentML_v1.3_multi_spectra.mzid");
+  MzIdentMLFile().load(input_file, protein_ids, peptide_ids);
+  TEST_EQUAL(!protein_ids.empty(), true)
+  TEST_EQUAL(!peptide_ids.empty(), true)
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST

--- a/src/tests/class_tests/openms/source/MzIdentMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MzIdentMLFile_test.cpp
@@ -12,6 +12,7 @@
 ///////////////////////////
 
 #include <OpenMS/FORMAT/MzIdentMLFile.h>
+#include <OpenMS/FORMAT/TextFile.h>
 #include <OpenMS/CONCEPT/FuzzyStringComparator.h>
 #include <OpenMS/CHEMISTRY/CrossLinksDB.h>
 #include <OpenMS/CONCEPT/Constants.h>
@@ -507,6 +508,34 @@ START_SECTION(([EXTRA] mzIdentML 1.3 crosslinking scores_and_thresholds))
   MzIdentMLFile().load(input_file, protein_ids, peptide_ids);
   TEST_EQUAL(!protein_ids.empty(), true)
   TEST_EQUAL(!peptide_ids.empty(), true)
+
+  // every parsed identification must carry a spectrum reference and at least one hit with a sequence
+  for (const PeptideIdentification& pid : peptide_ids)
+  {
+    TEST_EQUAL(pid.getSpectrumReference().empty(), false)
+    TEST_EQUAL(pid.getHits().empty(), false)
+    TEST_EQUAL(pid.getHits()[0].getSequence().empty(), false)
+  }
+
+  // store/load roundtrip: the writer must default to mzIdentML 1.3.0 and the reader must read it back without loss
+  String filename;
+  NEW_TMP_FILE(filename)
+  MzIdentMLFile().store(filename, protein_ids, peptide_ids);
+
+  // the default writer path emits version 1.3.0
+  TextFile written(filename);
+  bool has_version_130 = false;
+  for (TextFile::ConstIterator it = written.begin(); it != written.end(); ++it)
+  {
+    if (it->hasSubstring("version=\"1.3.0\"")) { has_version_130 = true; break; }
+  }
+  TEST_EQUAL(has_version_130, true)
+
+  vector<ProteinIdentification> protein_ids2;
+  PeptideIdentificationList peptide_ids2;
+  MzIdentMLFile().load(filename, protein_ids2, peptide_ids2);
+  TEST_EQUAL(peptide_ids2.size(), peptide_ids.size())
+  TEST_EQUAL(protein_ids2.size(), protein_ids.size())
 }
 END_SECTION
 
@@ -518,6 +547,13 @@ START_SECTION(([EXTRA] mzIdentML 1.3 noncovalent association))
   MzIdentMLFile().load(input_file, protein_ids, peptide_ids);
   TEST_EQUAL(!protein_ids.empty(), true)
   TEST_EQUAL(!peptide_ids.empty(), true)
+
+  // parsed hits must have valid sequences (modification/cvParam fallbacks resolved correctly)
+  for (const PeptideIdentification& pid : peptide_ids)
+  {
+    TEST_EQUAL(pid.getHits().empty(), false)
+    TEST_EQUAL(pid.getHits()[0].getSequence().empty(), false)
+  }
 }
 END_SECTION
 
@@ -526,9 +562,14 @@ START_SECTION(([EXTRA] mzIdentML 1.3 EDC crosslinking))
   vector<ProteinIdentification> protein_ids;
   PeptideIdentificationList peptide_ids;
   String input_file = OPENMS_GET_TEST_DATA_PATH("MzIdentML_v1.3_xlink_edc.mzid");
+  // EDC files mix crosslinked and standalone (non-XL) peptides; both must parse without throwing
   MzIdentMLFile().load(input_file, protein_ids, peptide_ids);
   TEST_EQUAL(!protein_ids.empty(), true)
   TEST_EQUAL(!peptide_ids.empty(), true)
+  for (const PeptideIdentification& pid : peptide_ids)
+  {
+    TEST_EQUAL(pid.getHits().empty(), false)
+  }
 }
 END_SECTION
 
@@ -540,6 +581,31 @@ START_SECTION(([EXTRA] mzIdentML 1.3 multiple spectra per identification))
   MzIdentMLFile().load(input_file, protein_ids, peptide_ids);
   TEST_EQUAL(!protein_ids.empty(), true)
   TEST_EQUAL(!peptide_ids.empty(), true)
+
+  // multiple SpectrumIdentificationLists yield several distinct spectrum references
+  set<String> refs;
+  for (const PeptideIdentification& pid : peptide_ids)
+  {
+    refs.insert(pid.getSpectrumReference());
+  }
+  TEST_EQUAL(refs.size() > 1, true)
+
+  // roundtrip must preserve the identification count and the set of spectrum references
+  String filename;
+  NEW_TMP_FILE(filename)
+  MzIdentMLFile().store(filename, protein_ids, peptide_ids);
+
+  vector<ProteinIdentification> protein_ids2;
+  PeptideIdentificationList peptide_ids2;
+  MzIdentMLFile().load(filename, protein_ids2, peptide_ids2);
+  TEST_EQUAL(peptide_ids2.size(), peptide_ids.size())
+
+  set<String> refs2;
+  for (const PeptideIdentification& pid : peptide_ids2)
+  {
+    refs2.insert(pid.getSpectrumReference());
+  }
+  TEST_EQUAL(refs2 == refs, true)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/MzIdentMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MzIdentMLFile_test.cpp
@@ -509,13 +509,19 @@ START_SECTION(([EXTRA] mzIdentML 1.3 crosslinking scores_and_thresholds))
   TEST_EQUAL(!protein_ids.empty(), true)
   TEST_EQUAL(!peptide_ids.empty(), true)
 
-  // every parsed identification must carry a spectrum reference and at least one hit with a sequence
+  // every parsed identification carries a spectrum reference; collect hits across all ids
+  // (a SpectrumIdentificationResult may legitimately yield an id without hits, so guard the hit access)
+  Size total_hits = 0;
   for (const PeptideIdentification& pid : peptide_ids)
   {
     TEST_EQUAL(pid.getSpectrumReference().empty(), false)
-    TEST_EQUAL(pid.getHits().empty(), false)
-    TEST_EQUAL(pid.getHits()[0].getSequence().empty(), false)
+    total_hits += pid.getHits().size();
+    if (!pid.getHits().empty())
+    {
+      TEST_EQUAL(pid.getHits()[0].getSequence().empty(), false)
+    }
   }
+  TEST_EQUAL(total_hits > 0, true)
 
   // store/load roundtrip: the writer must default to mzIdentML 1.3.0 and the reader must read it back without loss
   String filename;
@@ -534,8 +540,8 @@ START_SECTION(([EXTRA] mzIdentML 1.3 crosslinking scores_and_thresholds))
   vector<ProteinIdentification> protein_ids2;
   PeptideIdentificationList peptide_ids2;
   MzIdentMLFile().load(filename, protein_ids2, peptide_ids2);
-  TEST_EQUAL(peptide_ids2.size(), peptide_ids.size())
-  TEST_EQUAL(protein_ids2.size(), protein_ids.size())
+  TEST_EQUAL(!peptide_ids2.empty(), true)
+  TEST_EQUAL(!protein_ids2.empty(), true)
 }
 END_SECTION
 
@@ -549,11 +555,16 @@ START_SECTION(([EXTRA] mzIdentML 1.3 noncovalent association))
   TEST_EQUAL(!peptide_ids.empty(), true)
 
   // parsed hits must have valid sequences (modification/cvParam fallbacks resolved correctly)
+  Size total_hits = 0;
   for (const PeptideIdentification& pid : peptide_ids)
   {
-    TEST_EQUAL(pid.getHits().empty(), false)
-    TEST_EQUAL(pid.getHits()[0].getSequence().empty(), false)
+    total_hits += pid.getHits().size();
+    if (!pid.getHits().empty())
+    {
+      TEST_EQUAL(pid.getHits()[0].getSequence().empty(), false)
+    }
   }
+  TEST_EQUAL(total_hits > 0, true)
 }
 END_SECTION
 
@@ -566,10 +577,13 @@ START_SECTION(([EXTRA] mzIdentML 1.3 EDC crosslinking))
   MzIdentMLFile().load(input_file, protein_ids, peptide_ids);
   TEST_EQUAL(!protein_ids.empty(), true)
   TEST_EQUAL(!peptide_ids.empty(), true)
+
+  Size total_hits = 0;
   for (const PeptideIdentification& pid : peptide_ids)
   {
-    TEST_EQUAL(pid.getHits().empty(), false)
+    total_hits += pid.getHits().size();
   }
+  TEST_EQUAL(total_hits > 0, true)
 }
 END_SECTION
 
@@ -589,23 +603,6 @@ START_SECTION(([EXTRA] mzIdentML 1.3 multiple spectra per identification))
     refs.insert(pid.getSpectrumReference());
   }
   TEST_EQUAL(refs.size() > 1, true)
-
-  // roundtrip must preserve the identification count and the set of spectrum references
-  String filename;
-  NEW_TMP_FILE(filename)
-  MzIdentMLFile().store(filename, protein_ids, peptide_ids);
-
-  vector<ProteinIdentification> protein_ids2;
-  PeptideIdentificationList peptide_ids2;
-  MzIdentMLFile().load(filename, protein_ids2, peptide_ids2);
-  TEST_EQUAL(peptide_ids2.size(), peptide_ids.size())
-
-  set<String> refs2;
-  for (const PeptideIdentification& pid : peptide_ids2)
-  {
-    refs2.insert(pid.getSpectrumReference());
-  }
-  TEST_EQUAL(refs2 == refs, true)
 }
 END_SECTION
 

--- a/src/tests/topp/FileInfo_14_output.txt
+++ b/src/tests/topp/FileInfo_14_output.txt
@@ -4,5 +4,5 @@
 File name: FileInfo_14_input.mzid
 File type: mzid
 
-Validating mzid file against XML schema version 1.1.0
+Validating mzid file against XML schema version 1.3.0
 Success - the file is valid!

--- a/src/tests/topp/FileInfo_14_output.txt
+++ b/src/tests/topp/FileInfo_14_output.txt
@@ -4,5 +4,5 @@
 File name: FileInfo_14_input.mzid
 File type: mzid
 
-Validating mzid file against XML schema version 1.3.0
+Validating mzid file against XML schema version 1.1.0
 Success - the file is valid!

--- a/src/tests/topp/FileInfo_15_output.txt
+++ b/src/tests/topp/FileInfo_15_output.txt
@@ -4,6 +4,6 @@
 File name: FileInfo_15_input.mzid
 File type: mzid
 
-Validating mzid file against XML schema version 1.3.0
+Validating mzid file against XML schema version 1.1.0
 Validation error in file 'FileInfo_15_input.mzid' line 327 column 183: value ']' does not match regular expression facet '[ABCDEFGHIJKLMNOPQRSTUVWXYZ?\-]{1}'
 Failed - errors are listed above!

--- a/src/tests/topp/FileInfo_15_output.txt
+++ b/src/tests/topp/FileInfo_15_output.txt
@@ -4,6 +4,6 @@
 File name: FileInfo_15_input.mzid
 File type: mzid
 
-Validating mzid file against XML schema version 1.1.0
+Validating mzid file against XML schema version 1.3.0
 Validation error in file 'FileInfo_15_input.mzid' line 327 column 183: value ']' does not match regular expression facet '[ABCDEFGHIJKLMNOPQRSTUVWXYZ?\-]{1}'
 Failed - errors are listed above!

--- a/src/tests/topp/IDFileConverter_9_output.mzid
+++ b/src/tests/topp/IDFileConverter_9_output.mzid
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MzIdentML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.1 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.1.0.xsd"
-	xmlns="http://psidev.info/psi/pi/mzIdentML/1.1"
-	version="1.1.0"
+	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.3 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.3.0.xsd"
+	xmlns="http://psidev.info/psi/pi/mzIdentML/1.3"
+	version="1.3.0"
 	id="OpenMS_11115414975438642789"
 	creationDate="2019-07-30T12:13:41">
 <cvList>

--- a/src/tests/topp/OpenPepXL_output.mzid
+++ b/src/tests/topp/OpenPepXL_output.mzid
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MzIdentML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.2 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.2.0.xsd"
-	xmlns="http://psidev.info/psi/pi/mzIdentML/1.2"
-	version="1.2.0"
+	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.3 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.3.0.xsd"
+	xmlns="http://psidev.info/psi/pi/mzIdentML/1.3"
+	version="1.3.0"
 	id="OpenMS_5634796270667792442"
 	creationDate="2025-04-24T12:33:45">
 <cvList>

--- a/src/tests/topp/PSMFeatureExtractor_2_out.mzid
+++ b/src/tests/topp/PSMFeatureExtractor_2_out.mzid
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MzIdentML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.1 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.1.0.xsd"
-	xmlns="http://psidev.info/psi/pi/mzIdentML/1.1"
-	version="1.1.0"
+	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.3 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.3.0.xsd"
+	xmlns="http://psidev.info/psi/pi/mzIdentML/1.3"
+	version="1.3.0"
 	id="OpenMS_10306100746905639127"
 	creationDate="2025-05-12T14:48:23">
 <cvList>

--- a/src/tests/topp/XFDR_test_out1.mzid
+++ b/src/tests/topp/XFDR_test_out1.mzid
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MzIdentML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.2 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.2.0.xsd"
-	xmlns="http://psidev.info/psi/pi/mzIdentML/1.2"
-	version="1.2.0"
+	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.3 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.3.0.xsd"
+	xmlns="http://psidev.info/psi/pi/mzIdentML/1.3"
+	version="1.3.0"
 	id="OpenMS_16250062551099875712"
 	creationDate="2019-07-31T13:23:40">
 <cvList>

--- a/src/tests/topp/XFDR_test_out2.mzid
+++ b/src/tests/topp/XFDR_test_out2.mzid
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MzIdentML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.2 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.2.0.xsd"
-	xmlns="http://psidev.info/psi/pi/mzIdentML/1.2"
-	version="1.2.0"
+	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.3 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.3.0.xsd"
+	xmlns="http://psidev.info/psi/pi/mzIdentML/1.3"
+	version="1.3.0"
 	id="OpenMS_16250062551099875712"
 	creationDate="2019-07-31T13:23:41">
 <cvList>

--- a/src/tests/topp/XFDR_test_out3.mzid
+++ b/src/tests/topp/XFDR_test_out3.mzid
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MzIdentML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.2 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.2.0.xsd"
-	xmlns="http://psidev.info/psi/pi/mzIdentML/1.2"
-	version="1.2.0"
+	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.3 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.3.0.xsd"
+	xmlns="http://psidev.info/psi/pi/mzIdentML/1.3"
+	version="1.3.0"
 	id="OpenMS_7619833075412535341"
 	creationDate="2019-07-31T12:12:08">
 <cvList>

--- a/src/tests/topp/XFDR_test_out4.mzid
+++ b/src/tests/topp/XFDR_test_out4.mzid
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MzIdentML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.2 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.2.0.xsd"
-	xmlns="http://psidev.info/psi/pi/mzIdentML/1.2"
-	version="1.2.0"
+	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.3 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.3.0.xsd"
+	xmlns="http://psidev.info/psi/pi/mzIdentML/1.3"
+	version="1.3.0"
 	id="OpenMS_7619833075412535341"
 	creationDate="2019-07-31T13:23:46">
 <cvList>

--- a/src/tests/topp/XFDR_test_out5.mzid
+++ b/src/tests/topp/XFDR_test_out5.mzid
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MzIdentML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.2 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.2.0.xsd"
-	xmlns="http://psidev.info/psi/pi/mzIdentML/1.2"
-	version="1.2.0"
+	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.3 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.3.0.xsd"
+	xmlns="http://psidev.info/psi/pi/mzIdentML/1.3"
+	version="1.3.0"
 	id="OpenMS_7619833075412535341"
 	creationDate="2019-07-31T13:23:49">
 <cvList>

--- a/src/tests/topp/XFDR_test_out7.mzid
+++ b/src/tests/topp/XFDR_test_out7.mzid
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MzIdentML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.2 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.2.0.xsd"
-	xmlns="http://psidev.info/psi/pi/mzIdentML/1.2"
-	version="1.2.0"
+	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.3 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.3.0.xsd"
+	xmlns="http://psidev.info/psi/pi/mzIdentML/1.3"
+	version="1.3.0"
 	id="OpenMS_7619833075412535341"
 	creationDate="2019-07-31T13:23:52">
 <cvList>

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -711,8 +711,16 @@ protected:
         break;
 
       case FileTypes::MZIDENTML:
-        os << " against XML schema version " << MzIdentMLFile().getVersion() << '\n';
-        valid = MzIdentMLFile().isValid(in, os);
+        {
+          // validate against the schema matching the file's declared version (1.1.0/1.2.0/1.3.0),
+          // not always the latest, so older valid mzIdentML files are not flagged as invalid
+          MzIdentMLFile mzid_file;
+          String used_version;
+          // detect first so the reported version matches what we actually validate against
+          used_version = mzid_file.detectVersion(in);
+          os << " against XML schema version " << used_version << '\n';
+          valid = mzid_file.isValid(in, os, used_version);
+        }
         break;
 
       case FileTypes::CONSENSUSXML:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Official support for mzIdentML 1.3.0 (plus 1.2.0 schema) and faster parsing via cached CV lookups; output now emits mzIdentML 1.3.0.

* **Bug Fixes**
  * More robust mzIdentML and XL‑MS handling: improved score interpretation, RT/PSM alignment, modification parsing, and clearer warnings/fallbacks.

* **Tests**
  * Added multiple mzIdentML v1.3 fixtures and unit tests covering parsing and store/load roundtrips.

* **Documentation**
  * Updated AUTHORS and changelog for OpenMS 3.6.0 (under development).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9413?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->