### PR TITLE
Add Thermo RAW input support to seven TOPP tools

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/SwathFile.h
+++ b/src/openms/include/OpenMS/FORMAT/SwathFile.h
@@ -72,8 +72,26 @@ public:
                                               const String& readoptions = "normal",
                                               Interfaces::IMSDataConsumer* plugin_consumer = nullptr);
 
+    /**
+      @brief Loads a Swath run from a pre-loaded in-memory MSExperiment
+
+      Used when the input format does not have a streaming reader (e.g. Thermo .raw
+      via openms-thermo-bridge), so the full experiment has already been materialized.
+      Avoids the round-trip through a temporary mzML file.
+
+      @param[in] exp The pre-loaded experiment (must contain all spectra and metadata)
+      @param[in] tmp Temporary directory (used only for readoptions=="cache")
+      @param[out] exp_meta ExperimentalSettings extracted from @p exp
+      @param[in] readoptions "normal" (in-memory) or "cache" (disk-cached)
+      @return Swath maps for MS2 and MS1
+    */
+    std::vector<OpenSwath::SwathMap> loadFromMSExperiment(const std::shared_ptr<PeakMap>& exp,
+                                                          const String& tmp,
+                                                          std::shared_ptr<ExperimentalSettings>& exp_meta,
+                                                          const String& readoptions = "normal");
+
     /// Loads a Swath run from a single mzXML file
-    std::vector<OpenSwath::SwathMap> loadMzXML(const String& file, 
+    std::vector<OpenSwath::SwathMap> loadMzXML(const String& file,
                                                const String& tmp,
                                                std::shared_ptr<ExperimentalSettings>& exp_meta,
                                                const String& readoptions = "normal");

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -1571,7 +1571,7 @@ namespace OpenMS
     options.clearMSLevels();
     options.addMSLevel(2);
     f.getOptions() = options;
-    f.loadExperiment(in_spectra, spectra, {FileTypes::MZML, FileTypes::BRUKER_TDF});
+    f.loadExperiment(in_spectra, spectra, {FileTypes::MZML, FileTypes::BRUKER_TDF, FileTypes::RAW});
     spectra.sortSpectra(true);
 
     // load FASTA
@@ -1736,7 +1736,7 @@ namespace OpenMS
         options.clearMSLevels();
         options.addMSLevel(2);
         f.getOptions() = options;
-        f.loadExperiment(in_spectra_files[i], all_spectra[i], {FileTypes::MZML, FileTypes::BRUKER_TDF});
+        f.loadExperiment(in_spectra_files[i], all_spectra[i], {FileTypes::MZML, FileTypes::BRUKER_TDF, FileTypes::RAW});
         all_spectra[i].sortSpectra(true);
         preprocessSpectra_(all_spectra[i], fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm);
       }
@@ -2031,7 +2031,7 @@ namespace OpenMS
           options.clearMSLevels();
           options.addMSLevel(2);
           f.getOptions() = options;
-          f.loadExperiment(in_spectra, spectra, {FileTypes::MZML, FileTypes::BRUKER_TDF});
+          f.loadExperiment(in_spectra, spectra, {FileTypes::MZML, FileTypes::BRUKER_TDF, FileTypes::RAW});
         }
         spectra.sortSpectra(true);
 

--- a/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
@@ -630,7 +630,7 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
     options.clearMSLevels();
     options.addMSLevel(2);
     f.getOptions() = options;
-    f.loadExperiment(in_spectra, spectra, {FileTypes::MZML, FileTypes::BRUKER_TDF});
+    f.loadExperiment(in_spectra, spectra, {FileTypes::MZML, FileTypes::BRUKER_TDF, FileTypes::RAW});
     spectra.sortSpectra(true);
 
     startProgress(0, 1, "Filtering spectra...");

--- a/src/openms/source/APPLICATIONS/OpenSwathBase.cpp
+++ b/src/openms/source/APPLICATIONS/OpenSwathBase.cpp
@@ -140,15 +140,33 @@ namespace OpenMS
           }
         }
 #endif
+#ifdef WITH_THERMO_RAW
+        else if (in_file_type == FileTypes::RAW)
+        {
+          // Load .raw fully via ThermoRawFile (in-process), then build SwathMaps
+          // directly from the in-memory MSExperiment — no temp mzML round-trip.
+          auto exp_raw = std::make_shared<PeakMap>();
+          FileHandler().loadExperiment(f, *exp_raw, {FileTypes::RAW});
+          auto maps = swath_file.loadFromMSExperiment(exp_raw, tmp, exp_meta, readoptions);
+          for (auto & m : maps)
+          {
+            swath_maps.push_back(m);
+            swath_map_sources.push_back(f);
+          }
+        }
+#endif
         else
         {
+          throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                           "Input file needs to have a supported extension "
+                                           "(mzML, mzXML, sqMass"
 #ifdef WITH_OPENTIMS
-          throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                           "Input file needs to have ending mzML, mzXML, sqMass, or .d (Bruker TDF)");
-#else
-          throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                           "Input file needs to have ending mzML, mzXML, or sqMass");
+                                           ", .d (Bruker TDF)"
 #endif
+#ifdef WITH_THERMO_RAW
+                                           ", raw (Thermo)"
+#endif
+                                           ")");
         }
       }
     }
@@ -183,15 +201,30 @@ namespace OpenMS
         for (Size i = 0; i < swath_maps.size(); ++i) swath_map_sources.push_back(file_list[0]);
       }
 #endif
+#ifdef WITH_THERMO_RAW
+      else if (in_file_type == FileTypes::RAW)
+      {
+        // Load .raw fully via ThermoRawFile (in-process), then build SwathMaps
+        // directly from the in-memory MSExperiment — no temp mzML round-trip.
+        auto exp_raw = std::make_shared<PeakMap>();
+        FileHandler().loadExperiment(file_list[0], *exp_raw, {FileTypes::RAW});
+        swath_maps = swath_file.loadFromMSExperiment(exp_raw, tmp, exp_meta, readoptions);
+        swath_map_sources.clear();
+        for (Size i = 0; i < swath_maps.size(); ++i) swath_map_sources.push_back(file_list[0]);
+      }
+#endif
       else
       {
+        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                         "Input file needs to have a supported extension "
+                                         "(mzML, mzXML, sqMass"
 #ifdef WITH_OPENTIMS
-        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                         "Input file needs to have ending mzML, mzXML, sqMass, or .d (Bruker TDF)");
-#else
-        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                         "Input file needs to have ending mzML, mzXML, or sqMass");
+                                         ", .d (Bruker TDF)"
 #endif
+#ifdef WITH_THERMO_RAW
+                                         ", raw (Thermo)"
+#endif
+                                         ")");
       }
     }
   }

--- a/src/openms/source/FORMAT/SwathFile.cpp
+++ b/src/openms/source/FORMAT/SwathFile.cpp
@@ -195,6 +195,60 @@ namespace OpenMS
     return swath_maps;
   }
 
+  /// Loads a Swath run from a pre-loaded in-memory MSExperiment
+  std::vector<OpenSwath::SwathMap> SwathFile::loadFromMSExperiment(
+      const std::shared_ptr<PeakMap>& exp,
+      const String& tmp,
+      std::shared_ptr<ExperimentalSettings>& exp_meta,
+      const String& readoptions)
+  {
+    OPENMS_LOG_INFO << "Loading Swath run from in-memory MSExperiment with " << exp->size()
+                    << " spectra using readoptions " << readoptions << '\n';
+    String tmp_fname = tmp.hasSuffix('/') ? File::getUniqueName() : "";
+
+    // The provided experiment already contains all metadata + data.
+    exp_meta = exp;
+
+    std::vector<int> swath_counter;
+    int nr_ms1_spectra;
+    std::vector<OpenSwath::SwathMap> known_window_boundaries;
+    countScansInSwath_(exp->getSpectra(), swath_counter, nr_ms1_spectra, known_window_boundaries);
+    OPENMS_LOG_INFO << "Determined there to be " << swath_counter.size()
+                    << " SWATH windows and in total " << nr_ms1_spectra << " MS1 spectra\n";
+
+    std::shared_ptr<FullSwathFileConsumer> dataConsumer;
+    if (readoptions == "normal")
+    {
+      dataConsumer = std::make_shared<RegularSwathFileConsumer>(known_window_boundaries);
+    }
+    else if (readoptions == "cache")
+    {
+      dataConsumer = std::make_shared<CachedSwathFileConsumer>(known_window_boundaries, tmp, tmp_fname, nr_ms1_spectra, swath_counter);
+    }
+    else
+    {
+      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "Unknown or unsupported option " + readoptions);
+    }
+    dataConsumer->setExperimentalSettings(*exp_meta.get());
+
+    // Feed spectra directly to the consumer — no file I/O.
+    startProgress(0, exp->size(), "Building Swath maps from in-memory experiment");
+    Size progress = 0;
+    for (auto& spec : exp->getSpectra())
+    {
+      // consumeSpectrum takes a non-const ref; copy to a local since exp is shared.
+      auto spec_copy = spec;
+      dataConsumer->consumeSpectrum(spec_copy);
+      setProgress(progress++);
+    }
+    endProgress();
+
+    std::vector<OpenSwath::SwathMap> swath_maps;
+    dataConsumer->retrieveSwathMaps(swath_maps);
+    return swath_maps;
+  }
+
   /// Loads a Swath run from a single mzXML file
   std::vector<OpenSwath::SwathMap> SwathFile::loadMzXML(const String& file,
     const String& tmp,

--- a/src/topp/CometAdapter.cpp
+++ b/src/topp/CometAdapter.cpp
@@ -134,6 +134,9 @@ protected:
 #ifdef WITH_OPENTIMS
       "d",
 #endif
+#ifdef WITH_THERMO_RAW
+      "raw",
+#endif
     });
     registerOutputFile_("out", "<file>", "", "Output file (.idXML) or directory bundle (.idparquet) containing the search results.");
     setValidFormats_("out", { "idXML", "idparquet"} );
@@ -695,8 +698,39 @@ protected:
     MSExperiment exp;
     String input_file_with_index = inputfile_name;
 
+#ifdef WITH_THERMO_RAW
+    const bool is_thermo_raw = (FileHandler::getType(inputfile_name) == FileTypes::RAW);
+#endif
 #ifdef WITH_OPENTIMS
     const bool is_bruker_d = (FileHandler::getType(inputfile_name) == FileTypes::BRUKER_TDF);
+#endif
+
+#ifdef WITH_THERMO_RAW
+    if (is_thermo_raw)
+    {
+      // Load .raw via FileHandler (dispatches to ThermoRawFile).
+      // Only target MS level is loaded.
+      FileHandler fh;
+      fh.getOptions().clearMSLevels();
+      fh.getOptions().addMSLevel(ms_level);
+      fh.loadExperiment(inputfile_name, exp, {FileTypes::RAW}, log_type_);
+
+      OPENMS_LOG_INFO << "Loaded " << exp.size() << " MS" << ms_level
+                      << " spectra from Thermo .raw file." << std::endl;
+
+      // Thermo native IDs are "scan=N" with monotonic N — mzParser handles
+      // them correctly, so no native ID rewriting is needed (unlike the
+      // Bruker path below where "frame=F scan=S" triggers a sort UB).
+      auto tmp_mzml = File::getTemporaryFile() + ".mzML";
+      MzMLFile().store(tmp_mzml, exp);
+      input_file_with_index = tmp_mzml;
+
+      // Free peak data but keep spectrum metadata for post-processing.
+      for (auto& spec : exp.getSpectra()) { spec.clear(false); }
+    }
+    else
+#endif
+#ifdef WITH_OPENTIMS
     if (is_bruker_d)
     {
       // Load .d via BrukerTimsFile. Skip MS1 loading for MS2 searches since

--- a/src/topp/FileConverter.cpp
+++ b/src/topp/FileConverter.cpp
@@ -343,6 +343,15 @@ protected:
     registerFlag_("RawToMzML:no_peak_picking", "Disables vendor peak picking for raw files.", true);
     registerFlag_("RawToMzML:no_zlib_compression", "Disables zlib compression for raw file conversion. Enables compatibility with some tools that do not support compressed input files, e.g. X!Tandem.", true);
     registerFlag_("RawToMzML:include_noise", "Include noise data in mzML output.", true);
+    registerStringOption_("RawToMzML:reader", "<mode>", "external",
+      "Reader for Thermo .raw files. 'external' uses ThermoRawFileParser (external .NET process, mzML output only); "
+      "'inprocess' uses the built-in ThermoRawFile (in-process, supports any output format; requires WITH_THERMO_RAW build).",
+      false, true);
+    std::vector<String> raw_reader_modes = {"external"};
+#ifdef WITH_THERMO_RAW
+    raw_reader_modes.push_back("inprocess");
+#endif
+    setValidStrings_("RawToMzML:reader", raw_reader_modes);
     
   // OpenSwath / chromatogram options: allow passing a transition library to map extracted ion chromatograms to their matching metadata in the transition list
   registerTOPPSubsection_("OpenSwathWorkflow", "Options for loading OpenSWATH transition libraries used for chromatogram metadata");
@@ -483,6 +492,22 @@ protected:
     }
     else if (in_type == FileTypes::RAW)
     {
+      String raw_reader = getStringOption_("RawToMzML:reader");
+#ifdef WITH_THERMO_RAW
+      if (raw_reader == "inprocess")
+      {
+        if (getFlag_("RawToMzML:no_peak_picking") || getFlag_("RawToMzML:no_zlib_compression") || getFlag_("RawToMzML:include_noise"))
+        {
+          OPENMS_LOG_WARN << "RawToMzML:no_peak_picking, no_zlib_compression, and include_noise are "
+                          << "specific to the external ThermoRawFileParser; they are ignored when "
+                          << "RawToMzML:reader=inprocess." << std::endl;
+        }
+        // Fall through to generic output writing — supports any output format.
+        fh.loadExperiment(in, exp, {FileTypes::RAW}, log_type_, true, true);
+      }
+      else
+#endif
+      {
       if (out_type != FileTypes::MZML)
       {
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
@@ -525,6 +550,7 @@ protected:
         arguments.push_back("--noiseData");
       }
       return runExternalProcess_(net_executable, arguments);
+      } // close raw_reader == "external" block
     }
     else if (in_type == FileTypes::EDTA)
     {

--- a/src/topp/OpenSwathWorkflow.cpp
+++ b/src/topp/OpenSwathWorkflow.cpp
@@ -244,6 +244,9 @@ protected:
 #ifdef WITH_OPENTIMS
     in_formats.push_back("d");
 #endif
+#ifdef WITH_THERMO_RAW
+    in_formats.push_back("raw");
+#endif
     setValidFormats_("in", in_formats);
 
     registerInputFile_("tr", "<file>", "", "transition file ('TraML','tsv','pqp','oswpq')");

--- a/src/topp/ProSE.cpp
+++ b/src/topp/ProSE.cpp
@@ -88,7 +88,14 @@ class ProSE :
     void registerOptionsAndFlags_() override
     {
       registerInputFileList_("in", "<files>", StringList(), "Input spectrum file(s). Multiple files are searched against the same database; the fragment index is built once and reused.");
-      setValidFormats_("in", ListUtils::create<String>("mzML,d"));
+      setValidFormats_("in", { "mzML",
+#ifdef WITH_OPENTIMS
+        "d",
+#endif
+#ifdef WITH_THERMO_RAW
+        "raw",
+#endif
+      });
 
       registerInputFile_("database", "<file>", "", "Input protein sequence database in FASTA format.");
       setValidFormats_("database", ListUtils::create<String>("fasta"));

--- a/src/topp/ProteomicsLFQ.cpp
+++ b/src/topp/ProteomicsLFQ.cpp
@@ -161,6 +161,9 @@ protected:
 #ifdef WITH_OPENTIMS
       ",d"
 #endif
+#ifdef WITH_THERMO_RAW
+      ",raw"
+#endif
     ));
     registerInputFileList_("in_feat", "<files>", StringList(), "Optional input featureXML files containing pre-computed features. Bypasses internal feature finding. Must match the number of '-in' files.", false, false);
     setValidFormats_("in_feat", ListUtils::create<String>("featureXML"));
@@ -407,7 +410,7 @@ protected:
     // load raw file
 
     PeakMap ms_raw;
-    FileHandler().loadExperiment(mz_file, ms_raw, {FileTypes::MZML}, log_type_);
+    FileHandler().loadExperiment(mz_file, ms_raw, {FileTypes::MZML, FileTypes::RAW}, log_type_);
     ms_raw.clearMetaDataArrays();
     ms_raw.updateRanges();
 

--- a/src/topp/SageAdapter.cpp
+++ b/src/topp/SageAdapter.cpp
@@ -724,17 +724,12 @@ protected:
     // remove hits without charge state assigned or charge outside of default range (fix for downstream bugs). TODO: remove if all charges annotated in sage
     IDFilter::filterPeptidesByCharge(peptide_identifications, 2, numeric_limits<int>::max());
     
-    if (filenames.empty()) filenames = getStringList_("in");
-
-#ifdef WITH_THERMO_RAW
-    // Sage's PIN output references the temp mzML paths we passed in. Translate
-    // them back to the original .raw paths for the output run metadata.
-    for (auto& fn : filenames)
-    {
-      auto it = sage_tmp_basename_to_original.find(File::basename(fn));
-      if (it != sage_tmp_basename_to_original.end()) fn = it->second;
-    }
-#endif
+    // Fallback uses input_files (not getStringList_("in")) so that for Thermo
+    // .raw inputs the fallback gives the temp mzML paths Sage actually saw —
+    // post-processing (native-ID repair, FAIMS) needs those basenames to match
+    // file2specnr2nativeid keys built below from input_files. Equivalent to
+    // getStringList_("in") for mzML/.d inputs where no pre-conversion happened.
+    if (filenames.empty()) filenames = input_files;
 
     // TODO: allow optional split and create multiple idXMLs one per input file
     vector<ProteinIdentification> protein_identifications(1, ProteinIdentification());
@@ -926,6 +921,24 @@ protected:
         }
       }
     }
+
+#ifdef WITH_THERMO_RAW
+    // After all mzML-based post-processing (native-ID repair, FAIMS annotation)
+    // is done — those steps need temp mzML basenames to match file2specnr2nativeid
+    // / input_files — restore original .raw paths in PrimaryMSRunPath for the
+    // output metadata.
+    if (!sage_tmp_basename_to_original.empty())
+    {
+      StringList run_paths;
+      protein_identifications[0].getPrimaryMSRunPath(run_paths);
+      for (auto& fn : run_paths)
+      {
+        auto it = sage_tmp_basename_to_original.find(File::basename(fn));
+        if (it != sage_tmp_basename_to_original.end()) fn = it->second;
+      }
+      protein_identifications[0].setPrimaryMSRunPath(run_paths);
+    }
+#endif
 
     FileHandler().storeIdentifications(output_file, protein_identifications, peptide_identifications,
       {FileTypes::IDXML, FileTypes::IDPARQUET});

--- a/src/topp/SageAdapter.cpp
+++ b/src/topp/SageAdapter.cpp
@@ -423,7 +423,14 @@ protected:
   void registerOptionsAndFlags_() override
   {
     registerInputFileList_("in", "<files>", StringList(), "Input files separated by blank");
-    setValidFormats_("in", { "mzML", "d" } );
+    setValidFormats_("in", { "mzML",
+#ifdef WITH_OPENTIMS
+      "d",
+#endif
+#ifdef WITH_THERMO_RAW
+      "raw",
+#endif
+    });
 
     registerOutputFile_("out", "<file>", "", "Output file (.idXML) or directory bundle (.idparquet) containing all search results.", true, false);
     setValidFormats_("out", { "idXML", "idparquet" } );
@@ -566,6 +573,29 @@ protected:
     // run sage
     //-------------------------------------------------------------
     StringList input_files = getStringList_("in");
+
+#ifdef WITH_THERMO_RAW
+    // Sage does not natively read Thermo .raw files. Pre-convert any .raw
+    // inputs to temp mzML via FileHandler (ThermoRawFile) before passing
+    // to Sage. Track the temp basename → original path mapping so we can
+    // restore the original .raw path in the output run metadata.
+    std::map<String, String> sage_tmp_basename_to_original;
+    for (auto& f : input_files)
+    {
+      if (FileHandler::getType(f) == FileTypes::RAW)
+      {
+        OPENMS_LOG_INFO << "Converting Thermo .raw to temp mzML for Sage: " << f << std::endl;
+        MSExperiment exp_raw;
+        FileHandler fh_raw;
+        fh_raw.loadExperiment(f, exp_raw, {FileTypes::RAW}, log_type_);
+        auto tmp_mzml = File::getTemporaryFile() + ".mzML";
+        MzMLFile().store(tmp_mzml, exp_raw);
+        sage_tmp_basename_to_original[File::basename(tmp_mzml)] = f;
+        f = tmp_mzml;
+      }
+    }
+#endif
+
     String output_file = getStringOption_("out");
     String output_folder = File::path(output_file);
     String fasta_file = getStringOption_("database");
@@ -696,12 +726,22 @@ protected:
     
     if (filenames.empty()) filenames = getStringList_("in");
 
+#ifdef WITH_THERMO_RAW
+    // Sage's PIN output references the temp mzML paths we passed in. Translate
+    // them back to the original .raw paths for the output run metadata.
+    for (auto& fn : filenames)
+    {
+      auto it = sage_tmp_basename_to_original.find(File::basename(fn));
+      if (it != sage_tmp_basename_to_original.end()) fn = it->second;
+    }
+#endif
+
     // TODO: allow optional split and create multiple idXMLs one per input file
     vector<ProteinIdentification> protein_identifications(1, ProteinIdentification());
 
-    writeDebug_("write idXMLFile", 1);    
-    
-    protein_identifications[0].setPrimaryMSRunPath(filenames);  
+    writeDebug_("write idXMLFile", 1);
+
+    protein_identifications[0].setPrimaryMSRunPath(filenames);
     protein_identifications[0].setDateTime(DateTime::now());
     protein_identifications[0].setSearchEngine("Sage");
     protein_identifications[0].setSearchEngineVersion(sage_version);

--- a/src/topp/SimpleSearchEngine.cpp
+++ b/src/topp/SimpleSearchEngine.cpp
@@ -76,7 +76,14 @@ class SimpleSearchEngine :
     void registerOptionsAndFlags_() override
     {
       registerInputFile_("in", "<file>", "", "input file ");
-      setValidFormats_("in", ListUtils::create<String>("mzML,d"));
+      setValidFormats_("in", { "mzML",
+#ifdef WITH_OPENTIMS
+        "d",
+#endif
+#ifdef WITH_THERMO_RAW
+        "raw",
+#endif
+      });
 
       registerInputFile_("database", "<file>", "", "input file ");
       setValidFormats_("database", ListUtils::create<String>("fasta"));


### PR DESCRIPTION
## Summary

Builds on #9389 (in-process ThermoRawFile reader) to accept `.raw` input directly in seven TOPP tools. Each tool is wired in the way that fits its existing `.d` path — no temp-mzML round-trip where it can be avoided.

| Tool | Approach |
|------|----------|
| SimpleSearchEngine, ProSE, ProteomicsLFQ | Add `FileTypes::RAW` to `FileHandler::loadExperiment` allowed_types — `.raw` routes through the existing mzML path; no IM-specific code needed |
| CometAdapter | Load via `FileHandler` → temp mzML → Comet. No native-ID rewriting needed (Thermo `scan=N` is monotonic, unlike Bruker `frame=F scan=S`) |
| SageAdapter | Pre-convert `.raw` → temp mzML → external Sage; restore original `.raw` paths in `PrimaryMSRunPath` |
| FileConverter | New `RawToMzML:reader=external\|inprocess` parameter. `inprocess` falls through to the generic output writer (any output format, not just mzML), enabling side-by-side comparison with the external ThermoRawFileParser |
| OpenSwathWorkflow | New `SwathFile::loadFromMSExperiment()` builds SwathMaps directly from a pre-loaded `MSExperiment` — avoids the disk round-trip the temp-mzML approach would impose. Dispatched from `OpenSwathBase` for `.raw` input |

## Notes

- Format guards harmonised across tools: `#ifdef WITH_OPENTIMS` around `"d"`, `#ifdef WITH_THERMO_RAW` around `"raw"` in every `setValidFormats_`. Previously only CometAdapter guarded `"d"`.
- `FileTypes::RAW` is always defined as an enum, so `allowed_types` vectors don't need ifdefs — `FileHandler::loadExperiment` gates dispatch internally.
- `PeakPickerIM` was deliberately not modified — it requires ion-mobility data, which Thermo `.raw` does not carry.

## Test plan

- [ ] Build with `WITH_THERMO_RAW=ON` and run each tool against a Thermo `.raw` test file (e.g. `Angiotensin_AllScans.raw`)
- [ ] Build with `WITH_THERMO_RAW=OFF` and verify clean compilation + that `--help` does not list `raw` as a valid input format
- [ ] CometAdapter: verify PSM `spectrum_reference` values in output use the original `scan=N` form (no rewriting corruption)
- [ ] SageAdapter: verify `PrimaryMSRunPath` in the output references the original `.raw` path, not the temp mzML
- [ ] FileConverter: compare `RawToMzML:reader=external` vs `RawToMzML:reader=inprocess` mzML outputs for feature parity
- [ ] OpenSwathWorkflow: run on a Thermo DIA `.raw` and verify SWATH window discovery matches a mzML-converted control

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Thermo RAW support across multiple tools and adapters (ProSE, SimpleSearchEngine, OpenSwathWorkflow, ProteomicsLFQ, Comet, Sage)
  * FileConverter: choose RAW→mzML conversion mode (external or in-process)
  * SWATH workflows can ingest already-loaded in-memory experiments for direct processing
  * Adapters preserve original RAW file identities when converting to temporary mzML for downstream steps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->