### PR TITLE
build(cmake): modernize Doxygen handling to non-deprecated FindDoxygen API (#2827)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,7 +515,10 @@ include(cmake/cmake_findExternalLibs.cmake)
 
 #------------------------------------------------------------------------------
 # find the Doxygen (required by /doc and /src/OpenMS)
-find_package(Doxygen) ## defines 'DOXYGEN_HAVE_DOT', 'DOXYGEN_VERSION' etc
+## 'dot' (Graphviz) is requested as an OPTIONAL component so that machines without it still
+## build all non-dot documentation targets. Provides the Doxygen::doxygen / Doxygen::dot imported
+## targets and the modern Doxygen_FOUND, Doxygen_VERSION, Doxygen_dot_FOUND result variables.
+find_package(Doxygen OPTIONAL_COMPONENTS dot)
 
 
 #------------------------------------------------------------------------------

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -91,20 +91,30 @@ if(ENABLE_DOCS)
   # As soon as there is a TeX formula in the html documentation we need LaTeX, dvips and ghostscript.
   # Probably only affects class documentation.
 
-  if (DOXYGEN_FOUND)
-  
+  if (Doxygen_FOUND)
+
     # check doxygen for bug with generated latex files
     set(DOXYGEN_MIN_REQUIRED "1.8.13")
 
+    ## NOTE: keep the all-caps DOXYGEN_VERSION here. The mixed-case Doxygen_VERSION only exists in
+    ## CMake >= 4.2, while OpenMS still supports CMake 3.21; on older CMake it would be empty, making
+    ## this version check always fire and dropping the version argument passed to Doxygen_Warning_test
+    ## below. DOXYGEN_VERSION is set across the whole supported range (3.9 .. 4.2+).
     if (DOXYGEN_VERSION VERSION_LESS DOXYGEN_MIN_REQUIRED )
       message(STATUS "Warning: Doxygen ( vers. installed = ${DOXYGEN_VERSION} < ${DOXYGEN_MIN_REQUIRED}) does not correctly process \\include commands in developer's installation instructions. This will make them incomplete. Upgrade Doxygen to fix.")
     endif()
-    
-    ## if not found, use empty string to avoid `warning: the dot tool could not be found as 'DOXYGEN_DOT_EXECUTABLE-NOTFOUND/dot.exe'` in doxygen-error.log
-    if (DOXYGEN_DOT_EXECUTABLE) 
-      set(CF_DOXYGEN_DOT_EXECUTABLE "${DOXYGEN_DOT_EXECUTABLE}")
+
+    ## DOT (Graphviz) is an optional component. When present, substitute the full path to the dot
+    ## executable into the Doxyfile and enable HAVE_DOT; otherwise leave DOT_PATH empty (avoids
+    ## `warning: the dot tool could not be found ...` in doxygen-error.log) and set HAVE_DOT=NO.
+    ## Note: HAVE_DOT must be the literal YES/NO that doxygen expects, not the CMake TRUE/FALSE of
+    ## Doxygen_dot_FOUND, hence the explicit mapping below.
+    if (TARGET Doxygen::dot)
+      get_target_property(CF_DOXYGEN_DOT_EXECUTABLE Doxygen::dot IMPORTED_LOCATION)
+      set(DOXYGEN_HAVE_DOT "YES")
     else()
       set(CF_DOXYGEN_DOT_EXECUTABLE "")
+      set(DOXYGEN_HAVE_DOT "NO")
     endif()
       
     
@@ -212,7 +222,7 @@ if(ENABLE_DOCS)
       COMMAND ${CMAKE_COMMAND} -E echo "Creating html documentation"
       COMMAND ${CMAKE_COMMAND} -E echo ""
       COMMAND ${CMAKE_COMMAND} -E remove_directory html
-      COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} "${DOXYGEN_EXECUTABLE}" doxygen/Doxyfile
+      COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} $<TARGET_FILE:Doxygen::doxygen> doxygen/Doxyfile
       COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/index.html index.html
       COMMAND ${CMAKE_COMMAND} -E echo ""
       COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
@@ -251,7 +261,7 @@ if(ENABLE_DOCS)
                       COMMAND ${CMAKE_COMMAND} -E echo "Creating XML documentation"
                       COMMAND ${CMAKE_COMMAND} -E echo ""
                       COMMAND ${CMAKE_COMMAND} -E remove_directory xml_output
-                      COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} "${DOXYGEN_EXECUTABLE}" doxygen/Doxyfile_xml
+                      COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} $<TARGET_FILE:Doxygen::doxygen> doxygen/Doxyfile_xml
                       COMMAND ${CMAKE_COMMAND} -E echo ""
                       COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
                       COMMAND ${CMAKE_COMMAND} -E echo "The XML documentation has been successfully created."
@@ -267,7 +277,7 @@ if(ENABLE_DOCS)
                       COMMAND ${CMAKE_COMMAND} -E echo "Creating html documentation without class documentation"
                       COMMAND ${CMAKE_COMMAND} -E echo ""
                       COMMAND ${CMAKE_COMMAND} -E remove_directory html
-                      COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} "${DOXYGEN_EXECUTABLE}" doxygen/Doxyfile_noclass
+                      COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} $<TARGET_FILE:Doxygen::doxygen> doxygen/Doxyfile_noclass
                       COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/index.html index.html
                       COMMAND ${CMAKE_COMMAND} -E echo ""
                       COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
@@ -286,7 +296,7 @@ if(ENABLE_DOCS)
                       COMMAND ${CMAKE_COMMAND} -E echo "Creating html documentation without class/TOPP documentation"
                       COMMAND ${CMAKE_COMMAND} -E echo ""
                       COMMAND ${CMAKE_COMMAND} -E remove_directory html
-                      COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} "${DOXYGEN_EXECUTABLE}" doxygen/Doxyfile_noclass
+                      COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} $<TARGET_FILE:Doxygen::doxygen> doxygen/Doxyfile_noclass
                       COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/index.html index.html
                       COMMAND ${CMAKE_COMMAND} -E echo ""
                       COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
@@ -302,7 +312,7 @@ if(ENABLE_DOCS)
     # stage to avoid confusion if doc_minimal is built first
     add_dependencies(doc_minimal TOPP)
 
-    if (DOXYGEN_DOT_FOUND OR DOXYGEN_DOT_EXECUTABLE)
+    if (TARGET Doxygen::dot)
       #------------------------------------------------------------------------------
       # doc_dot target
       add_custom_target(doc_dot
@@ -311,7 +321,7 @@ if(ENABLE_DOCS)
                         COMMAND ${CMAKE_COMMAND} -E echo "Creating DOT html documentation"
                         COMMAND ${CMAKE_COMMAND} -E echo ""
                         COMMAND ${CMAKE_COMMAND} -E remove_directory html-dot
-                        COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} "${DOXYGEN_EXECUTABLE}" doxygen/Doxyfile_dot
+                        COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} $<TARGET_FILE:Doxygen::doxygen> doxygen/Doxyfile_dot
                         COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/index.html index.html
                         COMMAND ${CMAKE_COMMAND} -E echo ""
                         COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/doc/doxygen/Doxyfile.in
+++ b/doc/doxygen/Doxyfile.in
@@ -2265,7 +2265,7 @@ HIDE_UNDOC_RELATIONS   = NO
 # set to NO
 # The default value is: NO.
 
-HAVE_DOT               = @DOXYGEN_DOT_FOUND@
+HAVE_DOT               = @DOXYGEN_HAVE_DOT@
 
 # The DOT_NUM_THREADS specifies the number of dot invocations doxygen is allowed
 # to run in parallel. When set to 0 doxygen will base this on the number of


### PR DESCRIPTION
Closes #2827.

OpenMS used the legacy `FindDoxygen` result variables that were deprecated in CMake 3.9 (and, for `DOXYGEN_FOUND`/`DOXYGEN_VERSION`, again in CMake 4.2). They still work today only because a bare `find_package(Doxygen)` triggers the module's backward-compatibility path — there are no runtime deprecation warnings, so this is **pure future-proofing**, not a fix for anything broken.

## Changes
- `CMakeLists.txt`: `find_package(Doxygen)` → `find_package(Doxygen OPTIONAL_COMPONENTS dot)`. `OPTIONAL` (not required) so a machine without Graphviz still builds every non-dot documentation target, exactly as before.
- `doc/CMakeLists.txt`:
  - `DOXYGEN_FOUND` → `Doxygen_FOUND` (FindPackageHandleStandardArgs sets the mixed-case form on every CMake version).
  - dot detection via the `Doxygen::dot` imported target instead of `DOXYGEN_DOT_FOUND` / `DOXYGEN_DOT_EXECUTABLE`.
  - run doxygen via `$<TARGET_FILE:Doxygen::doxygen>` instead of `${DOXYGEN_EXECUTABLE}`.
- `doc/doxygen/Doxyfile.in`: `HAVE_DOT = @DOXYGEN_DOT_FOUND@` → `@DOXYGEN_HAVE_DOT@`, an explicit `YES`/`NO` mapping (doxygen's expected literals), since `Doxygen_dot_FOUND` is CMake `TRUE`/`FALSE`. `DOT_PATH` substitution shape is unchanged (still the full path to the dot executable).

### Cross-version note
The version variable is intentionally **kept** as the all-caps `DOXYGEN_VERSION`. The mixed-case `Doxygen_VERSION` only exists in CMake >= 4.2, whereas OpenMS still requires CMake 3.21 (`CMakeLists.txt`). On 3.21-4.1 it would be empty, which would make the `DOXYGEN_MIN_REQUIRED` check always fire and drop the version argument passed to `Doxygen_Warning_test`. `DOXYGEN_VERSION` is populated across the whole supported range, so it is the portable choice here (and emits no runtime deprecation warning).

The vendored `src/openms/extern/SQLiteCpp` doc block is upstream third-party code (its own `find_package`, default-OFF option) and is intentionally left untouched.

## Verification
Configured on a box with doxygen 1.9.8 and **no** `dot` (the exact case that could regress):
- `Doxygen_FOUND` stays TRUE without dot — all doc targets register, `doc_dot` is correctly disabled (matching prior behavior).
- The generated `Doxyfile` is **byte-identical** to the pre-change output: `HAVE_DOT = NO`, empty `DOT_PATH`.
- `$<TARGET_FILE:Doxygen::doxygen>` expands to the real doxygen path in all generated build rules.
- `Doxygen_Warning_test` receives the version arg `1.9.8` (not empty).

The dot-**present** path was not exercised here (no dot on the box), but it's source-backed: `FindDoxygen.cmake` sets `Doxygen::dot`'s `IMPORTED_LOCATION` to the same value the old `DOXYGEN_DOT_EXECUTABLE` carried, so `DOT_PATH` / `HAVE_DOT=YES` output will be identical. CI (which has Graphviz) exercises that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documentation build now treats Graphviz/DOT as optional so docs can be built without the visualization tool.
  * Documentation generation commands invoke Doxygen via its imported package target to improve reliability.
  * Doxygen configuration uses an updated substitution to more accurately reflect DOT availability during config.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->