### PR TITLE
pyOpenMS: make Element read-only so ElementDB stays immutable from Python

### DIFF
--- a/src/pyOpenMS/bindings/bind_chemistry.cpp
+++ b/src/pyOpenMS/bindings/bind_chemistry.cpp
@@ -434,23 +434,17 @@ Returns the "cuts before ..." regular expression
     // -----------------------------------------------------------------------
     // Element
     // -----------------------------------------------------------------------
-    nb::class_<OpenMS::Element>(m, "Element", "Representation of an element")
+    nb::class_<OpenMS::Element>(m, "Element", "Representation of an element (read-only; construct via the full constructor)")
         .def(nb::init<>())
         .def(nb::init<const OpenMS::Element &>())
         .def("__copy__", [](const OpenMS::Element& self) { return OpenMS::Element(self); })
         .def("__deepcopy__", [](const OpenMS::Element& self, nb::dict) { return OpenMS::Element(self); }, "memo"_a)
         .def(nb::init<OpenMS::String, OpenMS::String, unsigned int, double, double, OpenMS::IsotopeDistribution>())
-        .def("setAtomicNumber", [](OpenMS::Element& self, unsigned int atomic_number) { return self.setAtomicNumber(atomic_number); }, "atomic_number"_a, "Sets unique atomic number")
         .def("getAtomicNumber", [](const OpenMS::Element& self) { return self.getAtomicNumber(); }, "Returns the unique atomic number")
-        .def("setAverageWeight", [](OpenMS::Element& self, double weight) { return self.setAverageWeight(weight); }, "weight"_a, "Sets the average weight of the element")
         .def("getAverageWeight", [](const OpenMS::Element& self) { return self.getAverageWeight(); }, "Returns the average weight of the element")
-        .def("setMonoWeight", [](OpenMS::Element& self, double weight) { return self.setMonoWeight(weight); }, "weight"_a, "Sets the mono isotopic weight of the element")
         .def("getMonoWeight", [](const OpenMS::Element& self) { return self.getMonoWeight(); }, "Returns the mono isotopic weight of the element")
-        .def("setIsotopeDistribution", [](OpenMS::Element& self, const OpenMS::IsotopeDistribution& isotopes) { return self.setIsotopeDistribution(isotopes); }, "isotopes"_a, "Sets the isotope distribution of the element")
         .def("getIsotopeDistribution", [](const OpenMS::Element& self) -> const OpenMS::IsotopeDistribution & { return self.getIsotopeDistribution(); }, nb::rv_policy::reference_internal, "Returns the isotope distribution of the element")
-        .def("setName", [](OpenMS::Element& self, const OpenMS::String& name) { return self.setName(name); }, "name"_a, "Sets the name of the element")
         .def("getName", [](const OpenMS::Element& self) { return self.getName(); }, "Returns the name of the element")
-        .def("setSymbol", [](OpenMS::Element& self, const OpenMS::String& symbol) { return self.setSymbol(symbol); }, "symbol"_a, "Sets symbol of the element")
         .def("getSymbol", [](const OpenMS::Element& self) { return self.getSymbol(); }, "Returns symbol of the element")
         .def("__hash__", [](const OpenMS::Element& self) { return std::hash<OpenMS::Element>{}(self); })
         ;
@@ -466,11 +460,11 @@ The elements are initialized with data from IUPAC tables.
 
         .def("getElement", [](const OpenMS::ElementDB& self, const std::string& name) -> const OpenMS::Element* {
             return self.getElement(name);
-        }, "name"_a, nb::rv_policy::reference, "Get element by name or symbol")
+        }, "name"_a, nb::rv_policy::reference, "Get element by name or symbol (read-only reference into the immutable database)")
 
         .def("getElement", [](const OpenMS::ElementDB& self, unsigned int atomic_number) -> const OpenMS::Element* {
             return self.getElement(atomic_number);
-        }, "atomic_number"_a, nb::rv_policy::reference, "Get element by atomic number")
+        }, "atomic_number"_a, nb::rv_policy::reference, "Get element by atomic number (read-only reference into the immutable database)")
 
         .def("hasElement", [](const OpenMS::ElementDB& self, const std::string& name) {
             return self.hasElement(name);

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -312,43 +312,34 @@ def testElement():
     """
     @tests: Element
      Element.__init__
-     Element.setAtomicNumber
      Element.getAtomicNumber
-     Element.setAverageWeight
      Element.getAverageWeight
-     Element.setMonoWeight
      Element.getMonoWeight
-     Element.setIsotopeDistribution
      Element.getIsotopeDistribution
-     Element.setName
      Element.getName
-     Element.setSymbol
      Element.getSymbol
     """
-    ins = pyopenms.Element()
-
-    ins.setAtomicNumber(6)
-    ins.getAtomicNumber()
-    ins.setAverageWeight(12.011)
-    ins.getAverageWeight()
-    ins.setMonoWeight(12)
-    ins.getMonoWeight()
+    # Element is read-only: build it via the full constructor (no setters exposed)
     iso = pyopenms.IsotopeDistribution()
-    ins.setIsotopeDistribution(iso)
-    ins.getIsotopeDistribution()
-    ins.setName("Carbon")
-    ins.getName()
-    ins.setSymbol("C")
-    ins.getSymbol()
+    ins = pyopenms.Element("Carbon", "C", 6, 12.011, 12.0, iso)
 
-    e = pyopenms.Element()
-    e.setSymbol("blah")
-    e.setSymbol("blah")
-    e.setSymbol(u"blah")
-    e.setSymbol(str("blah"))
+    assert ins.getAtomicNumber() == 6
+    assert ins.getAverageWeight() == 12.011
+    assert ins.getMonoWeight() == 12.0
+    ins.getIsotopeDistribution()
+    assert ins.getName() == "Carbon"
+    assert ins.getSymbol() == "C"
+
+    # no mutators are exposed (the database elements are immutable)
+    assert not hasattr(ins, "setName")
+    assert not hasattr(ins, "setSymbol")
+    assert not hasattr(ins, "setIsotopeDistribution")
+
+    # the constructor accepts str and OpenMS String for name/symbol
     oms_string = s("blu")
-    e.setSymbol(oms_string)
-    assert oms_string
+    e = pyopenms.Element(oms_string, s("Bl"), 998, 1.0, 1.0, iso)
+    assert e.getName() == "blu"
+    assert e.getSymbol() == "Bl"
     assert oms_string.toString() == "blu"
 
     evil = u"blü"
@@ -6513,6 +6504,11 @@ def testElementDB():
     assert e2.getSymbol() == "O"
     assert e2.getIsotopeDistribution()
     # assert e == e2
+
+    # the database is immutable from Python: elements expose no setters
+    o = edb.getElement("O")
+    assert not hasattr(o, "setName")
+    assert not hasattr(o, "setIsotopeDistribution")
 
     #  not yet implemented
     #


### PR DESCRIPTION
## Summary

Follow-up to #9437 (immutable `ElementDB`). On the C++ side the element database is immutable, but the pyOpenMS binding still allowed mutating a shared, database-owned element: `ElementDB.getElement()` hands back the element and `Element` exposed setters, so `element.setIsotopeDistribution(...)` (or any setter) mutated the singleton.

`getElement()` must keep returning the database's **canonical** `Element` pointer — pyOpenMS relies on that identity (e.g. `EmpiricalFormula.getNumberOf(element)` does a pointer-keyed lookup), so returning a copy is not an option. Instead, this makes `Element` **read-only** in Python.

## Change

- Remove `Element`'s Python setters: `setName`, `setSymbol`, `setAtomicNumber`, `setAverageWeight`, `setMonoWeight`, `setIsotopeDistribution`. Getters are unchanged. Custom elements can still be built via the full-value constructor `Element(name, symbol, atomic_number, avg_weight, mono_weight, isotope_distribution)`.
- `getElement()` keeps `rv_policy::reference` (canonical pointer, read-only handle).
- Tests: `testElement` now constructs via the constructor and asserts no setters are exposed (incl. str/`String` name & symbol coverage); `testElementDB` asserts database elements are read-only.

pyOpenMS-only; no C++ API change. Breaking for any Python code that mutated an `Element` after construction (use the constructor instead).

https://claude.ai/code/session_01XGzEzT3bcvsRWvFxZHffU9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Element objects are now read-only from Python (mutating setters removed); construct via full constructor.
  * Element lookup returns a read-only reference into the immutable database (no Python-side mutation).

* **Tests**
  * Unit tests updated to assert immutability and to construct elements via the full constructor.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->