### PR TITLE
build(cmake): gate WNet class tests behind WITH_WNETALIGN

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -98,6 +98,7 @@ the authors tag in the respective file header.
  - Oliver Kohlbacher
  - Pasquale Domenico Colaianni
  - Patricia Scheil
+ - Patrick Boschmann
  - Peter J. Jones
  - Peter Kunszt
  - Petra Gutenbrunner

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -499,9 +499,7 @@ set(analysis_executables_list
   FeatureGroupingAlgorithmLabeled_test
   FeatureGroupingAlgorithmQT_test
   FeatureGroupingAlgorithmUnlabeled_test
-  FeatureGroupingAlgorithmWNet_test
   FeatureGroupingAlgorithm_test
-  WNetMatcher_test
   FeatureHandle_test
   FIAMSDataProcessor_test
   FLASHDeconvAlgorithm_test
@@ -592,6 +590,10 @@ set(analysis_executables_list
   XFDRAlgorithm_test
   XQuestScores_test
 )
+
+if(WITH_WNETALIGN)
+  list(APPEND analysis_executables_list FeatureGroupingAlgorithmWNet_test WNetMatcher_test)
+endif()
 
 set(applications_executables_list
   INIUpdater_test


### PR DESCRIPTION
## Description

WNet library sources are only compiled when `WITH_WNETALIGN=ON` (`source/ANALYSIS/MAPMATCHING/sources.cmake`), but `WNetMatcher_test` and `FeatureGroupingAlgorithmWNet_test` are listed unconditionally in `executables.cmake`. With `-DWITH_WNETALIGN=OFF`, `--target all` fails to link these two tests (`undefined reference to OpenMS::WNetMatcher::...`).

Fix: gate the two tests behind `if(WITH_WNETALIGN)`, mirroring the source gating and the existing `if(WITH_HDF5)` pattern in the same file. `WITH_WNETALIGN` defaults to `ON`, so default builds and CI are unaffected.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project contributors list.
  * Modified WNET-related test executables to be conditionally included based on build configuration settings rather than included by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->