### PR TITLE
IsobaricAnalyzer: fail loudly on MS3/activation mismatch (#7165)

### DIFF
--- a/src/openms/source/ANALYSIS/QUANTITATION/IsobaricChannelExtractor.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/IsobaricChannelExtractor.cpp
@@ -433,36 +433,90 @@ namespace OpenMS
 
     HasActivationMethod<PeakMap::SpectrumType> isValidActivation(ListUtils::create<String>(selected_activation_));
 
-    // walk through spectra and count the number of scans with valid activation method per MS-level
-    // only the highest level will be used for quantification (e.g. MS3, if present)
-    std::map<UInt, UInt> ms_level;
-    std::map<String, int> activation_modes;
+    // Walk through the spectra and count, per MS-level, the total number of MSn scans, the number of
+    // scans passing the activation-method filter, and a per-level breakdown of the activation modes
+    // encountered (used for diagnostics below).
+    //
+    // The MS level used for quantification is the *highest* MS level present in the data (e.g. MS3 for
+    // SPS-MS3 experiments, otherwise MS2). This is deliberately decided based on the MS-level structure
+    // alone and NOT on the activation filter: for SPS-MS3 the reporter ions are contained in the MS3
+    // scans, so quantifying a lower level would yield wrong results. The activation filter is only used
+    // to select the scans *within* the chosen quantification level. See OpenMS issue #7165.
+    std::map<UInt, UInt> ms_level_total;                            // all MSn scans per level
+    std::map<UInt, UInt> ms_level_pass;                             // scans passing the activation filter per level
+    std::map<UInt, std::map<String, UInt>> level_activation_modes;  // per-level activation-mode counts
     for (PeakMap::ConstIterator it = ms_exp_data.begin(); it != ms_exp_data.end(); ++it)
     {
       if (it->getMSLevel() == 1) continue; // never report MS1
-      ++activation_modes[getActivationMethod_(*it)]; // count HCD, CID, ...
+      const UInt lvl = it->getMSLevel();
+      ++ms_level_total[lvl];
+      ++level_activation_modes[lvl][getActivationMethod_(*it)]; // count HCD, CID, ... per level
       if (selected_activation_ == "any" || isValidActivation(*it))
       {
-        ++ms_level[it->getMSLevel()];
+        ++ms_level_pass[lvl];
       }
     }
-    if (ms_level.empty())
+
+    // helper to format the activation-mode breakdown of a given MS level, e.g. "HCD (106), CID (3)"
+    auto formatActivationModes = [&level_activation_modes](UInt lvl) -> String
     {
-      OPENMS_LOG_WARN << "Filtering by MS/MS(/MS) and activation mode: no spectra pass activation mode filter!\n"
-               << "Activation modes found:\n";
-      for (std::map<String, int>::const_iterator it = activation_modes.begin(); it != activation_modes.end(); ++it)
+      const auto lvl_it = level_activation_modes.find(lvl);
+      if (lvl_it == level_activation_modes.end()) return "<none>";
+      String s;
+      bool first = true;
+      for (const auto& am : lvl_it->second)
       {
-        OPENMS_LOG_WARN << "  mode " << (it->first.empty() ? "<none>" : it->first) << ": " << it->second << " scans\n";
+        if (!first) s += ", ";
+        s += (am.first.empty() ? "<none>" : am.first) + " (" + String(am.second) + ")";
+        first = false;
       }
-      OPENMS_LOG_WARN << "Result will be empty!\n";
+      return s;
+    };
+
+    if (ms_level_total.empty())
+    { // only MS1 (or no MSn) scans present
+      OPENMS_LOG_WARN << "No MS/MS(/MS) spectra found in the input. Result will be empty!\n";
       return;
     }
-    OPENMS_LOG_INFO << "Filtering by MS/MS(/MS) and activation mode:\n";
-    for (std::map<UInt, UInt>::const_iterator it = ms_level.begin(); it != ms_level.end(); ++it)
-    {
-      OPENMS_LOG_INFO << "  level " << it->first << ": " << it->second << " scans\n";
+
+    if (ms_level_pass.empty())
+    { // no scan at any MS level passes the activation filter
+      OPENMS_LOG_WARN << "Filtering by MS/MS(/MS) and activation mode '" << selected_activation_ << "': no spectra pass the activation mode filter!\n"
+               << "Activation modes found:\n";
+      for (const auto& lvl : level_activation_modes)
+      {
+        OPENMS_LOG_WARN << "  MS" << lvl.first << ": " << formatActivationModes(lvl.first) << "\n";
+      }
+      OPENMS_LOG_WARN << "Set 'select_activation' to 'auto', 'any', or a matching activation method. Result will be empty!\n";
+      return;
     }
-    UInt quant_ms_level = ms_level.rbegin()->first;
+
+    OPENMS_LOG_INFO << "Filtering by MS/MS(/MS) and activation mode '" << selected_activation_ << "':\n";
+    for (const auto& lvl : ms_level_total)
+    {
+      const UInt passed = ms_level_pass.count(lvl.first) ? ms_level_pass[lvl.first] : 0;
+      OPENMS_LOG_INFO << "  MS" << lvl.first << ": " << passed << "/" << lvl.second << " scans pass [activation modes: " << formatActivationModes(lvl.first) << "]\n";
+    }
+
+    // quantify on the highest MS level present in the data (see comment above)
+    const UInt quant_ms_level = ms_level_total.rbegin()->first;
+    const UInt passing_at_quant = ms_level_pass.count(quant_ms_level) ? ms_level_pass[quant_ms_level] : 0;
+
+    if (passing_at_quant == 0)
+    { // The highest MS level (used for quantification) contains scans, but none of them match the
+      // selected activation, while a lower MS level does. Silently quantifying the lower level would
+      // produce nonsensical results (e.g. SPS-MS3, where the reporter ions reside in the MS3 scans).
+      // Fail loudly instead of silently returning wrong quantities. See OpenMS issue #7165.
+      throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "None of the " + String(ms_level_total[quant_ms_level]) + " MS" + String(quant_ms_level) +
+        " scans (the highest MS level present, which is used for isobaric quantification) match the selected activation '" +
+        selected_activation_ + "', but lower MS-level scans do. For SPS-MS" + String(quant_ms_level) +
+        " experiments the reporter ions reside in the MS" + String(quant_ms_level) + " scans; quantifying a lower MS level "
+        "would give wrong results. Activation modes of the MS" + String(quant_ms_level) + " scans: " + formatActivationModes(quant_ms_level) +
+        ". Please set 'select_activation' to 'auto' (HCD/HCID), 'any' (disable filtering), or the activation method matching your MS" +
+        String(quant_ms_level) + " scans.");
+    }
+
     OPENMS_LOG_INFO << "Using MS-level " << quant_ms_level << " for quantification.\n";
 
     // now we have picked data

--- a/src/tests/class_tests/openms/source/IsobaricChannelExtractor_test.cpp
+++ b/src/tests/class_tests/openms/source/IsobaricChannelExtractor_test.cpp
@@ -805,6 +805,122 @@ START_SECTION(([EXTRA] TMT 32plex support)){
 }
 END_SECTION
 
+// SPS-MS3 MS-level / activation handling (see OpenMS issue #7165):
+// Build a synthetic SPS-MS3 TMT10 experiment where the reporter ions reside in the MS3 scan.
+//   MS1 -> MS2 (CID, no reporter ions) -> MS3 (HCD/beam-type CID, with TMT10 reporter ions)
+// The highest MS level present (MS3) must always be used for quantification. If the user selects an
+// activation method that only matches the MS2 scans (e.g. CID), the tool must fail loudly instead of
+// silently quantifying the MS2 scan (which would yield nonsense for SPS-MS3).
+START_SECTION(([EXTRA] SPS-MS3 activation/MS-level handling (issue #7165)))
+{
+  TMTTenPlexQuantitationMethod tmt10plex;
+
+  // MS1 precursor scan
+  MSSpectrum ms1;
+  ms1.setMSLevel(1);
+  ms1.setRT(100.0);
+  ms1.setNativeID("scan=1");
+  { Peak1D p; p.setMZ(500.0); p.setIntensity(1.0e6); ms1.push_back(p); }
+
+  // MS2 scan: trap-type CID, used only for identification, no reporter ions
+  MSSpectrum ms2;
+  ms2.setMSLevel(2);
+  ms2.setRT(100.1);
+  ms2.setNativeID("scan=2");
+  {
+    Precursor prec;
+    prec.setMZ(500.0);
+    prec.setCharge(2);
+    prec.setActivationMethods({Precursor::ActivationMethod::CID});
+    ms2.setPrecursors({prec});
+  }
+  { Peak1D p; p.setMZ(650.0); p.setIntensity(5000.0); ms2.push_back(p); }
+
+  // MS3 scan: beam-type CID (HCD), carries the TMT10 reporter ions
+  MSSpectrum ms3;
+  ms3.setMSLevel(3);
+  ms3.setRT(100.2);
+  ms3.setNativeID("scan=3");
+  {
+    Precursor prec;
+    prec.setMZ(650.0);
+    prec.setCharge(0); // skip purity computation
+    prec.setActivationMethods({Precursor::ActivationMethod::HCD});
+    ms3.setPrecursors({prec});
+  }
+  std::vector<double> ms3_intensities;
+  for (const auto& ch : tmt10plex.getChannelInformation())
+  {
+    Peak1D p;
+    p.setMZ(ch.center);
+    p.setIntensity(1000.0 * (ms3_intensities.size() + 1));
+    ms3.push_back(p);
+    ms3_intensities.push_back(p.getIntensity());
+  }
+  ms3.sortByPosition();
+
+  PeakMap exp;
+  exp.addSpectrum(ms1);
+  exp.addSpectrum(ms2);
+  exp.addSpectrum(ms3);
+  exp.sortSpectra(true);
+
+  // (1) Selecting CID matches only the MS2 scans, while the quantification level (MS3) has none ->
+  //     must throw instead of silently quantifying MS2.
+  {
+    IsobaricChannelExtractor ice(&tmt10plex);
+    Param p = ice.getParameters();
+    p.setValue("select_activation", "Collision-induced dissociation");
+    p.setValue("reporter_mass_shift", 0.003);
+    ice.setParameters(p);
+
+    ConsensusMap cm_out;
+    TEST_EXCEPTION(Exception::InvalidParameter, ice.extractChannels(exp, cm_out))
+  }
+
+  // (2) Selecting the matching activation (HCD) quantifies the MS3 scan correctly.
+  {
+    IsobaricChannelExtractor ice(&tmt10plex);
+    Param p = ice.getParameters();
+    p.setValue("select_activation", "beam-type collision-induced dissociation");
+    p.setValue("reporter_mass_shift", 0.003);
+    ice.setParameters(p);
+
+    ConsensusMap cm_out;
+    ice.extractChannels(exp, cm_out);
+
+    TEST_EQUAL(cm_out.size(), 1)
+    ABORT_IF(cm_out.size() != 1)
+    TEST_EQUAL(cm_out[0].getMetaValue("scan_id"), "scan=3")    // quantified on MS3
+    TEST_EQUAL(cm_out[0].getMetaValue("id_scan_id"), "scan=2") // identification from MS2
+    TEST_EQUAL(cm_out[0].size(), tmt10plex.getNumberOfChannels())
+    ABORT_IF(cm_out[0].size() != tmt10plex.getNumberOfChannels())
+    ConsensusFeature::iterator cf_it = cm_out[0].begin();
+    for (Size i = 0; i < ms3_intensities.size(); ++i)
+    {
+      TEST_REAL_SIMILAR(cf_it->getIntensity(), ms3_intensities[i])
+      ++cf_it;
+    }
+  }
+
+  // (3) Disabling activation filtering ('any') also quantifies on the highest level present (MS3).
+  {
+    IsobaricChannelExtractor ice(&tmt10plex);
+    Param p = ice.getParameters();
+    p.setValue("select_activation", "any");
+    p.setValue("reporter_mass_shift", 0.003);
+    ice.setParameters(p);
+
+    ConsensusMap cm_out;
+    ice.extractChannels(exp, cm_out);
+
+    TEST_EQUAL(cm_out.size(), 1)
+    ABORT_IF(cm_out.size() != 1)
+    TEST_EQUAL(cm_out[0].getMetaValue("scan_id"), "scan=3")
+  }
+}
+END_SECTION
+
 delete q_method;
 
 /////////////////////////////////////////////////////////////

--- a/src/topp/IsobaricAnalyzer.cpp
+++ b/src/topp/IsobaricAnalyzer.cpp
@@ -64,7 +64,10 @@ This tool currently supports iTRAQ 4-plex and 8-plex, and TMT 6-plex, 10-plex, 1
 Note: TMT 32-plex and 35-plex default to an identity correction matrix (no isotope correction) until lot-specific values are provided via the correction_matrix parameter.
 It extracts the isobaric reporter ion intensities from centroided MS2 or MS3 data (MSn), then performs isotope correction and stores the resulting quantitation in a consensus map,
 in which each consensus feature represents one relevant MSn scan (e.g. HCD; see parameters @p select_activation and @p min_precursor_intensity).
-The MS level for quantification is chosen automatically, i.e. if MS3 is present, MS2 will be ignored.
+The MS level for quantification is chosen automatically, i.e. the highest MS level present is used (if MS3 is present, e.g. for SPS-MS3, MS2 will be ignored).
+The @p select_activation filter is only applied within that quantification level. If MS3 scans are present but none of them match @p select_activation
+(e.g. setting CID while the MS3 reporter scans are HCD/"beam-type CID"), the tool fails with an error instead of silently quantifying the MS2 scans.
+Set @p select_activation to "auto" (HCD/HCID) or "any" (disable filtering) if in doubt.
 For intensity, the closest non-zero m/z signal to the theoretical position is taken as reporter ion abundance.
 The position (RT, m/z) of the consensus centroid is the precursor position in MS1 (from the MS2 spectrum);
 the consensus sub-elements correspond to the theoretical channel m/z (with m/z values of 113-121 Th for iTRAQ and 126-131 Th for TMT, respectively).

--- a/src/topp/IsobaricWorkflow.cpp
+++ b/src/topp/IsobaricWorkflow.cpp
@@ -85,8 +85,10 @@ using namespace std;
 
   This tool currently supports iTRAQ 4-plex and 8-plex, and TMT 6-plex, 10-plex, 11-plex, 16-plex, and 18-plex and higher labeling methods.
   It extracts the isobaric reporter ion intensities from centroided MS2 or MS3 data (MSn), then performs isotope correction and stores the resulting quantitation in a consensus map,
-  in which each consensus feature represents one relevant MSn scan (e.g. HCD; see parameters @p select_activation and @p min_precursor_intensity).
-  The MS level for quantification is chosen automatically, i.e. if MS3 is present, MS2 will be ignored.
+  in which each consensus feature represents one identified PSM together with its reporter ions.
+  The MS level for quantification is chosen automatically per PSM: if MS3 is present, the MS3 product spectrum of the identifying MS2 scan is used (SPS-MS3), otherwise the MS2 scan itself.
+  Unlike @ref TOPP_IsobaricAnalyzer, this tool does NOT filter quantification scans by activation method (@p extraction:select_activation is ignored),
+  because SPS-MS3 reporter scans are frequently labelled as plain CID rather than HCD; selection is therefore based on the MS-level structure alone.
   For intensity, the closest non-zero m/z signal to the theoretical position is taken as reporter ion abundance.
   The position (RT, m/z) of the consensus centroid is the precursor position in MS1 (from the MS2 spectrum);
   the consensus sub-elements correspond to the theoretical channel m/z (with m/z values of 113-121 Th for iTRAQ and 126-131 Th for TMT, respectively).
@@ -488,6 +490,23 @@ protected:
     IsobaricChannelExtractor channel_extractor(quant_method.get());
     channel_extractor.setParameters(extract_param);
     double min_reporter_intensity = channel_extractor.getParameters().getValue("min_reporter_intensity");
+
+    // IsobaricWorkflow selects the quantification spectrum per identified PSM purely by MS level
+    // (the MS3 product spectrum if MS3 is present, otherwise the identifying MS2 scan). It does NOT
+    // filter the quantification scans by activation method: for SPS-MS3 the MS3 reporter scans are
+    // frequently labelled as plain CID rather than HCD, so an activation filter would wrongly discard
+    // valid reporter scans. If the user explicitly requested a concrete activation method, warn that it
+    // is ignored here, so the behaviour is not silently different from IsobaricAnalyzer. See issue #7165.
+    {
+      const String sel_act = channel_extractor.getParameters().getValue("select_activation").toString();
+      if (!sel_act.empty() && sel_act != "any" && sel_act != "auto")
+      {
+        OPENMS_LOG_WARN << "Parameter 'extraction:select_activation' is set to '" << sel_act
+                        << "', but IsobaricWorkflow chooses the quantification spectrum automatically by MS level "
+                        << "(MS3 if present, otherwise MS2) and does not filter by activation method. "
+                        << "This setting will be ignored." << std::endl;
+      }
+    }
 
     // TODO since I am mostly using the internal classes IsobaricChannelCorrector and IsobaricNormalizer (if at all),
     //  I should only expose their parameters and only init their objects here.


### PR DESCRIPTION
Isobaric quantification always uses the highest MS level present (e.g. MS3
for SPS-MS3 experiments, where the reporter ions reside in the MS3 scans).
Previously the channel extractor conflated MS-level selection with the
'select_activation' filter: it quantified the highest level that *passed*
the activation filter. As a result, an SPS-MS3 run where the MS3 reporter
scans are HCD ('beam-type CID') but the user selected CID would silently
fall back to quantifying the MS2 scans, producing nonsensical results.

IsobaricChannelExtractor::extractChannels now:
- determines the quantification level from the MS-level structure alone
  (highest MSn level present), independent of the activation filter;
- applies 'select_activation' only within that level;
- throws an InvalidParameter exception with an actionable, per-level
  activation-mode breakdown when the quantification level has scans but
  none match the selected activation while a lower level does;
- preserves the existing 'no spectra pass the filter -> empty result'
  behaviour and improves the diagnostic logging.

Adds a synthetic SPS-MS3 TMT10 regression test covering the throw case,
the matching-activation (HCD) case, and 'any'. Updates IsobaricAnalyzer
documentation accordingly.

The newer IsobaricWorkflow already selects the level purely by MS-level
presence and is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Enhanced error messages when isobaric quantification fails to find matching spectra based on activation filters
  - Improved handling of complex multi-level mass spectrometry datasets

* **Documentation**
  - Clarified automatic MS-level selection behavior in isobaric analysis tools
  - Updated guidance on configuring activation filter parameters

* **Tests**
  - Extended test coverage for advanced isobaric quantification scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->