### PR TITLE
SimpleSearchEngine: remove stale ResidueDB critical section to parallelize candidate scoring

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@ PR - Pull Request (on GitHub), i.e. integration of a new feature or bugfix
 ------------------------------------------------------------------------------------------
 
 General:
+  - Performance: SimpleSearchEngine no longer serializes peptide-candidate parsing/modification on a global critical section. The per-candidate fromString()+modification application only does lock-free ResidueDB lookups of immutable standard residues and reads pre-resolved modification maps (no ResidueDB/ModificationsDB mutation), so the OpenMP parallel-for over the protein database now scales across threads where it previously bottlenecked on one lock.
   - macOS Intel builds discontinued; macOS deployment target raised to macOS 14
   - Ubuntu CI runners updated to 24.04
   - macOS code signing and notarization integrated directly into CI (#8486, #8494, #8527)

--- a/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
@@ -756,13 +756,15 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
 
         vector<AASequence> all_modified_peptides;
 
-        // this critical section is because ResidueDB is not thread safe and new residues are created based on the PTMs
-        #pragma omp critical (residuedb_access)
-        {
-          AASequence aas = AASequence::fromString(current_peptide);
-          ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications, aas);
-          ModifiedPeptideGenerator::applyVariableModifications(variable_modifications, aas, modifications_max_variable_mods_per_peptide_, all_modified_peptides);
-        }
+        // No lock needed here: current_peptide is an unmodified digest peptide, so
+        // AASequence::fromString() only performs lock-free ResidueDB::getResidue(char)
+        // lookups of the immutable standard residues; applyFixed/VariableModifications
+        // read the pre-resolved ResidueModification*->Residue* maps and touch neither
+        // ResidueDB nor ModificationsDB. (The annotation loop above already runs the
+        // same calls without a critical section.)
+        AASequence aas = AASequence::fromString(current_peptide);
+        ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications, aas);
+        ModifiedPeptideGenerator::applyVariableModifications(variable_modifications, aas, modifications_max_variable_mods_per_peptide_, all_modified_peptides);
 
         for (SignedSize mod_pep_idx = 0; mod_pep_idx < (SignedSize)all_modified_peptides.size(); ++mod_pep_idx)
         {


### PR DESCRIPTION
## Summary

The candidate-scoring `#pragma omp parallel for` over the protein database in `SimpleSearchEngineAlgorithm` wrapped its per-candidate `fromString()` + modification application in `#pragma omp critical (residuedb_access)`, with the comment *"ResidueDB is not thread safe and new residues are created based on the PTMs."* That rationale no longer holds, so this serializes the hot loop on one global lock for no reason.

## Why it's safe (verified by reading the call graph)

1. **`current_peptide` is unmodified** (`digestor.digestUnmodified(...)`), so `AASequence::fromString()` only takes the **lock-free** `ResidueDB::getResidue(char)` overload (`ResidueDB.cpp:68`, a direct read of the immutable standard-residue array). The locked `getModifiedResidue` path in the parser is only reached for *modified* input strings.
2. **`ModifiedPeptideGenerator::applyFixed/VariableModifications` perform no DB access** — they read the pre-resolved `ResidueModification* → const Residue*` map built once in `getModifications()`/`createResidueModificationToResidueMap_()`, and apply cached residue pointers. The only `ResidueDB`/`ModificationsDB` calls in `ModifiedPeptideGenerator` are in that one-time setup.
3. **The sibling annotation `parallel for` already runs the identical `fromString()` + `applyFixed/Variable` calls with no critical section** (same file), so removing the lock makes the two loops consistent rather than introducing new concurrent behavior.

Everything inside the removed block is now either a lock-free read of immutable data or thread-local (`aas`, `all_modified_peptides` are per-iteration).

## Effect

The parallel-for over the FASTA database scales across threads instead of bottlenecking on one lock during candidate parsing/modification. **No behavior or output change** — purely removes serialization.

## Notes
- Couldn't build/run locally; **CI (incl. `TOPP_SimpleSearchEngine`) is the verification** — the search output should be byte-identical.
- Worth a before/after profile of a variable-mod search to quantify the speedup; the structural win (one global lock removed from the parallel hot path) is clear regardless.

https://claude.ai/code/session_01XGzEzT3bcvsRWvFxZHffU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGzEzT3bcvsRWvFxZHffU9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * SimpleSearchEngine optimized for improved multi-threaded scaling in OpenMS 3.6.0, delivering faster peptide identification searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->