### PR TITLE
ci(windows): install doxygen from conda-forge instead of chocolatey

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -103,7 +103,12 @@ runs:
         conda info
 
         # None of the other arrow sublibraries seemed necessary, but it's an easy addition.
-        conda install -c conda-forge libarrow libparquet libzip -y
+        # doxygen is installed here (conda-forge) instead of via Chocolatey: the choco
+        # 'doxygen.portable' package downloads from doxygen.nl, which intermittently returns
+        # HTTP 403 and aborts the whole job before it can build. Windows builds the docs
+        # (enable_docs=ON) to catch Doxygen errors pre-merge, so it must be available; conda-forge
+        # ships its own artifact (installed into Library/bin, already on PATH below).
+        conda install -c conda-forge libarrow libparquet libzip doxygen -y
 
         # Set variables required for the following steps so they
         # don't need a conda environment or login shell:
@@ -140,9 +145,11 @@ runs:
       if: inputs.os == 'Windows'
       shell: bash
       run: |
+        # NOTE: doxygen is installed via conda-forge in the Conda step above, not here, because
+        # the chocolatey 'doxygen.portable' package downloads from doxygen.nl and frequently
+        # fails with HTTP 403 (the package is also flagged "Likely broken for FOSS users").
         choco install -y --no-progress \
           ccache \
-          doxygen.portable \
           ghostscript \
           graphviz
 


### PR DESCRIPTION
## Description

The Windows `build-and-test` job currently fails in the **dependency-install step, before any compilation**, because `choco install doxygen.portable` downloads from doxygen.nl, which intermittently returns HTTP 403:

```
Attempt to get headers for https://www.doxygen.nl/files/doxygen-1.14.0.windows.x64.bin.zip failed.
... The remote server returned an error: (403) Forbidden.
Chocolatey installed 5/6 packages. 1 packages failed.
 - doxygen.portable (exited 404) ...
##[error]Process completed with exit code 148.
```

Since `choco install -y` exits non-zero when any package fails, the whole job aborts before CMake/compilation runs. The package is also self-flagged *"Likely broken for FOSS users (due to download location changes)"*. This is an external-download flake that affects **every** Windows build and is **unrelated to the recent C++23 switch** — all four compiler builds pass and the Windows MSVC toolset (14.44.35207 / VS 2022 17.14) is current.

### Fix (`.github/actions/dependencies/action.yml`)

- Remove `doxygen.portable` from the Chocolatey package list.
- Install `doxygen` from **conda-forge** instead (alongside the existing `libarrow`/`libparquet`/`libzip`), which ships its own artifact and avoids doxygen.nl entirely. The conda env's `Library/bin` is already exported to `PATH`, so CMake's `find_package(Doxygen)` picks it up.

Doxygen is **kept rather than dropped** because Windows intentionally builds the docs (`enable_docs=ON`) to catch Doxygen errors pre-merge.

## Notes

- CI-infrastructure change only — no library/source, CHANGELOG, or Python-binding impact.
- The real confirmation is the next Windows CI run; the only load-bearing assumption is that conda-forge's `doxygen.exe` installs to `%PREFIX%\Library\bin` (the standard conda-forge layout, already on `PATH`).

https://claude.ai/code/session_01554aWq9m2NcmtreFA5ufSS

---
_Generated by [Claude Code](https://claude.ai/code/session_01554aWq9m2NcmtreFA5ufSS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency installation configuration for Windows builds to optimize the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->