### PR TITLE
Refactor Percolator vendored code into separate CMake target

### DIFF
--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -55,26 +55,13 @@ include (${PROJECT_SOURCE_DIR}/includes.cmake)
 
 #------------------------------------------------------------------------------
 # Vendored, namespace-isolated Percolator subtree.
-include(${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/percolator/sources.cmake)
-list(APPEND OpenMS_sources ${OpenMS_percolator_sources})
-
-# Suppress upstream-originated warnings on vendored files only.
-# GCC/Clang use -Wno-*; MSVC needs /wd<code> with the corresponding warning
-# numbers and chokes on the -Wno-* spellings (D8021).
-if (MSVC)
-  # /wd4100 + /wd4189 explicitly defeat the project-wide /we4100 + /we4189
-  # ("unused parameter" and "unused-but-initialized local variable" elevated
-  # to errors) on the vendored upstream code, which has plenty of both.
-  set_source_files_properties(${OpenMS_percolator_sources}
-    PROPERTIES
-      COMPILE_FLAGS "/wd4018 /wd4100 /wd4189 /wd4244 /wd4267 /wd4996 /wd4458")
-else()
-  set_source_files_properties(${OpenMS_percolator_sources}
-    PROPERTIES
-      COMPILE_FLAGS "-Wno-sign-compare -Wno-unused-parameter -Wno-deprecated-declarations -Wno-unused-variable -Wno-overloaded-virtual -Wno-reorder -Wno-reorder-ctor -Wno-uninitialized -Wno-ignored-qualifiers -Wno-unused-but-set-variable")
-  set_source_files_properties(${OpenMS_percolator_sources}
-    PROPERTIES COMPILE_OPTIONS "-fvisibility=hidden")
-endif()
+# Built as a standalone static library (OpenMS_Percolator) with its OWN compile
+# flags and linked PRIVATE into libOpenMS below. Keeping it a separate target
+# isolates the vendored upstream code from the OpenMS target's treat-warning-as-
+# error flags (/we4100, /we4189, -Werror) — folding the sources into libOpenMS
+# made a clean build depend on the (generator-specific) flag ordering — and
+# keeps the upstream sources out of the OpenMS target's file list in IDEs.
+add_subdirectory(thirdparty/percolator)
 
 #------------------------------------------------------------------------------
 # all the dependency libraries are linked into libOpenMS.so
@@ -106,6 +93,7 @@ set(OPENMS_DEP_PRIVATE_LIBRARIES
   nlohmann_json::nlohmann_json
   IsoSpec
   eol-bspline
+  OpenMS_Percolator
   )
 
 # Parquet support requires Arrow core + compute (filter expressions) + Parquet.
@@ -165,9 +153,10 @@ openms_add_library(TARGET_NAME  OpenMS
                    PRIVATE_LINK_LIBRARIES ${OPENMS_DEP_PRIVATE_LIBRARIES}
                    DLL_EXPORT_PATH "OpenMS/")
 
-# Vendored percolator headers are resolved via #include "X.h" (no subdir) —
-# add the dir PRIVATE so it's visible only to libOpenMS's own TUs.
-target_include_directories(OpenMS PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/percolator)
+# The vendored percolator headers (#include "X.h", no subdir) are used only by
+# libOpenMS's Percolator pimpl TU. Their directory is made visible via the
+# PUBLIC include dir propagated from the linked OpenMS_Percolator target (see
+# thirdparty/percolator/CMakeLists.txt), so no explicit include dir is needed.
 
 if (OPENMS_ARROW_DATASET_TARGET)
   target_compile_definitions(OpenMS PRIVATE WITH_ARROW_DATASET)

--- a/src/openms/thirdparty/percolator/CMakeLists.txt
+++ b/src/openms/thirdparty/percolator/CMakeLists.txt
@@ -1,0 +1,81 @@
+# Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# --------------------------------------------------------------------------
+# $Maintainer: Stephan Aiche, Chris Bielow $
+# $Authors: Andreas Bertsch, Chris Bielow, Stephan Aiche $
+# --------------------------------------------------------------------------
+
+# Vendored, namespace-isolated Percolator subtree (OpenMS::Internal::Percolator).
+#
+# This is built as a standalone STATIC library with its OWN compile flags and
+# linked PRIVATE into libOpenMS (see ../../CMakeLists.txt). Compiling it as a
+# separate target — instead of folding the sources into libOpenMS — is what
+# isolates this upstream code from the OpenMS target's "treat warning as error"
+# flags (MSVC /we4100 + /we4189, GCC -Werror).
+#
+# Previously the sources were added to OpenMS_sources and the per-file
+# suppressions (/wd4100 ...) had to "out-order" the target-wide /we4100 on the
+# same command line. CMake does not guarantee that ordering across generators /
+# versions, so a clean build was effectively luck: in some setups /we4100 won
+# and the vendored code failed to compile. A dedicated target never receives
+# /we4100 in the first place, so the suppressions are no longer order-sensitive.
+#
+# Side benefit: the upstream sources show up under this target in IDEs instead
+# of cluttering the OpenMS target's file list at the project root.
+
+project("OpenMS_Percolator")
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+
+# Source list (also consumed by the upstream-sync tooling). It PREPENDs this
+# directory to each entry, so it resolves correctly when included from here.
+include(${CMAKE_CURRENT_LIST_DIR}/sources.cmake)
+
+add_library(OpenMS_Percolator STATIC ${OpenMS_percolator_sources})
+
+# Compile at the same C++ standard as libOpenMS so the vendored headers — which
+# are also pulled into OpenMS's Percolator pimpl translation unit — behave
+# identically on both sides of the link.
+target_compile_features(OpenMS_Percolator PRIVATE cxx_std_23)
+
+# The vendored headers include each other as #include "X.h" (no subdirectory).
+# Expose this directory PUBLIC so the dependency propagates to libOpenMS's pimpl
+# TU (PercolatorImpl.h) through the link below. BUILD_INTERFACE only: these
+# headers are OpenMS-internal and never installed.
+target_include_directories(OpenMS_Percolator PUBLIC
+                           "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
+
+# External dependencies used by the vendored code: Eigen + Boost (header-only
+# here) and OpenMP for the #pragma omp regions. PRIVATE: these are build-time
+# usage requirements of this lib, not part of anything it exposes.
+target_link_libraries(OpenMS_Percolator PRIVATE Eigen3::Eigen Boost::boost)
+if (OPENMP_FOUND)
+  target_link_libraries(OpenMS_Percolator PRIVATE OpenMP::OpenMP_CXX)
+endif()
+
+# Linked into the shared libOpenMS, so the objects must be position-independent.
+set_target_properties(OpenMS_Percolator PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# Keep the vendored symbols out of libOpenMS's dynamic symbol table, matching
+# the previous in-tree -fvisibility=hidden treatment of these sources.
+set_target_properties(OpenMS_Percolator PROPERTIES
+                      CXX_VISIBILITY_PRESET hidden
+                      VISIBILITY_INLINES_HIDDEN 1)
+
+# Suppress upstream-originated warnings on this target ONLY. GCC/Clang use
+# -Wno-*; MSVC needs /wd<code> and chokes on the -Wno-* spellings (D8021).
+# Because this is a separate target, it never inherits OpenMS's /we* (errors),
+# so these are plain suppressions with no ordering dependency.
+if (MSVC)
+  target_compile_options(OpenMS_Percolator PRIVATE
+    /wd4018 /wd4100 /wd4189 /wd4244 /wd4267 /wd4996 /wd4458)
+else()
+  target_compile_options(OpenMS_Percolator PRIVATE
+    -Wno-sign-compare -Wno-unused-parameter -Wno-deprecated-declarations
+    -Wno-unused-variable -Wno-overloaded-virtual -Wno-reorder -Wno-reorder-ctor
+    -Wno-uninitialized -Wno-ignored-qualifiers -Wno-unused-but-set-variable)
+endif()
+
+# Note: intentionally NOT installed/exported. libOpenMS is always shared
+# (BUILD_SHARED_LIBS is forced ON) and links this PRIVATE, so the archive is
+# fully absorbed into libOpenMS.so and never appears in the OpenMS export set.

--- a/src/openms/thirdparty/percolator/sources.cmake
+++ b/src/openms/thirdparty/percolator/sources.cmake
@@ -1,5 +1,6 @@
 # src/openms/thirdparty/percolator/sources.cmake
-# Lists the .cpp files to be compiled as part of libOpenMS.
+# Lists the .cpp files compiled into the OpenMS_Percolator static library
+# (see CMakeLists.txt in this directory), which is linked PRIVATE into libOpenMS.
 
 set(OpenMS_percolator_sources
   BaseSpline.cpp


### PR DESCRIPTION
## Description

This PR refactors the build system to compile the vendored Percolator code as a separate static library (`OpenMS_Percolator`) instead of folding it directly into `libOpenMS`. This change improves build reliability and code organization.

### Motivation

Previously, Percolator source files were added to `libOpenMS` with per-file compiler flag suppressions to work around upstream code warnings. This approach had a critical flaw: CMake does not guarantee flag ordering across generators and versions, making clean builds unreliable. The `/we4100` (treat warning as error) flag could sometimes win over the `/wd4100` (suppress warning) suppression on the same command line, causing compilation failures.

### Changes

1. **New CMakeLists.txt** (`src/openms/thirdparty/percolator/CMakeLists.txt`):
   - Creates a dedicated `OpenMS_Percolator` static library target
   - Applies compiler flags and warning suppressions at the target level (not per-file)
   - Ensures the vendored code never inherits OpenMS's treat-warning-as-error flags
   - Configures proper include directories, C++ standard (C++23), and visibility settings
   - Links required dependencies: Eigen3, Boost, and OpenMP

2. **Updated OpenMS CMakeLists.txt** (`src/openms/CMakeLists.txt`):
   - Removes inline Percolator source list and per-file flag suppressions
   - Adds `add_subdirectory(thirdparty/percolator)` to build the separate target
   - Links `OpenMS_Percolator` as a PRIVATE dependency of `libOpenMS`
   - Removes explicit include directory (now propagated via target link)

3. **Updated sources.cmake** (`src/openms/thirdparty/percolator/sources.cmake`):
   - Updated comment to reflect that sources are compiled into the separate static library

### Benefits

- **Build reliability**: Separate target eliminates flag ordering dependency; suppressions are no longer order-sensitive
- **Cleaner IDE integration**: Vendored sources appear under their own target instead of cluttering the OpenMS target's file list
- **Better separation of concerns**: Upstream code is isolated from OpenMS's strict compiler settings
- **Maintainability**: Easier to manage and update vendored code independently

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

**Note**: This is a build system refactoring with no functional changes to OpenMS. Existing unit tests should pass without modification. No Python bindings updates are needed.

https://claude.ai/code/session_016ra2HZT9ukQCSx9H2gDQx4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized the internal build to treat the vendored Percolator subtree as a standalone, namespace-isolated static component that is linked privately into the main library.
  * Improved compiler warning isolation and include-path propagation to avoid interfering with project-wide "warnings as errors".
  * No public API or exported declarations changed; the vendored component is not installed or exported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->