### PR TITLE
Replace .find() != .end() with .contains() for cleaner code

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDBoostGraph.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDBoostGraph.h
@@ -133,7 +133,7 @@ namespace OpenMS
       template < typename Edge, typename Graph >
       void examine_edge(Edge e, const Graph & tg)
       {
-        if (m.find(e.m_target) == m.end())
+        if (!m.contains(e.m_target))
         {
           next_v = boost::add_vertex(tg[e.m_target], gs.back());
           m[e.m_target] = next_v;

--- a/src/openms/include/OpenMS/CHEMISTRY/DigestionEnzymeDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/DigestionEnzymeDB.h
@@ -110,19 +110,19 @@ namespace OpenMS
     /// returns true if the db contains a enzyme with the given name (supports synonym names)
     bool hasEnzyme(const String& name) const
     {
-      return (enzyme_names_.find(name) != enzyme_names_.end());
+      return (enzyme_names_.contains(name));
     }
 
     /// returns true if the db contains a enzyme with the given regex
     bool hasRegEx(const String& cleavage_regex) const
     {
-      return (enzyme_regex_.find(cleavage_regex) != enzyme_regex_.end());
+      return (enzyme_regex_.contains(cleavage_regex));
     }
 
     /// returns true if the db contains the enzyme of the given pointer
     bool hasEnzyme(const DigestionEnzymeType* enzyme) const
     {
-      return (const_enzymes_.find(enzyme) != const_enzymes_.end() );
+      return (const_enzymes_.contains(enzyme) );
     }
     //@}
 

--- a/src/openms/include/OpenMS/COMPARISON/SpectrumAlignment.h
+++ b/src/openms/include/OpenMS/COMPARISON/SpectrumAlignment.h
@@ -121,7 +121,7 @@ public:
 
             double score_align = diff_align;
 
-            if (matrix.find(i - 1) != matrix.end() && matrix[i - 1].find(j - 1) != matrix[i - 1].end())
+            if (matrix.contains(i - 1) && matrix[i - 1].contains(j - 1))
             {
               score_align += matrix[i - 1][j - 1];
             }
@@ -131,7 +131,7 @@ public:
             }
 
             double score_up = tolerance;
-            if (matrix.find(i) != matrix.end() && matrix[i].find(j - 1) != matrix[i].end())
+            if (matrix.contains(i) && matrix[i].contains(j - 1))
             {
               score_up += matrix[i][j - 1];
             }
@@ -141,7 +141,7 @@ public:
             }
 
             double score_left = tolerance;
-            if (matrix.find(i - 1) != matrix.end() && matrix[i - 1].find(j) != matrix[i - 1].end())
+            if (matrix.contains(i - 1) && matrix[i - 1].contains(j))
             {
               score_left += matrix[i - 1][j];
             }

--- a/src/openms/include/OpenMS/CONCEPT/UniqueIdIndexer.h
+++ b/src/openms/include/OpenMS/CONCEPT/UniqueIdIndexer.h
@@ -155,7 +155,7 @@ public:
         }
 
         // see if UID already present
-        while (uniqueid_to_index_.find(unique_id) != uniqueid_to_index_.end()) // double entry!
+        while (uniqueid_to_index_.contains(unique_id)) // double entry!
         {
           getBase_()[index].setUniqueId();
           unique_id = getBase_()[index].getUniqueId();

--- a/src/openms/include/OpenMS/DATASTRUCTURES/StringUtilsSimple.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/StringUtilsSimple.h
@@ -111,12 +111,12 @@ namespace OpenMS
 
     static inline bool hasSubstring(const String & this_s, const String& string)
     {
-      return this_s.find(string) != std::string::npos;
+      return this_s.contains(string);
     }
 
     static inline bool has(const String & this_s, Byte byte)
     {
-      return this_s.find(char(byte)) != std::string::npos;
+      return this_s.contains(char(byte));
     }
 
     static inline String prefix(const String & this_s, size_t length)

--- a/src/openms/include/OpenMS/KERNEL/ChromatogramTools.h
+++ b/src/openms/include/OpenMS/KERNEL/ChromatogramTools.h
@@ -146,7 +146,7 @@ public:
               ChromatogramPeak chr_p;
               chr_p.setRT(it->getRT());
               chr_p.setIntensity(p.getIntensity());
-              if (chroms_xic.find(mz) == chroms_xic.end())
+              if (!chroms_xic.contains(mz))
               {
                 // new chromatogram
                 chroms_xic[mz].getPrecursor().setMZ(mz);

--- a/src/openms/include/OpenMS/KERNEL/MRMTransitionGroup.h
+++ b/src/openms/include/OpenMS/KERNEL/MRMTransitionGroup.h
@@ -143,7 +143,7 @@ public:
 
     inline bool hasTransition(const String& key) const
     {
-      return transition_map_.find(key) != transition_map_.end();
+      return transition_map_.contains(key);
     }
 
     inline const TransitionType& getTransition(const String& key)
@@ -187,7 +187,7 @@ public:
 
     inline bool hasChromatogram(const String& key) const
     {
-      return chromatogram_map_.find(key) != chromatogram_map_.end();
+      return chromatogram_map_.contains(key);
     }
 
     inline ChromatogramType& getChromatogram(const String& key)
@@ -241,7 +241,7 @@ public:
 
     inline bool hasPrecursorChromatogram(const String& key) const
     {
-      return precursor_chromatogram_map_.find(key) != precursor_chromatogram_map_.end();
+      return precursor_chromatogram_map_.contains(key);
     }
 
     inline ChromatogramType & getPrecursorChromatogram(const String& key)

--- a/src/openms/include/OpenMS/METADATA/ID/AppliedProcessingStep.h
+++ b/src/openms/include/OpenMS/METADATA/ID/AppliedProcessingStep.h
@@ -84,7 +84,7 @@ namespace OpenMS
         }
         for (const auto& pair: scores)
         {
-          if (!scores_done.count(pair.first))
+          if (!scores_done.contains(pair.first))
           {
             result.push_back(pair);
             if (primary_only) return result;

--- a/src/openms/include/OpenMS/PROCESSING/FILTERING/WindowMower.h
+++ b/src/openms/include/OpenMS/PROCESSING/FILTERING/WindowMower.h
@@ -90,7 +90,7 @@ public:
       std::vector<Size> indices;
       for (ConstIterator it = spectrum.begin(); it != spectrum.end(); ++it)
       {
-        if (positions.find(it->getMZ()) != positions.end())
+        if (positions.contains(it->getMZ()))
         {
           Size index(it - spectrum.begin());
           indices.push_back(index);

--- a/src/openms/include/OpenMS/PROCESSING/ID/IDFilter.h
+++ b/src/openms/include/OpenMS/PROCESSING/ID/IDFilter.h
@@ -275,7 +275,7 @@ namespace OpenMS
       {
         for (const auto& acc : hit.extractProteinAccessionsSet())
         {
-          if (accessions.count(acc) > 0)
+          if (accessions.contains(acc))
             return true;
         }
         return false;
@@ -283,12 +283,12 @@ namespace OpenMS
 
       bool operator()(const ProteinHit& hit) const
       {
-        return accessions.count(hit.getAccession()) > 0;
+        return accessions.contains(hit.getAccession());
       }
 
       bool operator()(const PeptideEvidence& evidence) const
       {
-        return accessions.count(evidence.getProteinAccession()) > 0;
+        return accessions.contains(evidence.getProteinAccession());
       }
     };
 
@@ -330,7 +330,7 @@ namespace OpenMS
 
       bool exists(const HitType& hit) const
       {
-        return items.count(getHitKey(hit)) > 0;
+        return items.contains(getHitKey(hit));
       }
 
       const String& getHitKey(const PeptideEvidence& p) const

--- a/src/openms/include/OpenMS/PROCESSING/SPECTRAMERGING/SpectraMerger.h
+++ b/src/openms/include/OpenMS/PROCESSING/SPECTRAMERGING/SpectraMerger.h
@@ -740,7 +740,7 @@ protected:
       MapType exp_tmp;
       for (Size i = 0; i < exp.size(); ++i)
       {
-        if (merged_indices.count(i) == 0) // save unclustered ones
+        if (!merged_indices.contains(i)) // save unclustered ones
         {
           exp_tmp.addSpectrum(exp[i]);
           exp[i] = empty_spec;

--- a/src/openms/source/ANALYSIS/DECHARGING/FeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/FeatureDeconvolution.cpp
@@ -810,11 +810,11 @@ namespace OpenMS
         SignedSize target_cf0 = -1, target_cf1 = -1;
 
         // find the index of the ConsensusFeatures for the current pair
-        if (clique_register.count(f0_idx) > 0)
+        if (clique_register.contains(f0_idx))
         {
           target_cf0 = clique_register[f0_idx];
         }
-        if (clique_register.count(f1_idx) > 0)
+        if (clique_register.contains(f1_idx))
         {
           target_cf1 = clique_register[f1_idx];
         }
@@ -977,7 +977,7 @@ namespace OpenMS
     for (Size i = 0; i < fm_out.size(); ++i)
     {
       // find the index of the ConsensusFeature for the current feature
-      if (clique_register.count(i) > 0)
+      if (clique_register.contains(i))
         continue;
 
       Feature f_single = fm_out_untouched[i];

--- a/src/openms/source/ANALYSIS/DECHARGING/ILPDCWrapper.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/ILPDCWrapper.cpp
@@ -51,7 +51,7 @@ namespace OpenMS
       {
         Size f1 = pairs[i].getElementIndex(0);
         Size f2 = pairs[i].getElementIndex(1);
-        if ((f2g.find(f1) != f2g.end()) && (f2g.find(f2) != f2g.end())) // edge connects two distinct groups
+        if ((f2g.contains(f1)) && (f2g.contains(f2))) // edge connects two distinct groups
         {
           Size group1 = f2g[f1];
           Size group2 = f2g[f2];
@@ -68,13 +68,13 @@ namespace OpenMS
             g2f.erase(group2);
           }
         }
-        else if ((f2g.find(f1) != f2g.end()) && !(f2g.find(f2) != f2g.end())) // only f1 is part of a group
+        else if ((f2g.contains(f1)) && !(f2g.contains(f2))) // only f1 is part of a group
         {
           Size group1 = f2g[f1];
           f2g[f2] = group1;
           g2f[group1].insert(f2);
         }
-        else if (!(f2g.find(f1) != f2g.end()) && f2g.find(f2) != f2g.end()) // only f2 is part of a group
+        else if (!(f2g.contains(f1)) && f2g.contains(f2)) // only f2 is part of a group
         {
           Size group2 = f2g[f2];
           f2g[f1] = group2;

--- a/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
@@ -907,11 +907,11 @@ namespace OpenMS
         SignedSize target_cf0 = -1, target_cf1 = -1;
 
         // find the index of the ConsensusFeatures for the current pair
-        if (clique_register.count(f0_idx) > 0)
+        if (clique_register.contains(f0_idx))
         {
           target_cf0 = clique_register[f0_idx];
         }
-        if (clique_register.count(f1_idx) > 0)
+        if (clique_register.contains(f1_idx))
         {
           target_cf1 = clique_register[f1_idx];
         }
@@ -1023,7 +1023,7 @@ namespace OpenMS
     for (Size i = 0; i < fm_out.size(); ++i)
     {
       // find the index of the ConsensusFeature for the current feature
-      if (clique_register.count(i) > 0)
+      if (clique_register.contains(i))
         continue;
 
       Feature f_single = fm_out_untouched[i];

--- a/src/openms/source/ANALYSIS/ID/AccurateMassSearchEngine.cpp
+++ b/src/openms/source/ANALYSIS/ID/AccurateMassSearchEngine.cpp
@@ -741,7 +741,7 @@ namespace OpenMS
     {
       for (Size i = 0; i < r.getMatchingHMDBids().size(); ++i)
       {
-        if (!hmdb_properties_mapping_.count(r.getMatchingHMDBids()[i]))
+        if (!hmdb_properties_mapping_.contains(r.getMatchingHMDBids()[i]))
         {
           throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("DB entry '") + r.getMatchingHMDBids()[i] + "' not found in struct file!");
         }
@@ -818,7 +818,7 @@ namespace OpenMS
       StringList names;
       for (Size i = 0; i < result.getMatchingHMDBids().size(); ++i)
       { // mapping ok?
-        if (!hmdb_properties_mapping_.count(result.getMatchingHMDBids()[i]))
+        if (!hmdb_properties_mapping_.contains(result.getMatchingHMDBids()[i]))
         {
           throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("DB entry '") + result.getMatchingHMDBids()[i] + "' not found in struct file!");
         }
@@ -1383,7 +1383,7 @@ namespace OpenMS
         {
           String hmdb_id_key(parts[0]);
 
-          if (hmdb_properties_mapping_.count(hmdb_id_key))
+          if (hmdb_properties_mapping_.contains(hmdb_id_key))
           {
             throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("File '") + filename + "' in line '" + line + "' cannot be parsed. The ID entry was already used (see above)!");
           }

--- a/src/openms/source/ANALYSIS/ID/CometModification.cpp
+++ b/src/openms/source/ANALYSIS/ID/CometModification.cpp
@@ -104,7 +104,7 @@ namespace OpenMS
     // Add residues from other (avoiding duplicates)
     for (char c : other.residues)
     {
-      if (residues.find(c) == String::npos)
+      if (!residues.contains(c))
       {
         residues += c;
       }

--- a/src/openms/source/ANALYSIS/ID/IDBoostGraph.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDBoostGraph.cpp
@@ -1095,7 +1095,7 @@ namespace OpenMS
             auto& ev = peptidePtr->getPeptideEvidences();
             for (const auto& e : ev)
             {
-              if (accs_to_remove.find(e.getProteinAccession()) == accs_to_remove.end())
+              if (!accs_to_remove.contains(e.getProteinAccession()))
               {
                 newev.emplace_back(e);
               }

--- a/src/openms/source/ANALYSIS/ID/IDConflictResolverAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDConflictResolverAlgorithm.cpp
@@ -215,7 +215,7 @@ namespace OpenMS
       for (Size j = 0; j < hits.size(); ++j)
       {
         const AASequence& seq = hits[j].getSequence();
-        if (seen_in_run.count(seq) == 0)
+        if (!seen_in_run.contains(seq))
         {
           // First occurrence of this sequence in this ID: use its rank
           rank_sums[seq] += static_cast<double>(j);

--- a/src/openms/source/ANALYSIS/ID/IDMapper.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDMapper.cpp
@@ -491,7 +491,7 @@ namespace OpenMS
                 {
                   id_mapped = true;
                   was_added = true;
-                  if (mapping[cm_index].count(i) == 0)
+                  if (!mapping[cm_index].contains(i))
                   {
                     // Store the map index of the peptide feature in the id the feature was mapped to.
                     PeptideIdentification id_pep = ids[i];

--- a/src/openms/source/ANALYSIS/ID/IDRipper.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDRipper.cpp
@@ -39,7 +39,7 @@ namespace OpenMS
     for (const auto& prot_id : prot_ids)
     {
       const String& id_run_id = prot_id.getIdentifier();
-      if (this->index_map.find(id_run_id) != this->index_map.end())
+      if (this->index_map.contains(id_run_id))
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "IdentificationRun IDs are not unique!", id_run_id);
       }
@@ -397,7 +397,7 @@ IDRipper::OriginAnnotationFormat IDRipper::detectOriginAnnotationFormat_(map<Str
           {
             const String& file_origin = it->getMetaValue("file_origin");
             // Did we already assign an index to this file_origin?
-            if (file_origin_map.find(file_origin) == file_origin_map.end())
+            if (!file_origin_map.contains(file_origin))
             {
               // If not, assign a new unique index
               size_t cur_size = file_origin_map.size();

--- a/src/openms/source/ANALYSIS/ID/IDScoreGetterSetter.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDScoreGetterSetter.cpp
@@ -33,7 +33,7 @@ namespace OpenMS
       for (const auto &acc : grp.accessions)
       {
         // In groups, you usually want to check if at least one member is a real target
-        if (decoy_accs.find(acc) == decoy_accs.end())
+        if (!decoy_accs.contains(acc))
         {
           target = true;
           break;

--- a/src/openms/source/ANALYSIS/ID/OpenSearchModificationAnalysis.cpp
+++ b/src/openms/source/ANALYSIS/ID/OpenSearchModificationAnalysis.cpp
@@ -119,7 +119,7 @@ namespace OpenMS
       String full_name = residue->getFullName();
       double diff_mono_mass = residue->getDiffMonoMass();
       
-      if (full_name.find("substitution") == std::string::npos)
+      if (!full_name.contains("substitution"))
       {
         mass_to_modification[diff_mono_mass] = full_name;
       }
@@ -138,7 +138,7 @@ namespace OpenMS
     // Helper function to add or update modifications
     auto addOrUpdateModification = [&](const String& mod_name, double mass, double count, int num_charges)
     {
-      if (modifications.find(mod_name) == modifications.end())
+      if (!modifications.contains(mod_name))
       {
         ModificationPattern pattern;
         pattern.masses.push_back(mass);
@@ -720,13 +720,13 @@ namespace OpenMS
         stats.total_modified_psms++;
 
         // Get or create PTM entry
-        if (ptm_map.find(ptm_name) == ptm_map.end())
+        if (!ptm_map.contains(ptm_name))
         {
           PTMEntry entry;
           entry.name = ptm_name;
 
           // Get theoretical mass
-          if (name_to_mass.find(ptm_name) != name_to_mass.end())
+          if (name_to_mass.contains(ptm_name))
           {
             entry.theoretical_mass = name_to_mass[ptm_name];
           }
@@ -925,7 +925,7 @@ namespace OpenMS
       double diff_mono_mass = residue->getDiffMonoMass();
 
       // Skip substitutions
-      if (full_name.find("substitution") == std::string::npos)
+      if (!full_name.contains("substitution"))
       {
         mass_to_mod[diff_mono_mass] = full_name;
       }
@@ -938,7 +938,7 @@ namespace OpenMS
   {
     // Split compound names (e.g. "Oxidation//Deamidated" or "Oxidation+1Da") and resolve each part
     std::vector<String> parts;
-    if (mod_name.find("//") != std::string::npos)
+    if (mod_name.contains("//"))
     {
       mod_name.split("//", parts);
     }

--- a/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
@@ -757,7 +757,7 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
       for (std::vector<ProteinHit>::iterator p_hit = phits.begin(); p_hit != phits.end(); ++p_hit)
       {
         const String& acc = p_hit->getAccession();
-        if (acc_to_prot.find(acc) == acc_to_prot.end()) // acc_to_prot only contains found proteins from current run
+        if (!acc_to_prot.contains(acc)) // acc_to_prot only contains found proteins from current run
         { // old hit is orphaned
           ++stats_orphaned_proteins;
           if (keep_unreferenced_proteins_)

--- a/src/openms/source/ANALYSIS/ID/PeptideProteinResolution.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideProteinResolution.cpp
@@ -94,7 +94,7 @@ namespace OpenMS
       {
         Size idx = group_it - groups.begin();
         prot_acc_to_indist_prot_grp[*acc_it] = idx;
-        if (decoy_accs.find(*acc_it) != decoy_accs.end())
+        if (decoy_accs.contains(*acc_it))
         {
           indist_prot_grp_decoy[idx] = true;
         }

--- a/src/openms/source/ANALYSIS/ID/Percolator.cpp
+++ b/src/openms/source/ANALYSIS/ID/Percolator.cpp
@@ -1130,7 +1130,7 @@ PercolatorModel Percolator::loadModel(const String& filename)
     // between feature name and weight. A feature name cannot contain a ':'
     // without a TAB (names are written as the left-hand side of TAB-split
     // data rows), so checking for TAB first is unambiguous.
-    if (line.find('\t') == std::string::npos)
+    if (!line.contains('\t'))
     {
       const size_t colon = line.find(':');
       if (colon == std::string::npos)
@@ -1141,7 +1141,7 @@ PercolatorModel Percolator::loadModel(const String& filename)
       }
       const std::string key = trim(line.substr(0, colon));
       const std::string val = trim(line.substr(colon + 1));
-      if (known_keys.find(key) == known_keys.end())
+      if (!known_keys.contains(key))
       {
         throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
           filename + ": unknown header key '" + key + "'", line);
@@ -1159,7 +1159,7 @@ PercolatorModel Percolator::loadModel(const String& filename)
         else if (key == "bias")         { bias = std::stod(val); bias_seen = true; }
         else if (key == "normalizer")
         {
-          if (known_normalizers.find(val) == known_normalizers.end())
+          if (!known_normalizers.contains(val))
           {
             throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
               filename + ": invalid normalizer value (expected stdv|uni|none)",
@@ -1193,7 +1193,7 @@ PercolatorModel Percolator::loadModel(const String& filename)
   // Required-key completeness.
   for (const auto& required : known_keys)
   {
-    if (seen_keys.find(required) == seen_keys.end())
+    if (!seen_keys.contains(required))
     {
       throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
         filename + ": missing required header key '" + required + "'", "");

--- a/src/openms/source/ANALYSIS/ID/PercolatorFeatureSetHelper.cpp
+++ b/src/openms/source/ANALYSIS/ID/PercolatorFeatureSetHelper.cpp
@@ -303,7 +303,7 @@ namespace OpenMS
         String spectrum_reference = getScanMergeKey_(pit, new_peptide_ids.begin());
         //merge in unified map
         // insert newly identified spectra (PeptideIdentifications) or ..
-        if (unified.find(spectrum_reference) == unified.end())
+        if (!unified.contains(spectrum_reference))
         {
           unified[spectrum_reference] = ins;
           ++nc;

--- a/src/openms/source/ANALYSIS/ID/Scores.cpp
+++ b/src/openms/source/ANALYSIS/ID/Scores.cpp
@@ -54,7 +54,7 @@ namespace OpenMS
       chopped = chopped.chop(6);
     }
     const std::set<String>& possible_types = maps.type_to_str.at(type);
-    return possible_types.find(chopped) != possible_types.end();
+    return possible_types.contains(chopped);
   }
 
   Scores::IDType Scores::parseIDType(const String& score_type_in)
@@ -123,7 +123,7 @@ namespace OpenMS
     const auto& maps = getMaps_();
     for (const auto& [scoretype, names] : maps.type_to_str)
     {
-      if (names.find(name) != names.end())
+      if (names.contains(name))
       {
         type = scoretype;
         return true;
@@ -149,7 +149,7 @@ namespace OpenMS
 
     for (const auto& [type, names] : maps.type_to_str)
     {
-      if (names.find(normalized) != names.end())
+      if (names.contains(normalized))
       {
         return true;
       }

--- a/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
@@ -738,7 +738,7 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
         #pragma omp critical (processed_peptides_access)
         {
           // peptide (and all modified variants) already processed so skip it
-          if (processed_petides.find(c) != processed_petides.end())
+          if (processed_petides.contains(c))
           {
             already_processed = true;
           }

--- a/src/openms/source/ANALYSIS/MAPMATCHING/BaseGroupFinder.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/BaseGroupFinder.cpp
@@ -26,7 +26,7 @@ namespace OpenMS
       const ConsensusMap& map = maps[i];
       for (ConsensusMap::ColumnHeaders::const_iterator it = map.getColumnHeaders().begin(); it != map.getColumnHeaders().end(); ++it)
       {
-        if (used_ids.find(it->first) != used_ids.end())
+        if (used_ids.contains(it->first))
         {
           throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "file ids have to be unique");
         }

--- a/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmWNet.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmWNet.cpp
@@ -287,7 +287,7 @@ namespace OpenMS
 
         for (Size m : group_maps_[b])
         {
-          if (group_maps_[a].count(m)) return false; // would create duplicate map entry
+          if (group_maps_[a].contains(m)) return false; // would create duplicate map entry
         }
 
         if (rank_[a] < rank_[b]) swap(a, b);

--- a/src/openms/source/ANALYSIS/MAPMATCHING/LabeledPairFinder.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/LabeledPairFinder.cpp
@@ -278,8 +278,8 @@ namespace OpenMS
     for (ConsensusMap::const_iterator match = matches.begin(); match != matches.end(); ++match)
     {
       //check if features are not used yet
-      if (used_features.find(match->begin()->getUniqueId()) == used_features.end() &&
-          used_features.find(match->rbegin()->getUniqueId()) == used_features.end()
+      if (!used_features.contains(match->begin()->getUniqueId()) &&
+          !used_features.contains(match->rbegin()->getUniqueId())
           )
       {
         //if unused, add it to the final set of elements

--- a/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmKD.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmKD.cpp
@@ -220,7 +220,7 @@ void MapAlignmentAlgorithmKD::filterCCs_(const KDTreeFeatureMaps& kd_data, const
       {
         // filter out if too many features from same map
         Size map_idx = kd_data.mapIndex(*idx_it);
-        if (map_indices.find(map_idx) != map_indices.end())
+        if (map_indices.contains(map_idx))
         {
           if (++nr_conflicts > max_nr_conflicts)
           {

--- a/src/openms/source/ANALYSIS/MAPMATCHING/QTClusterFinder.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/QTClusterFinder.cpp
@@ -690,7 +690,7 @@ void QTClusterFinder::createConsensusFeature_(ConsensusFeature& feature,
 
             // Skip features that we have already used -> we cannot add them to
             // be neighbors any more
-            if (already_used_.find(neighbor_feature) != already_used_.end() )
+            if (already_used_.contains(neighbor_feature) )
             {
               continue;
             }

--- a/src/openms/source/ANALYSIS/NUXL/NuXLAnnotateAndLocate.cpp
+++ b/src/openms/source/ANALYSIS/NUXL/NuXLAnnotateAndLocate.cpp
@@ -526,7 +526,7 @@ namespace OpenMS
         for (auto pair_it = alignment.begin(); pair_it != alignment.end(); ++pair_it)
         {
           // only annotate experimental peaks with shift - i.e. do not annotated complete loss peaks again
-          if (peak_is_annotated.find(pair_it->second) != peak_is_annotated.end()) { continue; }
+          if (peak_is_annotated.contains(pair_it->second)) { continue; }
 
           // information on the experimental fragment in the alignment
           const Size & fragment_index = pair_it->second;
@@ -658,20 +658,20 @@ namespace OpenMS
 
         for (Size i = 0; i != n_shifts.size(); ++i)
         {
-          if (shifted_b_ions.find(i + 1) == shifted_b_ions.end()) { continue; }
+          if (!shifted_b_ions.contains(i + 1)) { continue; }
           for (auto& k : shifted_b_ions[i + 1]) { n_shifts[i] += k.intensity; }
         }
 
         for (Size i = 0; i != n_shifts.size(); ++i)
         {
-          if (shifted_a_ions.find(i + 1) == shifted_a_ions.end()) { continue; }
+          if (!shifted_a_ions.contains(i + 1)) { continue; }
           for (auto& k : shifted_a_ions[i + 1]) { n_shifts[i] += k.intensity; }
         }
 
         for (Size i = 0; i != c_shifts.size(); ++i)
         {
           const Size ion_index = c_shifts.size() - i;
-          if (shifted_y_ions.find(ion_index) == shifted_y_ions.end()) { continue; }
+          if (!shifted_y_ions.contains(ion_index)) { continue; }
           for (auto& k : shifted_y_ions[ion_index]) { c_shifts[i] += k.intensity; }
         }
 
@@ -679,20 +679,20 @@ namespace OpenMS
         vector<double> c_noshifts(sites_sum_score.size(), 0);
         for (Size i = 0; i != n_noshifts.size(); ++i)
         {
-          if (unshifted_b_ions.find(i + 1) == unshifted_b_ions.end()) { continue; }
+          if (!unshifted_b_ions.contains(i + 1)) { continue; }
           for (auto& k : unshifted_b_ions[i + 1]) { n_noshifts[i] += k.intensity; }
         }
 
         for (Size i = 0; i != n_noshifts.size(); ++i)
         {
-          if (unshifted_a_ions.find(i + 1) == unshifted_a_ions.end()) { continue; }
+          if (!unshifted_a_ions.contains(i + 1)) { continue; }
           for (auto& k : unshifted_a_ions[i + 1]) { n_noshifts[i] += k.intensity; }
         }
 
         for (Size i = 0; i != c_noshifts.size(); ++i)
         {
           const Size ion_index = c_noshifts.size() - i;
-          if (unshifted_y_ions.find(ion_index) == unshifted_y_ions.end()) { continue; }
+          if (!unshifted_y_ions.contains(ion_index)) { continue; }
           for (auto& k : unshifted_y_ions[ion_index]) { c_noshifts[i] += k.intensity; }
         }
 

--- a/src/openms/source/ANALYSIS/NUXL/NuXLFDR.cpp
+++ b/src/openms/source/ANALYSIS/NUXL/NuXLFDR.cpp
@@ -72,7 +72,7 @@ namespace OpenMS
 
     for (const auto & pi : xl_pi)
     {
-      if (native_id_to_id_index.find(pi.getMetaValue("spectrum_reference")) == native_id_to_id_index.end())
+      if (!native_id_to_id_index.contains(pi.getMetaValue("spectrum_reference")))
       {
         peptide_ids.push_back(pi);
       }

--- a/src/openms/source/ANALYSIS/NUXL/NuXLModificationsGenerator.cpp
+++ b/src/openms/source/ANALYSIS/NUXL/NuXLModificationsGenerator.cpp
@@ -260,7 +260,7 @@ NuXLModificationMassesResult NuXLModificationsGenerator::initModificationMassesN
           }
         }
 
-        if (formulas_of_modified_nucleotide.find(sum_formula.toString()) == formulas_of_modified_nucleotide.end())
+        if (!formulas_of_modified_nucleotide.contains(sum_formula.toString()))
         {
           actual_combinations.push_back(sum_formula);
           result.mod_combinations[sum_formula.toString()].insert(nt);  // add sum formula -> nucleotide
@@ -355,7 +355,7 @@ NuXLModificationMassesResult NuXLModificationsGenerator::initModificationMassesN
       
       // check if nucleotide formula contains a cross-linkable amino acid
       bool has_xl_nt(false);
-      for (auto const & c : nucleotide_style_formula) { if (can_xl.count(c) > 0) { has_xl_nt = true; break;};  }
+      for (auto const & c : nucleotide_style_formula) { if (can_xl.contains(c)) { has_xl_nt = true; break;};  }
 
       if (!has_xl_nt) 
       { // no cross-linked nucleotide => not valid
@@ -479,7 +479,7 @@ NuXLModificationMassesResult NuXLModificationsGenerator::initModificationMassesN
       }
 
       // only print ambiguous sequences once
-      if (printed.find(nucleotide_style_formula) == printed.end())
+      if (!printed.contains(nucleotide_style_formula))
       {
         OPENMS_LOG_INFO << nucleotide_style_formula << " ";
         printed.insert(nucleotide_style_formula);

--- a/src/openms/source/ANALYSIS/NUXL/NuXLParameterParsing.cpp
+++ b/src/openms/source/ANALYSIS/NUXL/NuXLParameterParsing.cpp
@@ -275,10 +275,10 @@ NuXLParameterParsing::getFeasibleFragmentAdducts(const String &exp_pc_adduct,
       if (*exp_pc_it == '+' || *exp_pc_it == '-') break;
 
       // count occurence of nucleotide
-      if (exp_pc_nucleotide_count.count(*exp_pc_it) == 0)
+      if (!exp_pc_nucleotide_count.contains(*exp_pc_it))
       {
         exp_pc_nucleotide_count[*exp_pc_it] = 1;
-        if (can_xl.count(*exp_pc_it)) { exp_pc_xl_nts.insert(*exp_pc_it); };
+        if (can_xl.contains(*exp_pc_it)) { exp_pc_xl_nts.insert(*exp_pc_it); };
       }
       else
       {
@@ -329,7 +329,7 @@ NuXLParameterParsing::getFeasibleFragmentAdducts(const String &exp_pc_adduct,
       const set<NuXLFragmentAdductDefinition>& fragment_adducts = n2fa.second; // all potential fragment adducts that may arise from the unmodified nucleotide
 
       // check if nucleotide is cross-linkable and part of the precursor adduct
-      if (exp_pc_xl_nts.find(nucleotide) != exp_pc_xl_nts.end())
+      if (exp_pc_xl_nts.contains(nucleotide))
       {
         OPENMS_LOG_DEBUG << "\t" << exp_pc_adduct << " found nucleotide: " << String(nucleotide) << " in precursor RNA." << endl;
         OPENMS_LOG_DEBUG << "\t" << exp_pc_adduct << " nucleotide: " << String(nucleotide) << " has fragment_adducts: " << fragment_adducts.size() << endl;
@@ -347,7 +347,7 @@ NuXLParameterParsing::getFeasibleFragmentAdducts(const String &exp_pc_adduct,
     for (auto const & n2fa : nucleotide_to_fragment_adducts)
     {
       const char & nucleotide = n2fa.first; // the nucleotide without any associated loss
-      if (exp_pc_nucleotide_count.find(nucleotide) != exp_pc_nucleotide_count.end())
+      if (exp_pc_nucleotide_count.contains(nucleotide))
       { 
         marker_ion_set.insert(n2fa.second.begin(), n2fa.second.end()); 
       }
@@ -363,7 +363,7 @@ NuXLParameterParsing::getFeasibleFragmentAdducts(const String &exp_pc_adduct,
       set<NuXLFragmentAdductDefinition> fas = n2fa.second; // all potential fragment adducts that may arise from NT assuming no loss on the precursor adduct
 
       // check if nucleotide is cross-linkable and part of the precursor adduct
-      if (exp_pc_xl_nts.find(nucleotide) != exp_pc_xl_nts.end())
+      if (exp_pc_xl_nts.contains(nucleotide))
       {
         OPENMS_LOG_DEBUG << "\t" << exp_pc_adduct << " found nucleotide: " << String(nucleotide) << " in precursor NA adduct." << endl;
         OPENMS_LOG_DEBUG << "\t" << exp_pc_adduct << " nucleotide: " << String(nucleotide) << " has fragment_adducts: " << fas.size() << endl;

--- a/src/openms/source/ANALYSIS/NUXL/NuXLReport.cpp
+++ b/src/openms/source/ANALYSIS/NUXL/NuXLReport.cpp
@@ -152,7 +152,7 @@ namespace OpenMS
         NuXLReportRow row;
 
         // case 1: no peptide identification: store rt, mz, charge and marker ion intensities
-        if (map_spectra_to_id.find(scan_index) == map_spectra_to_id.end())
+        if (!map_spectra_to_id.contains(scan_index))
         {
           row.no_id = true;
           row.rt = rt;
@@ -604,7 +604,7 @@ Output format:
     // one row per unlocalized peptide    
     for (const auto& [peptide, unlocalizedXLs] : region_loc.peptide2unlocalizedXL)
     {
-      if (remaining_peptides.find(peptide) == remaining_peptides.end()) continue;
+      if (!remaining_peptides.contains(peptide)) continue;
 
       // protein, AA, position
       String l = accession + "\t-\t-\t";
@@ -744,7 +744,7 @@ Output format:
       for (auto& ph_evidence : ph_evidences)
       {
         const String& acc = ph_evidence.getProteinAccession();
-        bool is_target = acc2protein_targets.find(acc) != acc2protein_targets.end();
+        bool is_target = acc2protein_targets.contains(acc);
         if (!is_target) continue; // skip decoys            
         peptide2proteins[peptide_sequence].insert(acc);
         protein2peptides[acc].insert(peptide_sequence);
@@ -894,7 +894,7 @@ Output format:
       else if (auto it = accessionToIndistinguishableGroup.find(accession);
         it != accessionToIndistinguishableGroup.end())
       { // ind. protein group
-        if (printed_ind_group.count(accession) == 0)
+        if (!printed_ind_group.contains(accession))
         {
           const ProteinIdentification::ProteinGroup* pg = it->second;
           String a = ListUtils::concatenate(pg->accessions, ",");

--- a/src/openms/source/ANALYSIS/OPENSWATH/ConfidenceScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/ConfidenceScoring.cpp
@@ -120,7 +120,7 @@ namespace OpenMS
         // for the "true" assay, we need to choose the same transitions as for the
         // feature:
         if (!transition_ids.empty() && 
-            (transition_ids.count(transition.getNativeID()) == 0)) continue;
+            (!transition_ids.contains(transition.getNativeID()))) continue;
         // seems like Boost's Bimap doesn't support "operator[]"...
         intensity_map.left.insert(make_pair(transition.getProductMZ(), 
                                             transition.getLibraryIntensity()));

--- a/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
@@ -157,19 +157,19 @@ namespace OpenMS
       // legacy
 #if 1
       const auto& cv_terms = transition.getCVTerms();
-      if (cv_terms.find("decoy") != cv_terms.end() && cv_terms.at("decoy")[0].getValue().toString() == "1" )
+      if (cv_terms.contains("decoy") && cv_terms.at("decoy")[0].getValue().toString() == "1" )
       {
         t.setDecoy(true);
       }
-      else if (cv_terms.find("MS:1002007") != cv_terms.end())    // target SRM transition
+      else if (cv_terms.contains("MS:1002007"))    // target SRM transition
       {
         t.setDecoy(false);
       }
-      else if (cv_terms.find("MS:1002008") != cv_terms.end())    // decoy SRM transition
+      else if (cv_terms.contains("MS:1002008"))    // decoy SRM transition
       {
         t.setDecoy(true);
       }
-      else if (cv_terms.find("MS:1002007") != cv_terms.end() && cv_terms.find("MS:1002008") != cv_terms.end())    // both == illegal
+      else if (cv_terms.contains("MS:1002007") && cv_terms.contains("MS:1002008"))    // both == illegal
       {
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                          "Transition " + t.transition_name + " cannot be target and decoy at the same time.");

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -531,7 +531,7 @@ namespace OpenMS
       }
 
       // Skip if target peptide is not in map, e.g. permutation threshold was reached
-      if (TargetPeptideMap.find(peptide.id) == TargetPeptideMap.end())
+      if (!TargetPeptideMap.contains(peptide.id))
       {
         continue;
       }
@@ -947,7 +947,7 @@ namespace OpenMS
           ReactionMonitoringTransition tr = *tr_it;
 
           if (
-              top_intensities.find(tr.getLibraryIntensity()) != top_intensities.end() &&
+              top_intensities.contains(tr.getLibraryIntensity()) &&
                tr.getDecoyTransitionType() != ReactionMonitoringTransition::DECOY &&
                j < (Size)max_transitions)
           {
@@ -974,7 +974,7 @@ namespace OpenMS
       setProgress(++progress);
 
       // Check if peptide has any transitions left
-      if (peptide_ids.find(peptide.id) != peptide_ids.end())
+      if (peptide_ids.contains(peptide.id))
       {
         peptides.push_back(peptide);
         for (const auto& protein_ref : peptide.protein_refs)
@@ -993,7 +993,7 @@ namespace OpenMS
       setProgress(++progress);
 
       // Check if protein has any peptides left
-      if (ProteinList.find(protein.id) != ProteinList.end())
+      if (ProteinList.contains(protein.id))
       {
         proteins.push_back(protein);
       }
@@ -1122,7 +1122,7 @@ namespace OpenMS
         for (TransitionVectorType::iterator tr_it = m->second.begin(); tr_it != m->second.end(); ++tr_it)
         {
           ReactionMonitoringTransition tr = *tr_it;
-          if (top_intensities.find(tr.getLibraryIntensity()) != top_intensities.end() && j < (Size)max_transitions)
+          if (top_intensities.contains(tr.getLibraryIntensity()) && j < (Size)max_transitions)
           {
             // Set meta value tag for detecting transition
             tr.setDetectingTransition(true);
@@ -1176,7 +1176,7 @@ namespace OpenMS
     for (const auto &it : compounds)
     {
       // extract potential target TransitionIds based on the decoy annotation '0_CompoundName_decoy_[M+H]+_448_0'
-      if (it.id.find("decoy") != std::string::npos)
+      if (it.id.contains("decoy"))
       {
         String current_decoy = it.id;
         String potential_target = current_decoy;
@@ -1498,7 +1498,7 @@ namespace OpenMS
         size_t j = 0;
         for (auto& tr : m.second)
         {
-          if (top_intensities.find(tr.library_intensity) != top_intensities.end() &&
+          if (top_intensities.contains(tr.library_intensity) &&
               !tr.getDecoy() &&
               j < static_cast<size_t>(max_transitions))
           {
@@ -1522,7 +1522,7 @@ namespace OpenMS
     {
       setProgress(++progress);
 
-      if (peptide_ids.find(compound.id) != peptide_ids.end())
+      if (peptide_ids.contains(compound.id))
       {
         compounds.push_back(compound);
         for (const auto& protein_ref : compound.protein_refs)
@@ -1536,7 +1536,7 @@ namespace OpenMS
     {
       setProgress(++progress);
 
-      if (protein_list.find(protein.id) != protein_list.end())
+      if (protein_list.contains(protein.id))
       {
         proteins.push_back(protein);
       }
@@ -1749,7 +1749,7 @@ namespace OpenMS
       }
 
       // Skip compounds that are not in target peptide map (e.g., those with too many permutations)
-      if (TargetPeptideMap.find(compound.id) == TargetPeptideMap.end())
+      if (!TargetPeptideMap.contains(compound.id))
       {
         continue;
       }

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMDecoy.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMDecoy.cpp
@@ -602,7 +602,7 @@ namespace OpenMS
       // Check that the decoy precursor does not happen to be a target precursor AND is not already present.
       // Use getModifiedPeptideSequence_ to match the key format used when populating allPeptideSequences above.
       const std::string peptide_key = MRMDecoy::getModifiedPeptideSequence_(peptide) + String(peptide.getChargeState());
-      if (allPeptideSequences.find(peptide_key) != allPeptideSequences.end())
+      if (allPeptideSequences.contains(peptide_key))
       {
         OPENMS_LOG_DEBUG << "[peptide] Skipping " << peptide.id << " since decoy peptide is also a target peptide or this decoy peptide is already present\n";
         exclusion_peptides.insert(peptide.id);
@@ -712,7 +712,7 @@ namespace OpenMS
                             decoy_transitions.begin(), decoy_transitions.end(),
                             [&exclusion_peptides](const OpenMS::ReactionMonitoringTransition& tr)
     {
-      return exclusion_peptides.find(tr.getPeptideRef()) != exclusion_peptides.end();
+      return exclusion_peptides.contains(tr.getPeptideRef());
     }), decoy_transitions.end());
     dec.setTransitions(std::move(decoy_transitions));
 
@@ -721,7 +721,7 @@ namespace OpenMS
     for (const auto& peptide : peptides)
     {
       // Check if peptide has any transitions left
-      if (exclusion_peptides.find(peptide.id) == exclusion_peptides.end())
+      if (!exclusion_peptides.contains(peptide.id))
       {
         decoy_peptides.push_back(peptide);
         for (Size j = 0; j < peptide.protein_refs.size(); ++j)
@@ -739,7 +739,7 @@ namespace OpenMS
     for (const auto& protein : proteins)
     {
       // Check if protein has any peptides left
-      if (protein_ids.find(protein.id) != protein_ids.end())
+      if (protein_ids.contains(protein.id))
       {
         decoy_proteins.push_back(protein);
       }
@@ -955,7 +955,7 @@ namespace OpenMS
       // which includes UniMod annotations. This ensures peptides with the same unmodified
       // sequence but different modifications are NOT considered duplicates.
       std::string decoy_key = full_decoy_sequence + String(decoy_compound.charge);
-      if (allPeptideSequences.find(decoy_key) != allPeptideSequences.end())
+      if (allPeptideSequences.contains(decoy_key))
       {
         OPENMS_LOG_DEBUG << "[peptide] Skipping " << decoy_compound.id << " since decoy peptide is also a target peptide or this decoy peptide is already present\n";
         exclusion_peptides.insert(decoy_compound.id);
@@ -1123,7 +1123,7 @@ namespace OpenMS
     decoy_transitions.erase(
         std::remove_if(decoy_transitions.begin(), decoy_transitions.end(),
                        [&exclusion_peptides](const OpenSwath::LightTransition& tr) {
-                         return exclusion_peptides.find(tr.peptide_ref) != exclusion_peptides.end();
+                         return exclusion_peptides.contains(tr.peptide_ref);
                        }),
         decoy_transitions.end());
 
@@ -1132,7 +1132,7 @@ namespace OpenMS
     std::unordered_set<std::string> protein_ids;
     for (const auto& compound : decoy_compounds)
     {
-      if (exclusion_peptides.find(compound.id) == exclusion_peptides.end())
+      if (!exclusion_peptides.contains(compound.id))
       {
         filtered_compounds.push_back(compound);
         for (const auto& prot_ref : compound.protein_refs)
@@ -1146,7 +1146,7 @@ namespace OpenMS
     std::vector<OpenSwath::LightProtein> filtered_proteins;
     for (const auto& protein : decoy_proteins)
     {
-      if (protein_ids.find(protein.id) != protein_ids.end())
+      if (protein_ids.contains(protein.id))
       {
         filtered_proteins.push_back(protein);
       }

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -1423,7 +1423,7 @@ namespace OpenMS
       chromatogram.setNativeID(transition->getNativeID());
 
       // Create new transition group if there is none for this peptide
-      if (transition_group_map.find(transition->getPeptideRef()) == transition_group_map.end())
+      if (!transition_group_map.contains(transition->getPeptideRef()))
       {
         MRMTransitionGroupType transition_group;
         transition_group.setTransitionGroupID(transition->getPeptideRef());

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureSelector.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureSelector.cpp
@@ -84,7 +84,7 @@ namespace OpenMS
       for (const Feature& feature : feature_name_map.at(elem.second))
       {
         const String name1 = elem.second + "_" + String(feature.getUniqueId());
-        if (variables.count(name1) == 0)
+        if (!variables.contains(name1))
         {
           const double score = computeScore_(feature, parameters.score_weights);
           const Int col_idx = addVariable_(problem, name1, true, score, parameters.variable_type);
@@ -135,7 +135,7 @@ namespace OpenMS
       {
         const String name1 = time_to_name[cnt1].second + "_" + String(feature_row1[i].getUniqueId());
 
-        if (variables.count(name1) == 0)
+        if (!variables.contains(name1))
         {
           constraints.push_back(addVariable_(problem, name1, true, 0, parameters.variable_type));
           variables.insert(name1);
@@ -171,7 +171,7 @@ namespace OpenMS
           for (Size j = 0; j < feature_row2.size(); ++j)
           {
             const String name2 = time_to_name[cnt2].second + "_" + String(feature_row2[j].getUniqueId());
-            if (variables.count(name2) == 0)
+            if (!variables.contains(name2))
             {
               addVariable_(problem, name2, true, 0, parameters.variable_type);
               variables.insert(name2);
@@ -232,12 +232,12 @@ namespace OpenMS
     {
       const String component_group_name = removeSpaces_(feature.getMetaValue("PeptideRef").toString());
       const double assay_retention_time = feature.getMetaValue("assay_rt");
-      if (names.count(component_group_name) == 0)
+      if (!names.contains(component_group_name))
       {
         time_to_name.emplace_back(assay_retention_time, component_group_name);
         names.insert(component_group_name);
       }
-      if (feature_name_map.count(component_group_name) == 0)
+      if (!feature_name_map.contains(component_group_name))
       {
         feature_name_map[component_group_name] = std::vector<Feature>();
       }
@@ -249,12 +249,12 @@ namespace OpenMS
       for (const Feature& subordinate : feature.getSubordinates())
       {
         const String component_name = removeSpaces_(subordinate.getMetaValue("native_id").toString());
-        if (names.count(component_name))
+        if (names.contains(component_name))
         {
           time_to_name.emplace_back(assay_retention_time, component_name);
           names.insert(component_name);
         }
-        if (feature_name_map.count(component_name) == 0)
+        if (!feature_name_map.contains(component_name))
         {
           feature_name_map[component_name] = std::vector<Feature>();
         }
@@ -313,7 +313,7 @@ namespace OpenMS
           ? removeSpaces_(feature.getMetaValue("PeptideRef").toString()) + "_" + String(feature.getUniqueId())
           : removeSpaces_(subordinate.getMetaValue("native_id").toString()) + "_" + String(feature.getUniqueId());
 
-        if (result_names_set.count(feature_name))
+        if (result_names_set.contains(feature_name))
         {
           subordinates_filtered.push_back(subordinate);
         }

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMIonSeries.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMIonSeries.cpp
@@ -21,7 +21,7 @@ namespace OpenMS
 
   std::pair<String, double> MRMIonSeries::getIon(IonSeries& ionseries, const String& ionid)
   {
-    if (ionseries.find(ionid) != ionseries.end())
+    if (ionseries.contains(ionid))
     {
       return make_pair(ionid, ionseries[ionid]);
     }
@@ -153,7 +153,7 @@ namespace OpenMS
     {
       return interpretation;
     }
-    else if (best_annotation[0].find("-") != std::string::npos)
+    else if (best_annotation[0].contains("-"))
     {
       std::vector<String> best_annotation_loss;
       best_annotation[0].split("-", best_annotation_loss);
@@ -173,7 +173,7 @@ namespace OpenMS
         fragment_loss = -1 * nl_formula.getMonoWeight();
       }
     }
-    else if (best_annotation[0].find("+") != std::string::npos)
+    else if (best_annotation[0].contains("+"))
     {
       std::vector<String> best_annotation_gain;
       best_annotation[0].split("+", best_annotation_gain);
@@ -249,7 +249,7 @@ namespace OpenMS
     tr.getMetaValue("annotation").toString().split("/", best_annotation);
 
     String annotation;
-    if (best_annotation[0].find("^") != std::string::npos)
+    if (best_annotation[0].contains("^"))
     {
       std::vector<String> best_annotation_charge;
       best_annotation[0].split("^", best_annotation_charge);

--- a/src/openms/source/ANALYSIS/OPENSWATH/MasstraceCorrelator.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MasstraceCorrelator.cpp
@@ -223,7 +223,7 @@ namespace OpenMS
     {
       setProgress(i);
 
-      if (used_already.find(i) != used_already.end()) 
+      if (used_already.contains(i)) 
       {
         continue;
       }

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathHelper.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathHelper.cpp
@@ -131,7 +131,7 @@ namespace OpenMS
     std::set<std::string> matching_proteins;
     for (Size i = 0; i < targeted_exp.compounds.size(); i++)
     {
-      if (matching_compounds.find(targeted_exp.compounds[i].id) != matching_compounds.end())
+      if (matching_compounds.contains(targeted_exp.compounds[i].id))
       {
         transition_exp_used.compounds.push_back( targeted_exp.compounds[i] );
         for (Size j = 0; j < targeted_exp.compounds[i].protein_refs.size(); j++)
@@ -142,7 +142,7 @@ namespace OpenMS
     }
     for (Size i = 0; i < targeted_exp.proteins.size(); i++)
     {
-      if (matching_proteins.find(targeted_exp.proteins[i].id) != matching_proteins.end())
+      if (matching_proteins.contains(targeted_exp.proteins[i].id))
       {
         transition_exp_used.proteins.push_back( targeted_exp.proteins[i] );
       }
@@ -195,9 +195,9 @@ namespace OpenMS
     // Separate compounds into priority and regular candidates
     for (auto & cmp : exp.getCompounds())
     {
-      if (good_ids.count(cmp.id))
+      if (good_ids.contains(cmp.id))
       {
-        if (priority_peptides.count(cmp.sequence))
+        if (priority_peptides.contains(cmp.sequence))
         {
           priority_candidates.push_back(cmp);
         }
@@ -281,7 +281,7 @@ namespace OpenMS
         
         for (auto & cmp : priority_candidates)
         {
-          if (cmp.rt >= lo && cmp.rt < hi && picked_sequences.find(cmp.sequence) == picked_sequences.end())
+          if (cmp.rt >= lo && cmp.rt < hi && !picked_sequences.contains(cmp.sequence))
             bucket.push_back(cmp);
         }
         
@@ -329,7 +329,7 @@ namespace OpenMS
           std::vector<OpenSwath::LightCompound> bucket;
           for (auto & cmp : candidates)
           {
-            if (cmp.rt >= lo && cmp.rt < hi && picked_sequences.find(cmp.sequence) == picked_sequences.end())
+            if (cmp.rt >= lo && cmp.rt < hi && !picked_sequences.contains(cmp.sequence))
               bucket.push_back(cmp);
           }
           
@@ -368,7 +368,7 @@ namespace OpenMS
         prot_ids.insert(pid);
     for (auto & prot : exp.getProteins())
     {
-      if (prot_ids.count(prot.id))
+      if (prot_ids.contains(prot.id))
         out_exp.proteins.push_back(prot);
     }
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathMatrixExporter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathMatrixExporter.cpp
@@ -64,12 +64,12 @@ namespace OpenMS
       std::set<String> used;
       for (const auto& row : rows)
       {
-        if (names.find(row.run_id) != names.end())
+        if (names.contains(row.run_id))
         {
           continue;
         }
         String label = row.run_name.empty() ? (String("RUN_ID_") + String(row.run_id)) : row.run_name;
-        if (used.count(label))
+        if (used.contains(label))
         {
           label += "_RUN" + String(row.run_id);
         }
@@ -150,7 +150,7 @@ namespace OpenMS
         {
           const PeptideKey key{row.sequence, row.full_peptide_name};
           const auto selected_it = selected_precursors.find(key);
-          if (selected_it == selected_precursors.end() || !selected_it->second.count(row.transition_group_id))
+          if (selected_it == selected_precursors.end() || !selected_it->second.contains(row.transition_group_id))
           {
             continue;
           }

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWParquetWriter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWParquetWriter.cpp
@@ -412,7 +412,7 @@ namespace OpenMS
     int64_t next_precursor_id = 1;
     for (const auto& compound : assay_library.compounds)
     {
-      if (compound_to_precursor.find(compound.id) != compound_to_precursor.end())
+      if (compound_to_precursor.contains(compound.id))
       {
         continue;
       }
@@ -434,7 +434,7 @@ namespace OpenMS
         // If numeric id collides with an already-used id, reject the numeric
         // value and fall back to auto-assigning. This prevents accidental
         // collisions between user-provided numeric ids and our auto ids.
-        if (used_precursor_ids.find(precursor_id) != used_precursor_ids.end() || precursor_id <= 0)
+        if (used_precursor_ids.contains(precursor_id) || precursor_id <= 0)
         {
           precursor_id = next_precursor_id++;
         }

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathPeptidoformInference.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathPeptidoformInference.cpp
@@ -193,7 +193,7 @@ namespace OpenMS
     missing_rows_added.reserve(rows.size());
     for (const auto& row : rows)
     {
-      if (features_with_precursor_evidence.find(row.feature_id) == features_with_precursor_evidence.end() &&
+      if (!features_with_precursor_evidence.contains(row.feature_id) &&
           missing_rows_added.insert(row.feature_id).second)
       {
         // No precursor-specific evidence is available for this feature, so fall back
@@ -382,7 +382,7 @@ namespace OpenMS
         (alignment_group_map.count(row.feature_id) ? alignment_group_map[row.feature_id] : -1);
       merged_rows.push_back(std::move(merged_row));
 
-      if (row.num_peptidoforms > 0 && num_peptidoforms_by_feature.find(row.feature_id) == num_peptidoforms_by_feature.end())
+      if (row.num_peptidoforms > 0 && !num_peptidoforms_by_feature.contains(row.feature_id))
       {
         num_peptidoforms_by_feature[row.feature_id] = row.num_peptidoforms;
       }

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -600,7 +600,7 @@ namespace OpenMS
           std::set<std::string> matching_proteins;
           for (Size compound_idx = 0; compound_idx < transition_exp.compounds.size(); compound_idx++)
           {
-            if (matching_compounds.find(transition_exp.compounds[compound_idx].id) != matching_compounds.end())
+            if (matching_compounds.contains(transition_exp.compounds[compound_idx].id))
             {
               context.transition_exp_used_all.compounds.push_back(transition_exp.compounds[compound_idx]);
               for (Size protein_ref_idx = 0;
@@ -613,7 +613,7 @@ namespace OpenMS
           }
           for (Size protein_idx = 0; protein_idx < transition_exp.proteins.size(); protein_idx++)
           {
-            if (matching_proteins.find(transition_exp.proteins[protein_idx].id) != matching_proteins.end())
+            if (matching_proteins.contains(transition_exp.proteins[protein_idx].id))
             {
               context.transition_exp_used_all.proteins.push_back(transition_exp.proteins[protein_idx]);
             }
@@ -988,7 +988,7 @@ namespace OpenMS
           std::set<std::string> matching_proteins;
           for (Size i = 0; i < transition_exp.compounds.size(); i++)
           {
-            if (matching_compounds.find(transition_exp.compounds[i].id) != matching_compounds.end())
+            if (matching_compounds.contains(transition_exp.compounds[i].id))
             {
               transition_exp_used_all.compounds.push_back( transition_exp.compounds[i] );
               for (Size j = 0; j < transition_exp.compounds[i].protein_refs.size(); j++)
@@ -999,7 +999,7 @@ namespace OpenMS
           }
           for (Size i = 0; i < transition_exp.proteins.size(); i++)
           {
-            if (matching_proteins.find(transition_exp.proteins[i].id) != matching_proteins.end())
+            if (matching_proteins.contains(transition_exp.proteins[i].id))
             {
               transition_exp_used_all.proteins.push_back( transition_exp.proteins[i] );
             }
@@ -1336,7 +1336,7 @@ namespace OpenMS
         // the transitions)
         if (ms1only) {continue;}
 
-        if (chromatogram_map.find(transition->getNativeID()) == chromatogram_map.end())
+        if (!chromatogram_map.contains(transition->getNativeID()))
         {
           if (mrm_) // in SRM/MRM mode, we can skip missing chromatograms, because it's unlikely that we will map all transitions to the already targeted extracted chromatograms
           {
@@ -1389,7 +1389,7 @@ namespace OpenMS
       for (int iso = 0; iso <= nr_ms1_isotopes; iso++)
       {
         String prec_id = OpenSwathHelper::computePrecursorId(transition_group.getTransitionGroupID(), iso);
-        if (!ms1_chromatograms.empty() && ms1_chromatogram_map.find(prec_id) != ms1_chromatogram_map.end())
+        if (!ms1_chromatograms.empty() && ms1_chromatogram_map.contains(prec_id))
         {
           const MSChromatogram& chromatogram = ms1_chromatograms[ ms1_chromatogram_map[prec_id] ];
           transition_group.addPrecursorChromatogram(chromatogram, chromatogram.getNativeID());
@@ -1593,7 +1593,7 @@ namespace OpenMS
 
     for (Size i = 0; i < all_transitions.size(); i++)
     {
-      if (selected_compounds.find(all_transitions[i].peptide_ref) != selected_compounds.end())
+      if (selected_compounds.contains(all_transitions[i].peptide_ref))
       {
         output.push_back(all_transitions[i]);
       }

--- a/src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp
@@ -1107,15 +1107,15 @@ namespace OpenMS
 
   void TargetedSpectraExtractor::BinnedSpectrumComparator::init(const std::vector<MSSpectrum>& library, const std::map<String,DataValue>& options)
   {
-    if (options.count("bin_size"))
+    if (options.contains("bin_size"))
     {
       bin_size_ = options.at("bin_size");
     }
-    if (options.count("peak_spread"))
+    if (options.contains("peak_spread"))
     {
       peak_spread_ = options.at("peak_spread");
     }
-    if (options.count("bin_offset"))
+    if (options.contains("bin_offset"))
     {
       bin_offset_ = options.at("bin_offset");
     }

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
@@ -739,11 +739,11 @@ namespace OpenMS
 
         int group_set_index = group_map[transition.group_id];
 
-        if (precursor_mz_map.find(group_set_index) == precursor_mz_map.end())
+        if (!precursor_mz_map.contains(group_set_index))
         {
           precursor_mz_map[group_set_index] = transition.precursor;
         }
-        if (precursor_decoy_map.find(group_set_index) == precursor_decoy_map.end())
+        if (!precursor_decoy_map.contains(group_set_index))
         {
           if (transition.detecting_transition == 1)
           {
@@ -829,7 +829,7 @@ namespace OpenMS
         gene_name = peptide.getMetaValue("GeneName");
       }
 
-      if (gene_map.find(gene_name) == gene_map.end()) gene_map[gene_name] = (int)gene_map.size();
+      if (!gene_map.contains(gene_name)) gene_map[gene_name] = (int)gene_map.size();
       peptide_gene_map.emplace_back(peptide_set_index, gene_map[gene_name]);
 
       insert_precursor_sql <<
@@ -1230,11 +1230,11 @@ namespace OpenMS
         const auto& tr = targeted_exp.transitions[i];
         int group_set_index = group_map[tr.peptide_ref];
 
-        if (precursor_mz_map.find(group_set_index) == precursor_mz_map.end())
+        if (!precursor_mz_map.contains(group_set_index))
         {
           precursor_mz_map[group_set_index] = tr.precursor_mz;
         }
-        if (precursor_decoy_map.find(group_set_index) == precursor_decoy_map.end())
+        if (!precursor_decoy_map.contains(group_set_index))
         {
           if (tr.isDetectingTransition())
           {
@@ -1314,14 +1314,14 @@ namespace OpenMS
 
         for (const auto& prot_ref : compound.protein_refs)
         {
-          if (protein_map.find(prot_ref) != protein_map.end())
+          if (protein_map.contains(prot_ref))
           {
             peptide_protein_map_vec.emplace_back(peptide_set_index, protein_map[prot_ref]);
           }
         }
 
         std::string gene_name = compound.gene_name.empty() ? "NA" : compound.gene_name;
-        if (gene_map.find(gene_name) == gene_map.end()) gene_map[gene_name] = (int)gene_map.size();
+        if (!gene_map.contains(gene_name)) gene_map[gene_name] = (int)gene_map.size();
         peptide_gene_map_vec.emplace_back(peptide_set_index, gene_map[gene_name]);
 
         insert_precursor_sql <<

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionParquetFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionParquetFile.cpp
@@ -308,7 +308,7 @@ namespace OpenMS
 
       for (const auto& accession : info.protein_accessions)
       {
-        if (protein_map.find(accession) == protein_map.end())
+        if (!protein_map.contains(accession))
         {
           OpenSwath::LightProtein protein;
           protein.id = accession;
@@ -429,7 +429,7 @@ namespace OpenMS
     std::unordered_set<int64_t> used_precursor_ids;
     for (const auto& compound : targeted_exp.compounds)
     {
-      if (compound_to_precursor.find(compound.id) != compound_to_precursor.end())
+      if (compound_to_precursor.contains(compound.id))
       {
         continue;
       }
@@ -448,7 +448,7 @@ namespace OpenMS
 
       if (parsed_numeric)
       {
-        if (precursor_id <= 0 || used_precursor_ids.find(precursor_id) != used_precursor_ids.end())
+        if (precursor_id <= 0 || used_precursor_ids.contains(precursor_id))
         {
           precursor_id = next_precursor_id++;
         }
@@ -472,7 +472,7 @@ namespace OpenMS
     std::unordered_map<std::string, double> precursor_mz;
     for (const auto& transition : targeted_exp.transitions)
     {
-      if (precursor_mz.find(transition.peptide_ref) == precursor_mz.end())
+      if (!precursor_mz.contains(transition.peptide_ref))
       {
         precursor_mz[transition.peptide_ref] = transition.precursor_mz;
       }

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionTSVFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionTSVFile.cpp
@@ -290,7 +290,7 @@ namespace OpenMS
           !extractName<double>(mytransition.rt_calibrated, "RetentionTime", tmp_line, header_dict) &&
           !extractName<double>(mytransition.rt_calibrated, "Tr_recalibrated", tmp_line, header_dict))
       {
-        if (header_dict.find("SpectraSTRetentionTime") != header_dict.end())
+        if (header_dict.contains("SpectraSTRetentionTime"))
         {
           spectrastRTExtract(tmp_line[header_dict["SpectraSTRetentionTime"]], mytransition.rt_calibrated, spectrast_legacy);
         }
@@ -384,7 +384,7 @@ namespace OpenMS
       !extractName<bool>(mytransition.decoy, "Decoy", tmp_line, header_dict) &&
       !extractName<bool>(mytransition.decoy, "IsDecoy", tmp_line, header_dict));
 
-      if (header_dict.find("SpectraSTAnnotation") != header_dict.end())
+      if (header_dict.contains("SpectraSTAnnotation"))
       {
         skip_transition = spectrastAnnotationExtract(tmp_line[header_dict["SpectraSTAnnotation"]], mytransition);
       }
@@ -498,20 +498,20 @@ namespace OpenMS
     std::vector<String> all_fragment_annotations;
     str_inp.split(",", all_fragment_annotations);
 
-    if (all_fragment_annotations[0].find("[") == std::string::npos && // non-unique peak annotation
-        all_fragment_annotations[0].find("]") == std::string::npos && // non-unique peak annotation
-        all_fragment_annotations[0].find("I") == std::string::npos && // immonium ion
-        all_fragment_annotations[0].find("p") == std::string::npos && // precursor ion
-        all_fragment_annotations[0].find("i") == std::string::npos && // isotope ion
-        all_fragment_annotations[0].find("m") == std::string::npos &&
-        all_fragment_annotations[0].find("?") == std::string::npos
+    if (!all_fragment_annotations[0].contains("[") && // non-unique peak annotation
+        !all_fragment_annotations[0].contains("]") && // non-unique peak annotation
+        !all_fragment_annotations[0].contains("I") && // immonium ion
+        !all_fragment_annotations[0].contains("p") && // precursor ion
+        !all_fragment_annotations[0].contains("i") && // isotope ion
+        !all_fragment_annotations[0].contains("m") &&
+        !all_fragment_annotations[0].contains("?")
         )
     {
       std::vector<String> best_fragment_annotation_with_deviation;
       all_fragment_annotations[0].split("/", best_fragment_annotation_with_deviation);
       String best_fragment_annotation = best_fragment_annotation_with_deviation[0];
 
-      if (best_fragment_annotation.find("^") != std::string::npos)
+      if (best_fragment_annotation.contains("^"))
       {
         std::vector<String> best_fragment_annotation_charge;
         best_fragment_annotation.split("^", best_fragment_annotation_charge);
@@ -523,7 +523,7 @@ namespace OpenMS
         mytransition.fragment_charge = 1; // assume 1 (most frequent charge state)
       }
 
-      if (best_fragment_annotation.find("-") != std::string::npos)
+      if (best_fragment_annotation.contains("-"))
       {
         std::vector<String> best_fragment_annotation_modification;
         best_fragment_annotation.split("-", best_fragment_annotation_modification);
@@ -532,7 +532,7 @@ namespace OpenMS
         mytransition.fragment_modification = -1 * String(best_fragment_annotation_modification[1]).toInt();
 
       }
-      else if (best_fragment_annotation.find("+") != std::string::npos)
+      else if (best_fragment_annotation.contains("+"))
       {
         std::vector<String> best_fragment_annotation_modification;
         best_fragment_annotation.split("+", best_fragment_annotation_modification);
@@ -597,8 +597,8 @@ namespace OpenMS
       exp.addTransition(rm_trans);
 
       // check whether we need a new peptide
-      if (peptide_map.find(tr_it->group_id) == peptide_map.end() &&
-          compound_map.find(tr_it->group_id) == compound_map.end() )
+      if (!peptide_map.contains(tr_it->group_id) &&
+          !compound_map.contains(tr_it->group_id) )
       {
         // should we make a peptide or a compound ?
         if (tr_it->isPeptide())
@@ -620,7 +620,7 @@ namespace OpenMS
       // check whether we need new proteins
       for (size_t i = 0; i < tr_it->ProteinName.size(); ++i)
       {
-        if (tr_it->isPeptide() && protein_map.find(tr_it->ProteinName[i]) == protein_map.end())
+        if (tr_it->isPeptide() && !protein_map.contains(tr_it->ProteinName[i]))
         {
           OpenMS::TargetedExperiment::Protein protein;
           String protein_name = tr_it->ProteinName[i];
@@ -754,7 +754,7 @@ namespace OpenMS
           !extractName<double>(mytransition.rt_calibrated, "RetentionTime", tmp_line, header_dict) &&
           !extractName<double>(mytransition.rt_calibrated, "Tr_recalibrated", tmp_line, header_dict))
       {
-        if (header_dict.find("SpectraSTRetentionTime") != header_dict.end())
+        if (header_dict.contains("SpectraSTRetentionTime"))
         {
           spectrastRTExtract(tmp_line[header_dict["SpectraSTRetentionTime"]], mytransition.rt_calibrated, spectrast_legacy);
         }
@@ -844,7 +844,7 @@ namespace OpenMS
            !extractName<bool>(mytransition.decoy, "Decoy", tmp_line, header_dict) &&
            !extractName<bool>(mytransition.decoy, "IsDecoy", tmp_line, header_dict));
 
-      if (header_dict.find("SpectraSTAnnotation") != header_dict.end())
+      if (header_dict.contains("SpectraSTAnnotation"))
       {
         skip_transition = spectrastAnnotationExtract(tmp_line[header_dict["SpectraSTAnnotation"]], mytransition);
       }
@@ -943,7 +943,7 @@ namespace OpenMS
       exp.transitions.push_back(std::move(transition));
 
       // --- Create compound if needed ---
-      if (compound_map.find(mytransition.group_id) == compound_map.end())
+      if (!compound_map.contains(mytransition.group_id))
       {
         OpenSwath::LightCompound compound;
         compound.id = mytransition.group_id;
@@ -1013,7 +1013,7 @@ namespace OpenMS
       // --- Create proteins if needed ---
       for (Size i = 0; i < mytransition.ProteinName.size(); ++i)
       {
-        if (mytransition.isPeptide() && protein_map.find(mytransition.ProteinName[i]) == protein_map.end())
+        if (mytransition.isPeptide() && !protein_map.contains(mytransition.ProteinName[i]))
         {
           OpenSwath::LightProtein protein;
           protein.id = mytransition.ProteinName[i];

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
@@ -301,7 +301,7 @@ namespace OpenMS
         String component_name = (String)unknowns[feature_it].getSubordinates()[sub_it].getMetaValue("native_id");
 
         // apply the calibration curve to components that are in the quant_method
-        if (quant_methods_.count(component_name)>0)
+        if (quant_methods_.contains(component_name))
         {
           double calculated_concentration = 0.0;
           std::map<String,AbsoluteQuantitationMethod>::iterator quant_methods_it = quant_methods_.find(component_name);

--- a/src/openms/source/ANALYSIS/QUANTITATION/IsobaricChannelExtractor.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/IsobaricChannelExtractor.cpp
@@ -835,7 +835,7 @@ namespace OpenMS
       ++cl_it)
     {
       OPENMS_LOG_INFO << "  ch " << String(cl_it->name).fillRight(' ', 4) << " (~" << String(cl_it->center).substr(0, 7).fillRight(' ', 7) << "): ";
-      if (stats.find(cl_it->name) != stats.end())
+      if (stats.contains(cl_it->name))
       {
         // sort
         double median = Math::median(stats[cl_it->name].mz_deltas.begin(), stats[cl_it->name].mz_deltas.end(), false);

--- a/src/openms/source/ANALYSIS/QUANTITATION/ItraqConstants.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/ItraqConstants.cpp
@@ -218,7 +218,7 @@ namespace OpenMS
         throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "ItraqConstants: Invalid entry in Param 'channel_active'; key or value is empty ('" + (*it) + "')");
       }
       Int channel = result[0].toInt();
-      if (map.find(channel) == map.end())
+      if (!map.contains(channel))
       {
         throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "ItraqConstants: Invalid entry in Param 'channel_active'; channel is not valid ('" + String(channel) + "')");
       }

--- a/src/openms/source/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.cpp
@@ -922,7 +922,7 @@ namespace OpenMS
               if (auto file_level_it = filename_to_channel_map.find(design_filename); 
                 file_level_it != filename_to_channel_map.end())
               {
-                if (file_level_it->second.find(0) != file_level_it->second.end()) throw Exception::MissingInformation(
+                if (file_level_it->second.contains(0)) throw Exception::MissingInformation(
                   __FILE__, 
                   __LINE__, 
                   OPENMS_PRETTY_FUNCTION, 
@@ -1301,7 +1301,7 @@ namespace OpenMS
       const OpenMS::String & hit_accession = hit.getAccession();
       const OpenMS::String & hit_sequence = hit.getSequence();
 
-      if (prot_quant_.find(hit_accession) != prot_quant_.end())
+      if (prot_quant_.contains(hit_accession))
       {
         if (hit_sequence.empty())
         {

--- a/src/openms/source/ANALYSIS/QUANTITATION/ProteinInference.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/ProteinInference.cpp
@@ -145,7 +145,7 @@ namespace OpenMS
            it_file != consensus_map.getColumnHeaders().end();
            ++it_file)
       {
-        if (ratios.find(it_file->first) != ratios.end())
+        if (ratios.contains(it_file->first))
         {
           //sort intensity ratios for map #it_file->first
           std::sort(ratios[it_file->first].begin(), ratios[it_file->first].end());

--- a/src/openms/source/ANALYSIS/TARGETED/DIAChromHandler.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/DIAChromHandler.cpp
@@ -86,7 +86,7 @@ std::vector<MSChromatogram> DIAChromHandler::collectIrtChromatogramsForIrt(
         std::set<std::string> matching_proteins;
         for (Size i = 0; i < irt_transitions.compounds.size(); i++)
         {
-          if (matching_compounds.find(irt_transitions.compounds[i].id) != matching_compounds.end())
+          if (matching_compounds.contains(irt_transitions.compounds[i].id))
           {
             transition_exp_used.compounds.push_back( irt_transitions.compounds[i] );
             for (Size j = 0; j < irt_transitions.compounds[i].protein_refs.size(); j++)
@@ -97,7 +97,7 @@ std::vector<MSChromatogram> DIAChromHandler::collectIrtChromatogramsForIrt(
         }
         for (Size i = 0; i < irt_transitions.proteins.size(); i++)
         {
-          if (matching_proteins.find(irt_transitions.proteins[i].id) != matching_proteins.end())
+          if (matching_proteins.contains(irt_transitions.proteins[i].id))
           {
             transition_exp_used.proteins.push_back( irt_transitions.proteins[i] );
           }

--- a/src/openms/source/ANALYSIS/TARGETED/MetaboTargetedTargetDecoy.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/MetaboTargetedTargetDecoy.cpp
@@ -117,7 +117,7 @@ namespace OpenMS
         auto found = match_compound_refs_decoy_mz.find(tr.getCompoundRef());
 
         // Check if the compound reference is found and if the product m/z matches any in the set.
-        if (found != match_compound_refs_decoy_mz.end() && found->second.count(tr.getProductMZ()) > 0) {
+        if (found != match_compound_refs_decoy_mz.end() && found->second.contains(tr.getProductMZ())) {
             // Create a new transition object based on the current transition.
             ReactionMonitoringTransition new_tr = tr;
 
@@ -181,7 +181,7 @@ namespace OpenMS
       if (it_target != t_exp.getCompounds().end())
       {
         compounds.emplace_back(*it_target);
-        if (TransitionsMap.find(it_target->id) != TransitionsMap.end())
+        if (TransitionsMap.contains(it_target->id))
         {
           transitions.insert(transitions.end(),
                                TransitionsMap[it_target->id].begin(),
@@ -191,7 +191,7 @@ namespace OpenMS
       if (it_decoy != t_exp.getCompounds().end())
       {
         compounds.emplace_back(*it_decoy);
-        if (TransitionsMap.find(it_decoy->id) != TransitionsMap.end())
+        if (TransitionsMap.contains(it_decoy->id))
         {
           transitions.insert(transitions.end(),
                                TransitionsMap[it_decoy->id].begin(),
@@ -210,7 +210,7 @@ namespace OpenMS
         potential_decoy_compound.id = it.decoy_compound_ref;
         potential_decoy_compound.setMetaValue("decoy", DataValue(1));
 
-        if (TransitionsMap.find(it_target->id) != TransitionsMap.end())
+        if (TransitionsMap.contains(it_target->id))
         {
           potential_decoy_transitions = TransitionsMap[it_target->id];
           for (size_t i = 0; i < potential_decoy_transitions.size(); ++i)

--- a/src/openms/source/ANALYSIS/TARGETED/TargetedExperiment.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/TargetedExperiment.cpp
@@ -403,7 +403,7 @@ namespace OpenMS
     {
       createProteinReferenceMap_();
     }
-    OPENMS_PRECONDITION(protein_reference_map_.find(ref) != protein_reference_map_.end(), "Could not find protein in map")
+    OPENMS_PRECONDITION(protein_reference_map_.contains(ref), "Could not find protein in map")
     return *(protein_reference_map_[ref]);
   }
 
@@ -413,7 +413,7 @@ namespace OpenMS
     {
       createProteinReferenceMap_();
     }
-    return protein_reference_map_.find(ref) != protein_reference_map_.end();
+    return protein_reference_map_.contains(ref);
   }
 
   void TargetedExperiment::addProtein(const Protein & protein)
@@ -480,7 +480,7 @@ namespace OpenMS
     {
       createPeptideReferenceMap_();
     }
-    return peptide_reference_map_.find(ref) != peptide_reference_map_.end();
+    return peptide_reference_map_.contains(ref);
   }
 
   bool TargetedExperiment::hasCompound(const String & ref) const
@@ -489,7 +489,7 @@ namespace OpenMS
     {
       createCompoundReferenceMap_();
     }
-    return compound_reference_map_.find(ref) != compound_reference_map_.end();
+    return compound_reference_map_.contains(ref);
   }
 
   void TargetedExperiment::addPeptide(const Peptide & rhs)
@@ -585,7 +585,7 @@ namespace OpenMS
     for (ProteinVectorType::const_iterator prot_it = getProteins().begin(); prot_it != getProteins().end(); ++prot_it)
     {
       // Create new transition group if it does not yet exist
-      if (unique_protein_map.find(prot_it->id) != unique_protein_map.end())
+      if (unique_protein_map.contains(prot_it->id))
       {
         OPENMS_LOG_ERROR << "Found duplicate protein id (must be unique): " + String(prot_it->id) << std::endl;
         return true;
@@ -598,7 +598,7 @@ namespace OpenMS
     for (PeptideVectorType::const_iterator pep_it = getPeptides().begin(); pep_it != getPeptides().end(); ++pep_it)
     {
       // Create new transition group if it does not yet exist
-      if (unique_peptide_map.find(pep_it->id) != unique_peptide_map.end())
+      if (unique_peptide_map.contains(pep_it->id))
       {
         OPENMS_LOG_ERROR << "Found duplicate peptide id (must be unique): " + String(pep_it->id) << std::endl;
         return true;
@@ -611,7 +611,7 @@ namespace OpenMS
     for (CompoundVectorType::const_iterator comp_it = getCompounds().begin(); comp_it != getCompounds().end(); ++comp_it)
     {
       // Create new transition group if it does not yet exist
-      if (unique_compounds_map.find(comp_it->id) != unique_compounds_map.end())
+      if (unique_compounds_map.contains(comp_it->id))
       {
         OPENMS_LOG_ERROR << "Found duplicate compound id (must be unique): " + String(comp_it->id) << std::endl;
         return true;
@@ -624,7 +624,7 @@ namespace OpenMS
     for (TransitionVectorType::const_iterator tr_it = getTransitions().begin(); tr_it != getTransitions().end(); ++tr_it)
     {
       // Create new transition group if it does not yet exist
-      if (unique_transition_map.find(tr_it->getNativeID()) != unique_transition_map.end())
+      if (unique_transition_map.contains(tr_it->getNativeID()))
       {
         OPENMS_LOG_ERROR << "Found duplicate transition id (must be unique): " + String(tr_it->getNativeID()) << std::endl;
         return true;
@@ -637,7 +637,7 @@ namespace OpenMS
     {
       for (std::vector<String>::const_iterator prot_it = getPeptides()[i].protein_refs.begin(); prot_it != getPeptides()[i].protein_refs.end(); ++prot_it)
       {
-        if (unique_protein_map.find(*prot_it) == unique_protein_map.end()) 
+        if (!unique_protein_map.contains(*prot_it)) 
         {
           OPENMS_LOG_ERROR << "Protein " << *prot_it << " is not present in the provided data structure." << std::endl;
           return true;
@@ -651,7 +651,7 @@ namespace OpenMS
       const ReactionMonitoringTransition& tr = getTransitions()[i];
       if (!tr.getPeptideRef().empty())
       {
-        if (unique_peptide_map.find(tr.getPeptideRef()) == unique_peptide_map.end()) 
+        if (!unique_peptide_map.contains(tr.getPeptideRef())) 
         {
           OPENMS_LOG_ERROR << "Peptide " << tr.getPeptideRef() << " is not present in the provided data structure." << std::endl;
           return true;
@@ -659,7 +659,7 @@ namespace OpenMS
       }
       else if (!tr.getCompoundRef().empty())
       {
-        if (unique_compounds_map.find(tr.getCompoundRef()) == unique_compounds_map.end()) 
+        if (!unique_compounds_map.contains(tr.getCompoundRef())) 
         {
           OPENMS_LOG_ERROR << "Compound " << tr.getPeptideRef() << " is not present in the provided data structure." << std::endl;
           return true;

--- a/src/openms/source/ANALYSIS/TOPDOWN/DeconvolvedSpectrum.cpp
+++ b/src/openms/source/ANALYSIS/TOPDOWN/DeconvolvedSpectrum.cpp
@@ -123,7 +123,7 @@ namespace OpenMS
     {
       for (const auto& p : spec_)
       {
-        if (deconvolved_mzs.find(p.getMZ()) != deconvolved_mzs.end()) // if p is deconvolved
+        if (deconvolved_mzs.contains(p.getMZ())) // if p is deconvolved
         {
           continue;
         }

--- a/src/openms/source/ANALYSIS/TOPDOWN/FLASHDeconvAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/TOPDOWN/FLASHDeconvAlgorithm.cpp
@@ -187,7 +187,7 @@ void FLASHDeconvAlgorithm::mergeSpectra_(MSExperiment& map, uint ms_level)
         const auto& native_id = spec.getNativeID();
         original_precursor_map[native_id] = spec.getPrecursors();
 
-        if (! spec.getPrecursors().empty() && native_id_precursor_peak_group_map_.find(native_id) != native_id_precursor_peak_group_map_.end())
+        if (! spec.getPrecursors().empty() && native_id_precursor_peak_group_map_.contains(native_id))
         {
           auto precursor_pg = native_id_precursor_peak_group_map_[native_id];
           auto precursor = spec.getPrecursors()[0];
@@ -213,7 +213,7 @@ void FLASHDeconvAlgorithm::mergeSpectra_(MSExperiment& map, uint ms_level)
 
         for (auto& native_id : native_ids)
         {
-          if (original_precursor_map.find(native_id) == original_precursor_map.end()) continue;
+          if (!original_precursor_map.contains(native_id)) continue;
           mspec.setPrecursors(original_precursor_map[native_id]);
         }
       }
@@ -316,7 +316,7 @@ void FLASHDeconvAlgorithm::runSpectralDeconvolution_(MSExperiment& map, std::vec
     for (Size index = 0; index < map.size(); index++)
     {
       int scan_number = merge_spec_ == 0 ? getScanNumber(map, index) :
-                        (rt_scan_map.find(map[index].getRT()) == rt_scan_map.end() ? getScanNumber(map, index) :
+                        (!rt_scan_map.contains(map[index].getRT()) ? getScanNumber(map, index) :
                                                                                      rt_scan_map[map[index].getRT()]);
       const auto& spec = map[index];
 
@@ -326,7 +326,7 @@ void FLASHDeconvAlgorithm::runSpectralDeconvolution_(MSExperiment& map, std::vec
 
       String native_id = spec.getNativeID();
       PeakGroup precursor_pg;
-      if (native_id_precursor_peak_group_map_.find(native_id) != native_id_precursor_peak_group_map_.end())
+      if (native_id_precursor_peak_group_map_.contains(native_id))
       {
         precursor_pg = native_id_precursor_peak_group_map_[native_id];
       }
@@ -660,7 +660,7 @@ void FLASHDeconvAlgorithm::updatePrecursorQScores_(std::vector<DeconvolvedSpectr
     auto precursor_pg = dspec.getPrecursorPeakGroup();
 
     int pscan = precursor_pg.getScanNumber();
-    if (scan_fullscan.find(pscan) == scan_fullscan.end()) continue;
+    if (!scan_fullscan.contains(pscan)) continue;
 
     auto fullscan = scan_fullscan[pscan];
 

--- a/src/openms/source/ANALYSIS/TOPDOWN/Qvalue.cpp
+++ b/src/openms/source/ANALYSIS/TOPDOWN/Qvalue.cpp
@@ -47,7 +47,7 @@ namespace OpenMS
       uint ms_level = deconvolved_spectrum.getOriginalSpectrum().getMSLevel();
       for (auto& pg : deconvolved_spectrum)
       {
-        if (pg.getFeatureIndex() > 0 && used_feature_indices.find(pg.getFeatureIndex()) != used_feature_indices.end())
+        if (pg.getFeatureIndex() > 0 && used_feature_indices.contains(pg.getFeatureIndex()))
           continue;
         used_feature_indices.insert(pg.getFeatureIndex());
 

--- a/src/openms/source/ANALYSIS/TOPDOWN/SpectralDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/TOPDOWN/SpectralDeconvolution.cpp
@@ -142,7 +142,7 @@ namespace OpenMS
 
     for (const auto& p : spec)
     {
-      if (signal_mzs.find(p.getMZ()) != signal_mzs.end()) { continue; }
+      if (signal_mzs.contains(p.getMZ())) { continue; }
       nspec.push_back(p);
     }
     deconvolved_spectrum_.setOriginalSpectrum(nspec);
@@ -1185,7 +1185,7 @@ namespace OpenMS
     {
       auto& pg = deconvolved_spectrum_[k];
 
-      if (!indices.empty() && (indices.find(k) == indices.end()))
+      if (!indices.empty() && (!indices.contains(k)))
       {
         continue;
       }

--- a/src/openms/source/ANALYSIS/TOPDOWN/TopDownIsobaricQuantification.cpp
+++ b/src/openms/source/ANALYSIS/TOPDOWN/TopDownIsobaricQuantification.cpp
@@ -155,7 +155,7 @@ TopDownIsobaricQuantification::TopDownIsobaricQuantification() : DefaultParamHan
         if (abs(trt.first - p.getRT()) > .01)
           continue;
         int scan = trt.second;
-        if (scan_precursors_map.find(scan) == scan_precursors_map.end())
+        if (!scan_precursors_map.contains(scan))
           continue;
         for (auto& pg : scan_precursors_map[scan])
         {
@@ -183,7 +183,7 @@ TopDownIsobaricQuantification::TopDownIsobaricQuantification() : DefaultParamHan
         continue;
       }
       auto& precursor = dspec.getPrecursorPeakGroup();
-      if (precursor.empty() || precursor_cluster_index.find(precursor) != precursor_cluster_index.end())
+      if (precursor.empty() || precursor_cluster_index.contains(precursor))
         continue;
       precursor_clusters.push_back(std::vector<PeakGroup> {precursor});
       precursor_cluster_index[precursor] = (int)precursor_clusters.size() - 1;
@@ -226,9 +226,9 @@ TopDownIsobaricQuantification::TopDownIsobaricQuantification() : DefaultParamHan
       std::vector<double> intensities (0);
       for (int ms2_scan : precursor_scan_ms2_scans[ms2_scan_precursor_scan[scan]])
       {
-        if (ms2_ints.find(ms2_scan) == ms2_ints.end() || ms2_ints[ms2_scan].empty())
+        if (!ms2_ints.contains(ms2_scan) || ms2_ints[ms2_scan].empty())
           continue;
-        if (ms2_scan_precursor_mz.find(ms2_scan) == ms2_scan_precursor_mz.end() || abs(ms2_scan_precursor_mz[ms2_scan] - pre_mz) > .01)
+        if (!ms2_scan_precursor_mz.contains(ms2_scan) || abs(ms2_scan_precursor_mz[ms2_scan] - pre_mz) > .01)
           continue;
         if (intensities.empty())
         {

--- a/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
@@ -306,7 +306,7 @@ namespace OpenMS
 
         bool already_processed = false;
 
-        if (processed_peptides.find(*cit) != processed_peptides.end())
+        if (processed_peptides.contains(*cit))
         {
           // peptide (and all modified variants) already processed so skip it
           already_processed = true;
@@ -1144,7 +1144,7 @@ namespace OpenMS
         PeptideHit& hit = id.getHits()[0];
         PeptideIdentification new_id;
         String current_spectrum = id.getMetaValue(Constants::UserParam::SPECTRUM_REFERENCE);
-        if (new_peptide_ids.find(current_spectrum) != new_peptide_ids.end())
+        if (new_peptide_ids.contains(current_spectrum))
         {
           new_id = (*new_peptide_ids.find(current_spectrum)).second;
         }

--- a/src/openms/source/ANALYSIS/XLMS/XFDRAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/XFDRAlgorithm.cpp
@@ -341,7 +341,7 @@ using namespace OpenMS;
         String id = getId_(ph);
         ph.setMetaValue("OpenPepXL:id", id);
         // candidates with the same ID will also have the same types
-        if (this->cross_link_classes_.find(id) == this->cross_link_classes_.end())
+        if (!this->cross_link_classes_.contains(id))
         {
           assignTypes_(ph, this->cross_link_classes_[id]);
         }
@@ -449,9 +449,9 @@ using namespace OpenMS;
                     std::vector< double > & fdr, bool mono) const
   {
     // Determine whether targetclass, decoyclass, and fulldecoyclass are present in the histogram map
-    bool targetclass_present = cum_histograms.find(targetclass) != cum_histograms.end();
-    bool decoyclass_present = cum_histograms.find(decoyclass) != cum_histograms.end();
-    bool fulldecoyclass_present = cum_histograms.find(fulldecoyclass) != cum_histograms.end();
+    bool targetclass_present = cum_histograms.contains(targetclass);
+    bool decoyclass_present = cum_histograms.contains(decoyclass);
+    bool fulldecoyclass_present = cum_histograms.contains(fulldecoyclass);
 
     for (double current_score = this->min_score_ +  (arg_binsize_/2);
         current_score <= this->max_score_ - (arg_binsize_/2);

--- a/src/openms/source/APPLICATIONS/INIUpdater.cpp
+++ b/src/openms/source/APPLICATIONS/INIUpdater.cpp
@@ -70,7 +70,7 @@ namespace OpenMS
     new_name = "";
     // try with type (as some new tools for one type might have the exact same name as old ones with several types)
     TDE old_withtype(old_name, ListUtils::create<String>(tools_type));
-    if (map_.find(old_withtype) != map_.end())
+    if (map_.contains(old_withtype))
     {
       new_name = map_[old_withtype].name;
       return true;
@@ -78,7 +78,7 @@ namespace OpenMS
 
     // try without type
     TDE old_notype(old_name, StringList());
-    if (map_.find(old_notype) != map_.end())
+    if (map_.contains(old_notype))
     {
       new_name = map_[old_notype].name;
       return true;
@@ -86,7 +86,7 @@ namespace OpenMS
 
     // default to ToolHandler
     const auto& topp = ToolHandler::getTOPPToolList();
-    if (topp.find(old_name) != topp.end())
+    if (topp.contains(old_name))
     {
       new_name = old_name;
       return true;

--- a/src/openms/source/APPLICATIONS/OpenSwathBase.cpp
+++ b/src/openms/source/APPLICATIONS/OpenSwathBase.cpp
@@ -46,9 +46,9 @@ namespace OpenMS
           for (const auto& arr : spectrum->getDataArrays())
           {
             // Check for CCS CV term (MS:1002954) or square angstrom unit (UO:0000324)
-            if (arr->description.find("MS:1002954") != std::string::npos ||
-                arr->description.find("UO:0000324") != std::string::npos ||
-                arr->description.find("collision cross section") != std::string::npos)
+            if (arr->description.contains("MS:1002954") ||
+                arr->description.contains("UO:0000324") ||
+                arr->description.contains("collision cross section"))
             {
               OPENMS_LOG_WARN << "Warning: Ion mobility data appears to be in CCS (Collisional Cross Section) format. "
                               << "OpenSwath expects ion mobility in 1/K0 (inverse reduced ion mobility) units. "

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -958,7 +958,7 @@ namespace OpenMS
     {
       String full_name = it.getName();
       String subsection = getSubsection_(full_name);
-      if (!subsection.empty() && (subsections_TOPP_.count(subsection) == 0))
+      if (!subsection.empty() && (!subsections_TOPP_.contains(subsection)))
       {
         subsections_TOPP_[subsection] = param.getSectionDescription(subsection);
       }
@@ -1887,10 +1887,10 @@ namespace OpenMS
     {
       // subsections (do not check content, but warn if not registered)
       String subsection = getSubsection_(it.getName());
-      if (!subsection.empty() && subsections_TOPP_.count(subsection) == 0) // not found in TOPP subsections
+      if (!subsection.empty() && !subsections_TOPP_.contains(subsection)) // not found in TOPP subsections
       {
         // for multi-level subsections, check only the first level:
-        if (subsections_.count(subsection.substr(0, subsection.find(':'))) == 0) // not found in normal subsections
+        if (!subsections_.contains(subsection.substr(0, subsection.find(':')))) // not found in normal subsections
         {
           if (!(location == "common::" && subsection == tool_name_))
           {

--- a/src/openms/source/APPLICATIONS/ToolHandler.cpp
+++ b/src/openms/source/APPLICATIONS/ToolHandler.cpp
@@ -213,7 +213,7 @@ namespace OpenMS
     std::vector<Internal::ToolDescription> internal_tools = getInternalTools_();
     for (std::vector<Internal::ToolDescription>::const_iterator it = internal_tools.begin(); it != internal_tools.end(); ++it)
     {
-      if (tools_map.find(it->name) == tools_map.end())
+      if (!tools_map.contains(it->name))
       {
         tools_map[it->name] = *it;
       }
@@ -230,7 +230,7 @@ namespace OpenMS
   {
     Internal::ToolDescription ret;
     ToolListType tools = getTOPPToolList();
-    if (tools.find(toolname) != tools.end())
+    if (tools.contains(toolname))
     {
       return tools[toolname].types;
     }
@@ -304,7 +304,7 @@ namespace OpenMS
   {
     ToolListType tools = getTOPPToolList();
     String s;
-    if (tools.find(toolname) != tools.end())
+    if (tools.contains(toolname))
     {
       s = tools[toolname].category;
     }

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -79,12 +79,12 @@ namespace OpenMS
 
   bool ElementDB::hasElement(const string& name) const
   {
-    return (names_.find(name) != names_.end()) || (symbols_.find(name) != symbols_.end());
+    return (names_.contains(name)) || (symbols_.contains(name));
   }
 
   bool ElementDB::hasElement(unsigned int atomic_number) const
   {
-    return atomic_numbers_.find(atomic_number) != atomic_numbers_.end();
+    return atomic_numbers_.contains(atomic_number);
   }
 
   double ElementDB::calculateAvgWeight_(const map<unsigned int, double>& abundance, const map<unsigned int, double>& mass)
@@ -614,7 +614,7 @@ namespace OpenMS
   {
     // overwrite existing element if it already exists
     // find() has to be protected here in a parallel context
-    if (atomic_numbers_.find(an) != atomic_numbers_.end())
+    if (atomic_numbers_.contains(an))
     {
       // in order to ensure that existing elements are still valid and memory
       // addresses do not change, we have to modify the Element in place

--- a/src/openms/source/CHEMISTRY/EmpiricalFormula.cpp
+++ b/src/openms/source/CHEMISTRY/EmpiricalFormula.cpp
@@ -369,7 +369,7 @@ namespace OpenMS
 
   bool EmpiricalFormula::hasElement(const Element* element) const
   {
-    return formula_.find(element) != formula_.end();
+    return formula_.contains(element);
   }
 
   bool EmpiricalFormula::contains(const EmpiricalFormula& ef) const

--- a/src/openms/source/CHEMISTRY/MASSDECOMPOSITION/IMS/IMSAlphabetTextParser.cpp
+++ b/src/openms/source/CHEMISTRY/MASSDECOMPOSITION/IMS/IMSAlphabetTextParser.cpp
@@ -31,7 +31,7 @@ void OpenMS::ims::IMSAlphabetTextParser::parse(std::istream & is)
   while (std::getline(is, line))
   {
     std::string::size_type i = line.find_first_not_of(delimits);
-    if (i == std::string::npos || comments.find(line[i]) != std::string::npos)
+    if (i == std::string::npos || comments.contains(line[i]))
     {
       continue;       // skip comment lines
     }

--- a/src/openms/source/CHEMISTRY/ModificationDefinitionsSet.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationDefinitionsSet.cpp
@@ -232,8 +232,8 @@ namespace OpenMS
       if (it->isModified())
       {
         String mod = it->getModification()->getFullId();
-        if (var_names.find(mod) == var_names.end() &&
-            fixed_names.find(mod) == fixed_names.end())
+        if (!var_names.contains(mod) &&
+            !fixed_names.contains(mod))
         {
           return false;
         }
@@ -243,8 +243,8 @@ namespace OpenMS
     if (peptide.hasNTerminalModification())
     {
       String mod = peptide.getNTerminalModification()->getFullId();
-      if (var_names.find(mod) == var_names.end() &&
-          fixed_names.find(mod) == fixed_names.end())
+      if (!var_names.contains(mod) &&
+          !fixed_names.contains(mod))
       {
         return false;
       }
@@ -253,8 +253,8 @@ namespace OpenMS
     if (peptide.hasCTerminalModification())
     {
       String mod = peptide.getCTerminalModification()->getFullId();
-      if (var_names.find(mod) == var_names.end() &&
-          fixed_names.find(mod) == fixed_names.end())
+      if (!var_names.contains(mod) &&
+          !fixed_names.contains(mod))
       {
         return false;
       }

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -289,7 +289,7 @@ namespace OpenMS
     bool has_mod;
     #pragma omp critical(OpenMS_ModificationsDB)
     {
-      has_mod = (modification_names_.find(modification) != modification_names_.end());
+      has_mod = (modification_names_.contains(modification));
     }
     return has_mod;
   }

--- a/src/openms/source/CHEMISTRY/ModomicsJSONDataProvider.cpp
+++ b/src/openms/source/CHEMISTRY/ModomicsJSONDataProvider.cpp
@@ -58,25 +58,25 @@ namespace OpenMS
     // @throw Exception::MissingInformation if some of the required info for the entry is missing
     void entryIsWellFormed_(const nlohmann::json::value_type& entry)
     {
-      if (entry.find("name") == entry.cend())
+      if (!entry.contains("name"))
       {
         String msg = "\"name\" entry missing for ribonucleotide";
         throw Exception::MissingInformation(__FILE__, __LINE__,
                                                 OPENMS_PRETTY_FUNCTION, msg);
       }
-      if (entry.find("short_name") == entry.cend())
+      if (!entry.contains("short_name"))
       {
         String msg = "\"short_name\" entry missing for ribonucleotide";
         throw Exception::MissingInformation(__FILE__, __LINE__,
                                                 OPENMS_PRETTY_FUNCTION, msg);
       }
-      if (entry.find("reference_moiety") == entry.cend())
+      if (!entry.contains("reference_moiety"))
       {
         String msg = "\"reference_moiety\" entry missing for ribonucleotide";
         throw Exception::MissingInformation(__FILE__, __LINE__,
                                                 OPENMS_PRETTY_FUNCTION, msg);
       }
-      if (entry.find("formula") == entry.cend())
+      if (!entry.contains("formula"))
       {
         String msg = "\"formula\" entry missing for ribonucleotide";
         throw Exception::MissingInformation(__FILE__, __LINE__,
@@ -165,7 +165,7 @@ namespace OpenMS
                                                 OPENMS_PRETTY_FUNCTION, msg, entry["reference_moiety"].dump());
       }
 
-      if (entry.find("abbrev") != entry.cend())
+      if (entry.contains("abbrev"))
       {
         ribo->setHTMLCode(entry.at("abbrev").get<std::string>()); //This is the single letter unicode representation that only SOME mods have
       }

--- a/src/openms/source/CHEMISTRY/MonosaccharideDB.cpp
+++ b/src/openms/source/CHEMISTRY/MonosaccharideDB.cpp
@@ -121,7 +121,7 @@ namespace OpenMS
 
   bool MonosaccharideDB::hasSymbol(const String& symbol) const
   {
-    return synonym_to_symbol_.find(symbol) != synonym_to_symbol_.end();
+    return synonym_to_symbol_.contains(symbol);
   }
 
   const MonosaccharideDB::Monosaccharide* MonosaccharideDB::getMonosaccharide(const String& symbol) const

--- a/src/openms/source/CHEMISTRY/ProForma.cpp
+++ b/src/openms/source/CHEMISTRY/ProForma.cpp
@@ -1705,7 +1705,7 @@ namespace
         const auto& label = mod.alternatives[0].second.value();
         if (label.type == Label::Type::CROSSLINK)
         {
-          if (counted_crosslinks.count(label.identifier) > 0) return;
+          if (counted_crosslinks.contains(label.identifier)) return;
           counted_crosslinks.insert(label.identifier);
         }
       }
@@ -2445,14 +2445,14 @@ MSSpectrum ProForma::generateSpectrum(
 
   TheoreticalSpectrumGenerator generator;
   Param param = generator.getParameters();
-  param.setValue("add_a_ions", ion_types.find('a') != std::string::npos ? "true" : "false");
-  param.setValue("add_b_ions", ion_types.find('b') != std::string::npos ? "true" : "false");
-  param.setValue("add_c_ions", ion_types.find('c') != std::string::npos ? "true" : "false");
-  param.setValue("add_x_ions", ion_types.find('x') != std::string::npos ? "true" : "false");
-  param.setValue("add_y_ions", ion_types.find('y') != std::string::npos ? "true" : "false");
-  param.setValue("add_z_ions", ion_types.find('z') != std::string::npos ? "true" : "false");
-  param.setValue("add_precursor_peaks", ion_types.find('M') != std::string::npos ? "true" : "false");
-  param.setValue("add_abundant_immonium_ions", ion_types.find('I') != std::string::npos ? "true" : "false");
+  param.setValue("add_a_ions", ion_types.contains('a') ? "true" : "false");
+  param.setValue("add_b_ions", ion_types.contains('b') ? "true" : "false");
+  param.setValue("add_c_ions", ion_types.contains('c') ? "true" : "false");
+  param.setValue("add_x_ions", ion_types.contains('x') ? "true" : "false");
+  param.setValue("add_y_ions", ion_types.contains('y') ? "true" : "false");
+  param.setValue("add_z_ions", ion_types.contains('z') ? "true" : "false");
+  param.setValue("add_precursor_peaks", ion_types.contains('M') ? "true" : "false");
+  param.setValue("add_abundant_immonium_ions", ion_types.contains('I') ? "true" : "false");
   param.setValue("add_losses", add_losses ? "true" : "false");
   param.setValue("add_metainfo", add_metainfo ? "true" : "false");
   generator.setParameters(param);
@@ -2501,13 +2501,13 @@ MSSpectrum ProForma::generateSpectrum(
 
   TheoreticalSpectrumGeneratorXLMS generator;
   Param param = generator.getParameters();
-  param.setValue("add_a_ions", ion_types.find('a') != std::string::npos ? "true" : "false");
-  param.setValue("add_b_ions", ion_types.find('b') != std::string::npos ? "true" : "false");
-  param.setValue("add_c_ions", ion_types.find('c') != std::string::npos ? "true" : "false");
-  param.setValue("add_x_ions", ion_types.find('x') != std::string::npos ? "true" : "false");
-  param.setValue("add_y_ions", ion_types.find('y') != std::string::npos ? "true" : "false");
-  param.setValue("add_z_ions", ion_types.find('z') != std::string::npos ? "true" : "false");
-  param.setValue("add_precursor_peaks", ion_types.find('M') != std::string::npos ? "true" : "false");
+  param.setValue("add_a_ions", ion_types.contains('a') ? "true" : "false");
+  param.setValue("add_b_ions", ion_types.contains('b') ? "true" : "false");
+  param.setValue("add_c_ions", ion_types.contains('c') ? "true" : "false");
+  param.setValue("add_x_ions", ion_types.contains('x') ? "true" : "false");
+  param.setValue("add_y_ions", ion_types.contains('y') ? "true" : "false");
+  param.setValue("add_z_ions", ion_types.contains('z') ? "true" : "false");
+  param.setValue("add_precursor_peaks", ion_types.contains('M') ? "true" : "false");
   param.setValue("add_losses", add_losses ? "true" : "false");
   param.setValue("add_metainfo", add_metainfo ? "true" : "false");
   generator.setParameters(param);

--- a/src/openms/source/CHEMISTRY/Residue.cpp
+++ b/src/openms/source/CHEMISTRY/Residue.cpp
@@ -584,7 +584,7 @@ namespace OpenMS
 
   bool Residue::isInResidueSet(const String& residue_set)
   {
-    return residue_sets_.find(residue_set) != residue_sets_.end();
+    return residue_sets_.contains(residue_set);
   }
 
   std::string Residue::residueTypeToIonLetter(const Residue::ResidueType& res_type)

--- a/src/openms/source/CHEMISTRY/ResidueDB.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueDB.cpp
@@ -125,7 +125,7 @@ namespace OpenMS
     bool found = false;
     #pragma omp critical (ResidueDB)
     {
-      found = residue_names_.find(res_name) != residue_names_.end();
+      found = residue_names_.contains(res_name);
     }  
     return found;
   }
@@ -135,8 +135,8 @@ namespace OpenMS
     bool found = false;
     #pragma omp critical (ResidueDB)
     {
-      found = (const_residues_.find(residue) != const_residues_.end() ||
-          const_modified_residues_.find(residue) != const_modified_residues_.end());
+      found = (const_residues_.contains(residue) ||
+          const_modified_residues_.contains(residue));
     } 
     return found;
   }
@@ -366,7 +366,7 @@ namespace OpenMS
       const auto& rm_entry = residue_mod_names_.find(res_name);
       if (rm_entry == residue_mod_names_.end())
       {
-        if (residue_names_.find(res_name) == residue_names_.end())
+        if (!residue_names_.contains(res_name))
         {
           residue_found = false;
         }
@@ -469,7 +469,7 @@ namespace OpenMS
       const auto& rm_entry = residue_mod_names_.find(res_name);
       if (rm_entry == residue_mod_names_.end())
       {
-        if (residue_names_.find(res_name) == residue_names_.end())
+        if (!residue_names_.contains(res_name))
         {
           residue_found = false;
         }

--- a/src/openms/source/COMPARISON/SpectrumCheapDPCorr.cpp
+++ b/src/openms/source/COMPARISON/SpectrumCheapDPCorr.cpp
@@ -178,7 +178,7 @@ namespace OpenMS
           consensuspeak.setIntensity((xit->getIntensity() * (1 - factor_) + yit->getIntensity() * factor_));
           lastconsensus_.push_back(consensuspeak);
 
-          if (!(peak_map_.find(xit - x.begin()) != peak_map_.end()))
+          if (!(peak_map_.contains(xit - x.begin())))
           {
             peak_map_[xit - x.begin()] = yit - y.begin();
           }
@@ -256,7 +256,7 @@ namespace OpenMS
         consensuspeak.setMZ((y[ystart + j - 1].getMZ() * (1 - factor_) + x[xstart + i - 1].getMZ() * factor_));
         consensuspeak.setIntensity((y[ystart + j - 1].getIntensity() * (1 - factor_) + x[xstart + i - 1].getIntensity() * factor_));
         lastconsensus_.push_back(consensuspeak);
-        if (!(peak_map_.find(xstart + i - 1) != peak_map_.end()))
+        if (!(peak_map_.contains(xstart + i - 1)))
         {
           peak_map_[xstart + i - 1] = ystart + j - 1;
         }

--- a/src/openms/source/CONCEPT/FuzzyStringComparator.cpp
+++ b/src/openms/source/CONCEPT/FuzzyStringComparator.cpp
@@ -280,8 +280,8 @@ namespace OpenMS
     for (StringList::const_iterator slit = whitelist_.begin();
          slit != whitelist_.end(); ++slit)
     {
-      if (line_str_1.find(*slit) != String::npos &&
-          line_str_2.find(*slit) != String::npos)
+      if (line_str_1.contains(*slit) &&
+          line_str_2.contains(*slit))
       {
         ++whitelist_cases_[*slit];
         // *log_dest_ << "whitelist_ case: " << *slit << '\n';
@@ -294,11 +294,11 @@ namespace OpenMS
     for (std::vector< std::pair<std::string, std::string> >::const_iterator pair_it = matched_whitelist_.begin(); 
          pair_it != matched_whitelist_.end(); ++pair_it)
     {
-      if ((line_str_1.find(pair_it->first) != String::npos &&
-           line_str_2.find(pair_it->second) != String::npos
+      if ((line_str_1.contains(pair_it->first) &&
+           line_str_2.contains(pair_it->second)
           ) ||
-          (line_str_1.find(pair_it->second) != String::npos &&
-           line_str_2.find(pair_it->first) != String::npos
+          (line_str_1.contains(pair_it->second) &&
+           line_str_2.contains(pair_it->first)
           )
          )
       {

--- a/src/openms/source/CONCEPT/LogStream.cpp
+++ b/src/openms/source/CONCEPT/LogStream.cpp
@@ -144,7 +144,7 @@ namespace OpenMS
     bool LogStreamBuf::isInCache_(std::string const & line)
     {
       //cout << "LogCache (count)" << log_cache_.count(line) << endl;
-      if (log_cache_.count(line) == 0)
+      if (!log_cache_.contains(line))
       {
         return false;
       }

--- a/src/openms/source/CONCEPT/StreamHandler.cpp
+++ b/src/openms/source/CONCEPT/StreamHandler.cpp
@@ -83,7 +83,7 @@ namespace OpenMS
   {
     Int state = 1;
 
-    if (name_to_stream_map_.count(stream_name) == 0) // this is an unknown stream .. register
+    if (!name_to_stream_map_.contains(stream_name)) // this is an unknown stream .. register
     {
       name_to_stream_map_[stream_name] = createStream_(type, stream_name);
       name_to_type_map_[stream_name] = type;
@@ -110,7 +110,7 @@ namespace OpenMS
 
   bool StreamHandler::hasStream(const StreamType type, const String & stream_name)
   {
-    if (name_to_stream_map_.count(stream_name) != 0)
+    if (name_to_stream_map_.contains(stream_name))
     {
       return name_to_type_map_[stream_name] == type;
     }
@@ -122,7 +122,7 @@ namespace OpenMS
 
   void StreamHandler::unregisterStream(StreamType const type, const String & stream_name)
   {
-    if (name_to_stream_map_.count(stream_name) != 0) // check if we know this stream
+    if (name_to_stream_map_.contains(stream_name)) // check if we know this stream
     {
       if (name_to_counter_map_[stream_name] > 1)
       {

--- a/src/openms/source/DATASTRUCTURES/CVMappings.cpp
+++ b/src/openms/source/DATASTRUCTURES/CVMappings.cpp
@@ -92,7 +92,7 @@ namespace OpenMS
 
   bool CVMappings::hasCVReference(const String& identifier)
   {
-    return cv_references_.find(identifier) != cv_references_.end();
+    return cv_references_.contains(identifier);
   }
 
 } // namespace OpenMS

--- a/src/openms/source/DATASTRUCTURES/Compomer.cpp
+++ b/src/openms/source/DATASTRUCTURES/Compomer.cpp
@@ -82,7 +82,7 @@ namespace OpenMS
     //  std::cerr << "Compomer::add() was given adduct with negative charge! Are you sure this is what you want?!\n";
     //}
 
-    if (cmp_[side].count(a.getFormula()) == 0)
+    if (!cmp_[side].contains(a.getFormula()))
     {
       cmp_[side][a.getFormula()] = a;
     }
@@ -231,7 +231,7 @@ namespace OpenMS
     {
       return false;
     }
-    if (cmp_[side].count(a.getFormula()) == 0)
+    if (!cmp_[side].contains(a.getFormula()))
     {
       return false;
     }
@@ -252,7 +252,7 @@ namespace OpenMS
       throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Compomer::removeAdduct() does not support this value for 'side'!", String(side));
     }
     Compomer tmp(*this);
-    if (tmp.cmp_[side].count(a.getFormula()) > 0)
+    if (tmp.cmp_[side].contains(a.getFormula()))
     {
       { // how many instances does this side contain?
         Int amount = tmp.cmp_[side][a.getFormula()].getAmount();

--- a/src/openms/source/DATASTRUCTURES/ConvexHull2D.cpp
+++ b/src/openms/source/DATASTRUCTURES/ConvexHull2D.cpp
@@ -45,7 +45,7 @@ namespace OpenMS
     //different points now => return false
     for (const auto& point_pair : rhs.map_points_)
     {
-      if (map_points_.find(point_pair.first) != map_points_.end())
+      if (map_points_.contains(point_pair.first))
       {
         if (map_points_.at(point_pair.first) != point_pair.second)
         {
@@ -162,7 +162,7 @@ namespace OpenMS
   {
     outer_points_.clear();
 
-    if (map_points_.find(point[0]) != map_points_.end())
+    if (map_points_.contains(point[0]))
     {
       if (map_points_.at(point[0]).encloses(point[1]))
       {
@@ -236,7 +236,7 @@ namespace OpenMS
       throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
     }
 
-    if (map_points_.find(point[0]) != map_points_.end())
+    if (map_points_.contains(point[0]))
     {
       if (map_points_.at(point[0]).encloses(point[1]))
       {

--- a/src/openms/source/DATASTRUCTURES/OSWData.cpp
+++ b/src/openms/source/DATASTRUCTURES/OSWData.cpp
@@ -58,7 +58,7 @@ namespace OpenMS
         // probably a precursor native ID, e.g. 5543_precursor_i0 .. currently not handled.
         continue;
       }
-      if (transitions_.find(nid) == transitions_.end())
+      if (!transitions_.contains(nid))
       {
         throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Transition with nativeID " + (String(nid)) + " not found in OSW data. Make sure the OSW data was loaded!");
       }
@@ -84,7 +84,7 @@ namespace OpenMS
       {
         for (const auto& tr : f.getTransitionIDs())
         {
-          if (transitions_.find(tr) == transitions_.end())
+          if (!transitions_.contains(tr))
           {
             throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Transition with ID " + String(tr) + " was referenced in Protein/Precursor/Feature but is not known!");
           }

--- a/src/openms/source/DATASTRUCTURES/Param.cpp
+++ b/src/openms/source/DATASTRUCTURES/Param.cpp
@@ -45,7 +45,7 @@ namespace OpenMS
       tags.insert(t[i]);
     }
     //check name
-    if (name.find(':') != std::string::npos)
+    if (name.contains(':'))
     {
       OPENMS_LOG_ERROR << "Error ParamEntry name must not contain ':' characters!" << std::endl;
     }
@@ -185,7 +185,7 @@ namespace OpenMS
     entries(),
     nodes()
   {
-      if (name.find(':') != std::string::npos)
+      if (name.contains(':'))
       {
         OPENMS_LOG_WARN << "Error ParamNode name must not contain ':' characters!\n";
       }
@@ -245,7 +245,7 @@ namespace OpenMS
   Param::ParamNode* Param::ParamNode::findParentOf(const std::string& local_name)
   {
     //cout << "findParentOf nodename: " << this->name << " - nodes: " << this->nodes.size() << " - find: "<< name << '\n';
-    if (local_name.find(':') != std::string::npos) //several subnodes to browse through
+    if (local_name.contains(':')) //several subnodes to browse through
     {
         size_t pos = local_name.find(':');
         std::string prefix = local_name.substr(0, pos);
@@ -305,7 +305,7 @@ namespace OpenMS
     std::string prefix2 = prefix + node.name;
 
     ParamNode* insert_node = this;
-    while (prefix2.find(':') != std::string::npos)
+    while (prefix2.contains(':'))
     {
       size_t pos = prefix2.find(':');
       std::string local_name = prefix2.substr(0, pos);
@@ -368,7 +368,7 @@ namespace OpenMS
     //std::cerr << " - inserting: " << prefix2 << '\n';
 
     ParamNode* insert_node = this;
-    while (prefix2.find(':') != std::string::npos)
+    while (prefix2.contains(':'))
     {
       size_t pos = prefix2.find(':');
       std::string local_name = prefix2.substr(0, pos);
@@ -479,7 +479,7 @@ namespace OpenMS
     //check for commas
     for (size_t i = 0; i < strings.size(); ++i)
     {
-      if (strings[i].find(',') != std::string::npos)
+      if (strings[i].contains(','))
       {
         throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Comma characters in Param string restrictions are not allowed!");
       }
@@ -944,7 +944,7 @@ namespace OpenMS
       }
 
       //with multiple argument
-      if (options_with_multiple_argument.find(arg) != options_with_multiple_argument.end())
+      if (options_with_multiple_argument.contains(arg))
       {
         //next argument is an option
         if (arg1_is_option)
@@ -971,12 +971,12 @@ namespace OpenMS
         }
       }
       //without argument
-      else if (options_without_argument.find(arg) != options_without_argument.end())
+      else if (options_without_argument.contains(arg))
       {
         root_.insert(ParamEntry("", "true", ""), options_without_argument.find(arg)->second);
       }
       //with one argument
-      else if (options_with_one_argument.find(arg) != options_with_one_argument.end())
+      else if (options_with_one_argument.contains(arg))
       {
         //next argument is not an option
         if (!arg1_is_option)
@@ -1620,7 +1620,7 @@ OPENMS_THREAD_CRITICAL(LOGSTREAM)
 
   void Param::addTag(const std::string& key, const std::string& tag)
   {
-    if (tag.find(',') != std::string::npos)
+    if (tag.contains(','))
     {
       throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Param tags may not contain comma characters", tag);
     }
@@ -1632,7 +1632,7 @@ OPENMS_THREAD_CRITICAL(LOGSTREAM)
     ParamEntry& entry = getEntry_(key);
     for (size_t i = 0; i != tags.size(); ++i)
     {
-      if (tags[i].find(',') != std::string::npos)
+      if (tags[i].contains(','))
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Param tags may not contain comma characters", tags[i]);
       }

--- a/src/openms/source/DATASTRUCTURES/QTCluster.cpp
+++ b/src/openms/source/DATASTRUCTURES/QTCluster.cpp
@@ -140,7 +140,7 @@ namespace OpenMS
     {
       NeighborMap& neighbors_ = data_->neighbors_;
 
-      if (neighbors_.find(map_index) == neighbors_.end() || distance < neighbors_[map_index].distance)
+      if (!neighbors_.contains(map_index) || distance < neighbors_[map_index].distance)
       {
         neighbors_[map_index] = Neighbor {distance, element};
         changed_ = true;

--- a/src/openms/source/FEATUREFINDER/Biosaur2Algorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/Biosaur2Algorithm.cpp
@@ -1539,9 +1539,9 @@ void Biosaur2Algorithm::linkScanToHills_(const MSSpectrum& spectrum,
     const int fi = use_im_current ? im_bin_per_peak[static_cast<Size>(idx)] : 0;
 
     // Collect candidate previous-scan peaks from neighboring m/z bins.
-    bool flag1 = prev_fast_dict.find(fm) != prev_fast_dict.end();
-    bool flag2 = prev_fast_dict.find(fm - 1) != prev_fast_dict.end();
-    bool flag3 = prev_fast_dict.find(fm + 1) != prev_fast_dict.end();
+    bool flag1 = prev_fast_dict.contains(fm);
+    bool flag2 = prev_fast_dict.contains(fm - 1);
+    bool flag3 = prev_fast_dict.contains(fm + 1);
 
     Size assigned_hill = numeric_limits<Size>::max();
 
@@ -1614,7 +1614,7 @@ void Biosaur2Algorithm::linkScanToHills_(const MSSpectrum& spectrum,
           {
             continue;
           }
-          if (banned_prev_idx_set.find(idx_prev) != banned_prev_idx_set.end())
+          if (banned_prev_idx_set.contains(idx_prev))
           {
             continue;
           }
@@ -2165,10 +2165,10 @@ map<int, pair<double, double>> Biosaur2Algorithm::performInitialIsotopeCalibrati
     {
       isotope_calib_map[ic] = calibrateMass_(isotope_errors[ic]);
     }
-    else if (ic > 1 && isotope_calib_map.find(ic - 1) != isotope_calib_map.end())
+    else if (ic > 1 && isotope_calib_map.contains(ic - 1))
     {
       auto prev = isotope_calib_map[ic - 1];
-      auto prev2 = isotope_calib_map.find(ic - 2) != isotope_calib_map.end() ?
+      auto prev2 = isotope_calib_map.contains(ic - 2) ?
                    isotope_calib_map[ic - 2] : make_pair(0.0, itol_ppm);
 
       double shift_delta = prev.first - prev2.first;
@@ -2738,7 +2738,7 @@ vector<Biosaur2Algorithm::PeptideFeature> Biosaur2Algorithm::selectNonOverlappin
     const double mono_mz_center = mono_hill.mz_weighted_mean;
 
     // Skip patterns whose monoisotopic hill is already used.
-    if (occupied_hills.find(mono_hill.hill_idx) != occupied_hills.end())
+    if (occupied_hills.contains(mono_hill.hill_idx))
     {
       continue;
     }
@@ -2746,7 +2746,7 @@ vector<Biosaur2Algorithm::PeptideFeature> Biosaur2Algorithm::selectNonOverlappin
     bool iso_conflict = false;
     for (const auto& iso : pc.isotopes)
     {
-      if (occupied_hills.find(iso.hill_idx) != occupied_hills.end())
+      if (occupied_hills.contains(iso.hill_idx))
       {
         iso_conflict = true;
         break;
@@ -2760,7 +2760,7 @@ vector<Biosaur2Algorithm::PeptideFeature> Biosaur2Algorithm::selectNonOverlappin
       vector<IsotopeCandidate> tmp_iso;
       for (const auto& iso : pc.isotopes)
       {
-        if (occupied_hills.find(iso.hill_idx) == occupied_hills.end())
+        if (!occupied_hills.contains(iso.hill_idx))
         {
           tmp_iso.push_back(iso);
         }

--- a/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmMetaboIdent.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmMetaboIdent.cpp
@@ -917,7 +917,7 @@ namespace OpenMS
            library_.getCompounds().begin(); it != library_.getCompounds().end();
          ++it)
     {
-      if (!found_refs.count(it->id))
+      if (!found_refs.contains(it->id))
       {
         PeptideIdentification peptide;
         peptide.setIdentifier("id");

--- a/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
@@ -1434,7 +1434,7 @@ namespace OpenMS
           RTMap &external_ids = ref_rt_map[peptide_id].second;
           for (RTRegion& reg : rt_regions)
           {
-            if (reg.ids.count(charge))
+            if (reg.ids.contains(charge))
             {
               OPENMS_LOG_DEBUG_NOFILE << "Charge " << charge << ", Region# " << counter + 1 << " (RT: "
                                << float(reg.start) << "-" << float(reg.end)
@@ -1637,7 +1637,7 @@ namespace OpenMS
     for (RTMap::const_iterator rt_it = rt_internal.begin();
          rt_it != rt_internal.end(); ++rt_it)
     {
-      if (!assigned_ids.count(rt_it->second))
+      if (!assigned_ids.contains(rt_it->second))
       {
         const PeptideIdentification& pep_id = *(rt_it->second);
         features.getUnassignedPeptideIdentifications().push_back(pep_id);
@@ -1680,7 +1680,7 @@ namespace OpenMS
       // - IM_min/max: spread of IM distribution (large spread may indicate issues)
       // Note: Uses full peptide ref (with region number) as this is the key in im_stats_
       String full_peptide_ref = peptide_ref; // keep full ref with region number
-      if (im_stats_.count(full_peptide_ref))
+      if (im_stats_.contains(full_peptide_ref))
       {
         const IMStats& stats = im_stats_.at(full_peptide_ref);
         feat.setMetaValue("IM_median", stats.median);

--- a/src/openms/source/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.cpp
@@ -233,7 +233,7 @@ namespace OpenMS
         // find splines for the mass traces of the lightest and other peptide
         size_t idx_1 = isotope;
         size_t idx_2 = peptide * isotopes_per_peptide_max_ + isotope;
-        if ((spline_chromatograms.find(idx_1) == spline_chromatograms.end()) || (spline_chromatograms.find(idx_2) == spline_chromatograms.end()))
+        if ((!spline_chromatograms.contains(idx_1)) || (!spline_chromatograms.contains(idx_2)))
         {
            continue;
         }

--- a/src/openms/source/FEATUREFINDER/FeatureFindingMetabo.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFindingMetabo.cpp
@@ -976,7 +976,7 @@ namespace OpenMS
       bool trace_coll = false;   // trace collision?
       for (Size lab_idx = 0; lab_idx < labels.size(); ++lab_idx)
       {
-        if (trace_excl_map.find(labels[lab_idx]) != trace_excl_map.end())
+        if (trace_excl_map.contains(labels[lab_idx]))
         {
           trace_coll = true;
           break;

--- a/src/openms/source/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -113,10 +113,10 @@ namespace OpenMS
     bool no_label = (samples_labels_.size() == 1) && 
       (samples_labels_[0].size() == 1) && 
       samples_labels_[0][0] == "no_label";
-    bool labelling_SILAC = ((labels_.find("Arg") != std::string::npos) || (labels_.find("Lys") != std::string::npos));
-    bool labelling_Leu = (labels_.find("Leu") != std::string::npos);
-    bool labelling_Dimethyl = (labels_.find("Dimethyl") != std::string::npos);
-    bool labelling_ICPL = (labels_.find("ICPL") != std::string::npos);
+    bool labelling_SILAC = ((labels_.contains("Arg")) || (labels_.contains("Lys")));
+    bool labelling_Leu = (labels_.contains("Leu"));
+    bool labelling_Dimethyl = (labels_.contains("Dimethyl"));
+    bool labelling_ICPL = (labels_.contains("ICPL"));
 
     bool labelling_numeric = false;
     if (!(no_label || labelling_SILAC || labelling_Leu || labelling_Dimethyl || labelling_ICPL))
@@ -171,7 +171,7 @@ namespace OpenMS
       {
         for (std::vector<String>::size_type j = 0; j < samples_labels_[i].size(); ++j)
         {
-          if (all_labels.find(samples_labels_[i][j]) == std::string::npos)
+          if (!all_labels.contains(samples_labels_[i][j]))
           {
             std::stringstream stream;
             stream << "The label " << samples_labels_[i][j] << " is unknown.";
@@ -205,11 +205,11 @@ namespace OpenMS
 
               for (unsigned j = 0; j < samples_labels_[i].size(); ++j)
               {
-                bool Arg6There = (samples_labels_[i][j].find("Arg6") != std::string::npos); // Is Arg6 in the SILAC label?
-                bool Arg10There = (samples_labels_[i][j].find("Arg10") != std::string::npos);
-                bool Lys4There = (samples_labels_[i][j].find("Lys4") != std::string::npos);
-                bool Lys6There = (samples_labels_[i][j].find("Lys6") != std::string::npos);
-                bool Lys8There = (samples_labels_[i][j].find("Lys8") != std::string::npos);
+                bool Arg6There = (samples_labels_[i][j].contains("Arg6")); // Is Arg6 in the SILAC label?
+                bool Arg10There = (samples_labels_[i][j].contains("Arg10"));
+                bool Lys4There = (samples_labels_[i][j].contains("Lys4"));
+                bool Lys6There = (samples_labels_[i][j].contains("Lys6"));
+                bool Lys8There = (samples_labels_[i][j].contains("Lys8"));
 
                 // construct label set
                 for (unsigned k = 1; k < Arg6There * (ArgPerPeptide + 1); ++k)

--- a/src/openms/source/FEATUREFINDER/MultiplexFiltering.cpp
+++ b/src/openms/source/FEATUREFINDER/MultiplexFiltering.cpp
@@ -324,7 +324,7 @@ namespace OpenMS
     for (const auto &it : satellites)
     {
       size_t idx_masstrace = it.first;    // mass trace index i.e. the index within the peptide multiplet pattern
-      if (rt_boundaries.find(idx_masstrace) == rt_boundaries.end())
+      if (!rt_boundaries.contains(idx_masstrace))
       {
         // That's the first satellite within this mass trace.
         rt_boundaries[idx_masstrace] = std::make_pair((it.second).getRTidx(), (it.second).getRTidx());

--- a/src/openms/source/FORMAT/AbsoluteQuantitationMethodFile.cpp
+++ b/src/openms/source/FORMAT/AbsoluteQuantitationMethodFile.cpp
@@ -79,14 +79,14 @@ namespace OpenMS
     aqm.setComponentName(headers.count("component_name") ? tl[headers.at("component_name")] : "");
     aqm.setFeatureName(headers.count("feature_name") ? tl[headers.at("feature_name")] : "");
     aqm.setISName(headers.count("IS_name") ? tl[headers.at("IS_name")] : "");
-    aqm.setLLOD(!headers.count("llod") || tl[headers.at("llod")].empty() ? 0 : std::stod(tl[headers.at("llod")]));
-    aqm.setULOD(!headers.count("ulod") || tl[headers.at("ulod")].empty() ? 0 : std::stod(tl[headers.at("ulod")]));
-    aqm.setLLOQ(!headers.count("lloq") || tl[headers.at("lloq")].empty() ? 0 : std::stod(tl[headers.at("lloq")]));
-    aqm.setULOQ(!headers.count("uloq") || tl[headers.at("uloq")].empty() ? 0 : std::stod(tl[headers.at("uloq")]));
+    aqm.setLLOD(!headers.contains("llod") || tl[headers.at("llod")].empty() ? 0 : std::stod(tl[headers.at("llod")]));
+    aqm.setULOD(!headers.contains("ulod") || tl[headers.at("ulod")].empty() ? 0 : std::stod(tl[headers.at("ulod")]));
+    aqm.setLLOQ(!headers.contains("lloq") || tl[headers.at("lloq")].empty() ? 0 : std::stod(tl[headers.at("lloq")]));
+    aqm.setULOQ(!headers.contains("uloq") || tl[headers.at("uloq")].empty() ? 0 : std::stod(tl[headers.at("uloq")]));
     aqm.setConcentrationUnits(headers.count("concentration_units") ? tl[headers.at("concentration_units")] : "");
-    aqm.setNPoints(!headers.count("n_points") || tl[headers.at("n_points")].empty() ? 0 : std::stoi(tl[headers.at("n_points")]));
+    aqm.setNPoints(!headers.contains("n_points") || tl[headers.at("n_points")].empty() ? 0 : std::stoi(tl[headers.at("n_points")]));
     aqm.setCorrelationCoefficient(
-      !headers.count("correlation_coefficient") || tl[headers.at("correlation_coefficient")].empty()
+      !headers.contains("correlation_coefficient") || tl[headers.at("correlation_coefficient")].empty()
         ? 0
         : std::stod(tl[headers.at("correlation_coefficient")])
     );

--- a/src/openms/source/FORMAT/ArrowIOHelpers.cpp
+++ b/src/openms/source/FORMAT/ArrowIOHelpers.cpp
@@ -240,7 +240,7 @@ void readMetaValues(
   for (int64_t i = 0; i < struct_arr->length(); ++i)
   {
     std::string name = name_arr->GetString(i);
-    if (excluded_keys.count(name)) continue;
+    if (excluded_keys.contains(name)) continue;
 
     std::string value_str = value_arr->GetString(i);
     std::string type_str = type_arr->GetString(i);

--- a/src/openms/source/FORMAT/BrukerTimsFile.cpp
+++ b/src/openms/source/FORMAT/BrukerTimsFile.cpp
@@ -958,7 +958,7 @@ namespace OpenMS
                 if (dm == 0 && ds == 0) continue;
                 if (auto nkey = neighborKey(mz_bin, scan_id, dm, ds))
                 {
-                  if (grid_.count(*nkey)) ++neighbors;
+                  if (grid_.contains(*nkey)) ++neighbors;
                 }
               }
             }
@@ -1000,7 +1000,7 @@ namespace OpenMS
                 if (dm == 0 && ds == 0) continue;
                 if (auto nkey = neighborKey(mz_bin, scan_id, dm, ds))
                 {
-                  if (grid_.count(*nkey)) ++neighbors;
+                  if (grid_.contains(*nkey)) ++neighbors;
                 }
               }
             }

--- a/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
@@ -271,7 +271,7 @@ std::shared_ptr<arrow::Table> ConsensusMapArrowExport::exportToArrow(const Conse
     {
       for (const auto& acc : ig.accessions)
       {
-        if (pg_qvalue_lookup.find(acc) == pg_qvalue_lookup.end())
+        if (!pg_qvalue_lookup.contains(acc))
         {
           pg_qvalue_lookup[acc] = ig.probability;
         }
@@ -358,7 +358,7 @@ std::shared_ptr<arrow::Table> ConsensusMapArrowExport::exportToArrow(const Conse
             {
               acc_str = "UNIMOD:" + std::to_string(mod->getUniModRecordId());
             }
-            if (mod_map.find(name) == mod_map.end())
+            if (!mod_map.contains(name))
             {
               mod_map[name] = {acc_str, {}};
             }
@@ -376,7 +376,7 @@ std::shared_ptr<arrow::Table> ConsensusMapArrowExport::exportToArrow(const Conse
           {
             acc_str = "UNIMOD:" + std::to_string(mod->getUniModRecordId());
           }
-          if (mod_map.find(name) == mod_map.end())
+          if (!mod_map.contains(name))
           {
             mod_map[name] = {acc_str, {}};
           }
@@ -477,7 +477,7 @@ std::shared_ptr<arrow::Table> ConsensusMapArrowExport::exportToArrow(const Conse
       best_hit->getKeys(keys);
       for (const auto& key : keys)
       {
-        if (excluded_hit_mvs.count(key)) continue;
+        if (excluded_hit_mvs.contains(key)) continue;
         const DataValue& val = best_hit->getMetaValue(key);
         if ((val.valueType() == DataValue::INT_VALUE || val.valueType() == DataValue::DOUBLE_VALUE)
             && Scores::isKnownScoreType(key))

--- a/src/openms/source/FORMAT/ConsensusMapArrowIO.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowIO.cpp
@@ -52,7 +52,7 @@ namespace // anonymous
     mii.getKeys(keys);
     for (const auto& key : keys)
     {
-      if (excluded_keys.count(key)) continue;
+      if (excluded_keys.contains(key)) continue;
       const DataValue& val = mii.getMetaValue(key);
       (void)struct_b->Append();
       (void)name_b->Append(key);

--- a/src/openms/source/FORMAT/ControlledVocabulary.cpp
+++ b/src/openms/source/FORMAT/ControlledVocabulary.cpp
@@ -573,7 +573,7 @@ namespace OpenMS
 
   bool ControlledVocabulary::exists(const String& id) const
   {
-    return terms_.find(id) != terms_.end();
+    return terms_.contains(id);
   }
 
   const ControlledVocabulary::CVTerm* ControlledVocabulary::checkAndGetTermByName(const OpenMS::String& name) const

--- a/src/openms/source/FORMAT/DATAACCESS/MSChromatogramParquetConsumer.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/MSChromatogramParquetConsumer.cpp
@@ -138,7 +138,7 @@ namespace OpenMS
       {
         // fall through to auto-assigned ID
       }
-      while (used_ids.count(next_id))
+      while (used_ids.contains(next_id))
       {
         ++next_id;
       }

--- a/src/openms/source/FORMAT/DATAACCESS/MobilogramParquetConsumer.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/MobilogramParquetConsumer.cpp
@@ -152,7 +152,7 @@ namespace OpenMS
       {
         // fall through to auto-assigned ID
       }
-      while (used_ids.count(next_id))
+      while (used_ids.contains(next_id))
       {
         ++next_id;
       }

--- a/src/openms/source/FORMAT/ExperimentalDesignFile.cpp
+++ b/src/openms/source/FORMAT/ExperimentalDesignFile.cpp
@@ -114,7 +114,7 @@ namespace OpenMS
         const String &h = header[i];
 
         // A header is unexpected if it is neither required nor optional and we do not allow other headers
-        const bool header_unexpected = (required.find(h) == required.end()) && (optional.find(h) == optional.end());
+        const bool header_unexpected = (!required.contains(h)) && (!optional.contains(h));
         parseErrorIf_(!allow_other_header && header_unexpected, filename, "Header not allowed in this section of the Experimental Design: " + h);
         column_map[h] = i;
       }
@@ -192,8 +192,8 @@ namespace OpenMS
             {"Fraction_Group", "Fraction", "Spectra_Filepath"},
             {"Label", "Sample"}, true
           );
-          has_label = fs_column_header_to_index.find("Label") != fs_column_header_to_index.end();
-          has_sample = fs_column_header_to_index.find("Sample") != fs_column_header_to_index.end();
+          has_label = fs_column_header_to_index.contains("Label");
+          has_sample = fs_column_header_to_index.contains("Sample");
 
           if (!has_label) // add label column to end of header
           {
@@ -358,8 +358,8 @@ namespace OpenMS
             {"Fraction_Group", "Fraction", "Spectra_Filepath"},
             {"Label", "Sample"}, false
           );
-          has_label = fs_column_header_to_index.find("Label") != fs_column_header_to_index.end();
-          has_sample = fs_column_header_to_index.find("Sample") != fs_column_header_to_index.end();
+          has_label = fs_column_header_to_index.contains("Label");
+          has_sample = fs_column_header_to_index.contains("Sample");
           
           n_col = fs_column_header_to_index.size();
         }
@@ -422,7 +422,7 @@ namespace OpenMS
         {
           // Parse Error if sample appears multiple times
           const String& sample = cells[sample_columnname_to_columnindex_["Sample"]];
-          parseErrorIf_(sample_sample_to_rowindex_.find(sample) != sample_sample_to_rowindex_.end(),
+          parseErrorIf_(sample_sample_to_rowindex_.contains(sample),
                         tsv_file,
                         "Sample: " + String(sample) + " appears multiple times in the sample table");
           sample_sample_to_rowindex_[sample] = line_number++;

--- a/src/openms/source/FORMAT/FeatureMapArrowIO.cpp
+++ b/src/openms/source/FORMAT/FeatureMapArrowIO.cpp
@@ -52,7 +52,7 @@ namespace // anonymous
     mii.getKeys(keys);
     for (const auto& key : keys)
     {
-      if (excluded_keys.count(key)) continue;
+      if (excluded_keys.contains(key)) continue;
       const DataValue& val = mii.getMetaValue(key);
       (void)struct_b->Append();
       (void)name_b->Append(key);

--- a/src/openms/source/FORMAT/FileTypes.cpp
+++ b/src/openms/source/FORMAT/FileTypes.cpp
@@ -32,7 +32,7 @@ namespace OpenMS
     {
       // Check that there are no double-spaces in the description, since Qt will replace "  " with " " in filters supplied to QFileDialog::getSaveFileName.
       // And if you later ask for the selected filter, you will get a different string back.
-      assert(description.find("  ") == std::string::npos);
+      assert(!description.contains("  "));
     }
   };
 

--- a/src/openms/source/FORMAT/GNPSMGFFile.cpp
+++ b/src/openms/source/FORMAT/GNPSMGFFile.cpp
@@ -301,7 +301,7 @@ namespace OpenMS
         int map_index = pep.first;
 
         // open on-disc experiments
-        if (map_index2file_index.find(map_index) == map_index2file_index.end())
+        if (!map_index2file_index.contains(map_index))
         {
           specs_list[num_msmaps_cached].openFile(mzml_file_paths[map_index], false); // open on-disc experiment and load meta-data
           map_index2file_index[map_index] = num_msmaps_cached;

--- a/src/openms/source/FORMAT/GNPSQuantificationFile.cpp
+++ b/src/openms/source/FORMAT/GNPSQuantificationFile.cpp
@@ -67,7 +67,7 @@ namespace OpenMS
         for (const auto& fh: cf.getFeatures()) index_to_feature[fh.getMapIndex()] = fh;
         for (size_t i = 0; i < consensus_map.getColumnHeaders().size(); i++)
         {
-            if (index_to_feature.count(i))
+            if (index_to_feature.contains(i))
             {
             out << index_to_feature[i].getRT() << index_to_feature[i].getMZ() << index_to_feature[i].getIntensity() << index_to_feature[i].getCharge() << index_to_feature[i].getWidth();
             }

--- a/src/openms/source/FORMAT/HANDLERS/ConsensusXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ConsensusXMLHandler.cpp
@@ -340,7 +340,7 @@ namespace OpenMS::Internal
         // Note: technically, it would be preferable to prefix the UID for faster string comparison, but this results in random write-orderings during file store (breaks tests)
         String identifier = prot_id_.getSearchEngine() + '_' + attributeAsString_(attributes, "date") + '_' + String(UniqueIdGenerator::getUniqueId());
 
-        if (id_identifier_.find(id) == id_identifier_.end())
+        if (!id_identifier_.contains(id))
         {
           prot_id_.setIdentifier(identifier);
           id_identifier_[id] = identifier;
@@ -439,7 +439,7 @@ namespace OpenMS::Internal
     else if (tag == "PeptideIdentification" || tag == "UnassignedPeptideIdentification")
     {
       String id = attributeAsString_(attributes, "identification_run_ref");
-      if (id_identifier_.find(id) == id_identifier_.end())
+      if (!id_identifier_.contains(id))
       {
         warning(LOAD, String("Peptide identification without ProteinIdentification found (id: '") + id + "')!");
       }
@@ -830,7 +830,7 @@ namespace OpenMS::Internal
   {
     String indent = String(indentation_level, '\t');
 
-    if (identifier_id_.find(id.getIdentifier()) == identifier_id_.end())
+    if (!identifier_id_.contains(id.getIdentifier()))
     {
       warning(STORE, String("Omitting peptide identification because of missing ProteinIdentification with identifier '") + id.getIdentifier()
               + "' while writing '" + filename + "'!");

--- a/src/openms/source/FORMAT/HANDLERS/FeatureXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/FeatureXMLHandler.cpp
@@ -447,7 +447,7 @@ namespace OpenMS::Internal
         // Note: technically, it would be preferable to prefix the UID for faster string comparison, but this results in random write-orderings during file store (breaks tests)
         String identifier = prot_id_.getSearchEngine() + '_' + attributeAsString_(attributes, "date") + '_' + String(UniqueIdGenerator::getUniqueId());
 
-        if (id_identifier_.find(id) == id_identifier_.end())
+        if (!id_identifier_.contains(id))
         {
           prot_id_.setIdentifier(identifier);
           id_identifier_[id] = identifier;
@@ -547,7 +547,7 @@ namespace OpenMS::Internal
     else if (tag == "PeptideIdentification" || tag == "UnassignedPeptideIdentification")
     {
       String id = attributeAsString_(attributes, "identification_run_ref");
-      if (id_identifier_.find(id) == id_identifier_.end())
+      if (!id_identifier_.contains(id))
       {
         warning(LOAD, String("Peptide identification without ProteinIdentification found (id: '") + id + "')!");
       }
@@ -953,7 +953,7 @@ namespace OpenMS::Internal
   {
     String indent = String(indentation_level, '\t');
 
-    if (identifier_id_.find(id.getIdentifier()) == identifier_id_.end())
+    if (!identifier_id_.contains(id.getIdentifier()))
     {
       warning(STORE, String("Omitting peptide identification because of missing ProteinIdentification with identifier '") + id.getIdentifier() + "' while writing '" + filename + "'!");
       return;

--- a/src/openms/source/FORMAT/HANDLERS/IndexedMzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/IndexedMzMLHandler.cpp
@@ -252,7 +252,7 @@ namespace OpenMS::Internal
 
   void IndexedMzMLHandler::getMSSpectrumByNativeId(const std::string& id, MSSpectrum& s)
   {
-    if (spectra_native_ids_.find(id) == spectra_native_ids_.end())
+    if (!spectra_native_ids_.contains(id))
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, 
           String( "Could not find spectrum id " + String(id) ));

--- a/src/openms/source/FORMAT/HANDLERS/MascotXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MascotXMLHandler.cpp
@@ -337,7 +337,7 @@ namespace OpenMS::Internal
         vector<String> parts;
 
         actual_title_ = title;
-        if (modified_peptides_.find(title) != modified_peptides_.end())
+        if (modified_peptides_.contains(title))
         {
           vector<AASequence>& temp_hits = modified_peptides_[title];
           vector<PeptideHit> temp_peptide_hits = id_data_[actual_query_ - 1].getHits();

--- a/src/openms/source/FORMAT/HANDLERS/MzDataHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzDataHandler.cpp
@@ -951,7 +951,7 @@ namespace OpenMS::Internal
           {
             Int precursor_ms_level = spec.getMSLevel() - 1;
             SignedSize precursor_id = -1;
-            if (level_id.find(precursor_ms_level) != level_id.end())
+            if (level_id.contains(precursor_ms_level))
             {
               precursor_id = level_id[precursor_ms_level];
             }

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -413,7 +413,7 @@ namespace OpenMS::Internal
               hit_pev_.push_back(pepevs);
 
               String pepref = String("OpenMS") + String(UniqueIdGenerator::getUniqueId());
-              if (pepset.find(ph->getSequence()) != pepset.end())
+              if (pepset.contains(ph->getSequence()))
               {
                 pepset.insert(ph->getSequence());
                 pep_map_.insert(make_pair(pepref, ph->getSequence()));
@@ -663,7 +663,7 @@ namespace OpenMS::Internal
                 cv_.getAllChildTerms(software_terms, "MS:1000531");
                 for (map<String, vector<CVTerm> >::const_iterator it = swn.first.getCVTerms().begin(); it != swn.first.getCVTerms().end(); ++it)
                 {
-                  if (software_terms.find(it->first) != software_terms.end())
+                  if (software_terms.contains(it->first))
                   {
                     swname = it->second.front().getName();
                     break;
@@ -1118,7 +1118,7 @@ namespace OpenMS::Internal
                     pair<CVTermList, map<String, DataValue> > params = parseParamGroup_(sub->getChildNodes());
                     for (map<String, vector<CVTerm> >::const_iterator it = params.first.getCVTerms().begin(); it != params.first.getCVTerms().end(); ++it)
                     {
-                      if (enzymes_terms.find(it->first) != enzymes_terms.end())
+                      if (enzymes_terms.contains(it->first))
                       {
                         enzymename = it->second.front().getName();
                       }
@@ -1186,7 +1186,7 @@ namespace OpenMS::Internal
           cv_.getAllChildTerms(threshold_terms, "MS:1002482"); //statistical threshold
           for (map<String, vector<OpenMS::CVTerm> >::const_iterator thit = tcv.getCVTerms().begin(); thit != tcv.getCVTerms().end(); ++thit)
           {
-            if (threshold_terms.find(thit->first) != threshold_terms.end())
+            if (threshold_terms.contains(thit->first))
             {
               if (thit->first != "MS:1001494") // no threshold
               {
@@ -1889,7 +1889,7 @@ namespace OpenMS::Internal
         ph_alpha.setMetaValue(Constants::UserParam::OPENPEPXL_XL_MOD, xl_mod_map_.at(peptides[alpha[0]]));
         ph_alpha.setMetaValue(Constants::UserParam::OPENPEPXL_XL_MASS,DataValue(xl_mass_map_.at(peptides[alpha[0]])));
       }
-      else if ( xl_mod_map_.find(peptides[alpha[0]]) != xl_mod_map_.end() )
+      else if ( xl_mod_map_.contains(peptides[alpha[0]]) )
       {
         ph_alpha.setMetaValue(Constants::UserParam::OPENPEPXL_XL_MOD, xl_mod_map_.at(peptides[alpha[0]]));
       }
@@ -1994,7 +1994,7 @@ namespace OpenMS::Internal
         {
           bool idec = false;
           OpenMS::PeptideEvidence pev;
-          if (pe_ev_map_.find(pev_it->second) != pe_ev_map_.end())
+          if (pe_ev_map_.contains(pev_it->second))
           {
             MzIdentMLDOMHandler::PeptideEvidence& pv = pe_ev_map_[pev_it->second];
             if (pv.pre != '-') pev.setAABefore(pv.pre);
@@ -2045,7 +2045,7 @@ namespace OpenMS::Internal
             }
           }
 
-          if (pv_db_map_.find(pev_it->second) != pv_db_map_.end())
+          if (pv_db_map_.contains(pev_it->second))
           {
             String& dpv = pv_db_map_[pev_it->second];
             DBSequence& db = db_sq_map_[dpv];
@@ -2128,7 +2128,7 @@ namespace OpenMS::Internal
       bool scoretype = false;
       for (map<String, vector<OpenMS::CVTerm>>::const_iterator scoreit = param_cv.getCVTerms().begin(); scoreit != param_cv.getCVTerms().end(); ++scoreit)
       {
-        if (q_score_child_terms_.find(scoreit->first) != q_score_child_terms_.end() || scoreit->first == "MS:1002354")
+        if (q_score_child_terms_.contains(scoreit->first) || scoreit->first == "MS:1002354")
         {
           if (scoreit->first != "MS:1002055") // do not use peptide-level q-values for now
           {
@@ -2140,7 +2140,7 @@ namespace OpenMS::Internal
           }
         }
         else if (scoreit->first != "MS:1001143" && // the parent term itself has no numeric value; handled in the special case below
-                 specific_score_child_terms_.find(scoreit->first) != specific_score_child_terms_.end())
+                 specific_score_child_terms_.contains(scoreit->first))
         {
           score = toDoubleOrZero_(scoreit->second.front().getValue().toString()); // cast fix needed as DataValue is init with XercesString
           spectrum_identification.setHigherScoreBetter(ControlledVocabulary::CVTerm::isHigherBetterScore(cv_.getTerm(scoreit->first)));
@@ -2148,7 +2148,7 @@ namespace OpenMS::Internal
           scoretype = true;
           break;
         }
-        else if (e_score_child_terms_.find(scoreit->first) != e_score_child_terms_.end())
+        else if (e_score_child_terms_.contains(scoreit->first))
         {
           score = toDoubleOrZero_(scoreit->second.front().getValue().toString()); // cast fix needed as DataValue is init with XercesString
           spectrum_identification.setHigherScoreBetter(false);
@@ -2202,7 +2202,7 @@ namespace OpenMS::Internal
         {
           bool idec = false;
           OpenMS::PeptideEvidence pev;
-          if (pe_ev_map_.find(pev_it->second) != pe_ev_map_.end())
+          if (pe_ev_map_.contains(pev_it->second))
           {
             MzIdentMLDOMHandler::PeptideEvidence& pv = pe_ev_map_[pev_it->second];
             if (pv.pre != '-') pev.setAABefore(pv.pre);
@@ -2255,7 +2255,7 @@ namespace OpenMS::Internal
             }
           }
 
-          if (pv_db_map_.find(pev_it->second) != pv_db_map_.end())
+          if (pv_db_map_.contains(pev_it->second))
           {
             String& dpv = pv_db_map_[pev_it->second];
             DBSequence& db = db_sq_map_[dpv];

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -250,7 +250,7 @@ namespace OpenMS::Internal
         to_ignore.insert("peptideSequence");
       }
 
-      if (to_ignore.find(tag_) != to_ignore.end())
+      if (to_ignore.contains(tag_))
       {
         return;
       }
@@ -423,7 +423,7 @@ namespace OpenMS::Internal
       tag_ = sm_.convert(qname);
       open_tags_.pop_back();
 
-      if (to_ignore.find(tag_) != to_ignore.end())
+      if (to_ignore.contains(tag_))
       {
         return;
       }
@@ -719,7 +719,7 @@ namespace OpenMS::Internal
           sdat_id = "SDAT_" + String(UniqueIdGenerator::getUniqueId());
 
           FileTypes::Type type = FileHandler::getTypeByFileName(sdat_file);
-          if (formats_map.find(type) == formats_map.end()) type = FileTypes::MZML; // default
+          if (!formats_map.contains(type)) type = FileTypes::MZML; // default
 
           //xml
           spectra_data += String("\t\t<SpectraData location=\"") + sdat_file + String("\" id=\"") + sdat_id + String("\">");
@@ -869,7 +869,7 @@ namespace OpenMS::Internal
 
         if (is_ppxl)
         {
-          if (ppxl_specref_2_element.find(sid)==ppxl_specref_2_element.end())
+          if (!ppxl_specref_2_element.contains(sid))
           {
             ppxl_specref_2_element[sid] = sidres;
           }
@@ -1553,12 +1553,12 @@ namespace OpenMS::Internal
         // Otherwise fall through to the dedicated alias branches below (e.g. Mascot/OMSSA), which would
         // otherwise be unreachable for score types that happen to be valid (non-score) PSI-MS term names.
         if (const auto* term = cv_.checkAndGetTermByName(st);
-            term != nullptr && peptide_result_details_.find(term->id) != peptide_result_details_.end())
+            term != nullptr && peptide_result_details_.contains(term->id))
         {
           (sii_tmp += "\t\t\t\t\t") += term->toXMLString(cv_ns, sc);
           copy_hit.removeMetaValue(term->id);
         }
-        else if (cv_.exists(st) && peptide_result_details_.find(st) != peptide_result_details_.end())
+        else if (cv_.exists(st) && peptide_result_details_.contains(st))
         {
           const auto& term = cv_.getTerm(st);
           (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);
@@ -2198,12 +2198,12 @@ namespace OpenMS::Internal
       // Only consume the score type here if it maps to a PSM-level search-engine statistic (MS:1001143 subtree);
       // otherwise fall through to the dedicated alias branches below.
       if (const auto* term = cv_.checkAndGetTermByName(st);
-          term != nullptr && peptide_result_details_.find(term->id) != peptide_result_details_.end())
+          term != nullptr && peptide_result_details_.contains(term->id))
       {
         (sii_tmp += "\t\t\t\t\t") += term->toXMLString(cv_ns, sc);
         copy_hit.removeMetaValue(term->id);
       }
-      else if (cv_.exists(st) && peptide_result_details_.find(st) != peptide_result_details_.end())
+      else if (cv_.exists(st) && peptide_result_details_.contains(st))
       {
         const auto& term = cv_.getTerm(st);
         (sii_tmp += "\t\t\t\t\t") += term.toXMLString(cv_ns, sc);

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -788,7 +788,7 @@ namespace OpenMS::Internal
         String source_file_ref;
         if (optionalAttributeAsString_(source_file_ref, attributes, s_source_file_ref))
         {
-          if (source_files_.find(source_file_ref) != source_files_.end())
+          if (source_files_.contains(source_file_ref))
           {
             spec_.setSourceFile(source_files_[source_file_ref]);
           }
@@ -3497,7 +3497,7 @@ namespace OpenMS::Internal
 
       for (std::vector<String>::iterator key = keys.begin(); key != keys.end(); ++key)
       {
-        if (exclude.count(*key)) continue; // skip excluded entries
+        if (exclude.contains(*key)) continue; // skip excluded entries
 
         // special treatment of GO and BTO terms
         // <cvParam cvRef="BTO" accession="BTO:0000199" name="cardiac muscle"/>
@@ -4139,63 +4139,63 @@ namespace OpenMS::Internal
       {
         ++file_content[exp[i].getInstrumentSettings().getScanMode()];
       }
-      if (file_content.find(InstrumentSettings::ScanMode::MASSSPECTRUM) != file_content.end())
+      if (file_content.contains(InstrumentSettings::ScanMode::MASSSPECTRUM))
       {
         os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000294\" name=\"mass spectrum\" />\n";
       }
-      if (file_content.find(InstrumentSettings::ScanMode::MS1SPECTRUM) != file_content.end())
+      if (file_content.contains(InstrumentSettings::ScanMode::MS1SPECTRUM))
       {
         os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000579\" name=\"MS1 spectrum\" />\n";
       }
-      if (file_content.find(InstrumentSettings::ScanMode::MSNSPECTRUM) != file_content.end())
+      if (file_content.contains(InstrumentSettings::ScanMode::MSNSPECTRUM))
       {
         os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000580\" name=\"MSn spectrum\" />\n";
       }
-      if (file_content.find(InstrumentSettings::ScanMode::SIM) != file_content.end())
+      if (file_content.contains(InstrumentSettings::ScanMode::SIM))
       {
         os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000582\" name=\"SIM spectrum\" />\n";
       }
-      if (file_content.find(InstrumentSettings::ScanMode::SRM) != file_content.end())
+      if (file_content.contains(InstrumentSettings::ScanMode::SRM))
       {
         os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000583\" name=\"SRM spectrum\" />\n";
       }
-      if (file_content.find(InstrumentSettings::ScanMode::CRM) != file_content.end())
+      if (file_content.contains(InstrumentSettings::ScanMode::CRM))
       {
         os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000581\" name=\"CRM spectrum\" />\n";
       }
-      if (file_content.find(InstrumentSettings::ScanMode::PRECURSOR) != file_content.end())
+      if (file_content.contains(InstrumentSettings::ScanMode::PRECURSOR))
       {
         os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000341\" name=\"precursor ion spectrum\" />\n";
       }
-      if (file_content.find(InstrumentSettings::ScanMode::CNG) != file_content.end())
+      if (file_content.contains(InstrumentSettings::ScanMode::CNG))
       {
         os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000325\" name=\"constant neutral gain spectrum\" />\n";
       }
-      if (file_content.find(InstrumentSettings::ScanMode::CNL) != file_content.end())
+      if (file_content.contains(InstrumentSettings::ScanMode::CNL))
       {
         os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000326\" name=\"constant neutral loss spectrum\" />\n";
       }
-      if (file_content.find(InstrumentSettings::ScanMode::EMR) != file_content.end())
+      if (file_content.contains(InstrumentSettings::ScanMode::EMR))
       {
         os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000804\" name=\"electromagnetic radiation spectrum\" />\n";
       }
-      if (file_content.find(InstrumentSettings::ScanMode::EMISSION) != file_content.end())
+      if (file_content.contains(InstrumentSettings::ScanMode::EMISSION))
       {
         os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000805\" name=\"emission spectrum\" />\n";
       }
-      if (file_content.find(InstrumentSettings::ScanMode::ABSORPTION) != file_content.end())
+      if (file_content.contains(InstrumentSettings::ScanMode::ABSORPTION))
       {
         os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000806\" name=\"absorption spectrum\" />\n";
       }
-      if (file_content.find(InstrumentSettings::ScanMode::EMC) != file_content.end())
+      if (file_content.contains(InstrumentSettings::ScanMode::EMC))
       {
         os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000789\" name=\"enhanced multiply charged spectrum\" />\n";
       }
-      if (file_content.find(InstrumentSettings::ScanMode::TDF) != file_content.end())
+      if (file_content.contains(InstrumentSettings::ScanMode::TDF))
       {
         os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000790\" name=\"time-delayed fragmentation spectrum\" />\n";
       }
-      if (file_content.find(InstrumentSettings::ScanMode::UNKNOWN) != file_content.end() || file_content.empty())
+      if (file_content.contains(InstrumentSettings::ScanMode::UNKNOWN) || file_content.empty())
       {
         os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000294\" name=\"mass spectrum\" />\n";
       }

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
@@ -127,7 +127,7 @@ namespace OpenMS::Internal
         Size id_orig = sqlite3_column_int( stmt, 0 );
 
         // map the sql table id to the index in the "containers" vector
-        if (sql_container_map.find(id_orig) == sql_container_map.end())
+        if (!sql_container_map.contains(id_orig))
         {
           Size tmp = sql_container_map.size();
           sql_container_map[id_orig] = tmp;

--- a/src/openms/source/FORMAT/HANDLERS/PASEFHillCentroider.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/PASEFHillCentroider.cpp
@@ -269,7 +269,7 @@ namespace OpenMS::Internal::PASEFHillCentroider
           for (int tidx : it->second)
           {
             if (tidx < 0 || static_cast<Size>(tidx) >= tails.size()) continue;
-            if (claimed_tail_idx.count(tidx)) continue;
+            if (claimed_tail_idx.contains(tidx)) continue;
             const auto& t = tails[static_cast<Size>(tidx)];
             const double dppm = std::abs(mz_cur - t.mz) / mz_cur * 1e6;
             if (dppm > mz_tol_ppm) continue;

--- a/src/openms/source/FORMAT/HANDLERS/TraMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/TraMLHandler.cpp
@@ -83,7 +83,7 @@ namespace OpenMS::Internal
       }
 
       // skip tags where nothing is to do
-      if (tags_to_ignore.find(tag_) != tags_to_ignore.end())
+      if (tags_to_ignore.contains(tag_))
       {
         return;
       }
@@ -327,7 +327,7 @@ namespace OpenMS::Internal
       }
 
       // skip tags where nothing is to do
-      if (tags_to_ignore.find(tag_) != tags_to_ignore.end())
+      if (tags_to_ignore.contains(tag_))
       {
         return;
       }

--- a/src/openms/source/FORMAT/HANDLERS/XQuestResultXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XQuestResultXMLHandler.cpp
@@ -138,7 +138,7 @@ namespace OpenMS::Internal
         PeptideEvidence pep_ev;
         const String& accession = *prot_list_it;
 
-        if (this->accessions_.find(accession) == this->accessions_.end())
+        if (!this->accessions_.contains(accession))
         {
           this->accessions_.insert(accession);
 

--- a/src/openms/source/FORMAT/IdXMLFile.cpp
+++ b/src/openms/source/FORMAT/IdXMLFile.cpp
@@ -516,7 +516,7 @@ namespace OpenMS
 
       //search parameters
       String ref = attributeAsString_(attributes, "search_parameters_ref");
-      if (parameters_.find(ref) == parameters_.end())
+      if (!parameters_.contains(ref))
       {
         fatalError(LOAD, String("Invalid search parameters reference '") + ref + "'");
       }

--- a/src/openms/source/FORMAT/InspectInfile.cpp
+++ b/src/openms/source/FORMAT/InspectInfile.cpp
@@ -258,7 +258,7 @@ namespace OpenMS
             PTMXMLFile().load(modifications_filename, ptm_informations);
           }
           // if the modification cannot be found
-          if (ptm_informations.find(mod_parts.front()) != ptm_informations.end())
+          if (ptm_informations.contains(mod_parts.front()))
           {
             mass = ptm_informations[mod_parts.front()].first; // composition
             residues = ptm_informations[mod_parts.front()].second; // residues
@@ -335,7 +335,7 @@ namespace OpenMS
         {
           type = mod_parts.front();
           type.toUpper();
-          if (types.find(type) != String::npos)
+          if (types.contains(type))
           {
             mod_parts.erase(mod_parts.begin());
           }
@@ -365,7 +365,7 @@ namespace OpenMS
         }
 
         // insert the modification
-        if (PTMname_residues_mass_type_.find(name) == PTMname_residues_mass_type_.end())
+        if (!PTMname_residues_mass_type_.contains(name))
         {
           PTMname_residues_mass_type_[name] = vector<String>(3);
           PTMname_residues_mass_type_[name][0] = residues;

--- a/src/openms/source/FORMAT/InspectOutfile.cpp
+++ b/src/openms/source/FORMAT/InspectOutfile.cpp
@@ -182,7 +182,7 @@ namespace OpenMS
 
       // map the database position of the protein to its position in the
       // protein hits and insert it, if it's a new protein
-      if (rn_position_map.find(record_number) == rn_position_map.end())
+      if (!rn_position_map.contains(record_number))
       {
         rn_position_map[record_number] = protein_identification.getHits().size();
         protein_identification.insertHit(protein_hit);

--- a/src/openms/source/FORMAT/MSExperimentArrowExport.cpp
+++ b/src/openms/source/FORMAT/MSExperimentArrowExport.cpp
@@ -47,7 +47,7 @@ bool passesMSLevelFilter(const MSSpectrum& spec,
                          const std::unordered_set<UInt>& ms_levels_set)
 {
   if (ms_levels_set.empty()) return true;
-  return ms_levels_set.find(spec.getMSLevel()) != ms_levels_set.end();
+  return ms_levels_set.contains(spec.getMSLevel());
 }
 
 /// Get iterator range for RT-filtered spectra using binary search

--- a/src/openms/source/FORMAT/MSPFile.cpp
+++ b/src/openms/source/FORMAT/MSPFile.cpp
@@ -183,7 +183,7 @@ namespace OpenMS
               mod_split[i].split(',', single_mod);
 
               String mod_name = single_mod[2];
-              if (modname_to_unimod.find(mod_name) != modname_to_unimod.end())
+              if (modname_to_unimod.contains(mod_name))
               {
                 mod_name = modname_to_unimod[mod_name];
               }

--- a/src/openms/source/FORMAT/MSstatsFile.cpp
+++ b/src/openms/source/FORMAT/MSstatsFile.cpp
@@ -121,7 +121,7 @@ void MSstatsFile::constructFile_(const String& retention_time_summarization_meth
       set<MSstatsFile::Intensity> intensities{};
       for (const auto &p : line.second)
       {
-        if (retention_times.find(get<1>(p)) != retention_times.end())
+        if (retention_times.contains(get<1>(p)))
         {
           OPENMS_LOG_WARN << "Peptide ion appears multiple times at the same retention time."
                              " This is not expected."
@@ -751,7 +751,7 @@ void MSstatsFile::assembleRunMap_(
   for (ExperimentalDesign::MSFileSectionEntry const& r : msfile_section)
   {
     std::pair< String, unsigned> tpl = std::make_pair(File::basename(r.path), r.fraction);
-    if (run_map.find(tpl) == run_map.end())
+    if (!run_map.contains(tpl))
     {
       run_map[tpl] = run_counter++;
     }

--- a/src/openms/source/FORMAT/MascotRemoteQuery.cpp
+++ b/src/openms/source/FORMAT/MascotRemoteQuery.cpp
@@ -266,15 +266,15 @@ namespace OpenMS
 
     if (hasError()) return;
 
-    if (response.find("Logged in successfu") != string::npos)
+    if (response.contains("Logged in successfu"))
     {
       OPENMS_LOG_INFO << "Login successful!" << std::endl;
     }
-    else if (response.find("Error: You have entered an invalid password") != string::npos)
+    else if (response.contains("Error: You have entered an invalid password"))
     {
       error_message_ = "Error: You have entered an invalid password";
     }
-    else if (response.find("is not a valid user") != string::npos)
+    else if (response.contains("is not a valid user"))
     {
       error_message_ = "Error: Username is not valid";
     }
@@ -311,7 +311,7 @@ namespace OpenMS
     if (hasError()) return;
 
     // Check for "Click here to see Search Report"
-    if (response.find("Click here to see Search Report") == string::npos)
+    if (!response.contains("Click here to see Search Report"))
     {
       // Check for Mascot error codes
       regex mascot_error_regex(R"(\[M[0-9]{5}\])");
@@ -363,7 +363,7 @@ namespace OpenMS
     if (hasError()) return;
 
     // Check if this is a decoy response
-    if (xml_response.find("<decoy>") != string::npos)
+    if (xml_response.contains("<decoy>"))
     {
       mascot_decoy_xml_ = std::move(xml_response);
       return;
@@ -393,8 +393,8 @@ namespace OpenMS
     if (hasError()) return {};
 
     // Handle Mascot 2.4 continuation links (these are in-body HTML, NOT HTTP redirects)
-    while (response.find("Finished after") != string::npos &&
-           response.find("<a id=\"continuation-link\"") != string::npos)
+    while (response.contains("Finished after") &&
+           response.contains("<a id=\"continuation-link\""))
     {
       regex rx(R"xx(<a id="continuation-link" href="(.*?)")xx");
       smatch match;

--- a/src/openms/source/FORMAT/MzTabFile.cpp
+++ b/src/openms/source/FORMAT/MzTabFile.cpp
@@ -3318,7 +3318,7 @@ namespace OpenMS
         tmp_out.addLine("\n");
         ++line;
       }
-      else if (comment_rows.find(line) != comment_rows.end()) // check if current line was originally a comment line
+      else if (comment_rows.contains(line)) // check if current line was originally a comment line
       {
         tmp_out.addLine(comment_rows[line]);
         ++line;

--- a/src/openms/source/FORMAT/MzTabM.cpp
+++ b/src/openms/source/FORMAT/MzTabM.cpp
@@ -364,7 +364,7 @@ namespace OpenMS
 
     for (const auto& db : id_data.getDBSearchParams())
     {
-      if (db.database.find("custom") != std::string::npos) // custom database
+      if (db.database.contains("custom")) // custom database
       {
         meta_db.prefix.setNull(true);
         meta_db.version = MzTabString(db.database_version);
@@ -728,7 +728,7 @@ namespace OpenMS
     {
       adduct_name = (*match_ref->adduct_opt)->getName();
       // M+H;1+ -> [M+H]1+
-      if (adduct_name.find(';') != std::string::npos) // wrong format -> reformat
+      if (adduct_name.contains(';')) // wrong format -> reformat
       {
         String prefix = adduct_name.substr(0, adduct_name.find(';'));
         String suffix = adduct_name.substr(adduct_name.find(';') + 1, adduct_name.size());

--- a/src/openms/source/FORMAT/OMSSAXMLFile.cpp
+++ b/src/openms/source/FORMAT/OMSSAXMLFile.cpp
@@ -127,7 +127,7 @@ namespace OpenMS
           </MSModHit_modtype>
         </MSModHit>
       */
-      if (mods_map_.find(actual_mod_type_.toInt()) != mods_map_.end() && !mods_map_[actual_mod_type_.toInt()].empty())
+      if (mods_map_.contains(actual_mod_type_.toInt()) && !mods_map_[actual_mod_type_.toInt()].empty())
       {
         if (mods_map_[actual_mod_type_.toInt()].size() > 1)
         {
@@ -388,7 +388,7 @@ namespace OpenMS
     set<String> mod_names = mod_set.getVariableModificationNames();
     for (set<String>::const_iterator it = mod_names.begin(); it != mod_names.end(); ++it)
     {
-      if (!(mods_to_num_.find(*it) != mods_to_num_.end()))
+      if (!(mods_to_num_.contains(*it)))
       {
         mods_map_[omssa_mod_num].push_back(ModificationsDB::getInstance()->getModification(*it));
         mods_to_num_[*it] = omssa_mod_num;

--- a/src/openms/source/FORMAT/OSWFile.cpp
+++ b/src/openms/source/FORMAT/OSWFile.cpp
@@ -2053,7 +2053,7 @@ namespace OpenMS
             Sql::extractDouble(stmt, 4),
             Sql::extractDouble(stmt, 5)
           };
-          if (!existing_ids.count(aligned_feature_id))
+          if (!existing_ids.contains(aligned_feature_id))
           {
             new_feature_ids.push_back(aligned_feature_id);
             existing_ids.insert(aligned_feature_id);

--- a/src/openms/source/FORMAT/PEFFFile.cpp
+++ b/src/openms/source/FORMAT/PEFFFile.cpp
@@ -811,7 +811,7 @@ namespace OpenMS
               size_t local_pos = var->position - 1 - start;  // Position within peptide
 
               // Check for conflicting variants at same position
-              if (modified_positions.count(local_pos))
+              if (modified_positions.contains(local_pos))
               {
                 has_conflict = true;
                 break;
@@ -1157,7 +1157,7 @@ namespace OpenMS
             size_t local_pos = var->position - 1 - start;
 
             // Check for conflicting variants at same position
-            if (modified_positions.count(local_pos))
+            if (modified_positions.contains(local_pos))
             {
               has_conflict = true;
               break;
@@ -1757,7 +1757,7 @@ namespace OpenMS
       else if (line[start] == '>')
       {
         // Check if description contains PEFF annotations (backslash keywords)
-        if (line.find('\\') != std::string::npos)
+        if (line.contains('\\'))
         {
           return true;
         }
@@ -2097,7 +2097,7 @@ namespace OpenMS
       const char up = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
       // IUPAC nucleotide ambiguity codes.
       const std::string allowed = "ACGTURYSWKMBDHVN";
-      return allowed.find(up) != std::string::npos;
+      return allowed.contains(up);
     };
 
     // Parse each annotation
@@ -2136,7 +2136,7 @@ namespace OpenMS
       String value = annotation.substr(eq_pos + 1);
 
       // Fix #7: Detect duplicate keys (spec section 3.3.3: same key MUST NOT appear twice)
-      if (seen_keys.count(key))
+      if (seen_keys.contains(key))
       {
         OPENMS_LOG_WARN << "PEFF: Duplicate key '" << key << "' in entry '" << entry.identifier << "'.\n";
       }
@@ -2258,7 +2258,7 @@ namespace OpenMS
             (void)annot_id;
 
             std::vector<String> pos_tokens;
-            if (pos_field.find(',') != String::npos)
+            if (pos_field.contains(','))
             {
               pos_field.split(',', pos_tokens);
             }
@@ -2310,7 +2310,7 @@ namespace OpenMS
 	          if (!parts_check.empty())
 	          {
 	            auto [annot_id, pos_field] = extractAnnotationId(parts_check[0]);
-	            if (pos_field.find(',') != String::npos)
+	            if (pos_field.contains(','))
             {
               std::vector<String> positions;
               pos_field.split(',', positions);
@@ -2709,7 +2709,7 @@ namespace OpenMS
       {
         mod.position = 0;
       }
-      else if (pos_field.find(',') != String::npos)
+      else if (pos_field.contains(','))
       {
         // Take first position; caller will handle expansion
         std::vector<String> positions;

--- a/src/openms/source/FORMAT/ParamCTDFile.cpp
+++ b/src/openms/source/FORMAT/ParamCTDFile.cpp
@@ -111,22 +111,22 @@ namespace OpenMS
             os << param_it->value.toString() << R"(" type="double")";
             break;
           case ParamValue::STRING_VALUE:
-            if (tag_list.find(TOPPBase::TAG_INPUT_FILE) != tag_list.end())
+            if (tag_list.contains(TOPPBase::TAG_INPUT_FILE))
             {
               os << escapeXML(param_it->value.toString()) << R"(" type="input-file")";
               tag_list.erase(TOPPBase::TAG_INPUT_FILE);
             }
-            else if (tag_list.find(TOPPBase::TAG_OUTPUT_FILE) != tag_list.end())
+            else if (tag_list.contains(TOPPBase::TAG_OUTPUT_FILE))
             {
               os << escapeXML(param_it->value.toString()) << R"(" type="output-file")";
               tag_list.erase(TOPPBase::TAG_OUTPUT_FILE);
             }
-            else if (tag_list.find(TOPPBase::TAG_OUTPUT_DIR) != tag_list.end())
+            else if (tag_list.contains(TOPPBase::TAG_OUTPUT_DIR))
             {
               os << escapeXML(param_it->value.toString()) << R"(" type="output-dir")";
               tag_list.erase(TOPPBase::TAG_OUTPUT_DIR);
             }
-            else if (tag_list.find(TOPPBase::TAG_OUTPUT_PREFIX) != tag_list.end())
+            else if (tag_list.contains(TOPPBase::TAG_OUTPUT_PREFIX))
             {
               os << escapeXML(param_it->value.toString()) << R"(" type="output-prefix")";
               tag_list.erase(TOPPBase::TAG_OUTPUT_PREFIX);
@@ -139,7 +139,7 @@ namespace OpenMS
             else
             {
               std::string value = param_it->value.toString();
-              if (value.find('\t') != std::string::npos)
+              if (value.contains('\t'))
               {
                 replace(value, '\t', "&#x9;");
               }
@@ -147,12 +147,12 @@ namespace OpenMS
             }
             break;
           case ParamValue::STRING_LIST:
-            if (tag_list.find(TOPPBase::TAG_INPUT_FILE) != tag_list.end())
+            if (tag_list.contains(TOPPBase::TAG_INPUT_FILE))
             {
               os << R"(" type="input-file")";
               tag_list.erase(TOPPBase::TAG_INPUT_FILE);
             }
-            else if (tag_list.find(TOPPBase::TAG_OUTPUT_FILE) != tag_list.end())
+            else if (tag_list.contains(TOPPBase::TAG_OUTPUT_FILE))
             {
               os << R"(" type="output-file")";
               tag_list.erase(TOPPBase::TAG_OUTPUT_FILE);
@@ -177,7 +177,7 @@ namespace OpenMS
 
         os << " description=\"" << escapeXML(description) << "\"";
 
-        if (tag_list.find("required") != tag_list.end())
+        if (tag_list.contains("required"))
         {
           os << R"( required="true")";
           tag_list.erase("required");
@@ -187,7 +187,7 @@ namespace OpenMS
           os << R"( required="false")";
         }
 
-        if (tag_list.find("advanced") != tag_list.end())
+        if (tag_list.contains("advanced"))
         {
           os << R"( advanced="true")";
           tag_list.erase("advanced");
@@ -269,7 +269,7 @@ namespace OpenMS
 
           if (!restrictions.empty())
           {
-            if (param_it->tags.find("input file") != param_it->tags.end() || param_it->tags.find("output file") != param_it->tags.end() || param_it->tags.find("output prefix") != param_it->tags.end())
+            if (param_it->tags.contains("input file") || param_it->tags.contains("output file") || param_it->tags.contains("output prefix"))
             {
               os << " supported_formats=\"" << escapeXML(restrictions) << "\"";
             }
@@ -294,7 +294,7 @@ namespace OpenMS
           case ParamValue::STRING_LIST:
             for (auto item : static_cast<const std::vector<std::string>&>(param_it->value))
             {
-              if (item.find('\t') != std::string::npos)
+              if (item.contains('\t'))
               {
                 replace(item, '\t', "&#x9;");
               }
@@ -340,15 +340,15 @@ namespace OpenMS
   std::string ParamCTDFile::escapeXML(const std::string& to_escape)
   {
     std::string copy = to_escape;
-    if (copy.find('&') != std::string::npos)
+    if (copy.contains('&'))
       replace(copy, '&', "&amp;");
-    if (copy.find('>') != std::string::npos)
+    if (copy.contains('>'))
       replace(copy, '>', "&gt;");
-    if (copy.find('"') != std::string::npos)
+    if (copy.contains('"'))
       replace(copy, '"', "&quot;");
-    if (copy.find('<') != std::string::npos)
+    if (copy.contains('<'))
       replace(copy, '<', "&lt;");
-    if (copy.find('\'') != std::string::npos)
+    if (copy.contains('\''))
       replace(copy, '\'', "&apos;");
 
     return copy;

--- a/src/openms/source/FORMAT/ParamJSONFile.cpp
+++ b/src/openms/source/FORMAT/ParamJSONFile.cpp
@@ -97,10 +97,10 @@ namespace OpenMS
             {
               value = node.get<bool>() ? "true" : "false";
             }
-            else if (entry.tags.count("input file"))
+            else if (entry.tags.contains("input file"))
             {
               // If this is an input file and 'is_executable' is set. this can be of 'class: File' or 'type: string'
-              if (entry.tags.count("is_executable"))
+              if (entry.tags.contains("is_executable"))
               {
                 if (node.is_object())
                 {
@@ -132,7 +132,7 @@ namespace OpenMS
           }
           else if (entry.value.valueType() == ParamValue::ValueType::STRING_LIST)
           {
-            if (entry.tags.count("input file"))
+            if (entry.tags.contains("input file"))
             {
               value = node["path"].get<std::vector<std::string>>();
             }
@@ -265,7 +265,7 @@ namespace OpenMS
             {
                 node = param_it->value.toBool();
             } else {
-                if (tags.count("file") > 0 && tags.count("output") == 0) {
+                if (tags.contains("file") && !tags.contains("output")) {
                     node["class"] = "File";
                     node["path"] = param_it->value.toString();
                 } else {
@@ -280,7 +280,7 @@ namespace OpenMS
             node = param_it->value.toDoubleVector();
             break;
           case ParamValue::STRING_LIST:
-            if (tags.count("file") > 0 && tags.count("output") == 0) {
+            if (tags.contains("file") && !tags.contains("output")) {
                 node["class"] = "File";
                 node["path"] = param_it->value.toStringVector();
             } else {

--- a/src/openms/source/FORMAT/ParamXMLFile.cpp
+++ b/src/openms/source/FORMAT/ParamXMLFile.cpp
@@ -111,17 +111,17 @@ namespace OpenMS
           break;
 
         case ParamValue::STRING_VALUE:
-          if (tag_list.find("input file") != tag_list.end())
+          if (tag_list.contains("input file"))
           {
             os << indentation << "<ITEM name=\"" << writeXMLEscape(it->name) << "\" value=\"" << writeXMLEscape(it->value.toString()) << R"(" type="input-file")";
             tag_list.erase("input file");
           }
-          else if (tag_list.find("output file") != tag_list.end())
+          else if (tag_list.contains("output file"))
           {
             os << indentation << "<ITEM name=\"" << writeXMLEscape(it->name) << "\" value=\"" << writeXMLEscape(it->value.toString()) << R"(" type="output-file")";
             tag_list.erase("output file");
           }
-          else if (tag_list.find("output prefix") != tag_list.end())
+          else if (tag_list.contains("output prefix"))
           {
             os << indentation << "<ITEM name=\"" << writeXMLEscape(it->name) << "\" value=\"" << writeXMLEscape(it->value.toString()) << R"(" type="output-prefix")";
             tag_list.erase("output prefix");
@@ -141,12 +141,12 @@ namespace OpenMS
           break;
 
         case ParamValue::STRING_LIST:
-          if (tag_list.find("input file") != tag_list.end())
+          if (tag_list.contains("input file"))
           {
             os << indentation << "<ITEMLIST name=\"" << writeXMLEscape(it->name) << R"(" type="input-file")";
             tag_list.erase("input file");
           }
-          else if (tag_list.find("output file") != tag_list.end())
+          else if (tag_list.contains("output file"))
           {
             os << indentation << "<ITEMLIST name=\"" << writeXMLEscape(it->name) << R"(" type="output-file")";
             tag_list.erase("output file");
@@ -178,7 +178,7 @@ namespace OpenMS
         os << " description=\"" << writeXMLEscape(d) << "\"";
 
         // required
-        if (tag_list.find("required") != tag_list.end())
+        if (tag_list.contains("required"))
         {
           os << " required=\"true\"";
           tag_list.erase("required");
@@ -189,7 +189,7 @@ namespace OpenMS
         }
 
         // advanced
-        if (tag_list.find("advanced") != tag_list.end())
+        if (tag_list.contains("advanced"))
         {
           os << " advanced=\"true\"";
           tag_list.erase("advanced");
@@ -273,9 +273,9 @@ namespace OpenMS
           // for files we store the restrictions as supported_formats
           if (!restrictions.empty())
           {
-            if (it->tags.find("input file") != it->tags.end() 
-              || it->tags.find("output file") != it->tags.end()
-              || it->tags.find("output prefix") != it->tags.end())
+            if (it->tags.contains("input file") 
+              || it->tags.contains("output file")
+              || it->tags.contains("output prefix"))
             {
               os << " supported_formats=\"" << writeXMLEscape(restrictions) << "\"";
             }

--- a/src/openms/source/FORMAT/PepNovoOutfile.cpp
+++ b/src/openms/source/FORMAT/PepNovoOutfile.cpp
@@ -100,7 +100,7 @@ namespace OpenMS
       if (mod_it.empty())
         continue;
       //cout<<*mod_it<<endl;
-      if (pnovo_modkey_to_mod_id.find(mod_it) != pnovo_modkey_to_mod_id.end())
+      if (pnovo_modkey_to_mod_id.contains(mod_it))
       {
         //cout<<keys_to_id.find(*mod_it)->second<<endl;
         const ResidueModification* tmp_mod = ModificationsDB::getInstance()->getModification(pnovo_modkey_to_mod_id.find(mod_it)->second);
@@ -167,7 +167,7 @@ namespace OpenMS
         bool success = false;
         if (!index_to_precursor.empty())
         {
-          if (index_to_precursor.find(index) != index_to_precursor.end())
+          if (index_to_precursor.contains(index))
           {
             peptide_identification.setRT(index_to_precursor.find(index)->second.first);
             peptide_identification.setMZ(index_to_precursor.find(index)->second.second);

--- a/src/openms/source/FORMAT/PercolatorInfile.cpp
+++ b/src/openms/source/FORMAT/PercolatorInfile.cpp
@@ -124,7 +124,7 @@ namespace OpenMS
         annos.getRow(i, row);
         
         //Check if mapping already has PSM, if it does add 
-        if (anno_mapping.find(row[to_idx_a.at("psm_id")].toInt()) == anno_mapping.end())
+        if (!anno_mapping.contains(row[to_idx_a.at("psm_id")].toInt()))
         {                 
           //Make a new vector of annotations 
           PeptideHit::PeakAnnotation peak_temp; 
@@ -244,7 +244,7 @@ namespace OpenMS
       if (file_name_column_index >= 0)
       {
         raw_file_name = row[file_name_column_index];
-        if (map_filename_to_idx.find(raw_file_name) == map_filename_to_idx.end())
+        if (!map_filename_to_idx.contains(raw_file_name))
         {
           filenames.push_back(raw_file_name);
           map_filename_to_idx[raw_file_name] = filenames.size() - 1;
@@ -370,7 +370,7 @@ namespace OpenMS
       // add annotations
       if (SageAnnotation)
       {
-        if (anno_mapping.find(sSpecId.toInt()) != anno_mapping.end())
+        if (anno_mapping.contains(sSpecId.toInt()))
         {
           // copy annotations from mapping to PeptideHit
           vector<PeptideHit::PeakAnnotation> pep_vec;
@@ -554,7 +554,7 @@ namespace OpenMS
       const auto& hits = stamped[pid_idx].getHits();
       for (size_t hit_idx = 0; hit_idx < hits.size(); ++hit_idx)
       {
-        if (skipped.count({pid_idx, hit_idx})) continue;
+        if (skipped.contains({pid_idx, hit_idx})) continue;
         const PeptideHit& hit = hits[hit_idx];
 
         StringList feats;

--- a/src/openms/source/FORMAT/ProteinIdentificationArrowIO.cpp
+++ b/src/openms/source/FORMAT/ProteinIdentificationArrowIO.cpp
@@ -58,7 +58,7 @@ namespace // anonymous
     mii.getKeys(keys);
     for (const auto& key : keys)
     {
-      if (excluded_keys.count(key)) continue;
+      if (excluded_keys.contains(key)) continue;
       const DataValue& val = mii.getMetaValue(key);
       (void)struct_b->Append();
       (void)name_b->Append(key);

--- a/src/openms/source/FORMAT/QPXFile.cpp
+++ b/src/openms/source/FORMAT/QPXFile.cpp
@@ -309,7 +309,7 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
               acc_str = "UNIMOD:" + std::to_string(mod->getUniModRecordId());
             }
             std::string pos_str = std::string(residue.getOneLetterCode()) + "." + std::to_string(pos + 1);
-            if (mod_map.find(name) == mod_map.end())
+            if (!mod_map.contains(name))
             {
               mod_map[name] = {acc_str, {}};
             }
@@ -328,7 +328,7 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
             acc_str = "UNIMOD:" + std::to_string(mod->getUniModRecordId());
           }
           std::string pos_str = "C-term." + std::to_string(seq.size() + 1);
-          if (mod_map.find(name) == mod_map.end())
+          if (!mod_map.contains(name))
           {
             mod_map[name] = {acc_str, {}};
           }
@@ -418,7 +418,7 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
         hit.getKeys(keys);
         for (const auto& key : keys)
         {
-          if (excluded_hit_mvs_psm.count(key)) continue;
+          if (excluded_hit_mvs_psm.contains(key)) continue;
           const DataValue& val = hit.getMetaValue(key);
           if ((val.valueType() == DataValue::INT_VALUE || val.valueType() == DataValue::DOUBLE_VALUE)
               && Scores::isKnownScoreType(key))
@@ -568,7 +568,7 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
         hit.getKeys(keys);
         for (const auto& key : keys)
         {
-          if (excluded_hit_mvs_psm.count(key)) continue;
+          if (excluded_hit_mvs_psm.contains(key)) continue;
           const DataValue& val = hit.getMetaValue(key);
           // Skip known scores (already in additional_scores)
           if ((val.valueType() == DataValue::INT_VALUE || val.valueType() == DataValue::DOUBLE_VALUE)
@@ -981,7 +981,7 @@ std::shared_ptr<arrow::Table> QPXFile::exportPSMsToQPXArrow(
             {
               acc_str = "UNIMOD:" + std::to_string(mod->getUniModRecordId());
             }
-            if (mod_map.find(name) == mod_map.end())
+            if (!mod_map.contains(name))
             {
               mod_map[name] = {acc_str, {}};
             }
@@ -999,7 +999,7 @@ std::shared_ptr<arrow::Table> QPXFile::exportPSMsToQPXArrow(
           {
             acc_str = "UNIMOD:" + std::to_string(mod->getUniModRecordId());
           }
-          if (mod_map.find(name) == mod_map.end())
+          if (!mod_map.contains(name))
           {
             mod_map[name] = {acc_str, {}};
           }
@@ -1098,7 +1098,7 @@ std::shared_ptr<arrow::Table> QPXFile::exportPSMsToQPXArrow(
         hit.getKeys(keys);
         for (const auto& key : keys)
         {
-          if (excluded_hit_mvs.count(key)) continue;
+          if (excluded_hit_mvs.contains(key)) continue;
           const DataValue& val = hit.getMetaValue(key);
           if ((val.valueType() == DataValue::INT_VALUE || val.valueType() == DataValue::DOUBLE_VALUE)
               && Scores::isKnownScoreType(key))

--- a/src/openms/source/FORMAT/QcMLFile.cpp
+++ b/src/openms/source/FORMAT/QcMLFile.cpp
@@ -793,7 +793,7 @@ namespace OpenMS
       to_ignore.insert("binary"); // ...
     }
 
-    if (to_ignore.find(tag_) != to_ignore.end())
+    if (to_ignore.contains(tag_))
     {
       return;
     }
@@ -920,7 +920,7 @@ namespace OpenMS
     //close current tag
     open_tags_.pop_back();
 
-    if (to_ignore.find(tag_) != to_ignore.end())
+    if (to_ignore.contains(tag_))
     {
       return;
     }

--- a/src/openms/source/FORMAT/RationalScan2ImConverter.cpp
+++ b/src/openms/source/FORMAT/RationalScan2ImConverter.cpp
@@ -185,7 +185,7 @@ namespace OpenMS
           frame_to_cal[frame_id] = cal_id;
 
           // Verify calibration ID exists
-          if (calibrations.find(cal_id) == calibrations.end())
+          if (!calibrations.contains(cal_id))
           {
             OPENMS_LOG_WARN << "Frame " << frame_id
                             << " references unknown TimsCalibration Id=" << cal_id

--- a/src/openms/source/FORMAT/SVOutStream.cpp
+++ b/src/openms/source/FORMAT/SVOutStream.cpp
@@ -59,7 +59,7 @@ namespace OpenMS
 
   SVOutStream& SVOutStream::operator<<(String str)
   {
-    if (str.find('\n') != String::npos)
+    if (str.contains('\n'))
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "argument must not contain newline characters");
     }

--- a/src/openms/source/FORMAT/SequestInfile.cpp
+++ b/src/openms/source/FORMAT/SequestInfile.cpp
@@ -771,7 +771,7 @@ namespace OpenMS
             PTMXMLFile().load(modifications_filename, ptm_informations);
           }
           // if the modification cannot be found
-          if (ptm_informations.find(mod_parts.front()) != ptm_informations.end())
+          if (ptm_informations.contains(mod_parts.front()))
           {
             mass = ptm_informations[mod_parts.front()].first;             // composition
             residues = ptm_informations[mod_parts.front()].second;             // residues
@@ -848,7 +848,7 @@ namespace OpenMS
         {
           type = mod_parts.front();
           type.toUpper();
-          if (types.find(type) != String::npos)
+          if (types.contains(type))
           {
             mod_parts.erase(mod_parts.begin());
           }
@@ -878,7 +878,7 @@ namespace OpenMS
         }
 
         // insert the modification
-        if (PTMname_residues_mass_type_.find(name) == PTMname_residues_mass_type_.end())
+        if (!PTMname_residues_mass_type_.contains(name))
         {
           PTMname_residues_mass_type_[name] = vector<String>(3);
           PTMname_residues_mass_type_[name][0] = residues;

--- a/src/openms/source/FORMAT/TriqlerFile.cpp
+++ b/src/openms/source/FORMAT/TriqlerFile.cpp
@@ -321,7 +321,7 @@ void TriqlerFile::assembleRunMap_(
   for (ExperimentalDesign::MSFileSectionEntry const& r : msfile_section)
   {
     std::pair< String, unsigned> tpl = std::make_pair(File::basename(r.path), r.fraction);
-    if (run_map.find(tpl) == run_map.end())
+    if (!run_map.contains(tpl))
     {
       run_map[tpl] = run_counter++;
     }

--- a/src/openms/source/FORMAT/VALIDATORS/MzDataValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/MzDataValidator.cpp
@@ -81,7 +81,7 @@ namespace OpenMS::Internal
             if (cv_.exists(parsed_term.unit_accession))
             {
               // check whether this unit is allowed within the cv term
-              if (term.units.find(parsed_term.unit_accession) == term.units.end())
+              if (!term.units.contains(parsed_term.unit_accession))
               {
                 // last chance, a child term of the units was used
                 auto lambda = [&parsed_term] (const String& child)

--- a/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
@@ -324,7 +324,7 @@ namespace OpenMS::Internal
             if (cv_.exists(parsed_term.unit_accession))
             {
               // check whether this unit is allowed within the cv term
-              if (term.units.find(parsed_term.unit_accession) == term.units.end())
+              if (!term.units.contains(parsed_term.unit_accession))
               {
                 // last chance, a child term of the units was used
                 set<String> child_terms;

--- a/src/openms/source/FORMAT/XICParquetFile.cpp
+++ b/src/openms/source/FORMAT/XICParquetFile.cpp
@@ -696,8 +696,8 @@ namespace OpenMS
           cond.column = it->second;
         }
 
-        const bool unsupported_col = unsupported.count(upper_(cond.column)) > 0;
-        const bool exists_in_schema = name_map.find(upper_(cond.column)) != name_map.end();
+        const bool unsupported_col = unsupported.contains(upper_(cond.column));
+        const bool exists_in_schema = name_map.contains(upper_(cond.column));
         if (unsupported_col || !exists_in_schema)
         {
           dropped_columns.push_back(original);
@@ -1604,12 +1604,12 @@ namespace OpenMS
     for (const auto& name : requested_columns)
     {
       const String upper_name = upper_(name);
-      if (allowed_columns.find(upper_name) == allowed_columns.end())
+      if (!allowed_columns.contains(upper_name))
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                       "Unsupported analyte column", name);
       }
-      if (schema_columns.find(upper_name) == schema_columns.end())
+      if (!schema_columns.contains(upper_name))
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                       "Column not found in parquet schema", name);
@@ -1626,7 +1626,7 @@ namespace OpenMS
 
     auto want = [&](const String& name) -> bool
     {
-      return requested_set.find(name) != requested_set.end();
+      return requested_set.contains(name);
     };
 
     auto table = readParquetTableColumns_(filenames_, normalized_columns);

--- a/src/openms/source/FORMAT/XIMParquetFile.cpp
+++ b/src/openms/source/FORMAT/XIMParquetFile.cpp
@@ -784,8 +784,8 @@ namespace OpenMS
           cond.column = it->second;
         }
 
-        const bool unsupported_col = unsupported.count(upper_(cond.column)) > 0;
-        const bool exists_in_schema = name_map.find(upper_(cond.column)) != name_map.end();
+        const bool unsupported_col = unsupported.contains(upper_(cond.column));
+        const bool exists_in_schema = name_map.contains(upper_(cond.column));
         if (unsupported_col || !exists_in_schema)
         {
           dropped_columns.push_back(original);
@@ -1715,12 +1715,12 @@ namespace OpenMS
     for (const auto& name : requested_columns)
     {
       const String upper_name = upper_(name);
-      if (allowed_columns.find(upper_name) == allowed_columns.end())
+      if (!allowed_columns.contains(upper_name))
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                       "Unsupported analyte column", name);
       }
-      if (schema_columns.find(upper_name) == schema_columns.end())
+      if (!schema_columns.contains(upper_name))
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                       "Column not found in parquet schema", name);
@@ -1745,7 +1745,7 @@ namespace OpenMS
       bool has_precursor_discriminator = false;
       for (const auto& key : precursor_discriminators)
       {
-        if (requested_set.find(key) != requested_set.end())
+        if (requested_set.contains(key))
         {
           has_precursor_discriminator = true;
           break;
@@ -1761,7 +1761,7 @@ namespace OpenMS
 
     auto want = [&](const String& name) -> bool
     {
-      return requested_set.find(name) != requested_set.end();
+      return requested_set.contains(name);
     };
 
     auto table = readParquetTableColumns_(filenames_, normalized_columns);

--- a/src/openms/source/FORMAT/XTandemInfile.cpp
+++ b/src/openms/source/FORMAT/XTandemInfile.cpp
@@ -119,13 +119,13 @@ namespace OpenMS
         orig = "[";
       }
       // check double usage
-      if (origin_set.find(orig) != origin_set.end())
+      if (origin_set.contains(orig))
       {
         OPENMS_LOG_WARN << "X! Tandem config file: Duplicate modification assignment to origin '" << orig << "'. "
                  << "X! Tandem will ignore the first modification '" << origin_set.find(orig)->second << "'!\n";
       }
       // check if already used before (i.e. we are currently looking at variable mods)
-      if (affected_origins.find(orig) != affected_origins.end())
+      if (affected_origins.contains(orig))
       {
         OPENMS_LOG_INFO << "X! Tandem config file: Fixed modification and variable modification to origin '" << orig << "' detected. "
                  << "Using corrected mass of " << mod_mass - affected_origins.find(orig)->second << " instead of " << mod_mass << ".\n";
@@ -318,8 +318,8 @@ namespace OpenMS
       }
 
       if (!force_default_mods_ &&
-          (var_mods.find("Gln->pyro-Glu (N-term Q)") != var_mods.end()) &&
-          (var_mods.find("Glu->pyro-Glu (N-term E)") != var_mods.end()))
+          (var_mods.contains("Gln->pyro-Glu (N-term Q)")) &&
+          (var_mods.contains("Glu->pyro-Glu (N-term E)")))
       {
         writeNote_(os, "protein, quick pyrolidone", true);
         OPENMS_LOG_INFO << "Modifications 'Gln->pyro-Glu (N-term Q)' and 'Glu->pyro-Glu (N-term E)' are handled implicitly by the X! Tandem option 'protein, quick pyrolidone'. Set the 'force' flag in XTandemAdapter to force explicit inclusion of these modifications." << endl;
@@ -327,7 +327,7 @@ namespace OpenMS
 
       // special case for "Acetyl (N-term)" modification:
       if (!force_default_mods_ &&
-          (var_mods.find("Acetyl (N-term)") != var_mods.end()))
+          (var_mods.contains("Acetyl (N-term)")))
       {
         writeNote_(os, "protein, quick acetyl", true);
         OPENMS_LOG_INFO << "Modification 'Acetyl (N-term)' is handled implicitly by the X! Tandem option 'protein, quick acetyl'. Set the 'force' flag in XTandemAdapter to force explicit inclusion of this modification." << endl;

--- a/src/openms/source/FORMAT/XTandemXMLFile.cpp
+++ b/src/openms/source/FORMAT/XTandemXMLFile.cpp
@@ -116,7 +116,7 @@ namespace OpenMS
  
       String seq = attributeAsString_(attributes, "seq");
       // is this the same peptide as before, just in a different protein (scores will be the same)?
-      if ((peptide_hits_.find(id) == peptide_hits_.end()) || (seq != previous_seq_))
+      if ((!peptide_hits_.contains(id)) || (seq != previous_seq_))
       {
         PeptideHit hit;
         // can't parse sequences permissively because that would skip characters
@@ -300,7 +300,7 @@ namespace OpenMS
     if (tag_ == "protein")
     {
       UInt uid = attributeAsInt_(attributes, "uid");
-      if (protein_uids_.find(uid) == protein_uids_.end()) // new protein
+      if (!protein_uids_.contains(uid)) // new protein
       {
         ProteinHit hit;
         // accession may be overwritten based on '<note label="description">', but set it for now:

--- a/src/openms/source/IMAGING/MSImagingGeometry.cpp
+++ b/src/openms/source/IMAGING/MSImagingGeometry.cpp
@@ -61,7 +61,7 @@ namespace OpenMS
     }
 
     const UInt64 key = packKey_(x, y);
-    if (lookup_.find(key) != lookup_.end())
+    if (lookup_.contains(key))
     {
       throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                     "Duplicate pixel coordinate",
@@ -74,7 +74,7 @@ namespace OpenMS
 
   bool MSImagingGeometry::hasPixel(UInt x, UInt y) const
   {
-    return lookup_.find(packKey_(x, y)) != lookup_.end();
+    return lookup_.contains(packKey_(x, y));
   }
 
   Size MSImagingGeometry::getSpectrumIndex(UInt x, UInt y) const

--- a/src/openms/source/IONMOBILITY/IMDataConverter.cpp
+++ b/src/openms/source/IONMOBILITY/IMDataConverter.cpp
@@ -354,15 +354,15 @@ namespace OpenMS
 
       if (cv.isChildOf(cv_term.id, "MS:1002893")) // is child of generic 'ion mobility array'?
       {
-        if (cv_term.units.find("MS:1002814") != cv_term.units.end())
+        if (cv_term.units.contains("MS:1002814"))
         { // MS:1002814 ! volt-second per square centimeter
           unit = DriftTimeUnit::VSSC;
         }
-        else if (cv_term.units.find("UO:0000028") != cv_term.units.end())
+        else if (cv_term.units.contains("UO:0000028"))
         { // UO:0000028 ! millisecond
           unit = DriftTimeUnit::MILLISECOND;
         }
-        else if (cv_term.units.find("UO:0000324") != cv_term.units.end())
+        else if (cv_term.units.contains("UO:0000324"))
         { // UO:0000324 ! square angstrom (CCS)
           unit = DriftTimeUnit::CCS;
         }

--- a/src/openms/source/KERNEL/ConsensusMap.cpp
+++ b/src/openms/source/KERNEL/ConsensusMap.cpp
@@ -671,7 +671,7 @@ OPENMS_THREAD_CRITICAL(LOGSTREAM)
       const ConsensusFeature& elem = (*this)[i];
       for (ConsensusFeature::HandleSetType::const_iterator it = elem.begin(); it != elem.end(); ++it)
       {
-        if (column_description_.find(it->getMapIndex()) == column_description_.end())
+        if (!column_description_.contains(it->getMapIndex()))
         {
           ++stats_wrongMID;
           ++wrong_ID_count[it->getMapIndex()];

--- a/src/openms/source/KERNEL/OnDiscMSExperiment.cpp
+++ b/src/openms/source/KERNEL/OnDiscMSExperiment.cpp
@@ -73,7 +73,7 @@ namespace OpenMS
       }
     }
 
-    if (chromatograms_native_ids_.find(id) == chromatograms_native_ids_.end())
+    if (!chromatograms_native_ids_.contains(id))
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
           String("Could not find chromatogram with id '") + id + "'.");
@@ -105,7 +105,7 @@ namespace OpenMS
       }
     }
 
-    if (spectra_native_ids_.find(id) == spectra_native_ids_.end())
+    if (!spectra_native_ids_.contains(id))
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
           String("Could not find spectrum with id '") + id + "'.");

--- a/src/openms/source/METADATA/AbsoluteQuantitationStandards.cpp
+++ b/src/openms/source/METADATA/AbsoluteQuantitationStandards.cpp
@@ -109,7 +109,7 @@ namespace OpenMS
     }
     std::map<String, std::vector<AbsoluteQuantitationStandards::featureConcentration>> components_to_concentrations;
     mapComponentsToConcentrations(filtered_rc, feature_maps, components_to_concentrations);
-    if (components_to_concentrations.count(component_name))
+    if (components_to_concentrations.contains(component_name))
     {
       feature_concentrations = components_to_concentrations.at(component_name);
     }

--- a/src/openms/source/METADATA/CVTermList.cpp
+++ b/src/openms/source/METADATA/CVTermList.cpp
@@ -70,7 +70,7 @@ namespace OpenMS
 
   bool CVTermList::hasCVTerm(const String& accession) const
   {
-    return cv_terms_.find(accession) != cv_terms_.end();
+    return cv_terms_.contains(accession);
   }
 
   bool CVTermList::operator==(const CVTermList& cv_term_list) const

--- a/src/openms/source/METADATA/ExperimentalDesign.cpp
+++ b/src/openms/source/METADATA/ExperimentalDesign.cpp
@@ -624,7 +624,7 @@ namespace OpenMS
     template<typename T>
     void ExperimentalDesign::errorIfAlreadyExists(std::set<T> &container, T &item, const String &message)
     {
-      if (container.find(item) != container.end())
+      if (container.contains(item))
       {
        throw Exception::MissingInformation(
        __FILE__,
@@ -755,7 +755,7 @@ namespace OpenMS
       msfile_section_.erase(std::remove_if(msfile_section_.begin(), msfile_section_.end(),
       [&bns](MSFileSectionEntry& e)
       {
-        return bns.find(File::basename(e.path)) == bns.end();
+        return !bns.contains(File::basename(e.path));
       }), msfile_section_.end());
 
       const Size diff = before - msfile_section_.size();
@@ -852,12 +852,12 @@ namespace OpenMS
 
     bool ExperimentalDesign::SampleSection::hasSample(const String& sample) const
     {
-      return sample_to_rowindex_.find(sample) != sample_to_rowindex_.end();
+      return sample_to_rowindex_.contains(sample);
     }
 
     bool ExperimentalDesign::SampleSection::hasFactor(const String &factor) const
     {
-      return columnname_to_columnindex_.find(factor) != columnname_to_columnindex_.end();
+      return columnname_to_columnindex_.contains(factor);
     }
 
     String ExperimentalDesign::SampleSection::getFactorValue(unsigned sample_idx, const String &factor) const

--- a/src/openms/source/METADATA/ID/IdentificationData.cpp
+++ b/src/openms/source/METADATA/ID/IdentificationData.cpp
@@ -42,7 +42,7 @@ namespace OpenMS
   {
     removeFromSetIf_(container, [&lookup](typename ContainerType::iterator it)
                       {
-                        return !lookup.count(uintptr_t(&(*it)));
+                        return !lookup.contains(uintptr_t(&(*it)));
                       });
   }
 
@@ -102,7 +102,7 @@ namespace OpenMS
       removeFromSetIf_(element.parent_matches,
                         [&](const ParentMatches::iterator it)
                         {
-                          return !lookup.count(it->first);
+                          return !lookup.contains(it->first);
                         });
     }
 
@@ -845,7 +845,7 @@ namespace OpenMS
     }
     removeFromSetIf_(observation_matches_, [&](ObservationMatches::iterator it)
                      {
-                       return !id_vars.count(it->identified_molecule_var);
+                       return !id_vars.contains(it->identified_molecule_var);
                      });
 
     // remove observation matches based on observation match groups:
@@ -897,7 +897,7 @@ namespace OpenMS
       removeFromSetIfNotHashed_(identified_oligos_, identified_oligo_lookup_);
       removeFromSetIf_(adducts_, [&](Adducts::iterator it)
       {
-        return !adduct_refs.count(it);
+        return !adduct_refs.contains(it);
       });
     }
     // update look-up tables of addresses:

--- a/src/openms/source/METADATA/ID/IdentificationDataConverter.cpp
+++ b/src/openms/source/METADATA/ID/IdentificationDataConverter.cpp
@@ -497,7 +497,7 @@ namespace OpenMS
       // generate hits in different ID runs for different processing steps:
       for (const ID::AppliedProcessingStep& applied : parent.steps_and_scores)
       {
-        if (applied.scores.empty() && !steps.count(applied.processing_step_opt))
+        if (applied.scores.empty() && !steps.contains(applied.processing_step_opt))
         {
           continue; // no scores and no associated peptides -> skip
         }
@@ -818,7 +818,7 @@ namespace OpenMS
         ID::ProcessingSoftwareRef sw_ref =
           (*applied.processing_step_opt)->software_ref;
         // mention each search engine only once:
-        if (!sw_refs.count(sw_ref))
+        if (!sw_refs.contains(sw_ref))
         {
           MzTabParameter param;
           param.setName(sw_ref->getName());
@@ -837,7 +837,7 @@ namespace OpenMS
       for (const pair<ID::ScoreTypeRef, double>& score_pair :
              applied.getScoresInOrder())
       {
-        if (!score_map.count(score_pair.first)) // new score type
+        if (!score_map.contains(score_pair.first)) // new score type
         {
           score_map.insert(make_pair(score_pair.first, score_map.size() + 1));
         }

--- a/src/openms/source/METADATA/IdentifierMSRunMapper.cpp
+++ b/src/openms/source/METADATA/IdentifierMSRunMapper.cpp
@@ -81,7 +81,7 @@ namespace OpenMS
 
   bool IdentifierMSRunMapper::hasIdentifier(const String& identifier) const
   {
-    return identifier_to_msrunpath_.find(identifier) != identifier_to_msrunpath_.end();
+    return identifier_to_msrunpath_.contains(identifier);
   }
 
   const String& IdentifierMSRunMapper::getIdentifier(const StringList& ms_run_paths) const
@@ -127,7 +127,7 @@ namespace OpenMS
 
   bool IdentifierMSRunMapper::hasRunPath(const StringList& ms_run_paths) const
   {
-    return runpath_to_identifier_.find(ms_run_paths) != runpath_to_identifier_.end();
+    return runpath_to_identifier_.contains(ms_run_paths);
   }
 
   bool IdentifierMSRunMapper::tryGetIdentifier(const StringList& ms_run_paths, String& identifier) const

--- a/src/openms/source/METADATA/MetaInfo.cpp
+++ b/src/openms/source/METADATA/MetaInfo.cpp
@@ -131,14 +131,14 @@ namespace OpenMS
     UInt index = registry_.getIndex(name);
     if (index != UInt(-1))
     {
-      return (index_to_value_.find(index) != index_to_value_.end());
+      return (index_to_value_.contains(index));
     }
     return false;
   }
 
   bool MetaInfo::exists(UInt index) const
   {
-    return (index_to_value_.find(index) != index_to_value_.end());
+    return (index_to_value_.contains(index));
   }
 
   void MetaInfo::removeValue(const String& name)

--- a/src/openms/source/METADATA/ProteinIdentification.cpp
+++ b/src/openms/source/METADATA/ProteinIdentification.cpp
@@ -351,7 +351,7 @@ namespace OpenMS
     for (const ProteinHit& protein : getHits())
     {
       const String& acc = protein.getAccession();
-      if (groupedAccessions.find(acc) == groupedAccessions.end())
+      if (!groupedAccessions.contains(acc))
       {
         groupedAccessions.insert(acc);
         ProteinGroup pg;
@@ -640,7 +640,7 @@ namespace OpenMS
 
       const String& accession = this->protein_hits_[i].getAccession();
       double coverage = 0.0;
-      if (map_acc_2_evidence.find(accession) != map_acc_2_evidence.end())
+      if (map_acc_2_evidence.contains(accession))
       {
         const set<PeptideEvidence>& evidences = map_acc_2_evidence.find(accession)->second;
         for (const auto & evidence : evidences)
@@ -684,7 +684,7 @@ namespace OpenMS
     for (auto & protein_hit : protein_hits_)
     {
       const String& accession = protein_hit.getAccession();
-      if (prot2mod.find(accession) != prot2mod.end())
+      if (prot2mod.contains(accession))
       {
         protein_hit.setModifications(prot2mod[accession]);
       }
@@ -708,7 +708,7 @@ namespace OpenMS
     for (auto & protein_hit : protein_hits_)
     {
       const String& accession = protein_hit.getAccession();
-      if (prot2mod.find(accession) != prot2mod.end())
+      if (prot2mod.contains(accession))
       {
         protein_hit.setModifications(prot2mod[accession]);
       }

--- a/src/openms/source/ML/CLUSTERING/ClusteringGrid.cpp
+++ b/src/openms/source/ML/CLUSTERING/ClusteringGrid.cpp
@@ -32,7 +32,7 @@ std::vector<double> ClusteringGrid::getGridSpacingY() const
 
 void ClusteringGrid::addCluster(const CellIndex &cell_index, const int &cluster_index)
 {
-    if (cells_.find(cell_index) == cells_.end())
+    if (!cells_.contains(cell_index))
     {
         // If hash grid cell does not yet exist, create a new one.
         std::list<int> clusters;
@@ -48,7 +48,7 @@ void ClusteringGrid::addCluster(const CellIndex &cell_index, const int &cluster_
 
 void ClusteringGrid::removeCluster(const CellIndex &cell_index, const int &cluster_index)
 {
-    if (cells_.find(cell_index) != cells_.end())
+    if (cells_.contains(cell_index))
     {
         cells_.find(cell_index)->second.remove(cluster_index);
         if (cells_.find(cell_index)->second.empty())
@@ -85,7 +85,7 @@ ClusteringGrid::CellIndex ClusteringGrid::getIndex(const Point &position) const
 
 bool ClusteringGrid::isNonEmptyCell(const CellIndex &cell_index) const
 {
-    return cells_.find(cell_index) != cells_.end();
+    return cells_.contains(cell_index);
 }
 
 int ClusteringGrid::getCellCount() const

--- a/src/openms/source/ML/SVM/SimpleSVM.cpp
+++ b/src/openms/source/ML/SVM/SimpleSVM.cpp
@@ -553,7 +553,7 @@ void scaleDataUsingTrainingRanges(SimpleSVM::PredictorMap& predictors, const map
     auto val_end = pred_it->second.end();
     for (; val_begin != val_end; ++val_begin)
     {
-      if (scaling.count(pred_it->first) == 0)
+      if (!scaling.contains(pred_it->first))
       {
         //std::cout << "Predictor: '" << pred_it->first << "' not found in scale map because it was uninformative during training." << std::endl;
         continue;

--- a/src/openms/source/PROCESSING/CALIBRATION/InternalCalibration.cpp
+++ b/src/openms/source/PROCESSING/CALIBRATION/InternalCalibration.cpp
@@ -429,7 +429,7 @@ namespace OpenMS
           {
             sv << "invalid"; // this only happens if ALL models are invalid (since otherwise they would use 'neighbour')
           }
-          else if (invalid_models.count(i) > 0)
+          else if (invalid_models.contains(i))
           {
             sv << "neighbor";
           }

--- a/src/openms/source/PROCESSING/FEATURE/FeatureOverlapFilter.cpp
+++ b/src/openms/source/PROCESSING/FEATURE/FeatureOverlapFilter.cpp
@@ -200,7 +200,7 @@ namespace OpenMS
     std::unordered_set<Size> removed_uids;
     for (auto& f : fmap)
     {
-      if (removed_uids.count(f.getUniqueId()) == 0)
+      if (!removed_uids.contains(f.getUniqueId()))
       {
         for (auto& overlap : quadtree.query(getBox(&f)))
         {

--- a/src/openms/source/PROCESSING/ID/IDFilter.cpp
+++ b/src/openms/source/PROCESSING/ID/IDFilter.cpp
@@ -150,7 +150,7 @@ namespace OpenMS
         if (seq[i].isModified())
         {
           String mod_name = seq[i].getModification()->getFullId();
-          if (mods_.count(mod_name) > 0)
+          if (mods_.contains(mod_name))
             return true;
         }
       }
@@ -159,13 +159,13 @@ namespace OpenMS
       if (seq.hasNTerminalModification())
       {
         String mod_name = seq.getNTerminalModification()->getFullId();
-        if (mods_.count(mod_name) > 0)
+        if (mods_.contains(mod_name))
           return true;
       }
       if (seq.hasCTerminalModification())
       {
         String mod_name = seq.getCTerminalModification()->getFullId();
-        if (mods_.count(mod_name) > 0)
+        if (mods_.contains(mod_name))
           return true;
       }
 
@@ -187,7 +187,7 @@ namespace OpenMS
     bool operator()(const PeptideHit& hit) const
     {
       const String& query = (ignore_mods_ ? hit.getSequence().toUnmodifiedString() : hit.getSequence().toString());
-      return (sequences_.count(query) > 0);
+      return (sequences_.contains(query));
     }
   };
 
@@ -385,7 +385,7 @@ namespace OpenMS
       ProteinIdentification::ProteinGroup filtered;
       for (const String& acc : group.accessions)
       {
-        if (valid_accessions.find(acc) != valid_accessions.end())
+        if (valid_accessions.contains(acc))
         {
           filtered.accessions.push_back(acc);
         }

--- a/src/openms/source/QC/Contaminants.cpp
+++ b/src/openms/source/QC/Contaminants.cpp
@@ -118,7 +118,7 @@ namespace OpenMS
       ++utotal;
 
       // peptide is not in contaminant database
-      if (!digested_db_.count(key))
+      if (!digested_db_.contains(key))
       {
         fu_hit.setMetaValue("is_contaminant", 0);
         continue;
@@ -159,7 +159,7 @@ namespace OpenMS
     ++total;
     sum_total += intensity;
     // peptide is not in contaminant database
-    if (!digested_db_.count(key))
+    if (!digested_db_.contains(key))
     {
       pep_hit.setMetaValue("is_contaminant", 0);
       return;

--- a/src/openms/source/QC/DBSuitability.cpp
+++ b/src/openms/source/QC/DBSuitability.cpp
@@ -225,7 +225,7 @@ namespace OpenMS
     const set<String>& accessions = hit.extractProteinAccessionsSet();
     for (const String& acc : accessions)
     {
-      if (acc.find(Constants::UserParam::CONCAT_PEPTIDE) == String::npos && !boost::regex_search(String(acc).toLower(), decoy_pattern_))
+      if (!acc.contains(Constants::UserParam::CONCAT_PEPTIDE) && !boost::regex_search(String(acc).toLower(), decoy_pattern_))
       {
         return false;
       }
@@ -610,7 +610,7 @@ namespace OpenMS
         const set<String> accessions = hit.extractProteinAccessionsSet();
         for (const String& acc : accessions)
         {
-          if (acc.find(Constants::UserParam::CONCAT_PEPTIDE) != String::npos)// skip novo accessions
+          if (acc.contains(Constants::UserParam::CONCAT_PEPTIDE))// skip novo accessions
           {
             continue;
           }
@@ -679,7 +679,7 @@ namespace OpenMS
       top_hit.getKeys(meta_keys);
       for (const String& key : meta_keys)
       {
-        if (key.find(score_name) != String::npos)
+        if (key.contains(score_name))
         {
           score = top_hit.getMetaValue(key);
           score_found = true;

--- a/src/topp/CVInspector.cpp
+++ b/src/topp/CVInspector.cpp
@@ -367,7 +367,7 @@ protected:
         if (tit->getAllowChildren())
         {
           // check whether we want to ignore this term
-          if (!(tit->getAccession().has(':') && ignore_cv_list.find(tit->getAccession().prefix(':')) != ignore_cv_list.end()))
+          if (!(tit->getAccession().has(':') && ignore_cv_list.contains(tit->getAccession().prefix(':'))))
           {
             cv.getAllChildTerms(allowed_terms, tit->getAccession());
           }
@@ -390,7 +390,7 @@ protected:
     set<String> unused_terms;
     for (const auto& [acc, _] : terms)
     {
-      if (used_terms.find(acc) == used_terms.end())
+      if (!used_terms.contains(acc))
       {
         unused_terms.insert(acc);
       }

--- a/src/topp/ConsensusID.cpp
+++ b/src/topp/ConsensusID.cpp
@@ -443,23 +443,23 @@ protected:
       std::copy(sp.variable_modifications.begin(), sp.variable_modifications.end(), std::inserter(var_mods_set, var_mods_set.end()));
     }
 
-    if (specs.find(EnzymaticDigestion::SPEC_NONE) != specs.end())
+    if (specs.contains(EnzymaticDigestion::SPEC_NONE))
     {
       new_sp.enzyme_term_specificity = EnzymaticDigestion::SPEC_NONE;
     }
-    else if (specs.find(EnzymaticDigestion::SPEC_SEMI) != specs.end())
+    else if (specs.contains(EnzymaticDigestion::SPEC_SEMI))
     {
       new_sp.enzyme_term_specificity = EnzymaticDigestion::SPEC_SEMI;
     }
-    else if (specs.find(EnzymaticDigestion::SPEC_NONTERM) != specs.end())
+    else if (specs.contains(EnzymaticDigestion::SPEC_NONTERM))
     {
       new_sp.enzyme_term_specificity = EnzymaticDigestion::SPEC_NONTERM;
     }
-    else if (specs.find(EnzymaticDigestion::SPEC_NOCTERM) != specs.end())
+    else if (specs.contains(EnzymaticDigestion::SPEC_NOCTERM))
     {
       new_sp.enzyme_term_specificity = EnzymaticDigestion::SPEC_NOCTERM;
     }
-    else if (specs.find(EnzymaticDigestion::SPEC_FULL) != specs.end())
+    else if (specs.contains(EnzymaticDigestion::SPEC_FULL))
     {
       new_sp.enzyme_term_specificity = EnzymaticDigestion::SPEC_FULL;
     }

--- a/src/topp/DatabaseFilter.cpp
+++ b/src/topp/DatabaseFilter.cpp
@@ -88,7 +88,7 @@ protected:
     for (const auto& entry : db)
     {
       const String& fasta_accession = entry.identifier;
-      const bool found = id_accessions.find(fasta_accession) != id_accessions.end();
+      const bool found = id_accessions.contains(fasta_accession);
       if ((found && whitelist) || (! found && ! whitelist)) // either found in the whitelist or not found in the blacklist
       {
         db_new.push_back(entry);

--- a/src/topp/DecoyDatabase.cpp
+++ b/src/topp/DecoyDatabase.cpp
@@ -385,7 +385,7 @@ protected:
       //-------------------------------------------------------------
       while (f.readNext(entry))
       {
-        if (identifiers.find(entry.identifier) != identifiers.end())
+        if (identifiers.contains(entry.identifier))
         {
           OPENMS_LOG_WARN << "DecoyDatabase: Warning, identifier '" << entry.identifier << "' occurs more than once!" << endl;
         }

--- a/src/topp/EICExtractor.cpp
+++ b/src/topp/EICExtractor.cpp
@@ -346,7 +346,7 @@ public:
         {
           if (cf.getRT() < 0)
           {
-            if (mz_doubles.find(cf.getMZ()) == mz_doubles.end())
+            if (!mz_doubles.contains(cf.getMZ()))
             {
               mz_doubles.insert(cf.getMZ());
             }

--- a/src/topp/FLASHDeconv.cpp
+++ b/src/topp/FLASHDeconv.cpp
@@ -269,7 +269,7 @@ protected:
     for (const auto& it : map)
     {
       uint ms_level = it.getMSLevel();
-      if (per_ms_level_spec_count.find(ms_level) == per_ms_level_spec_count.end()) per_ms_level_spec_count[ms_level] = 0;
+      if (!per_ms_level_spec_count.contains(ms_level)) per_ms_level_spec_count[ms_level] = 0;
       per_ms_level_spec_count[ms_level]++;
     }
 
@@ -279,8 +279,8 @@ protected:
       scan_rt_map[deconvolved_spectrum.getScanNumber()] = deconvolved_spectrum.getOriginalSpectrum().getRT();
 
       if (deconvolved_spectrum.empty()) continue;
-      if (per_ms_level_deconv_spec_count.find(ms_level) == per_ms_level_deconv_spec_count.end()) per_ms_level_deconv_spec_count[ms_level] = 0;
-      if (per_ms_level_mass_count.find(ms_level) == per_ms_level_mass_count.end()) per_ms_level_mass_count[ms_level] = 0;
+      if (!per_ms_level_deconv_spec_count.contains(ms_level)) per_ms_level_deconv_spec_count[ms_level] = 0;
+      if (!per_ms_level_mass_count.contains(ms_level)) per_ms_level_mass_count[ms_level] = 0;
 
       per_ms_level_deconv_spec_count[ms_level]++;
       per_ms_level_mass_count[ms_level] += (int)deconvolved_spectrum.size();
@@ -323,7 +323,7 @@ protected:
       std::vector<ofstream> out_spec_streams = std::vector<ofstream>(out_spec_file.size());
       for (Size i = 0; i < out_spec_file.size(); i++)
       {
-        if (out_spec_file[i].empty() || (! keep_empty_out && per_ms_level_deconv_spec_count.find(i + 1) == per_ms_level_deconv_spec_count.end()))
+        if (out_spec_file[i].empty() || (! keep_empty_out && !per_ms_level_deconv_spec_count.contains(i + 1)))
           continue;
         OPENMS_LOG_INFO << "writing spectrum tsv for MS level " << (i + 1) << " ..." << endl;
 
@@ -347,7 +347,7 @@ protected:
 
       for (Size i = 0; i < out_spec_file.size(); i++)
       {
-        if (out_spec_file[i].empty() || (! keep_empty_out && per_ms_level_deconv_spec_count.find(i + 1) == per_ms_level_deconv_spec_count.end()))
+        if (out_spec_file[i].empty() || (! keep_empty_out && !per_ms_level_deconv_spec_count.contains(i + 1)))
           continue;
         out_spec_streams[i].close();
       }
@@ -382,7 +382,7 @@ protected:
       for (Size i = 0; i < out_topfd_feature_file.size(); i++)
       {
         if (out_topfd_feature_file[i].empty()
-            || (! keep_empty_out && per_ms_level_deconv_spec_count.find(i + 1) == per_ms_level_deconv_spec_count.end()))
+            || (! keep_empty_out && !per_ms_level_deconv_spec_count.contains(i + 1)))
           continue;
         OPENMS_LOG_INFO << "writing topfd *.feature for MS level " << (i + 1) << " ..." << endl;
 
@@ -405,7 +405,7 @@ protected:
 
       for (Size i = 0; i < out_topfd_file.size(); i++)
       {
-        if (out_topfd_file[i].empty() || (! keep_empty_out && per_ms_level_deconv_spec_count.find(i + 1) == per_ms_level_deconv_spec_count.end()))
+        if (out_topfd_file[i].empty() || (! keep_empty_out && !per_ms_level_deconv_spec_count.contains(i + 1)))
           continue;
         OPENMS_LOG_INFO << "writing topfd *.msalign for MS level " << (i + 1) << " ..." << endl;
 
@@ -429,7 +429,7 @@ protected:
 
       for (Size i = 0; i < out_topfd_file.size(); i++)
       {
-        if (out_topfd_file[i].empty() || (! keep_empty_out && per_ms_level_deconv_spec_count.find(i + 1) == per_ms_level_deconv_spec_count.end()))
+        if (out_topfd_file[i].empty() || (! keep_empty_out && !per_ms_level_deconv_spec_count.contains(i + 1)))
           continue;
         out_topfd_streams[i].close();
       }

--- a/src/topp/FileFilter.cpp
+++ b/src/topp/FileFilter.cpp
@@ -1455,7 +1455,7 @@ protected:
       for (const FeatureHandle& fh : cm)
       {
         UInt64 map_index = fh.getMapIndex();
-        if (map_ids.empty() || map_ids.find(map_index) != map_ids.end())
+        if (map_ids.empty() || map_ids.contains(map_index))
         {
           Peak2D p;
           p.setMZ(fh.getMZ());
@@ -1506,14 +1506,14 @@ protected:
       if (is_blacklist)
       {
         // blacklist: add all spectra not contained in list
-        if (list_idx.find(i) == list_idx.end())
+        if (!list_idx.contains(i))
         {
           exp2.addSpectrum(exp[i]);
         }
       }
       else   // whitelist: add all non MS2 spectra, and MS2 only if in list
       {
-        if (exp[i].getMSLevel() != 2 || list_idx.find(i) != list_idx.end())
+        if (exp[i].getMSLevel() != 2 || list_idx.contains(i))
         {
           exp2.addSpectrum(exp[i]);
         }
@@ -1594,14 +1594,14 @@ protected:
       if (is_blacklist)
       {
         // blacklist: add all spectra not contained in list
-        if (list_idx.find(i) == list_idx.end())
+        if (!list_idx.contains(i))
         {
           exp2.addSpectrum(exp[i]);
         }
       }
       else   // whitelist: add all non-MS2 spectra + matched MS2 spectra
       {
-        if (exp[i].getMSLevel() != 2 || list_idx.find(i) != list_idx.end())
+        if (exp[i].getMSLevel() != 2 || list_idx.contains(i))
         {
           exp2.addSpectrum(exp[i]);
         }

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -899,7 +899,7 @@ protected:
       {
         for (char c : entry.sequence)
         {
-          if (NUCLEOTIDE_CHARS.find(c) == std::string_view::npos)
+          if (!NUCLEOTIDE_CHARS.contains(c))
           {
             is_nucleic_acid = false;
             break;
@@ -1475,13 +1475,13 @@ protected:
         }
 
         // annotate peak type (profile / centroided) from meta data
-        if (level_annotated_picked.count(level) == 0)
+        if (!level_annotated_picked.contains(level))
         {
           level_annotated_picked[level] = static_cast<UInt>(spectrum.getType(false));
         }
 
         // estimate peak type once for every level (take a spectrum with enough peaks for stable estimation)
-        if (level_estimated_picked.count(level) == 0 && spectrum.size() > 10)
+        if (!level_estimated_picked.contains(level) && spectrum.size() > 10)
         {
           level_estimated_picked[level] = static_cast<UInt>(PeakTypeEstimator::estimateType(spectrum.begin(), spectrum.end()));
         }
@@ -1609,7 +1609,7 @@ protected:
           os << String("  ") + ChromatogramSettings::ChromatogramNames[static_cast<size_t>(it->first)] + ":                         "
              << it->second << '\n';
         }
-        if (getFlag_("d") && chrom_types.find(ChromatogramSettings::ChromatogramType::SELECTED_REACTION_MONITORING_CHROMATOGRAM) != chrom_types.end())
+        if (getFlag_("d") && chrom_types.contains(ChromatogramSettings::ChromatogramType::SELECTED_REACTION_MONITORING_CHROMATOGRAM))
         {
           os << '\n'
              << " -- Detailed chromatogram listing -- "
@@ -1714,7 +1714,7 @@ protected:
           for (Size m = 0; m < exp[s].getFloatDataArrays().size(); ++m)
           {
             String name = exp[s].getFloatDataArrays()[m].getName();
-            if (names.find(name) != names.end())
+            if (names.contains(name))
             {
               os << "Error: Duplicate meta data array name '" << name << "' in spectrum (RT: " << exp[s].getRT() << ")"
                  << '\n';
@@ -1727,7 +1727,7 @@ protected:
           for (Size m = 0; m < exp[s].getIntegerDataArrays().size(); ++m)
           {
             String name = exp[s].getIntegerDataArrays()[m].getName();
-            if (names.find(name) != names.end())
+            if (names.contains(name))
             {
               os << "Error: Duplicate meta data array name '" << name << "' in spectrum (RT: " << exp[s].getRT() << ")"
                  << '\n';
@@ -1740,7 +1740,7 @@ protected:
           for (Size m = 0; m < exp[s].getStringDataArrays().size(); ++m)
           {
             String name = exp[s].getStringDataArrays()[m].getName();
-            if (names.find(name) != names.end())
+            if (names.contains(name))
             {
               os << "Error: Duplicate meta data array name '" << name << "' in spectrum (RT: " << exp[s].getRT() << ")"
                  << '\n';

--- a/src/topp/IDExtractor.cpp
+++ b/src/topp/IDExtractor.cpp
@@ -137,7 +137,7 @@ protected:
         {
           chosen_ids.push_back(it->second.getHits()[0].getSequence().toString());
           chosen_identifications.push_back(it->second);
-          if (identifiers.find(it->second.getIdentifier()) == identifiers.end())
+          if (!identifiers.contains(it->second.getIdentifier()))
           {
             temp_identifications.clear();
           }
@@ -169,7 +169,7 @@ protected:
         {
           chosen_ids.push_back(identifications[indices[index]].getHits()[0].getSequence().toString());
           chosen_identifications.push_back(identifications[indices[index]]);
-          if (identifiers.find(identifications[indices[index]].getIdentifier()) == identifiers.end())
+          if (!identifiers.contains(identifications[indices[index]].getIdentifier()))
           {
             temp_identifications.clear();
           }
@@ -195,7 +195,7 @@ protected:
     {
       temp_protein_hits = protein_identifications[i].getHits();
       chosen_protein_hits.clear();
-      if (identifiers.find(protein_identifications[i].getIdentifier()) != identifiers.end())
+      if (identifiers.contains(protein_identifications[i].getIdentifier()))
       {
         temp_identifications = identifiers[protein_identifications[i].getIdentifier()];
         for (Size j = 0; j < temp_protein_hits.size(); ++j)

--- a/src/topp/IDMerger.cpp
+++ b/src/topp/IDMerger.cpp
@@ -426,7 +426,7 @@ protected:
           const PeptideHit& hit = pep_it->getHits()[0];
           OPENMS_LOG_DEBUG << "peptide: " << hit.getSequence().toString() << endl;
           // skip ahead if peptide is not new:
-          if (sequences.find(hit.getSequence()) != sequences.end()) continue;
+          if (sequences.contains(hit.getSequence())) continue;
           OPENMS_LOG_DEBUG << "new peptide!" << endl;
           pep_it->getHits().resize(1); // restrict to best hit for simplicity
           peptides.push_back(*pep_it);
@@ -438,7 +438,7 @@ protected:
           {
             OPENMS_LOG_DEBUG << "accession: " << acc << endl;
             // skip ahead if accession is not new:
-            if (accessions.find(acc) != accessions.end())
+            if (accessions.contains(acc))
             {
               continue;
             }
@@ -446,7 +446,7 @@ protected:
             // first find the right protein identification:
             const String& id = pep_it->getIdentifier();
             OPENMS_LOG_DEBUG << "identifier: " << id << endl;
-            if (proteins_by_id.find(id) == proteins_by_id.end())
+            if (!proteins_by_id.contains(id))
             {
               writeLogError_("Error: identifier '" + id + "' linking peptides and proteins not found. Skipping.");
               continue;
@@ -461,7 +461,7 @@ protected:
               continue;
             }
             // we may need to copy protein ID meta data, if we haven't yet:
-            if (selected_proteins.find(id) == selected_proteins.end())
+            if (!selected_proteins.contains(id))
             {
               OPENMS_LOG_DEBUG << "adding protein identification" << endl;
               selected_proteins_order.push_back(id);

--- a/src/topp/LuciphorAdapter.cpp
+++ b/src/topp/LuciphorAdapter.cpp
@@ -330,7 +330,7 @@ protected:
       l_psm.predicted_pep_score = elements[8].toDouble();
       l_psm.global_flr = elements[10].toDouble();
       l_psm.local_flr = elements[11].toDouble();
-      if (l_psms.count(l_psm.scan_idx) > 0)
+      if (l_psms.contains(l_psm.scan_idx))
       {
         return "Duplicate scannr existing " + String(l_psm.scan_nr) + ".";
       }
@@ -618,7 +618,7 @@ protected:
         addScoreToMetaValues_(scored_hit, pep.getScoreType());
         
         struct LuciphorPSM l_psm;
-        if (l_psms.count(scan_idx) > 0)
+        if (l_psms.contains(scan_idx))
         {
           l_psm = l_psms.at(scan_idx);
           AASequence original_seq = scored_hit.getSequence();

--- a/src/topp/MRMTransitionGroupPicker.cpp
+++ b/src/topp/MRMTransitionGroupPicker.cpp
@@ -155,7 +155,7 @@ protected:
       {
         for (Size i = 0; i < assay_it->second.size(); i++)
         {
-          if (chromatogram_map.find(assay_it->second[i]->getNativeID()) == chromatogram_map.end())
+          if (!chromatogram_map.contains(assay_it->second[i]->getNativeID()))
           {
             return false;
           }
@@ -175,7 +175,7 @@ protected:
 
         // Check first whether we have a mapping (e.g. see -force option)
         const TransitionType* transition = assay_map[id][i];
-        if (chromatogram_map.find(transition->getNativeID()) == chromatogram_map.end())
+        if (!chromatogram_map.contains(transition->getNativeID()))
         {
           OPENMS_LOG_DEBUG << "Found no matching chromatogram for id " << transition->getNativeID() << std::endl;
           continue;

--- a/src/topp/MetaProSIP.cpp
+++ b/src/topp/MetaProSIP.cpp
@@ -305,7 +305,7 @@ public:
       y.push_back(it->second);
     }
 
-    if (rate2score.find(100.0) == rate2score.end() && x[x.size() - 1] < 100.0)
+    if (!rate2score.contains(100.0) && x[x.size() - 1] < 100.0)
     {
       x.push_back(100.0);
       y.push_back(0);
@@ -369,7 +369,7 @@ public:
       // build histogram of rates
       for (vector<SIPIncorporation>::const_iterator iit = cit->incorporations.begin(); iit != cit->incorporations.end(); ++iit)
       {
-        if (hist.find(iit->rate) == hist.end())
+        if (!hist.contains(iit->rate))
         {
           hist[iit->rate] = 1.0;
         }
@@ -1017,7 +1017,7 @@ public:
 
         String protein_accession = prot_it->first;
         String protein_description = "none";
-        if (proteinid_to_description.find(protein_accession.trim().toUpper()) != proteinid_to_description.end())
+        if (proteinid_to_description.contains(protein_accession.trim().toUpper()))
         {
           protein_description = proteinid_to_description.at(protein_accession.trim().toUpper());
         }
@@ -1146,7 +1146,7 @@ public:
             String protein_accession = v_it->accessions[ac];
             accessions_string += protein_accession;
 
-            if (proteinid_to_description.find(protein_accession.trim().toUpper()) != proteinid_to_description.end())
+            if (proteinid_to_description.contains(protein_accession.trim().toUpper()))
             {
               if (description_string == "none")
               {
@@ -1264,7 +1264,7 @@ public:
         current_accession.trim().toUpper();
         accession_string += current_accession;
 
-        if (proteinid_to_description.find(current_accession) != proteinid_to_description.end())
+        if (proteinid_to_description.contains(current_accession))
         {
           if (protein_descriptions == "none")
           {
@@ -1899,7 +1899,7 @@ public:
       for (; it != peak_map.areaEndConst(); ++it)
       {
         double rt = it.getRT();
-        if (xic.find(rt) != xic.end())
+        if (xic.contains(rt))
         {
           xic[rt] += it->getIntensity();
         }

--- a/src/topp/NucleicAcidSearchEngine.cpp
+++ b/src/topp/NucleicAcidSearchEngine.cpp
@@ -1175,7 +1175,7 @@ protected:
     Param param = spectrum_generator.getParameters();
     vector<String> temp = getStringList_("fragment:ions");
     set<String> selected_ions(temp.begin(), temp.end());
-    if (resolve_ambiguous_mods_ && !selected_ions.count("a-B"))
+    if (resolve_ambiguous_mods_ && !selected_ions.contains("a-B"))
     {
       OPENMS_LOG_WARN << "Warning: option 'modifications:resolve_ambiguities' requires a-B ions in parameter 'fragment:ions' - disabling the option." << endl;
       resolve_ambiguous_mods_ = false;
@@ -1183,7 +1183,7 @@ protected:
     for (const auto& code : fragment_ion_codes_)
     {
       String param_name = "add_" + code + "_ions";
-      if (selected_ions.count(code))
+      if (selected_ions.contains(code))
       {
         param.setValue(param_name, "true");
       }

--- a/src/topp/OpenNuXL.cpp
+++ b/src/topp/OpenNuXL.cpp
@@ -221,11 +221,11 @@ struct NuXLLinearRescore
               predictors[f].push_back(value);
             }
             // only add label for training data (rank = 0 and previously selected for training)
-            if (psm_rank == 0 && top_indices.count(index) != 0)
+            if (psm_rank == 0 && top_indices.contains(index))
             {
               labels[current_row] = 1.0;
             }
-            else if (psm_rank == 0 && bottom_indices.count(index) != 0)
+            else if (psm_rank == 0 && bottom_indices.contains(index))
             {
               labels[current_row] = 0.0;
             }
@@ -360,7 +360,7 @@ struct NuXLLinearRescore
                predictors[f].push_back(value);
              }
              // only add label for training data (rank = 0 and previously selected for training)
-             if (psm_rank == 0 && training_indices.count(index) > 0)
+             if (psm_rank == 0 && training_indices.contains(index))
              {
                labels[current_row] = is_target;
              }
@@ -3554,7 +3554,7 @@ static void scoreXLIons_(
       { 
         const Residue& r = fixed_and_variable_modified_peptide[i];
         if (!r.isModified()) continue;
-        if (variable_modifications.val.find(r.getModification()) != variable_modifications.val.end())
+        if (variable_modifications.val.contains(r.getModification()))
         {
           ++n_var_mods;
         }
@@ -3565,9 +3565,9 @@ static void scoreXLIons_(
       auto c_term_mod = fixed_and_variable_modified_peptide.getCTerminalModification();
 
       if (n_term_mod != nullptr &&
-        variable_modifications.val.find(n_term_mod) != variable_modifications.val.end()) ++n_var_mods;
+        variable_modifications.val.contains(n_term_mod)) ++n_var_mods;
       if (c_term_mod != nullptr &&
-        variable_modifications.val.find(c_term_mod) != variable_modifications.val.end()) ++n_var_mods;
+        variable_modifications.val.contains(c_term_mod)) ++n_var_mods;
 
       ph.setMetaValue(String("variable_modifications"), n_var_mods);
       ph.setMetaValue(String("n_theoretical_peaks"), ah.n_theoretical_peaks);
@@ -3817,7 +3817,7 @@ static void scoreXLIons_(
       for (auto & ph : pid.getHits())
       {
         const String& unmodified_sequence = ph.getSequence().toUnmodifiedString();
-        if (sequence_is_topPSM.find(unmodified_sequence) != sequence_is_topPSM.end())
+        if (sequence_is_topPSM.contains(unmodified_sequence))
         {  
           ph.setMetaValue("CountSequenceIsTop", sequence_is_topPSM[unmodified_sequence]);
           ph.setMetaValue("CountSequenceCharges", sequence_charges[unmodified_sequence].size());
@@ -4626,7 +4626,7 @@ static void scoreXLIons_(
         vector<size_t> idx_to_keep; // inverse
         for (size_t i = 0; i != s.size(); ++i)
         { // add indices we don't want to remove
-          if (idx_to_remove.find(i) == idx_to_remove.end()) idx_to_keep.push_back(i);
+          if (!idx_to_remove.contains(i)) idx_to_keep.push_back(i);
         }
         filtered_peaks_count += idx_to_remove.size();
         s.select(idx_to_keep);
@@ -4881,7 +4881,7 @@ static void scoreXLIons_(
                 const String other_native_id = f->getMetaValue("native_id");
 
                 // skip self-comparison and already identified spectra
-                if (this_native_id == other_native_id || skip_peptide_spectrum.count(other_native_id) > 0) continue;
+                if (this_native_id == other_native_id || skip_peptide_spectrum.contains(other_native_id)) continue;
 
                 const MSSpectrum& this_spec = spectra[lookup.findByNativeID(this_native_id)];
                 const MSSpectrum& other_spec = spectra[lookup.findByNativeID(other_native_id)];
@@ -5387,7 +5387,7 @@ static void scoreXLIons_(
 #endif
         {
           // skip peptide (and all modified variants) if already processed
-          if (processed_petides.find(*cit) != processed_petides.end())
+          if (processed_petides.contains(*cit))
           {
             already_processed = true;
           }
@@ -5692,7 +5692,7 @@ static void scoreXLIons_(
                       const PeakSpectrum & exp_spectrum = spectra[scan_index];
                       //////////////////////////////////////////
                       //               ID-Filter
-                      if (skip_peptide_spectrum.find(exp_spectrum.getNativeID()) != skip_peptide_spectrum.end()) { continue; }
+                      if (skip_peptide_spectrum.contains(exp_spectrum.getNativeID())) { continue; }
 
 #pragma omp atomic
                       ++nr_candidates[scan_index]; // count candidate for spectrum
@@ -5900,7 +5900,7 @@ static void scoreXLIons_(
                 const String& precursor_na_adduct = *mod_combinations_it->second.begin(); // For fast scoring it should be sufficient to only consider any of the adducts for this mass and formula (e.g., C-H3N vs U-H2O)
                 MSSpectrum& exp_spectrum = spectra[scan_index];
 
-                if (precursor_na_adduct != "none" && skip_peptide_spectrum.find(exp_spectrum.getNativeID()) != skip_peptide_spectrum.end()) continue;
+                if (precursor_na_adduct != "none" && skip_peptide_spectrum.contains(exp_spectrum.getNativeID())) continue;
 
 #pragma omp atomic       
                 ++nr_candidates[scan_index];

--- a/src/topp/OpenSwathFeatureXMLToTSV.cpp
+++ b/src/topp/OpenSwathFeatureXMLToTSV.cpp
@@ -157,24 +157,24 @@ void write_out_body_(std::ostream &os, Feature *feature_it, TargetedExperiment &
   }
 
   // handle decoy tag
-  if (peptide_transition_map.find(peptide_ref) != peptide_transition_map.end() && !peptide_transition_map[peptide_ref].empty())
+  if (peptide_transition_map.contains(peptide_ref) && !peptide_transition_map[peptide_ref].empty())
   {
     const ReactionMonitoringTransition *transition = peptide_transition_map[peptide_ref][0];
 #if 1
     const auto& terms = transition->getCVTerms();
-    if (terms.find("decoy") != terms.end())
+    if (terms.contains("decoy"))
     {
       decoy = transition->getCVTerms().at("decoy")[0].getValue().toString();
     }
-    else if (terms.find("MS:1002007") != terms.end() )    // target SRM transition
+    else if (terms.contains("MS:1002007") )    // target SRM transition
     {
       decoy = "0";
     }
-    else if (terms.find("MS:1002008") != terms.end() )    // decoy SRM transition
+    else if (terms.contains("MS:1002008") )    // decoy SRM transition
     {
       decoy = "1";
     }
-    else if (terms.find("MS:1002007") != terms.end() && terms.find("MS:1002008") != terms.end() )    // both == illegal
+    else if (terms.contains("MS:1002007") && terms.contains("MS:1002008") )    // both == illegal
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                        "Peptide " + peptide_ref + " cannot be target and decoy at the same time.");

--- a/src/topp/OpenSwathRewriteToFeatureXML.cpp
+++ b/src/topp/OpenSwathRewriteToFeatureXML.cpp
@@ -107,9 +107,9 @@ class TOPPOpenSwathRewriteToFeatureXML :
       }
     }
 
-    if (header_dict_inv.find("id") == header_dict_inv.end() || 
-        header_dict_inv.find("m_score") == header_dict_inv.end() || 
-        header_dict_inv.find("d_score") == header_dict_inv.end() )
+    if (!header_dict_inv.contains("id") || 
+        !header_dict_inv.contains("m_score") || 
+        !header_dict_inv.contains("d_score") )
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Error: The tsv file is expected to have at least the following headers: id, m_score, d_score. " );
     }
@@ -148,13 +148,13 @@ class TOPPOpenSwathRewriteToFeatureXML :
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Error: Could not convert String" + ((String)current_row[header_dict_inv["d_score"]]) + " on line " + String(line_nr));
       }
 
-      if (feature_map_ref.find(id) != feature_map_ref.end() )
+      if (feature_map_ref.contains(id) )
       {
         Feature* feature = feature_map_ref.find(id)->second;
         feature->setMetaValue("m_score", m_score);
         feature->setMetaValue("d_score", d_score);
         // we are not allowed to have duplicate unique ids
-        if (added_already.find(id) != added_already.end())
+        if (added_already.contains(id))
         {
           throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Error: Duplicate id found in CSV file: " + id );
         }

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -570,7 +570,7 @@ protected:
       writeDebug_("PSM identifier in pout file: " + spec_ref, 10);
 
       // retain only the best result in the unlikely case that a PSMId+peptide combination occurs multiple times
-      if (pep_map.find(spec_ref) == pep_map.end())
+      if (!pep_map.contains(spec_ref))
       {
         pep_map.insert( map<String, PercolatorResult>::value_type ( spec_ref, res ) );
       }
@@ -994,7 +994,7 @@ protected:
         StringList numeric_features;
         for (const String& f : feature_set)
         {
-          if (pin_metadata_not_feature.count(f)) continue;
+          if (pin_metadata_not_feature.contains(f)) continue;
           numeric_features.push_back(f);
         }
         if (all_peptide_ids.empty() || all_peptide_ids.front().getHits().empty()
@@ -1026,7 +1026,7 @@ protected:
           const auto& pid = all_peptide_ids[i];
           for (size_t j = 0; j < pid.getHits().size(); ++j)
           {
-            if (skipped.count({i, j})) continue;
+            if (skipped.contains({i, j})) continue;
             const PeptideHit& hit = pid.getHits()[j];
 
             // Build feature row from stamped meta values.

--- a/src/topp/ProteinQuantifier.cpp
+++ b/src/topp/ProteinQuantifier.cpp
@@ -442,12 +442,12 @@ protected:
               for (Size c = 1; c <= ed.getNumberOfLabels(); ++c)
               {
                 bool no_quant = false;
-                if (filename_to_chargemap.find(filename) != filename_to_chargemap.end())
+                if (filename_to_chargemap.contains(filename))
                 {
-                  if (const auto& charge_map = filename_to_chargemap.at(filename); charge_map.find(charge) != charge_map.end())
+                  if (const auto& charge_map = filename_to_chargemap.at(filename); charge_map.contains(charge))
                   {
                     const auto& channel_to_abundance = charge_map.at(charge);
-                    if (channel_to_abundance.find(c) != channel_to_abundance.end())
+                    if (channel_to_abundance.contains(c))
                     {
                       out << channel_to_abundance.at(c);
                     }

--- a/src/topp/RNADigestor.cpp
+++ b/src/topp/RNADigestor.cpp
@@ -118,7 +118,7 @@ protected:
       for (vector<NASequence>::const_iterator frag_it = fragments.begin();
            frag_it != fragments.end(); ++frag_it)
       {
-        if (!unique || !unique_fragments.count(*frag_it))
+        if (!unique || !unique_fragments.contains(*frag_it))
         {
           String id = entry.identifier + "_" + String(counter);
           String desc;


### PR DESCRIPTION
## Description

This PR modernizes the codebase by replacing the verbose `.find() != .end()` pattern with the more concise `.contains()` method for checking container membership. This change applies to:

- `std::map`, `std::set`, and `std::unordered_set` containers
- `std::string` and `std::string_view` substring checks
- Custom container types that support the `.contains()` method

The refactoring improves code readability and maintainability without changing any functionality. All logic remains identical; this is purely a stylistic modernization to use C++20 features where available.

### Changes Made

- Replaced `container.find(key) != container.end()` with `container.contains(key)` across ~100+ locations
- Replaced `container.count(key) > 0` with `container.contains(key)` for consistency
- Replaced `string.find(substring) != string::npos` with `string.contains(substring)` for string checks
- Inverted logic where appropriate (e.g., `!container.contains(key)` instead of `container.find(key) == container.end()`)

### Files Modified

Core analysis and processing modules:
- `TransitionTSVFile.cpp`, `MRMAssay.cpp`, `MRMDecoy.cpp`, `MRMFeatureSelector.cpp`
- `OpenSwathHelper.cpp`, `OpenSwathWorkflow.cpp`, `TransitionPQPFile.cpp`
- `TargetedExperiment.cpp`, `ProForma.cpp`

Format handlers and I/O:
- `MzMLHandler.cpp`, `MzIdentMLHandler.cpp`, `MzIdentMLDOMHandler.cpp`
- `ParamCTDFile.cpp`, `ParamXMLFile.cpp`, `ParamJSONFile.cpp`
- `MascotRemoteQuery.cpp`, `QPXFile.cpp`, `PEFFFile.cpp`

And many others across identification, quantitation, feature finding, and utility modules.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

## Testing

This is a refactoring change with no functional modifications. All existing unit tests should pass without changes. The `.contains()` method provides identical semantics to the `.find() != .end()` pattern it replaces.

https://claude.ai/code/session_01NXmjsh7d8Tc8efCK7gRddj