### PR TITLE
Fix non-ascii paths

### DIFF
--- a/cmake/add_library_macros.cmake
+++ b/cmake/add_library_macros.cmake
@@ -237,7 +237,8 @@ function(openms_add_library)
             $<TARGET_FILE_DIR:${openms_add_library_TARGET_NAME}>
             )
 
-    if(GENERATOR_IS_MULTI_CONFIG)
+    get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    if(is_multi_config)
       file(TO_NATIVE_PATH "${OPENMS_HOST_BINARY_DIRECTORY}/src/tests/class_tests/bin/$<CONFIG>/" DLL_TEST_TARGET_PATH)
       file(TO_NATIVE_PATH "${OPENMS_HOST_BINARY_DIRECTORY}/doc/doxygen/parameters/$<CONFIG>/" DLL_DOC_TARGET_PATH)
     else()

--- a/cmake/add_library_macros.cmake
+++ b/cmake/add_library_macros.cmake
@@ -55,22 +55,19 @@ endfunction(convert_to_unity_build)
 ## @note This macro will do nothing outside of Windows since the linker will find the libs.
 macro(copy_dll_to_extern_bin targetname)
   if (WIN32)
-    if (CMAKE_GENERATOR MATCHES "Visual Studio")
-      file(TO_NATIVE_PATH "${OPENMS_HOST_BINARY_DIRECTORY}/src/tests/class_tests/bin/$(ConfigurationName)/$(TargetFileName)" DLL_TEST_TARGET)
-      file(TO_NATIVE_PATH "${OPENMS_HOST_BINARY_DIRECTORY}/src/tests/class_tests/bin/$(ConfigurationName)" DLL_TEST_TARGET_PATH)
+    get_property(_copy_dll_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    if(_copy_dll_is_multi_config)
+      file(TO_NATIVE_PATH "${OPENMS_HOST_BINARY_DIRECTORY}/src/tests/class_tests/bin/$<CONFIG>/$<TARGET_FILE_NAME:${targetname}>" DLL_TEST_TARGET)
+      file(TO_NATIVE_PATH "${OPENMS_HOST_BINARY_DIRECTORY}/src/tests/class_tests/bin/$<CONFIG>" DLL_TEST_TARGET_PATH)
 
-      file(TO_NATIVE_PATH "${OPENMS_HOST_BINARY_DIRECTORY}/doc/doxygen/parameters/$(ConfigurationName)/$(TargetFileName)" DLL_DOC_TARGET)
-      file(TO_NATIVE_PATH "${OPENMS_HOST_BINARY_DIRECTORY}/doc/doxygen/parameters/$(ConfigurationName)" DLL_DOC_TARGET_PATH)
-    elseif(NOT GENERATOR_IS_MULTI_CONFIG)
-      file(TO_NATIVE_PATH "${OPENMS_HOST_BINARY_DIRECTORY}/src/tests/class_tests/bin/" DLL_TEST_TARGET)
+      file(TO_NATIVE_PATH "${OPENMS_HOST_BINARY_DIRECTORY}/doc/doxygen/parameters/$<CONFIG>/$<TARGET_FILE_NAME:${targetname}>" DLL_DOC_TARGET)
+      file(TO_NATIVE_PATH "${OPENMS_HOST_BINARY_DIRECTORY}/doc/doxygen/parameters/$<CONFIG>" DLL_DOC_TARGET_PATH)
+    else()
+      file(TO_NATIVE_PATH "${OPENMS_HOST_BINARY_DIRECTORY}/src/tests/class_tests/bin/$<TARGET_FILE_NAME:${targetname}>" DLL_TEST_TARGET)
       file(TO_NATIVE_PATH "${OPENMS_HOST_BINARY_DIRECTORY}/src/tests/class_tests/bin/" DLL_TEST_TARGET_PATH)
 
-      file(TO_NATIVE_PATH "${OPENMS_HOST_BINARY_DIRECTORY}/doc/doxygen/parameters/" DLL_DOC_TARGET)
+      file(TO_NATIVE_PATH "${OPENMS_HOST_BINARY_DIRECTORY}/doc/doxygen/parameters/$<TARGET_FILE_NAME:${targetname}>" DLL_DOC_TARGET)
       file(TO_NATIVE_PATH "${OPENMS_HOST_BINARY_DIRECTORY}/doc/doxygen/parameters/" DLL_DOC_TARGET_PATH)
-    else()
-      message(WARNING "Sorry, multiconfig generators on windows other than Visual Studio not supported yet.
-              Please look for the line of this error and implement some CMake Generator expressions to copy
-              DLLs to the binaries, or modify your environment for the tests to find all library DLLs.")
     endif()
     add_custom_command(TARGET ${targetname}
             POST_BUILD

--- a/src/openms/include/OpenMS/SYSTEM/PathUtils.h
+++ b/src/openms/include/OpenMS/SYSTEM/PathUtils.h
@@ -14,10 +14,23 @@
 namespace OpenMS
 {
   /// Convert a UTF-8 std::string to std::filesystem::path safely on all platforms.
-  /// On Windows, std::filesystem::path(std::string) uses the current code page, not UTF-8.
+  /// On Windows, std::filesystem::path(std::string) uses the current code page, not UTF-8,
+  /// so we explicitly construct from u8string. If the bytes are not valid UTF-8 (e.g., a
+  /// filename from argv in the ANSI code page), fall back to the native code page.
   inline std::filesystem::path to_path(const std::string& s)
   {
-    return std::filesystem::path(
-      std::u8string(reinterpret_cast<const char8_t*>(s.data()), s.size()));
+#ifdef OPENMS_WINDOWSPLATFORM
+    try
+    {
+      return std::filesystem::path(std::u8string(reinterpret_cast<const char8_t*>(s.data()), s.size()));
+    }
+    catch (const std::system_error&)
+    {
+      // Not valid UTF-8 (e.g., ANSI-encoded filename from argv); let Windows use the current code page.
+      return std::filesystem::path(s);
+    }
+#else
+    return std::filesystem::path(std::u8string(reinterpret_cast<const char8_t*>(s.data()), s.size()));
+#endif
   }
 } // namespace OpenMS

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -129,6 +129,7 @@ set(system_executables_list
   File_test
   Network_test
   JavaInfo_test
+  PathUtils_test
   PythonInfo_test
   StopWatch_test
   SysInfo_test

--- a/src/tests/class_tests/openms/source/PathUtils_test.cpp
+++ b/src/tests/class_tests/openms/source/PathUtils_test.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Chris Bielow $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+#include <OpenMS/SYSTEM/PathUtils.h>
+
+using namespace OpenMS;
+
+START_TEST(PathUtils, "$Id$")
+
+START_SECTION(std::filesystem::path to_path(const std::string& s))
+{
+  // ASCII: identical on all platforms
+  TEST_EQUAL(to_path("ASCII_only.txt").string(), "ASCII_only.txt")
+
+  // UTF-8 encoded 'ä' (U+00E4 → 0xC3 0xA4): valid UTF-8, works on all platforms
+  const std::string utf8_ae{'\xC3', '\xA4'};
+  std::filesystem::path p_utf8 = to_path(utf8_ae + ".mzML");
+  TEST_FALSE(p_utf8.empty())
+
+#ifdef _WIN32
+  // Windows-1252 encoded 'ä' (0xE4) — previously crashed with std::system_error
+  // because the lone byte 0xE4 is not valid UTF-8. The fixed to_path() must fall
+  // back to the ANSI code page and succeed.
+  const std::string ansi_ae{'\xE4'};
+  bool threw = false;
+  std::filesystem::path p_ansi;
+  try
+  {
+    p_ansi = to_path(ansi_ae + ".mzML");
+  }
+  catch (...)
+  {
+    threw = true;
+  }
+  TEST_FALSE(threw)
+  TEST_FALSE(p_ansi.empty())
+  // Verify the wide representation contains 'ä' (U+00E4)
+  TEST_TRUE(p_ansi.wstring().find(L'\xE4') != std::wstring::npos)
+#endif
+}
+END_SECTION
+
+END_TEST


### PR DESCRIPTION
## Description

fix regression introduced in #8938 for filepaths on Windows containing non-ASCII characters (e.g. `ä`).

Also: fix missing copy of openms_thermo_bridged.dll to test's /bin folder (`GENERATOR_IS_MULTI_CONFIG` is a property, not a variable; needs translation) and potentially support more multi-config generators on Windows.


## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows path handling with UTF-8 character support; now gracefully handles non-UTF-8 encoded input as a fallback.

* **Tests**
  * Added comprehensive unit tests for path utilities, covering ASCII paths, UTF-8 input, and Windows-specific ANSI character handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->