### PR TITLE
MapAlignerPoseClustering: skip un-alignable files instead of crashing (fixes #7010)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -247,7 +247,7 @@ TOPP tools:
         this filtering was silent and hardcoded; a warning is now emitted reporting how many hits were dropped (#9068)
     MapAlignerIdentification, MapAlignerPoseClustering, MapAlignerTreeGuided:
       - Added optional spectra file transformation (-in_spectra_files, -out_spectra_files) to transform mzML files along with alignment (#8536)
-      - Fix: MapAlignerPoseClustering no longer aborts the whole run when a single input file cannot be aligned to the reference (e.g. a blank/near-empty LC-MS run). Both the mzML and featureXML branches now catch any alignment failure (Exception::BaseException, covering IllegalArgument, InvalidValue, UnableToFit, DivisionByZero, ...) and fall back to the identity transformation for that file, so the remaining files are still processed (fixes #7010)
+      - Fix: MapAlignerPoseClustering no longer aborts the whole run when a single input file cannot be aligned to the reference (e.g. a blank/near-empty LC-MS run). Both the mzML and featureXML branches now catch any alignment failure (Exception::BaseException, covering IllegalArgument, InvalidValue, UnableToFit, DivisionByZero, ...) and fall back to the identity transformation for that file, so the remaining files are still processed (fixes #7010). Per-file I/O errors (unreadable input, unwritable output) inside the OpenMP loop are now also caught and propagated as a clean error exit instead of crashing the process via std::terminate at the parallel-region boundary
     FileInfo:
       - Now prints both assigned and unassigned peptide identification counts for FeatureXML and ConsensusXML files (#8395)
       - Added sequence length stats and nucleic acid support for FASTA files (#8643)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -247,6 +247,7 @@ TOPP tools:
         this filtering was silent and hardcoded; a warning is now emitted reporting how many hits were dropped (#9068)
     MapAlignerIdentification, MapAlignerPoseClustering, MapAlignerTreeGuided:
       - Added optional spectra file transformation (-in_spectra_files, -out_spectra_files) to transform mzML files along with alignment (#8536)
+      - Fix: MapAlignerPoseClustering no longer aborts the whole run when a single input file cannot be aligned to the reference (e.g. a blank/near-empty LC-MS run). Both the mzML and featureXML branches now catch all alignment failures (IllegalArgument, InvalidValue, UnableToFit) and fall back to the identity transformation for that file, so the remaining files are still processed (fixes #7010)
     FileInfo:
       - Now prints both assigned and unassigned peptide identification counts for FeatureXML and ConsensusXML files (#8395)
       - Added sequence length stats and nucleic acid support for FASTA files (#8643)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -247,7 +247,7 @@ TOPP tools:
         this filtering was silent and hardcoded; a warning is now emitted reporting how many hits were dropped (#9068)
     MapAlignerIdentification, MapAlignerPoseClustering, MapAlignerTreeGuided:
       - Added optional spectra file transformation (-in_spectra_files, -out_spectra_files) to transform mzML files along with alignment (#8536)
-      - Fix: MapAlignerPoseClustering no longer aborts the whole run when a single input file cannot be aligned to the reference (e.g. a blank/near-empty LC-MS run). Both the mzML and featureXML branches now catch all alignment failures (IllegalArgument, InvalidValue, UnableToFit) and fall back to the identity transformation for that file, so the remaining files are still processed (fixes #7010)
+      - Fix: MapAlignerPoseClustering no longer aborts the whole run when a single input file cannot be aligned to the reference (e.g. a blank/near-empty LC-MS run). Both the mzML and featureXML branches now catch any alignment failure (Exception::BaseException, covering IllegalArgument, InvalidValue, UnableToFit, DivisionByZero, ...) and fall back to the identity transformation for that file, so the remaining files are still processed (fixes #7010)
     FileInfo:
       - Now prints both assigned and unassigned peptide identification counts for FeatureXML and ConsensusXML files (#8395)
       - Added sequence length stats and nucleic acid support for FASTA files (#8643)

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -1298,6 +1298,29 @@ set_tests_properties("TOPP_MapAlignerPoseClustering_4_out1" PROPERTIES DEPENDS "
 add_test("TOPP_MapAlignerPoseClustering_4_out2" ${DIFF} -in1 ${TESTS_TEMP_DIR}/MapAlignerPoseClustering_4_trafo2.tmp.trafoXML -in2 ${DATA_DIR_TOPP}/MapAlignerPoseClustering_1_trafo1.trafoXML )
 set_tests_properties("TOPP_MapAlignerPoseClustering_4_out2" PROPERTIES DEPENDS "TOPP_MapAlignerPoseClustering_4")
 
+# Un-alignable input must not abort the whole run (issue #7010). On develop the mzML branch
+# called align() without a try/catch, so any alignment failure crashed the tool with an
+# uncaught exception. The fix falls back to the identity transformation for the failing file
+# and keeps processing the rest. align() can throw three sibling exceptions; the two tests
+# below cover the two that occur for near-empty input (and that the earlier, incomplete
+# attempt in PR #8376 handled only partially).
+
+# _5: realistic case - a normal reference (input1) plus a near-empty blank (a single peak).
+# The blank cannot be matched to the reference, so the linear fit over zero matched pairs
+# throws Exception::IllegalArgument. The tool must exit 0 and give the blank the identity trafo.
+add_test("TOPP_MapAlignerPoseClustering_5" ${TOPP_BIN_PATH}/MapAlignerPoseClustering -test -ini ${DATA_DIR_TOPP}/MapAlignerPoseClustering_2_parameters.ini -in ${DATA_DIR_TOPP}/MapAlignerPoseClustering_2_input1.mzML ${DATA_DIR_TOPP}/MapAlignerPoseClustering_3_blank.mzML -out ${TESTS_TEMP_DIR}/MapAlignerPoseClustering_5_output1.tmp.mzML ${TESTS_TEMP_DIR}/MapAlignerPoseClustering_5_output2.tmp.mzML -trafo_out ${TESTS_TEMP_DIR}/MapAlignerPoseClustering_5_trafo1.tmp.trafoXML ${TESTS_TEMP_DIR}/MapAlignerPoseClustering_5_trafo2.tmp.trafoXML -reference:index 1)
+add_test("TOPP_MapAlignerPoseClustering_5_out1" ${DIFF} -in1 ${TESTS_TEMP_DIR}/MapAlignerPoseClustering_5_trafo2.tmp.trafoXML -in2 ${DATA_DIR_TOPP}/MapAlignerPoseClustering_1_trafo1.trafoXML )
+set_tests_properties("TOPP_MapAlignerPoseClustering_5_out1" PROPERTIES DEPENDS "TOPP_MapAlignerPoseClustering_5")
+
+# _6: exercises the Exception::InvalidValue path that PR #8376 did NOT catch (it caught only
+# IllegalArgument + UnableToFit). Using the single-peak blank as BOTH reference and scene gives
+# two maps with zero RT span, so the superimposer's slope estimate divides by zero (NaN) and
+# throws InvalidValue. Both develop (no catch) and PR #8376 (no InvalidValue catch) crash here;
+# the fix falls back to the identity trafo for the aligned (non-reference) file.
+add_test("TOPP_MapAlignerPoseClustering_6" ${TOPP_BIN_PATH}/MapAlignerPoseClustering -test -ini ${DATA_DIR_TOPP}/MapAlignerPoseClustering_2_parameters.ini -in ${DATA_DIR_TOPP}/MapAlignerPoseClustering_3_blank.mzML ${DATA_DIR_TOPP}/MapAlignerPoseClustering_3_blank.mzML -out ${TESTS_TEMP_DIR}/MapAlignerPoseClustering_6_output1.tmp.mzML ${TESTS_TEMP_DIR}/MapAlignerPoseClustering_6_output2.tmp.mzML -trafo_out ${TESTS_TEMP_DIR}/MapAlignerPoseClustering_6_trafo1.tmp.trafoXML ${TESTS_TEMP_DIR}/MapAlignerPoseClustering_6_trafo2.tmp.trafoXML -reference:index 1)
+add_test("TOPP_MapAlignerPoseClustering_6_out1" ${DIFF} -in1 ${TESTS_TEMP_DIR}/MapAlignerPoseClustering_6_trafo2.tmp.trafoXML -in2 ${DATA_DIR_TOPP}/MapAlignerPoseClustering_1_trafo1.trafoXML )
+set_tests_properties("TOPP_MapAlignerPoseClustering_6_out1" PROPERTIES DEPENDS "TOPP_MapAlignerPoseClustering_6")
+
 #------------------------------------------------------------------------------
 # MapAlignerIdentification tests:
 add_test("TOPP_MapAlignerIdentification_1" ${TOPP_BIN_PATH}/MapAlignerIdentification -test -ini ${DATA_DIR_TOPP}/MapAlignerIdentification_parameters.ini -in ${DATA_DIR_TOPP}/MapAlignerIdentification_1_input1.featureXML ${DATA_DIR_TOPP}/MapAlignerIdentification_1_input2.featureXML -out ${TESTS_TEMP_DIR}/MapAlignerIdentification_1_output1.tmp.featureXML ${TESTS_TEMP_DIR}/MapAlignerIdentification_1_output2.tmp.featureXML)

--- a/src/tests/topp/MapAlignerPoseClustering_3_blank.mzML
+++ b/src/tests/topp/MapAlignerPoseClustering_3_blank.mzML
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" accession="" version="1.1.0">
+	<cvList count="2">
+		<cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" URI="http://psidev.cvs.sourceforge.net/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo"/>
+		<cv id="UO" fullName="Unit Ontology" URI="http://obo.cvs.sourceforge.net/obo/obo/ontology/phenotype/unit.obo"/>
+	</cvList>
+	<fileDescription>
+		<fileContent>
+			<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+		</fileContent>
+	</fileDescription>
+	<softwareList count="1">
+		<software id="so_default" version="" >
+			<cvParam cvRef="MS" accession="MS:1000799" name="custom unreleased software tool" value="" />
+		</software>
+	</softwareList>
+	<instrumentConfigurationList count="1">
+		<instrumentConfiguration id="ic_0">
+			<cvParam cvRef="MS" accession="MS:1000031" name="instrument model" />
+			<softwareRef ref="so_default" />
+		</instrumentConfiguration>
+	</instrumentConfigurationList>
+	<dataProcessingList count="1">
+		<dataProcessing id="dp_sp_0">
+			<processingMethod order="0" softwareRef="so_default">
+				<cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" />
+			</processingMethod>
+		</dataProcessing>
+	</dataProcessingList>
+	<run id="ru_0" defaultInstrumentConfigurationRef="ic_0">
+		<spectrumList count="1" defaultDataProcessingRef="dp_sp_0">
+			<spectrum id="spectrum=0" index="0" defaultArrayLength="1" dataProcessingRef="dp_sp_0">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="100" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="12">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAABAf0A=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="12">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAABAj0A=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+		</spectrumList>
+	</run>
+</mzML>

--- a/src/topp/MapAlignerPoseClustering.cpp
+++ b/src/topp/MapAlignerPoseClustering.cpp
@@ -220,7 +220,10 @@ protected:
     {
       auto fallbackToIdentity = [&](const Exception::BaseException& e)
       {
-        OPENMS_LOG_ERROR << "Aligning " << in_files[i] << " to reference " << in_files[reference_index]
+        // reference_index is set to in_files.size() (an invalid index) when -reference:file is
+        // used, so fall back to the user-specified reference filename in that case.
+        const String ref_name = (reference_index < in_files.size()) ? in_files[reference_index] : reference_file;
+        OPENMS_LOG_ERROR << "Aligning " << in_files[i] << " to reference " << ref_name
                          << " failed. No transformation will be applied (RT not changed for this file)." << endl;
         writeLogError_("Alignment failed (" + String(e.getName()) + "): " + String(e.what()) +
                        ". Using identity transformation for this file.");

--- a/src/topp/MapAlignerPoseClustering.cpp
+++ b/src/topp/MapAlignerPoseClustering.cpp
@@ -210,40 +210,33 @@ protected:
     // Align a single map to the reference, falling back to the identity
     // transformation when the alignment fails so that one un-alignable file
     // (e.g. a blank/near-empty LC-MS run) no longer aborts the whole tool
-    // (fixes #7010). align() can throw three exceptions that all derive
-    // directly from Exception::BaseException and are therefore siblings -
-    // catching one does not catch the others, so each is handled explicitly:
+    // (fixes #7010). Depending on how degenerate the input is, align() can fail
+    // with several different OpenMS exceptions, e.g.:
     //  - IllegalArgument: empty map / no data points for the linear model
     //  - InvalidValue:    superimposer cannot estimate an initial transformation
     //  - UnableToFit:     degenerate linear fit
+    //  - DivisionByZero:  superimposer estimates a zero slope, then inverts it
+    // These all derive from Exception::BaseException, so we catch that common
+    // base rather than an explicit list of subtypes: any exception escaping this
+    // OpenMP parallel region would call std::terminate and abort the whole tool -
+    // precisely the failure mode #7010 is about - so the catch must be exhaustive.
     auto alignOrIdentity = [&](auto& map, TransformationDescription& trafo, int i)
     {
-      auto fallbackToIdentity = [&](const Exception::BaseException& e)
+      try
       {
-        // reference_index is set to in_files.size() (an invalid index) when -reference:file is
-        // used, so fall back to the user-specified reference filename in that case.
+        algorithm.align(map, trafo);
+      }
+      catch (const Exception::BaseException& e)
+      {
+        // reference_index is set to in_files.size() (an invalid index) when
+        // -reference:file is used, so fall back to the user-specified reference
+        // filename in that case.
         const String ref_name = (reference_index < in_files.size()) ? in_files[reference_index] : reference_file;
         OPENMS_LOG_ERROR << "Aligning " << in_files[i] << " to reference " << ref_name
                          << " failed. No transformation will be applied (RT not changed for this file)." << endl;
         writeLogError_("Alignment failed (" + String(e.getName()) + "): " + String(e.what()) +
                        ". Using identity transformation for this file.");
         trafo.fitModel("identity");
-      };
-      try
-      {
-        algorithm.align(map, trafo);
-      }
-      catch (Exception::IllegalArgument& e)
-      {
-        fallbackToIdentity(e);
-      }
-      catch (Exception::InvalidValue& e)
-      {
-        fallbackToIdentity(e);
-      }
-      catch (Exception::UnableToFit& e)
-      {
-        fallbackToIdentity(e);
       }
     };
 

--- a/src/topp/MapAlignerPoseClustering.cpp
+++ b/src/topp/MapAlignerPoseClustering.cpp
@@ -15,6 +15,8 @@
 #include <omp.h>
 #endif
 
+#include <exception>
+
 using namespace OpenMS;
 using namespace std;
 
@@ -240,11 +242,12 @@ protected:
       }
     };
 
+    // Process one input file: load it, align it to the reference (or fall back to
+    // the identity transformation, see alignOrIdentity), then transform and store
+    // the requested outputs. Pulled out of the loop so the parallel region can wrap
+    // the whole per-file body in a single try/catch (see below).
     // TODO: it should all work on featureXML files, since we might need them for output anyway. Converting to consensusXML is just wasting memory!
-#ifdef _OPENMP
-#pragma omp parallel for schedule(dynamic, 1)
-#endif
-    for (int i = 0; i < static_cast<int>(in_files.size()); ++i)
+    auto processFile = [&](int i)
     {
       TransformationDescription trafo;
       if (in_type == FileTypes::FEATUREXML)
@@ -299,6 +302,33 @@ protected:
       {
         FileHandler().storeTransformations(out_trafos[i], trafo, {FileTypes::TRANSFORMATIONXML});
       }
+    };
+
+    // Unlike alignment failures (handled inside alignOrIdentity by falling back to
+    // identity), I/O failures (unreadable input, unwritable output) are real errors
+    // that must abort the run with a proper exit code. But an exception escaping an
+    // OpenMP parallel region calls std::terminate, so capture the first one here and
+    // rethrow it after the region, where TOPPBase's handler turns it into a clean
+    // error exit instead of aborting the whole tool mid-loop.
+    std::exception_ptr first_error = nullptr;
+#ifdef _OPENMP
+#pragma omp parallel for schedule(dynamic, 1)
+#endif
+    for (int i = 0; i < static_cast<int>(in_files.size()); ++i)
+    {
+      try
+      {
+        processFile(i);
+      }
+      catch (...)
+      {
+#ifdef _OPENMP
+#pragma omp critical (MAPose_Error)
+#endif
+        {
+          if (!first_error) { first_error = std::current_exception(); }
+        }
+      }
 
 #ifdef _OPENMP
 #pragma omp critical (MAPose_Progress)
@@ -309,6 +339,13 @@ protected:
     }
 
     plog.endProgress();
+
+    // Re-throw the first per-file error (if any) now that we are outside the
+    // parallel region, so it propagates to TOPPBase's exception handler.
+    if (first_error)
+    {
+      std::rethrow_exception(first_error);
+    }
     
     // Transform optional spectra files
     // Note: MapAlignerPoseClustering does not support store_original_rt flag

--- a/src/topp/MapAlignerPoseClustering.cpp
+++ b/src/topp/MapAlignerPoseClustering.cpp
@@ -206,6 +206,44 @@ protected:
 
     plog.startProgress(0, in_files.size(), "Aligning input maps");
     Size progress(0); // thread-safe progress
+
+    // Align a single map to the reference, falling back to the identity
+    // transformation when the alignment fails so that one un-alignable file
+    // (e.g. a blank/near-empty LC-MS run) no longer aborts the whole tool
+    // (fixes #7010). align() can throw three exceptions that all derive
+    // directly from Exception::BaseException and are therefore siblings -
+    // catching one does not catch the others, so each is handled explicitly:
+    //  - IllegalArgument: empty map / no data points for the linear model
+    //  - InvalidValue:    superimposer cannot estimate an initial transformation
+    //  - UnableToFit:     degenerate linear fit
+    auto alignOrIdentity = [&](auto& map, TransformationDescription& trafo, int i)
+    {
+      auto fallbackToIdentity = [&](const Exception::BaseException& e)
+      {
+        OPENMS_LOG_ERROR << "Aligning " << in_files[i] << " to reference " << in_files[reference_index]
+                         << " failed. No transformation will be applied (RT not changed for this file)." << endl;
+        writeLogError_("Alignment failed (" + String(e.getName()) + "): " + String(e.what()) +
+                       ". Using identity transformation for this file.");
+        trafo.fitModel("identity");
+      };
+      try
+      {
+        algorithm.align(map, trafo);
+      }
+      catch (Exception::IllegalArgument& e)
+      {
+        fallbackToIdentity(e);
+      }
+      catch (Exception::InvalidValue& e)
+      {
+        fallbackToIdentity(e);
+      }
+      catch (Exception::UnableToFit& e)
+      {
+        fallbackToIdentity(e);
+      }
+    };
+
     // TODO: it should all work on featureXML files, since we might need them for output anyway. Converting to consensusXML is just wasting memory!
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic, 1)
@@ -220,23 +258,13 @@ protected:
         FileHandler f_fxml_tmp; // do not use OMP-firstprivate, since FeatureXMLFile has no copy c'tor
         f_fxml_tmp.getFeatOptions() = f_fxml.getFeatOptions();
         f_fxml_tmp.loadFeatures(in_files[i], map);
-        if (i == static_cast<int>(reference_index)) 
+        if (i == static_cast<int>(reference_index))
         {
           trafo.fitModel("identity");
         }
-        else 
+        else
         {
-          try
-          {
-            algorithm.align(map, trafo);
-          }
-          catch (Exception::IllegalArgument& e)
-          {
-            OPENMS_LOG_ERROR << "Aligning " << in_files[i] << " to reference " << in_files[reference_index]
-                             << " failed. No transformation will be applied (RT not changed for this file)." << endl;
-            writeLogError_("Illegal argument (" + String(e.getName()) + "): " + String(e.what()) + ".");
-            trafo.fitModel("identity");
-          }
+          alignOrIdentity(map, trafo, i);
         }
 
         if (!out_files.empty())
@@ -257,7 +285,7 @@ protected:
         }
         else
         {
-          algorithm.align(map, trafo);
+          alignOrIdentity(map, trafo, i);
         }
         if (!out_files.empty())
         {


### PR DESCRIPTION
## Problem

`MapAlignerPoseClustering` aborts the **entire** batch with `FATAL: uncaught exception!` when a single input file cannot be aligned to the reference (e.g. a blank / near-empty LC-MS run). Removing the offending file lets all the others align fine — so one bad run shouldn't kill the whole job. Fixes #7010.

Two gaps caused this:
- the **mzML** branch called `algorithm.align(map, trafo)` with **no try/catch at all**;
- the **featureXML** branch caught only `Exception::IllegalArgument`.

`MapAlignmentAlgorithmPoseClustering::align()` can throw **three** exceptions that all derive *directly* from `Exception::BaseException` and are therefore siblings — catching one does **not** catch the others:

| Exception | Origin |
|---|---|
| `IllegalArgument` | empty map / "no data points for 'linear' model" (`TransformationModelLinear`) |
| `InvalidValue` | "Superimposer could not compute an initial transformation!" (NaN slope) |
| `UnableToFit` | degenerate linear fit (`TransformationModelLinear`) |

The earlier attempt (closed PR #8376) caught only `IllegalArgument` + `UnableToFit`, leaving `InvalidValue` uncaught.

## Fix

The alignment + identity fallback is factored into one generic lambda `alignOrIdentity()` used by **both** the featureXML and mzML branches. The framing is deliberately *"catch every exception `align()` can throw"* rather than *"catch InvalidValue"*: any of the three escaping the OpenMP loop aborts the whole run, so all three fall back to `trafo.fitModel("identity")`. On failure it logs which file failed (the exception name + message) and the file keeps its original RT; the remaining files are still processed.

## A note on the tests (please read — the `_6` construction looks odd on purpose)

The issue's and #8376's mental model is *"single peak → `InvalidValue`."* **That turns out to be empirically false**, and it changes the test design:

- With a **real, multi-RT reference**, the superimposer *clamps* the degenerate scaling, so a near-empty input does **not** throw `InvalidValue`. The realistic failure is `IllegalArgument`, thrown later by the empty linear fit (zero matched pairs).
- `InvalidValue` is thrown only when `rt_high == rt_low` (→ `0/0` → NaN slope). Since `rt_high - rt_low = ((model RT span) + (scene RT span)) / 2`, this requires **both** maps to have zero RT span. A normal reference (wide RT span) makes `InvalidValue` *unreachable*.

So the InvalidValue path cannot be exercised with `input1` as the reference. Hence the two complementary tests (both reuse the deterministic, `threads=1` `_2` parameters, and both reuse one new data file — a blank with exactly one isolated peak):

- **`MapAlignerPoseClustering_5`** — realistic case: normal reference (`input1`) + the single-peak blank. The empty linear fit throws `IllegalArgument`; the tool exits 0 and the blank gets the identity trafo, `input1` is still processed. (Crashes on `develop`.)
- **`MapAlignerPoseClustering_6`** — the single-peak blank used as **both** reference and scene → two zero-RT-span maps → NaN slope → `InvalidValue`, the path #8376 missed. (Crashes on both `develop` and #8376; passes here.) The blank-as-its-own-reference is the *minimal* construction that reaches `InvalidValue` — not a mistake.

Verification: removing only the `InvalidValue` catch (simulating #8376) and rebuilding makes `_6` crash (`exit 134`, `FATAL ... InvalidValue ... line 1015`); restoring it makes it pass. All 21 `-R MapAlignerPoseClustering` tests pass, and the existing `_1..4` are unchanged (they align successfully and never enter the catch).

## Acceptance criteria
- [x] Normal reference + blank mzML completes (exit 0) instead of crashing; blank receives identity, other files still processed.
- [x] New tests pass on the fix and fail on `develop` (mzML branch crash) and on #8376's approach (the `InvalidValue` path, via `_6`).
- [x] Existing `MapAlignerPoseClustering_1..4` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MapAlignerPoseClustering no longer aborts the run when a single input fails to align; it logs the failure, applies an identity transformation for that file, and continues (mzML and featureXML). Per-file I/O errors occurring inside parallel processing now produce a clean error exit instead of crashing.

* **Tests**
  * Added automated tests to verify graceful identity-fallback behavior for near-empty/blank inputs.

* **Documentation**
  * Added changelog entry for the upcoming 3.6.0 release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->