### PR TITLE
fix(ci): fix nightly ARM source-tarball step (tar 'file changed as we read it')

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -453,14 +453,17 @@ jobs:
     - name: Create tarball
       if: steps.set-vars.outputs.pkg_type != 'none' && startsWith(matrix.os, 'ubuntu') && runner.arch == 'arm64'
       run: |
+        # Write the archive to RUNNER_TEMP, i.e. OUTSIDE ${{ github.workspace }} (the directory
+        # being archived). Writing it in-tree makes the output file grow inside the directory tar
+        # is reading, so GNU tar reports "tar: .: file changed as we read it" and exits 1, which
+        # fails the step under `bash -e`.
         tar --exclude='bld/*' \
-            --exclude='OpenMS-${{ steps.create_changelog.outputs.version_number }}.tar.gz' \
             --exclude='THIRDPARTY/**' \
             --exclude='contrib/**' \
             --exclude='.git/**' \
             --exclude='.github/**' \
             --exclude='vcpkg*/**' \
-            -czf OpenMS-${{ steps.create_changelog.outputs.version_number }}.tar.gz -C ${{ github.workspace }} .
+            -czf ${{ runner.temp }}/OpenMS-${{ steps.create_changelog.outputs.version_number }}.tar.gz -C ${{ github.workspace }} .
 
    # Upload the source tar
     - name: Upload source tar as artifact
@@ -469,7 +472,7 @@ jobs:
       with:
         name: OpenMS-${{ steps.create_changelog.outputs.version_number }}.tar.gz
         path: |
-          ${{ github.workspace }}/OpenMS-${{ steps.create_changelog.outputs.version_number }}.tar.gz
+          ${{ runner.temp }}/OpenMS-${{ steps.create_changelog.outputs.version_number }}.tar.gz
 
 
     # Only upload docs when we are building the package, use the ubuntu build simply 'cause its fast


### PR DESCRIPTION
## Problem

The **ubuntu-24.04-arm** job of `openms_ci_matrix_full.yml` fails **every** nightly at the **Create tarball** step, which is the main reason the nightly matrix is red (the other is macOS notarization, #9457 — separate, account-side):

```
tar ... -czf OpenMS-.tar.gz -C /home/runner/work/OpenMS/OpenMS .
tar: .: file changed as we read it
##[error]Process completed with exit code 1.
```

Deterministic — reproduced on the 2026-06-03, -04, -05 and -06 nightlies. Build + tests pass; only this packaging step fails. The step is gated to `runner.arch == 'arm64'`, so the x86 Linux jobs (which skip it) stay green.

## Root cause

The output path was **relative**, so the tarball was created in the step's working directory (`${{ github.workspace }}`) — the **same directory being archived** by `-C ${{ github.workspace }} .`. As `tar` streamed the growing archive into that directory, GNU tar detected that `.` changed and exited `1`, failing the step under `bash -e`. The previous `--exclude='OpenMS-….tar.gz'` removed the file from the archive *contents* but did not stop tar from noticing the *directory* changed.

## Fix

Write the archive to `${{ runner.temp }}` (outside `${{ github.workspace }}`) and upload it from there, so the archived directory no longer changes during the read. The now-dead self-exclude is dropped.

```diff
-            -czf OpenMS-${{ ...version_number }}.tar.gz -C ${{ github.workspace }} .
+            -czf ${{ runner.temp }}/OpenMS-${{ ...version_number }}.tar.gz -C ${{ github.workspace }} .
```
(plus the matching `upload-artifact` `path:`)

## Notes

- This step only runs on the `nightly`/`release` package path, so it can't be exercised by PR CI; the change is a pure output-location move (artifact name unchanged), validated by YAML parse + review.
- Out of scope (follow-up): on nightly the artifact is named `OpenMS-.tar.gz` because `version_number` comes from `create_changelog`, which only runs for `release` builds — worth date-stamping the nightly tarball like the macOS pkg.

Fixes #9458

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to optimize build artifact handling and output location management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->