### PR TITLE
MSGFPlusAdapter: add -allow_dense_centroided_peaks flag

### DIFF
--- a/src/tests/topp/PSMFeatureExtractor_1_out.idXML
+++ b/src/tests/topp/PSMFeatureExtractor_1_out.idXML
@@ -41,6 +41,7 @@
 				<UserParam type="int" name="MSGFPlusAdapter:1:tasks" value="0"/>
 				<UserParam type="stringList" name="MSGFPlusAdapter:1:fixed_modifications" value="[]"/>
 				<UserParam type="stringList" name="MSGFPlusAdapter:1:variable_modifications" value="[Oxidation (M)]"/>
+				<UserParam type="string" name="MSGFPlusAdapter:1:allow_dense_centroided_peaks" value="false"/>
 				<UserParam type="string" name="MSGFPlusAdapter:1:legacy_conversion" value="false"/>
 				<UserParam type="string" name="MSGFPlusAdapter:1:conf" value=""/>
 				<UserParam type="string" name="MSGFPlusAdapter:1:java_executable" value="java"/>

--- a/src/tests/topp/PSMFeatureExtractor_2_out.mzid
+++ b/src/tests/topp/PSMFeatureExtractor_2_out.mzid
@@ -90,6 +90,7 @@
 			<userParam name="MSGFPlusAdapter:1:tasks" unitName="xsd:integer" value="0"/>
 			<userParam name="MSGFPlusAdapter:1:fixed_modifications" unitName="xsd:string" value="[]"/>
 			<userParam name="MSGFPlusAdapter:1:variable_modifications" unitName="xsd:string" value="[Oxidation (M)]"/>
+			<userParam name="MSGFPlusAdapter:1:allow_dense_centroided_peaks" unitName="xsd:string" value="false"/>
 			<userParam name="MSGFPlusAdapter:1:legacy_conversion" unitName="xsd:string" value="false"/>
 			<userParam name="MSGFPlusAdapter:1:conf" unitName="xsd:string" value=""/>
 			<userParam name="MSGFPlusAdapter:1:java_executable" unitName="xsd:string" value="java"/>

--- a/src/tests/topp/PSMFeatureExtractor_3_out.idXML
+++ b/src/tests/topp/PSMFeatureExtractor_3_out.idXML
@@ -41,6 +41,7 @@
 				<UserParam type="int" name="MSGFPlusAdapter:1:tasks" value="0"/>
 				<UserParam type="stringList" name="MSGFPlusAdapter:1:fixed_modifications" value="[]"/>
 				<UserParam type="stringList" name="MSGFPlusAdapter:1:variable_modifications" value="[Oxidation (M)]"/>
+				<UserParam type="string" name="MSGFPlusAdapter:1:allow_dense_centroided_peaks" value="false"/>
 				<UserParam type="string" name="MSGFPlusAdapter:1:legacy_conversion" value="false"/>
 				<UserParam type="string" name="MSGFPlusAdapter:1:conf" value=""/>
 				<UserParam type="string" name="MSGFPlusAdapter:1:java_executable" value="java"/>

--- a/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1_out.idXML
@@ -41,6 +41,7 @@
 				<UserParam type="int" name="MSGFPlusAdapter:1:tasks" value="0"/>
 				<UserParam type="stringList" name="MSGFPlusAdapter:1:fixed_modifications" value="[]"/>
 				<UserParam type="stringList" name="MSGFPlusAdapter:1:variable_modifications" value="[Oxidation (M)]"/>
+				<UserParam type="string" name="MSGFPlusAdapter:1:allow_dense_centroided_peaks" value="false"/>
 				<UserParam type="string" name="MSGFPlusAdapter:1:legacy_conversion" value="false"/>
 				<UserParam type="string" name="MSGFPlusAdapter:1:conf" value=""/>
 				<UserParam type="string" name="MSGFPlusAdapter:1:java_executable" value="java"/>

--- a/src/tests/topp/THIRDPARTY/third_party_tests.cmake
+++ b/src/tests/topp/THIRDPARTY/third_party_tests.cmake
@@ -107,7 +107,16 @@ if (NOT (${MSGFPLUS_BINARY} STREQUAL "MSGFPLUS_BINARY-NOTFOUND"))
   
   ## MS2 profile spectra are not allowed
   add_test("TOPP_MSGFPlusAdapter_PROFILE" ${TOPP_BIN_PATH}/MSGFPlusAdapter -test -database ${DATA_DIR_TOPP}/THIRDPARTY/proteinslong.fasta -in ${DATA_DIR_TOPP}/THIRDPARTY/MS2_profile.mzML -out MSGFPlusAdapter_3_out.tmp.idXML -executable "${MSGFPLUS_BINARY}")
-  set_tests_properties("TOPP_MSGFPlusAdapter_PROFILE" PROPERTIES WILL_FAIL 1) 
+  set_tests_properties("TOPP_MSGFPlusAdapter_PROFILE" PROPERTIES WILL_FAIL 1)
+
+  ## smoke test for the new -allow_dense_centroided_peaks flag: same input/output as test 1, only the flag differs.
+  ## The flag does not change the search result for these (non-dense) spectra, so the output equals MSGFPlusAdapter_1_out
+  ## except for the recorded parameter value (allow_dense_centroided_peaks=true instead of false), which is whitelisted.
+  add_test("TOPP_MSGFPlusAdapter_2" ${TOPP_BIN_PATH}/MSGFPlusAdapter -test -ini ${DATA_DIR_TOPP}/THIRDPARTY/MSGFPlusAdapter_1.ini -database ${DATA_DIR_TOPP}/THIRDPARTY/proteins.fasta -in ${DATA_DIR_TOPP}/THIRDPARTY/spectra.mzML -out MSGFPlusAdapter_2_out1.tmp.idXML -mzid_out MSGFPlusAdapter_2_out2.tmp.mzid -executable "${MSGFPLUS_BINARY}" -allow_dense_centroided_peaks)
+  add_test("TOPP_MSGFPlusAdapter_2_out1" ${DIFF} -in1 MSGFPlusAdapter_2_out1.tmp.idXML -in2 ${DATA_DIR_TOPP}/THIRDPARTY/MSGFPlusAdapter_1_out.idXML -whitelist "IdentificationRun date" "SearchParameters id=\"SP_0\" db=" "UserParam type=\"stringList\" name=\"spectra_data\" value=" "UserParam type=\"string\" name=\"MSGFPlusAdapter:1:in\" value=" "UserParam type=\"string\" name=\"MSGFPlusAdapter:1:executable\" value=" "UserParam type=\"string\" name=\"MSGFPlusAdapter:1:database\" value=" "MSGFPlusAdapter:1:out\"" "MSGFPlusAdapter:1:mzid_out\"" "MSGFPlusAdapter:1:allow_dense_centroided_peaks")
+  set_tests_properties("TOPP_MSGFPlusAdapter_2_out1" PROPERTIES DEPENDS "TOPP_MSGFPlusAdapter_2")
+  add_test("TOPP_MSGFPlusAdapter_2_out2" ${DIFF} -in1 MSGFPlusAdapter_2_out2.tmp.mzid -in2 ${DATA_DIR_TOPP}/THIRDPARTY/MSGFPlusAdapter_1_out.mzid -whitelist "creationDate=" "SearchDatabase numDatabaseSequences=\"10\" location=" "SpectraData location=" "AnalysisSoftware")
+  set_tests_properties("TOPP_MSGFPlusAdapter_2_out2" PROPERTIES DEPENDS "TOPP_MSGFPlusAdapter_2")
 endif()
 ## test returncode when MSGFPlus not found:
 add_test("TOPP_MSGFPlusAdapter_missing" ${TOPP_BIN_PATH}/MSGFPlusAdapter -test -database ${DATA_DIR_TOPP}/THIRDPARTY/proteins.fasta -in ${DATA_DIR_TOPP}/THIRDPARTY/spectra.mzML -out MSGFPlusAdapter_1_out.tmp.idXML -executable "/does/not/exists/path.exe")

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -206,6 +206,8 @@ protected:
                         false);
     setValidStrings_("variable_modifications", all_mods);
 
+    registerFlag_("allow_dense_centroided_peaks", "Pass '-allowDenseCentroidedPeaks 1' to MS-GF+ to also search spectra whose median distance of consecutive peaks is below ~50 ppm. The MS-GF+ default treats such (centroided) spectra as profile spectra and skips them.", false);
+
     registerFlag_("legacy_conversion", "Use the indirect conversion of MS-GF+ results to idXML via export to TSV. Try this only if the default conversion takes too long or uses too much memory.", true);
 
     registerInputFile_("conf", "<file>", "", "Optional MSGF+ configuration file (passed as -conf <file> to MSGF+). See documentation for examples. Parameters of the adapter take precedence. Use conf file only for settings not available here (for example, any fixed/var modifications, in the conf file will be ignored, since they are provided via -mod flag)", false, false);
@@ -598,6 +600,12 @@ protected:
       "-tasks", String(getIntOption_("tasks")),
       "-thread", String(getIntOption_("threads"))
     };
+    if (getFlag_("allow_dense_centroided_peaks"))
+    {
+      // pass flag and value as separate tokens (each vector element becomes one argv entry)
+      process_params.push_back("-allowDenseCentroidedPeaks");
+      process_params.push_back("1");
+    }
     String conf = getStringOption_("conf");
     if (!conf.empty())
     {


### PR DESCRIPTION
## Description

Exposes MS-GF+'s `-allowDenseCentroidedPeaks` option in `MSGFPlusAdapter`. When set, high-resolution **centroided** MS2 spectra whose median consecutive-peak distance is below ~50 ppm are searched instead of being misclassified by MS-GF+ as profile spectra and silently skipped.

This revives and finishes #6606 (originally by @bernt-matthias), rebased onto current `develop` and squashed to a single clean commit. It also fixes two defects that were latent in the original PR:

- **Argument passing:** the flag/value is now emitted as **two separate tokens** (`"-allowDenseCentroidedPeaks"`, `"1"`) instead of one space-joined string. `process_params` is an argv vector (`boost::process::args`), so each element becomes one argv entry with no whitespace splitting — the original `"-allowDenseCentroidedPeaks 1"` would have reached MS-GF+ as a single unparseable argument.
- **Test reference:** every registered parameter is written into the idXML `SearchParameters` (via `writeParametersToMetaValues`, in registration order). Because `FuzzyDiff` compares lines positionally, the new `UserParam` line is added to the reference `MSGFPlusAdapter_1_out.idXML` rather than merely whitelisted (a whitelist cannot absorb an inserted line).

## Changes

- Register `allow_dense_centroided_peaks` flag in `MSGFPlusAdapter`.
- Pass `-allowDenseCentroidedPeaks 1` to MS-GF+ when the flag is set.
- Record the new parameter in the `MSGFPlusAdapter_1` reference idXML.
- Add `TOPP_MSGFPlusAdapter_2`: runs the adapter with the flag enabled.

## Testing

Verified locally against a real MS-GF+ run (MSGFPlus.jar, Java 21): the adapter runs succeed with the flag, the parameter is recorded as `true`/`false`, and direct diffs of the produced idXML/mzid against the references differ only in already-whitelisted lines (`out` / `mzid_out` / `allow_dense_centroided_peaks` / `date` / paths).

## Remaining / follow-up

- [ ] CHANGELOG entry
- [ ] AUTHORS (original author already credited via co-author trailer on the commit)
- [ ] The new test only verifies the flag is **accepted and recorded**. A dedicated dense-centroided MS2 fixture that fails *without* the flag (as requested in #6606) is still TODO.

Closes #6606


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to allow searching dense (centroided) spectra so they are not skipped during analysis.

* **Tests**
  * Added and updated tests to verify dense-centroided-peak handling; test outputs now record the chosen option value for verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->