### PR TITLE
feat(pyopenms): nanobind DataFrame helper for FeatureFinderAlgorithmMetaboIdent (incl. IM & Adduct)

### DIFF
--- a/src/pyOpenMS/bindings/bind_featurefinder.cpp
+++ b/src/pyOpenMS/bindings/bind_featurefinder.cpp
@@ -287,7 +287,25 @@ estimated for arbitrary m/z using a spline interpolation.
     // -----------------------------------------------------------------------
     nb::class_<OpenMS::FeatureFinderAlgorithmMetaboIdent::FeatureFinderMetaboIdentCompound>(m, "FeatureFinderMetaboIdentCompound",
         R"doc(
-Represents a compound in the assay library for FeatureFinderAlgorithmMetaboIdent.
+Represents one target compound in the assay library for FeatureFinderAlgorithmMetaboIdent.
+
+Constructor:
+    FeatureFinderMetaboIdentCompound(name, formula, mass, charges, rts, rt_ranges,
+                                     iso_distrib, ion_mobilities=[], adduct="")
+
+Arguments:
+    name           Unique target name.
+    formula        Sum formula (e.g. 'C6H12O6'); may be empty if mass > 0.
+    mass           Neutral mass; <= 0 means "derive from formula".
+    charges        Charge states (list[int]); each non-zero entry yields one transition.
+    rts            Expected retention times in seconds (list[float], one entry per target).
+    rt_ranges      RT tolerance per RT; one value is broadcast, [] uses the algorithm default.
+    iso_distrib    Pre-computed isotope intensities; [] or [0] computes them from the formula.
+    ion_mobilities Optional ion-mobility values; one value or one per RT, [] disables IM filtering.
+    adduct         Optional adduct string (e.g. '[M+H]+', '[M+Na]+', '[M-H]-'); empty infers
+                   [M+H]+/[M-H]- from charge polarity.
+
+For a pandas-based interface see FeatureFinderAlgorithmMetaboIdent.compounds_from_df().
 )doc")
         .def(nb::init<const OpenMS::String&, const OpenMS::String&, double, const std::vector<int>&, const std::vector<double>&, const std::vector<double>&, const std::vector<double>&, const std::vector<double>&, const OpenMS::String&>(),
             "name"_a, "formula"_a, "mass"_a, "charges"_a, "rts"_a, "rt_ranges"_a, "iso_distrib"_a, "ion_mobilities"_a = std::vector<double>(), "adduct"_a = OpenMS::String(""))

--- a/src/pyOpenMS/bindings/bind_misc.cpp
+++ b/src/pyOpenMS/bindings/bind_misc.cpp
@@ -662,12 +662,20 @@ ff = FeatureFinderAlgorithmMetaboIdent()
 ff.setMSData(exp)
 fm = FeatureMap() # detected features will be stored here
 library = []
-# fill library with compounds: FeatureFinderMetaboIdentCompound(name, formula, mass, [charges] [RTs_in_sec], [RT_ranges], [isotope distributions])
+# fill library with compounds: FeatureFinderMetaboIdentCompound(name, formula, mass, [charges], [RTs_in_sec], [RT_ranges], [isotope_distributions], [ion_mobilities], adduct)
 # e.g. FeatureFinderMetaboIdentCompound('glucose','C6H12O6', 0.0, [-1], [123.4], [0.0], [0.0])
 params = ff.getParameters() # optional!
 params[param_name] = new_value # e.g. params[b'extract:n_isotopes'] = 3
 ff.setParameters(params)
 ff.run(library, fm, path_to_file)
+
+# Alternatively (requires pandas), build the library from a DataFrame whose
+# columns mirror the FeatureFinderMetaboIdent TSV, including the optional
+# IonMobility and Adduct columns:
+#   ff.run_from_df(df, fm, path_to_file)
+# or build the compound list explicitly and inspect/round-trip it:
+#   compounds = FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+#   df2 = FeatureFinderAlgorithmMetaboIdent.compounds_to_df(compounds)
 )doc")
         .def(nb::init<>())
         .def("getMSData", [](OpenMS::FeatureFinderAlgorithmMetaboIdent& self) -> OpenMS::MSExperiment & { return self.getMSData(); }, nb::rv_policy::reference_internal, "Returns spectra")

--- a/src/pyOpenMS/pyopenms/addons/featurefinderalgorithmmetaboident.py
+++ b/src/pyOpenMS/pyopenms/addons/featurefinderalgorithmmetaboident.py
@@ -1,0 +1,265 @@
+"""Pure Python addon for FeatureFinderAlgorithmMetaboIdent.
+
+Adds a Pythonic, pandas-friendly interface for building the target compound
+library, so users no longer have to construct ``FeatureFinderMetaboIdentCompound``
+objects by hand.
+
+The accepted DataFrame columns mirror the input TSV of the ``FeatureFinderMetaboIdent``
+TOPP tool (see its documentation), including the optional ``IonMobility`` and
+``Adduct`` columns:
+
+    CompoundName  SumFormula  Mass  Charge  RetentionTime  RetentionTimeRange  IsoDistribution  [IonMobility]  [Adduct]
+"""
+from __future__ import annotations
+
+from . import addon
+
+
+# Canonical column name -> set of accepted aliases (all matched case-insensitively,
+# ignoring surrounding whitespace). The canonical name itself is always accepted.
+_COLUMN_ALIASES = {
+    "CompoundName": ("compoundname", "compound_name", "name"),
+    "SumFormula": ("sumformula", "sum_formula", "formula"),
+    "Mass": ("mass",),
+    "Charge": ("charge", "charges"),
+    "RetentionTime": ("retentiontime", "retention_time", "rt"),
+    "RetentionTimeRange": ("retentiontimerange", "retention_time_range", "rt_range", "rtrange"),
+    "IsoDistribution": ("isodistribution", "iso_distribution", "isotope_distribution"),
+    "IonMobility": ("ionmobility", "ion_mobility", "im"),
+    "Adduct": ("adduct", "adducts"),
+}
+
+# Columns that must be present for a valid compound library.
+_REQUIRED_COLUMNS = (
+    "CompoundName", "SumFormula", "Mass", "Charge",
+    "RetentionTime", "RetentionTimeRange", "IsoDistribution",
+)
+
+# Build a flat alias -> canonical lookup once at import time.
+_ALIAS_TO_CANONICAL = {}
+for _canonical, _aliases in _COLUMN_ALIASES.items():
+    _ALIAS_TO_CANONICAL[_canonical.lower()] = _canonical
+    for _alias in _aliases:
+        _ALIAS_TO_CANONICAL[_alias] = _canonical
+
+
+def _normalize_columns(df):
+    """Return ``df`` with its columns renamed to canonical names.
+
+    Raises ``ValueError`` if two source columns map to the same canonical name
+    (e.g. both ``rt`` and ``RetentionTime``), which would otherwise silently
+    create ambiguous duplicate columns.
+    """
+    rename = {}
+    canonical_to_source = {}
+    for col in df.columns:
+        canonical = _ALIAS_TO_CANONICAL.get(str(col).lower().strip())
+        if canonical is None:
+            continue  # leave unrecognized columns untouched
+        if canonical in canonical_to_source:
+            raise ValueError(
+                f"Columns '{canonical_to_source[canonical]}' and '{col}' both map "
+                f"to '{canonical}'. Please provide only one."
+            )
+        canonical_to_source[canonical] = col
+        rename[col] = canonical
+    return df.rename(columns=rename)
+
+
+def _to_list(value, dtype, np):
+    """Convert a scalar / list / numpy array / comma-separated string to ``list[dtype]``.
+
+    Empty strings, ``None`` and NaN scalars yield an empty list. Integer parsing
+    accepts float-like tokens (``"1.0"`` -> ``1``) so spreadsheet exports work.
+    """
+    if value is None:
+        return []
+    # Scalar NaN (float or numpy float) -> treat as "not provided".
+    if isinstance(value, float) and np.isnan(value):
+        return []
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return []
+        return [_coerce(tok.strip(), dtype) for tok in stripped.split(",") if tok.strip()]
+    if isinstance(value, (list, tuple, np.ndarray)):
+        return [_coerce(x, dtype) for x in value]
+    return [_coerce(value, dtype)]
+
+
+def _coerce(x, dtype):
+    """Coerce a single token to ``dtype`` (int parsing tolerates float-like tokens)."""
+    if dtype is int:
+        return int(float(x))
+    return dtype(x)
+
+
+@addon("FeatureFinderAlgorithmMetaboIdent", "compounds_from_df")
+@staticmethod
+def compounds_from_df(df):
+    """
+    Convert a pandas DataFrame to a list of ``FeatureFinderMetaboIdentCompound`` objects.
+
+    Column names are case-insensitive and accept ``snake_case`` and common
+    aliases (e.g. ``rt`` for ``RetentionTime``, ``im`` for ``IonMobility``).
+    The columns mirror the input TSV of the ``FeatureFinderMetaboIdent`` TOPP tool.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Table with the following columns (required unless noted):
+
+        - ``CompoundName`` (``compound_name``, ``name``): str, unique identifier.
+        - ``SumFormula`` (``sum_formula``, ``formula``): str, chemical formula
+          (may be empty if ``Mass`` is given).
+        - ``Mass`` (``mass``): float, neutral mass; ``0`` = derive from formula.
+        - ``Charge`` (``charges``): int, list[int], or comma-separated str.
+        - ``RetentionTime`` (``retention_time``, ``rt``): float, list[float], or
+          comma-separated str.
+        - ``RetentionTimeRange`` (``rt_range``): float/list/str; ``0`` = use the
+          ``extract:rt_window`` parameter.
+        - ``IsoDistribution`` (``iso_distribution``): float/list/str; ``0`` =
+          calculate from formula.
+        - ``IonMobility`` (``ion_mobility``, ``im``) *(optional)*: float/list/str;
+          one value, or one per RT entry; absent or ``0`` disables IM filtering.
+        - ``Adduct`` (``adducts``) *(optional)*: str, e.g. ``"[M+H]+"``,
+          ``"[M+Na]+"``, ``"[M-H]-"``; if omitted, ``[M+H]+`` / ``[M-H]-`` is
+          assumed from charge polarity.
+
+    Returns
+    -------
+    list of FeatureFinderMetaboIdentCompound
+
+    Raises
+    ------
+    ValueError
+        If required columns are missing, two columns map to the same field,
+        compound names are empty or duplicated, or ``Charge``/``RetentionTime``
+        are empty for any compound.
+    ImportError
+        If pandas or numpy are not installed.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from pyopenms import FeatureFinderAlgorithmMetaboIdent
+    >>> df = pd.DataFrame({
+    ...     'CompoundName': ['glucose', 'fructose'],
+    ...     'SumFormula': ['C6H12O6', 'C6H12O6'],
+    ...     'Mass': [0.0, 0.0],
+    ...     'Charge': [-1, '-1,1'],
+    ...     'RetentionTime': [123.4, '200.0,250.0'],
+    ...     'RetentionTimeRange': [0.0, 0.0],
+    ...     'IsoDistribution': [0.0, 0.0],
+    ...     'IonMobility': [0.0, 0.95],   # optional
+    ...     'Adduct': ['[M-H]-', ''],     # optional
+    ... })
+    >>> compounds = FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+    """
+    try:
+        import numpy as np
+        import pandas as pd
+    except ImportError as e:
+        raise ImportError(
+            "pandas and numpy are required for compounds_from_df. "
+            "Install with: pip install pandas numpy"
+        ) from e
+
+    from pyopenms._pyopenms_featurefinder import FeatureFinderMetaboIdentCompound
+
+    df = _normalize_columns(df)
+
+    missing = [c for c in _REQUIRED_COLUMNS if c not in df.columns]
+    if missing:
+        raise ValueError(
+            f"Missing required columns: {missing}. "
+            f"Required: {list(_REQUIRED_COLUMNS)} (optional: IonMobility, Adduct)."
+        )
+
+    has_im = "IonMobility" in df.columns
+    has_adduct = "Adduct" in df.columns
+
+    compounds = []
+    seen_names = set()
+
+    for idx, row in df.iterrows():
+        name = row["CompoundName"]
+        if pd.isna(name) or (isinstance(name, str) and not name.strip()):
+            raise ValueError(f"Row {idx}: CompoundName cannot be empty")
+        name = str(name).strip()
+        if name in seen_names:
+            raise ValueError(f"Row {idx}: Duplicate CompoundName '{name}'")
+        seen_names.add(name)
+
+        formula = row["SumFormula"]
+        formula = "" if pd.isna(formula) else str(formula).strip()
+
+        mass = row["Mass"]
+        mass = 0.0 if pd.isna(mass) else float(mass)
+
+        try:
+            charges = _to_list(row["Charge"], int, np)
+        except (ValueError, TypeError) as e:
+            raise ValueError(f"Row {idx} ('{name}'): could not parse Charge "
+                             f"value {row['Charge']!r}: {e}") from e
+        if not charges:
+            raise ValueError(f"Row {idx} ('{name}'): Charge cannot be empty")
+
+        try:
+            rts = _to_list(row["RetentionTime"], float, np)
+        except (ValueError, TypeError) as e:
+            raise ValueError(f"Row {idx} ('{name}'): could not parse RetentionTime "
+                             f"value {row['RetentionTime']!r}: {e}") from e
+        if not rts:
+            raise ValueError(f"Row {idx} ('{name}'): RetentionTime cannot be empty")
+
+        rt_ranges = _to_list(row["RetentionTimeRange"], float, np) or [0.0]
+        iso_dist = _to_list(row["IsoDistribution"], float, np) or [0.0]
+
+        ion_mobilities = _to_list(row["IonMobility"], float, np) if has_im else []
+
+        adduct = ""
+        if has_adduct:
+            a = row["Adduct"]
+            adduct = "" if pd.isna(a) else str(a).strip()
+
+        compounds.append(
+            FeatureFinderMetaboIdentCompound(
+                name, formula, mass, charges, rts, rt_ranges, iso_dist,
+                ion_mobilities, adduct,
+            )
+        )
+
+    return compounds
+
+
+@addon("FeatureFinderAlgorithmMetaboIdent")
+def run_from_df(self, df, features, spectra_path=""):
+    """
+    Run targeted feature extraction using compounds from a pandas DataFrame.
+
+    Convenience wrapper that combines :meth:`compounds_from_df` and :meth:`run`.
+    The spectra must be set beforehand via :meth:`setMSData`.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Compound table (see :meth:`compounds_from_df` for the accepted columns,
+        including the optional ``IonMobility`` and ``Adduct`` columns).
+    features : FeatureMap
+        Output map; detected features are stored here (modified in-place).
+    spectra_path : str, optional
+        Path to the spectra file, used as a fallback for the primary MS run path
+        annotated in the feature map.
+
+    Examples
+    --------
+    >>> exp = MSExperiment()
+    >>> MzMLFile().load("spectra.mzML", exp)
+    >>> ff = FeatureFinderAlgorithmMetaboIdent()
+    >>> ff.setMSData(exp)
+    >>> features = FeatureMap()
+    >>> ff.run_from_df(df, features, "spectra.mzML")
+    """
+    compounds = type(self).compounds_from_df(df)
+    self.run(compounds, features, spectra_path)

--- a/src/pyOpenMS/pyopenms/addons/featurefinderalgorithmmetaboident.py
+++ b/src/pyOpenMS/pyopenms/addons/featurefinderalgorithmmetaboident.py
@@ -134,8 +134,10 @@ def compounds_from_df(df):
     ------
     ValueError
         If required columns are missing, two columns map to the same field,
-        compound names are empty or duplicated, or ``Charge``/``RetentionTime``
-        are empty for any compound.
+        or a compound violates the contract: empty/duplicate name; empty
+        ``Charge``/``RetentionTime``; a zero charge; neither ``Mass`` > 0 nor a
+        ``SumFormula``; or a ``RetentionTimeRange``/``IonMobility`` whose length
+        is neither 1 nor the number of retention times.
     ImportError
         If pandas or numpy are not installed.
 
@@ -223,6 +225,23 @@ def compounds_from_df(df):
             a = row["Adduct"]
             adduct = "" if pd.isna(a) else str(a).strip()
 
+        # Fail fast on the FeatureFinderMetaboIdentCompound contract instead of
+        # letting run() silently drop the target later (it only logs an error).
+        if mass <= 0.0 and not formula:
+            raise ValueError(f"Row {idx} ('{name}'): either Mass > 0 or a non-empty "
+                             f"SumFormula is required to derive the m/z")
+        if any(c == 0 for c in charges):
+            raise ValueError(f"Row {idx} ('{name}'): Charge entries must be non-zero")
+        n_rt = len(rts)
+        if len(rt_ranges) not in (1, n_rt):
+            raise ValueError(f"Row {idx} ('{name}'): RetentionTimeRange has "
+                             f"{len(rt_ranges)} value(s); expected 1 or {n_rt} "
+                             f"(one per RetentionTime)")
+        if ion_mobilities and len(ion_mobilities) not in (1, n_rt):
+            raise ValueError(f"Row {idx} ('{name}'): IonMobility has "
+                             f"{len(ion_mobilities)} value(s); expected 1 or {n_rt} "
+                             f"(one per RetentionTime)")
+
         compounds.append(
             FeatureFinderMetaboIdentCompound(
                 name, formula, mass, charges, rts, rt_ranges, iso_dist,
@@ -231,6 +250,63 @@ def compounds_from_df(df):
         )
 
     return compounds
+
+
+@addon("FeatureFinderAlgorithmMetaboIdent", "compounds_to_df")
+@staticmethod
+def compounds_to_df(compounds):
+    """
+    Convert a list of ``FeatureFinderMetaboIdentCompound`` objects to a DataFrame.
+
+    Inverse of :meth:`compounds_from_df`: the returned DataFrame uses the
+    canonical column names and can be fed straight back into
+    :meth:`compounds_from_df`. The multi-value fields (``Charge``,
+    ``RetentionTime``, ``RetentionTimeRange``, ``IsoDistribution``,
+    ``IonMobility``) are returned as Python lists; ``Adduct`` is a string.
+
+    Parameters
+    ----------
+    compounds : iterable of FeatureFinderMetaboIdentCompound
+
+    Returns
+    -------
+    pandas.DataFrame
+        One row per compound, columns in canonical order.
+
+    Raises
+    ------
+    ImportError
+        If pandas is not installed.
+
+    Examples
+    --------
+    >>> df2 = FeatureFinderAlgorithmMetaboIdent.compounds_to_df(compounds)
+    >>> # round-trips back through compounds_from_df:
+    >>> compounds2 = FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df2)
+    """
+    try:
+        import pandas as pd
+    except ImportError as e:
+        raise ImportError(
+            "pandas is required for compounds_to_df. Install with: pip install pandas"
+        ) from e
+
+    columns = ["CompoundName", "SumFormula", "Mass", "Charge", "RetentionTime",
+               "RetentionTimeRange", "IsoDistribution", "IonMobility", "Adduct"]
+    rows = []
+    for c in compounds:
+        rows.append({
+            "CompoundName": str(c.getName()),
+            "SumFormula": str(c.getFormula()),
+            "Mass": c.getMass(),
+            "Charge": list(c.getCharges()),
+            "RetentionTime": list(c.getRTs()),
+            "RetentionTimeRange": list(c.getRTRanges()),
+            "IsoDistribution": list(c.getIsotopeDistribution()),
+            "IonMobility": list(c.getIonMobilities()),
+            "Adduct": str(c.getAdduct()),
+        })
+    return pd.DataFrame(rows, columns=columns)
 
 
 @addon("FeatureFinderAlgorithmMetaboIdent")

--- a/src/pyOpenMS/pyopenms/addons/featurefinderalgorithmmetaboident.py
+++ b/src/pyOpenMS/pyopenms/addons/featurefinderalgorithmmetaboident.py
@@ -66,31 +66,39 @@ def _normalize_columns(df):
     return df.rename(columns=rename)
 
 
-def _to_list(value, dtype, np):
+def _to_list(value, dtype, np, pd):
     """Convert a scalar / list / numpy array / comma-separated string to ``list[dtype]``.
 
-    Empty strings, ``None`` and NaN scalars yield an empty list. Integer parsing
-    accepts float-like tokens (``"1.0"`` -> ``1``) so spreadsheet exports work.
+    Empty strings and missing scalars (``None``, NaN, ``pandas.NA``) yield an
+    empty list. Integer parsing accepts float-like tokens whose value is integral
+    (``"1.0"`` -> ``1``) so spreadsheet exports work, but rejects non-integral
+    tokens (``"1.9"``).
     """
-    if value is None:
-        return []
-    # Scalar NaN (float or numpy float) -> treat as "not provided".
-    if isinstance(value, float) and np.isnan(value):
-        return []
+    # Containers first: pd.isna() returns an array (ambiguous truth) for these.
+    if isinstance(value, (list, tuple, np.ndarray)):
+        return [_coerce(x, dtype) for x in value]
     if isinstance(value, str):
         stripped = value.strip()
         if not stripped:
             return []
         return [_coerce(tok.strip(), dtype) for tok in stripped.split(",") if tok.strip()]
-    if isinstance(value, (list, tuple, np.ndarray)):
-        return [_coerce(x, dtype) for x in value]
+    # Scalars: None / NaN / pandas.NA all mean "not provided".
+    if value is None or pd.isna(value):
+        return []
     return [_coerce(value, dtype)]
 
 
 def _coerce(x, dtype):
-    """Coerce a single token to ``dtype`` (int parsing tolerates float-like tokens)."""
+    """Coerce a single token to ``dtype``.
+
+    Integer parsing accepts float-like tokens with an integral value
+    (``"1.0"`` -> ``1``) but raises ``ValueError`` for non-integral tokens.
+    """
     if dtype is int:
-        return int(float(x))
+        val = float(x)
+        if not val.is_integer():
+            raise ValueError(f"expected an integer, got {x!r}")
+        return int(val)
     return dtype(x)
 
 
@@ -200,7 +208,7 @@ def compounds_from_df(df):
         mass = 0.0 if pd.isna(mass) else float(mass)
 
         try:
-            charges = _to_list(row["Charge"], int, np)
+            charges = _to_list(row["Charge"], int, np, pd)
         except (ValueError, TypeError) as e:
             raise ValueError(f"Row {idx} ('{name}'): could not parse Charge "
                              f"value {row['Charge']!r}: {e}") from e
@@ -208,17 +216,17 @@ def compounds_from_df(df):
             raise ValueError(f"Row {idx} ('{name}'): Charge cannot be empty")
 
         try:
-            rts = _to_list(row["RetentionTime"], float, np)
+            rts = _to_list(row["RetentionTime"], float, np, pd)
         except (ValueError, TypeError) as e:
             raise ValueError(f"Row {idx} ('{name}'): could not parse RetentionTime "
                              f"value {row['RetentionTime']!r}: {e}") from e
         if not rts:
             raise ValueError(f"Row {idx} ('{name}'): RetentionTime cannot be empty")
 
-        rt_ranges = _to_list(row["RetentionTimeRange"], float, np) or [0.0]
-        iso_dist = _to_list(row["IsoDistribution"], float, np) or [0.0]
+        rt_ranges = _to_list(row["RetentionTimeRange"], float, np, pd) or [0.0]
+        iso_dist = _to_list(row["IsoDistribution"], float, np, pd) or [0.0]
 
-        ion_mobilities = _to_list(row["IonMobility"], float, np) if has_im else []
+        ion_mobilities = _to_list(row["IonMobility"], float, np, pd) if has_im else []
 
         adduct = ""
         if has_adduct:

--- a/src/pyOpenMS/tests/unittests/test_FeatureFinderAlgorithmMetaboIdent_df.py
+++ b/src/pyOpenMS/tests/unittests/test_FeatureFinderAlgorithmMetaboIdent_df.py
@@ -1,0 +1,246 @@
+"""Tests for FeatureFinderAlgorithmMetaboIdent DataFrame helper methods.
+
+Covers the nanobind addon `compounds_from_df` / `run_from_df`, including the
+optional IonMobility and Adduct columns.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+
+pd = pytest.importorskip("pandas")
+import pyopenms
+
+
+def _base_df(**overrides):
+    """A minimal single-compound DataFrame; override individual columns."""
+    data = {
+        'CompoundName': ['glucose'],
+        'SumFormula': ['C6H12O6'],
+        'Mass': [0.0],
+        'Charge': [-1],
+        'RetentionTime': [123.4],
+        'RetentionTimeRange': [0.0],
+        'IsoDistribution': [0.0],
+    }
+    data.update(overrides)
+    return pd.DataFrame(data)
+
+
+class TestCompoundsFromDF(unittest.TestCase):
+    """Test cases for FeatureFinderAlgorithmMetaboIdent.compounds_from_df()."""
+
+    def test_basic_conversion(self):
+        df = pd.DataFrame({
+            'CompoundName': ['glucose', 'fructose'],
+            'SumFormula': ['C6H12O6', 'C6H12O6'],
+            'Mass': [0.0, 180.063],
+            'Charge': [-1, 1],
+            'RetentionTime': [123.4, 200.0],
+            'RetentionTimeRange': [0.0, 10.0],
+            'IsoDistribution': [0.0, 0.0]
+        })
+
+        compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+
+        self.assertEqual(len(compounds), 2)
+        self.assertEqual(compounds[0].getName(), 'glucose')
+        self.assertEqual(compounds[0].getFormula(), 'C6H12O6')
+        self.assertAlmostEqual(compounds[0].getMass(), 0.0)
+        self.assertEqual(list(compounds[0].getCharges()), [-1])
+        self.assertEqual(list(compounds[0].getRTs()), [123.4])
+        self.assertEqual(list(compounds[0].getRTRanges()), [0.0])
+        self.assertEqual(list(compounds[0].getIsotopeDistribution()), [0.0])
+        # No IM / adduct columns -> defaults
+        self.assertEqual(list(compounds[0].getIonMobilities()), [])
+        self.assertEqual(compounds[0].getAdduct(), '')
+
+        self.assertEqual(compounds[1].getName(), 'fructose')
+        self.assertAlmostEqual(compounds[1].getMass(), 180.063)
+        self.assertEqual(list(compounds[1].getCharges()), [1])
+        self.assertEqual(list(compounds[1].getRTs()), [200.0])
+        self.assertEqual(list(compounds[1].getRTRanges()), [10.0])
+
+    def test_multivalue_as_python_lists(self):
+        df = _base_df(
+            CompoundName=['compound1'],
+            Charge=[[-1, 1, 2]],
+            RetentionTime=[[100.0, 200.0, 300.0]],
+            RetentionTimeRange=[[5.0, 10.0, 15.0]],
+            IsoDistribution=[[0.5, 0.3, 0.2]],
+        )
+
+        compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+
+        self.assertEqual(list(compounds[0].getCharges()), [-1, 1, 2])
+        self.assertEqual(list(compounds[0].getRTs()), [100.0, 200.0, 300.0])
+        self.assertEqual(list(compounds[0].getRTRanges()), [5.0, 10.0, 15.0])
+        self.assertAlmostEqual(compounds[0].getIsotopeDistribution()[0], 0.5)
+
+    def test_multivalue_as_comma_separated_strings(self):
+        df = _base_df(
+            CompoundName=['compound1'],
+            Charge=['-1, 1, 2'],
+            RetentionTime=['100.0, 200.0, 300.0'],
+            RetentionTimeRange=['5.0, 10.0'],
+            IsoDistribution=['0.5, 0.3, 0.2'],
+        )
+
+        compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+
+        self.assertEqual(list(compounds[0].getCharges()), [-1, 1, 2])
+        self.assertEqual(list(compounds[0].getRTs()), [100.0, 200.0, 300.0])
+        self.assertEqual(list(compounds[0].getRTRanges()), [5.0, 10.0])
+
+    def test_ion_mobility_column(self):
+        """Optional IonMobility column is exposed on the compound."""
+        df = _base_df(IonMobility=[0.95])
+        compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertEqual(list(compounds[0].getIonMobilities()), [0.95])
+
+    def test_ion_mobility_multivalue(self):
+        """IonMobility accepts one value per RT entry (list or comma string)."""
+        df = _base_df(
+            RetentionTime=[[100.0, 200.0]],
+            IonMobility=['0.8, 0.9'],
+        )
+        compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertEqual(list(compounds[0].getIonMobilities()), [0.8, 0.9])
+
+    def test_ion_mobility_alias_and_zero(self):
+        """The 'im' alias works and a 0/NaN value disables IM filtering."""
+        df = _base_df(im=[np.nan])
+        compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertEqual(list(compounds[0].getIonMobilities()), [])
+
+    def test_adduct_column(self):
+        """Optional Adduct column is exposed on the compound."""
+        df = _base_df(Adduct=['[M-H]-'])
+        compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertEqual(compounds[0].getAdduct(), '[M-H]-')
+
+    def test_adduct_nan_becomes_empty(self):
+        df = _base_df(Adduct=[np.nan])
+        compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertEqual(compounds[0].getAdduct(), '')
+
+    def test_case_insensitive_columns(self):
+        df = pd.DataFrame({
+            'compoundname': ['glucose'], 'sumformula': ['C6H12O6'], 'mass': [0.0],
+            'charge': [-1], 'retentiontime': [123.4], 'retentiontimerange': [0.0],
+            'isodistribution': [0.0]
+        })
+        compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertEqual(compounds[0].getName(), 'glucose')
+
+    def test_snake_case_columns(self):
+        df = pd.DataFrame({
+            'compound_name': ['glucose'], 'sum_formula': ['C6H12O6'], 'mass': [0.0],
+            'charge': [-1], 'retention_time': [123.4], 'retention_time_range': [0.0],
+            'iso_distribution': [0.0]
+        })
+        compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertEqual(compounds[0].getName(), 'glucose')
+
+    def test_rt_shorthand_column(self):
+        df = pd.DataFrame({
+            'CompoundName': ['glucose'], 'SumFormula': ['C6H12O6'], 'Mass': [0.0],
+            'Charge': [-1], 'rt': [123.4], 'rt_range': [0.0], 'IsoDistribution': [0.0]
+        })
+        compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertEqual(list(compounds[0].getRTs()), [123.4])
+
+    def test_duplicate_column_mapping_raises(self):
+        """Two columns mapping to the same canonical field is an error."""
+        df = _base_df()
+        df['rt'] = [999.0]  # both 'RetentionTime' and 'rt' present
+        with self.assertRaises(ValueError) as ctx:
+            pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertIn('map', str(ctx.exception))
+
+    def test_missing_required_column(self):
+        df = pd.DataFrame({'CompoundName': ['glucose'], 'SumFormula': ['C6H12O6']})
+        with self.assertRaises(ValueError) as ctx:
+            pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertIn('Missing required columns', str(ctx.exception))
+
+    def test_empty_compound_name(self):
+        df = _base_df(CompoundName=[''])
+        with self.assertRaises(ValueError) as ctx:
+            pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertIn('CompoundName cannot be empty', str(ctx.exception))
+
+    def test_nan_compound_name(self):
+        df = _base_df(CompoundName=[np.nan])
+        with self.assertRaises(ValueError) as ctx:
+            pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertIn('CompoundName cannot be empty', str(ctx.exception))
+
+    def test_duplicate_compound_names(self):
+        df = pd.DataFrame({
+            'CompoundName': ['glucose', 'glucose'], 'SumFormula': ['C6H12O6', 'C6H12O6'],
+            'Mass': [0.0, 0.0], 'Charge': [-1, 1], 'RetentionTime': [123.4, 200.0],
+            'RetentionTimeRange': [0.0, 0.0], 'IsoDistribution': [0.0, 0.0]
+        })
+        with self.assertRaises(ValueError) as ctx:
+            pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertIn('Duplicate CompoundName', str(ctx.exception))
+
+    def test_empty_charge(self):
+        df = _base_df(Charge=[''])
+        with self.assertRaises(ValueError) as ctx:
+            pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertIn('Charge cannot be empty', str(ctx.exception))
+
+    def test_empty_retention_time(self):
+        df = _base_df(RetentionTime=[''])
+        with self.assertRaises(ValueError) as ctx:
+            pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertIn('RetentionTime cannot be empty', str(ctx.exception))
+
+    def test_unparseable_charge_reports_row(self):
+        df = _base_df(Charge=['abc'])
+        with self.assertRaises(ValueError) as ctx:
+            pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertIn('Charge', str(ctx.exception))
+
+    def test_nan_in_optional_fields(self):
+        df = _base_df(SumFormula=[np.nan], Mass=[np.nan],
+                      RetentionTimeRange=[np.nan], IsoDistribution=[np.nan])
+        compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertEqual(compounds[0].getFormula(), '')
+        self.assertAlmostEqual(compounds[0].getMass(), 0.0)
+        self.assertEqual(list(compounds[0].getRTRanges()), [0.0])
+        self.assertEqual(list(compounds[0].getIsotopeDistribution()), [0.0])
+
+    def test_numpy_arrays_in_multivalue_fields(self):
+        df = _base_df(
+            CompoundName=['compound1'],
+            Charge=[np.array([-1, 1])],
+            RetentionTime=[np.array([100.0, 200.0])],
+            RetentionTimeRange=[np.array([5.0])],
+            IsoDistribution=[np.array([0.5, 0.5])],
+        )
+        compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertEqual(list(compounds[0].getCharges()), [-1, 1])
+        self.assertEqual(list(compounds[0].getRTs()), [100.0, 200.0])
+
+    def test_empty_dataframe(self):
+        df = pd.DataFrame({c: [] for c in (
+            'CompoundName', 'SumFormula', 'Mass', 'Charge',
+            'RetentionTime', 'RetentionTimeRange', 'IsoDistribution')})
+        compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertEqual(len(compounds), 0)
+
+
+class TestRunFromDF(unittest.TestCase):
+    """Test cases for FeatureFinderAlgorithmMetaboIdent.run_from_df()."""
+
+    def test_run_from_df_exists(self):
+        ff = pyopenms.FeatureFinderAlgorithmMetaboIdent()
+        self.assertTrue(callable(getattr(ff, 'run_from_df', None)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/pyOpenMS/tests/unittests/test_FeatureFinderAlgorithmMetaboIdent_df.py
+++ b/src/pyOpenMS/tests/unittests/test_FeatureFinderAlgorithmMetaboIdent_df.py
@@ -205,10 +205,28 @@ class TestCompoundsFromDF(unittest.TestCase):
             pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
         self.assertIn('Charge', str(ctx.exception))
 
+    def test_non_integral_charge_string_raises(self):
+        # A non-integral charge token must be rejected, not truncated to 1.
+        df = _base_df(Charge=['1.9'])
+        with self.assertRaises(ValueError) as ctx:
+            pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertIn('Charge', str(ctx.exception))
+
     def test_nan_in_optional_fields(self):
         # Keep a valid SumFormula so the m/z can still be derived (Mass NaN -> 0.0).
         df = _base_df(Mass=[np.nan],
                       RetentionTimeRange=[np.nan], IsoDistribution=[np.nan])
+        compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertEqual(compounds[0].getFormula(), 'C6H12O6')
+        self.assertAlmostEqual(compounds[0].getMass(), 0.0)
+        self.assertEqual(list(compounds[0].getRTRanges()), [0.0])
+        self.assertEqual(list(compounds[0].getIsotopeDistribution()), [0.0])
+
+    def test_pd_na_in_optional_fields(self):
+        # pandas.NA (nullable dtypes) must behave like np.nan: "not provided".
+        # SumFormula stays valid so the fail-fast m/z check still passes.
+        df = _base_df(Mass=[pd.NA],
+                      RetentionTimeRange=[pd.NA], IsoDistribution=[pd.NA])
         compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
         self.assertEqual(compounds[0].getFormula(), 'C6H12O6')
         self.assertAlmostEqual(compounds[0].getMass(), 0.0)

--- a/src/pyOpenMS/tests/unittests/test_FeatureFinderAlgorithmMetaboIdent_df.py
+++ b/src/pyOpenMS/tests/unittests/test_FeatureFinderAlgorithmMetaboIdent_df.py
@@ -206,13 +206,55 @@ class TestCompoundsFromDF(unittest.TestCase):
         self.assertIn('Charge', str(ctx.exception))
 
     def test_nan_in_optional_fields(self):
-        df = _base_df(SumFormula=[np.nan], Mass=[np.nan],
+        # Keep a valid SumFormula so the m/z can still be derived (Mass NaN -> 0.0).
+        df = _base_df(Mass=[np.nan],
                       RetentionTimeRange=[np.nan], IsoDistribution=[np.nan])
         compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
-        self.assertEqual(compounds[0].getFormula(), '')
+        self.assertEqual(compounds[0].getFormula(), 'C6H12O6')
         self.assertAlmostEqual(compounds[0].getMass(), 0.0)
         self.assertEqual(list(compounds[0].getRTRanges()), [0.0])
         self.assertEqual(list(compounds[0].getIsotopeDistribution()), [0.0])
+
+    def test_formula_nan_with_mass_ok(self):
+        # No formula but a positive mass is still valid (m/z derives from mass).
+        df = _base_df(SumFormula=[np.nan], Mass=[180.063])
+        compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertEqual(compounds[0].getFormula(), '')
+        self.assertAlmostEqual(compounds[0].getMass(), 180.063)
+
+    def test_no_mass_no_formula_raises(self):
+        df = _base_df(SumFormula=[''], Mass=[0.0])
+        with self.assertRaises(ValueError) as ctx:
+            pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertIn('Mass', str(ctx.exception))
+
+    def test_zero_charge_raises(self):
+        df = _base_df(Charge=[0])
+        with self.assertRaises(ValueError) as ctx:
+            pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertIn('non-zero', str(ctx.exception))
+
+    def test_rt_range_length_mismatch_raises(self):
+        # 2 RT ranges for 3 RTs is neither 1 nor len(rts) -> error.
+        df = _base_df(RetentionTime=[[100.0, 200.0, 300.0]],
+                      RetentionTimeRange=[[5.0, 10.0]])
+        with self.assertRaises(ValueError) as ctx:
+            pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertIn('RetentionTimeRange', str(ctx.exception))
+
+    def test_ion_mobility_length_mismatch_raises(self):
+        df = _base_df(RetentionTime=[[100.0, 200.0, 300.0]],
+                      IonMobility=[[0.8, 0.9]])
+        with self.assertRaises(ValueError) as ctx:
+            pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertIn('IonMobility', str(ctx.exception))
+
+    def test_rt_range_broadcast_ok(self):
+        # A single RT range broadcasts to all RTs.
+        df = _base_df(RetentionTime=[[100.0, 200.0, 300.0]],
+                      RetentionTimeRange=[5.0])
+        compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        self.assertEqual(list(compounds[0].getRTRanges()), [5.0])
 
     def test_numpy_arrays_in_multivalue_fields(self):
         df = _base_df(
@@ -232,6 +274,54 @@ class TestCompoundsFromDF(unittest.TestCase):
             'RetentionTime', 'RetentionTimeRange', 'IsoDistribution')})
         compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
         self.assertEqual(len(compounds), 0)
+
+
+class TestCompoundsToDF(unittest.TestCase):
+    """Test cases for FeatureFinderAlgorithmMetaboIdent.compounds_to_df()."""
+
+    def test_columns_and_values(self):
+        df = _base_df(IonMobility=[0.95], Adduct=['[M-H]-'])
+        compounds = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        out = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_to_df(compounds)
+        self.assertEqual(list(out.columns), [
+            'CompoundName', 'SumFormula', 'Mass', 'Charge', 'RetentionTime',
+            'RetentionTimeRange', 'IsoDistribution', 'IonMobility', 'Adduct'])
+        self.assertEqual(out.iloc[0]['CompoundName'], 'glucose')
+        self.assertEqual(out.iloc[0]['Charge'], [-1])
+        self.assertEqual(out.iloc[0]['IonMobility'], [0.95])
+        self.assertEqual(out.iloc[0]['Adduct'], '[M-H]-')
+
+    def test_empty_list(self):
+        out = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_to_df([])
+        self.assertEqual(len(out), 0)
+        self.assertIn('IonMobility', out.columns)
+
+    def test_round_trip(self):
+        df = pd.DataFrame({
+            'CompoundName': ['glucose', 'fructose'],
+            'SumFormula': ['C6H12O6', ''],
+            'Mass': [0.0, 180.063],
+            'Charge': [[-1], [1, 2]],
+            'RetentionTime': [[123.4], [200.0, 250.0]],
+            'RetentionTimeRange': [[0.0], [5.0]],
+            'IsoDistribution': [[0.0], [0.0]],
+            'IonMobility': [[], [0.9]],
+            'Adduct': ['[M-H]-', ''],
+        })
+        c1 = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df)
+        df2 = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_to_df(c1)
+        c2 = pyopenms.FeatureFinderAlgorithmMetaboIdent.compounds_from_df(df2)
+
+        self.assertEqual(len(c1), len(c2))
+        for a, b in zip(c1, c2):
+            self.assertEqual(a.getName(), b.getName())
+            self.assertEqual(a.getFormula(), b.getFormula())
+            self.assertAlmostEqual(a.getMass(), b.getMass())
+            self.assertEqual(list(a.getCharges()), list(b.getCharges()))
+            self.assertEqual(list(a.getRTs()), list(b.getRTs()))
+            self.assertEqual(list(a.getRTRanges()), list(b.getRTRanges()))
+            self.assertEqual(list(a.getIonMobilities()), list(b.getIonMobilities()))
+            self.assertEqual(a.getAdduct(), b.getAdduct())
 
 
 class TestRunFromDF(unittest.TestCase):

--- a/src/pyOpenMS/tests/unittests/test_FeatureFinderAlgorithmMetaboIdent_df.py
+++ b/src/pyOpenMS/tests/unittests/test_FeatureFinderAlgorithmMetaboIdent_df.py
@@ -83,7 +83,7 @@ class TestCompoundsFromDF(unittest.TestCase):
             CompoundName=['compound1'],
             Charge=['-1, 1, 2'],
             RetentionTime=['100.0, 200.0, 300.0'],
-            RetentionTimeRange=['5.0, 10.0'],
+            RetentionTimeRange=['5.0, 10.0, 15.0'],
             IsoDistribution=['0.5, 0.3, 0.2'],
         )
 
@@ -91,7 +91,7 @@ class TestCompoundsFromDF(unittest.TestCase):
 
         self.assertEqual(list(compounds[0].getCharges()), [-1, 1, 2])
         self.assertEqual(list(compounds[0].getRTs()), [100.0, 200.0, 300.0])
-        self.assertEqual(list(compounds[0].getRTRanges()), [5.0, 10.0])
+        self.assertEqual(list(compounds[0].getRTRanges()), [5.0, 10.0, 15.0])
 
     def test_ion_mobility_column(self):
         """Optional IonMobility column is exposed on the compound."""


### PR DESCRIPTION
## Summary

Modernizes the FeatureFinderAlgorithmMetaboIdent (FFMI) DataFrame helper from PR #8697 to the current **nanobind** binding system, and adds the missing **ion mobility** and **adduct** support.

- Adds `compounds_from_df(df)` and `run_from_df(df, features, spectra_path="")` via the pure-Python `pyopenms.addons` system (no Cython/`.pyx`).
- Exposes the optional **`IonMobility`** and **`Adduct`** columns, reaching parity with the `FeatureFinderMetaboIdent` TOPP tool TSV and the C++ `FeatureFinderMetaboIdentCompound` constructor.

## Background

PR #8697 implemented the same idea as a Cython `addons/*.pyx` file. Since then pyOpenMS migrated from autowrap/Cython to nanobind, so that `.pyx` is no longer consumed by the build and would never load. This PR reimplements the feature the supported way.

## What changed vs. #8697

- **Nanobind addon** instead of `.pyx` — registered with `@addon("FeatureFinderAlgorithmMetaboIdent", ...)`.
- **IonMobility / Adduct columns** are now read and passed through to the compound constructor (the original helper passed only the first 7 positional args and silently dropped IM/adduct). Aliases: `im`, `ion_mobility`, `adduct`.
- **Ambiguous-column detection** — two columns mapping to the same field (e.g. both `rt` and `RetentionTime`) now raise a clear `ValueError` instead of crashing on duplicate pandas columns.
- **Clearer parse errors** — an unparseable `Charge`/`RetentionTime` reports the row and value; integer parsing tolerates float-like tokens (`"1.0"` → `1`).
- **Simplified** the column-normalization logic (removed dead code).
- pandas/numpy kept optional (imported lazily inside the method).

## Accepted columns

```
CompoundName  SumFormula  Mass  Charge  RetentionTime  RetentionTimeRange  IsoDistribution  [IonMobility]  [Adduct]
```
Case-insensitive, `snake_case`, and common aliases supported.

## Example

```python
import pandas as pd
from pyopenms import FeatureFinderAlgorithmMetaboIdent, MSExperiment, MzMLFile, FeatureMap

exp = MSExperiment()
MzMLFile().load("spectra.mzML", exp)

df = pd.DataFrame({
    'CompoundName': ['glucose', 'fructose'],
    'SumFormula': ['C6H12O6', 'C6H12O6'],
    'Mass': [0.0, 0.0],
    'Charge': [-1, '-1,1'],
    'RetentionTime': [123.4, '200.0,250.0'],
    'RetentionTimeRange': [0.0, 0.0],
    'IsoDistribution': [0.0, 0.0],
    'IonMobility': [0.0, 0.95],   # optional
    'Adduct': ['[M-H]-', ''],     # optional
})

ff = FeatureFinderAlgorithmMetaboIdent()
ff.setMSData(exp)
features = FeatureMap()
ff.run_from_df(df, features, "spectra.mzML")
```

## Test plan

- [x] Unit tests for basic conversion, multi-value fields (lists / numpy arrays / comma strings), case-insensitive & snake_case & alias columns, NaN handling, validation (missing columns, empty/NaN/duplicate names, empty charge/RT).
- [x] New tests for `IonMobility` (scalar, multi-value, `im` alias, zero/NaN disables) and `Adduct` (value, NaN→empty).
- [x] New test for ambiguous duplicate-column mapping and for unparseable-value error reporting.
- [x] Parsing/validation/normalization logic validated in isolation (stubbed compound class).
- [ ] Full pytest run against a compiled nanobind `pyopenms` (not available in the authoring environment).

## Notes / open questions

- The `.pyx` file from #8697 is intentionally **not** included; that PR can be closed in favor of this one.
- Validation is fail-fast (raises on empty/duplicate names), whereas the TOPP tool skips such rows with a log warning. Happy to switch to lenient behavior if preferred.

https://claude.ai/code/session_011RijKkCc7xcQEbixazvL7J

---
_Generated by [Claude Code](https://claude.ai/code/session_011RijKkCc7xcQEbixazvL7J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DataFrame-based APIs to import/export compound libraries and a convenience run-from-DataFrame entry; supports flexible case-insensitive column aliases, multivalue parsing, defaults/broadcasting, and strict validation (unique non-empty names, charge/RT checks).

* **Documentation**
  * Expanded constructor and module examples demonstrating DataFrame workflows and optional fields (ion mobility, adduct).

* **Tests**
  * Added comprehensive unit tests for conversions, parsing formats, optional-field behavior, round-trip consistency, and validation/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->