### PR TITLE
Mirror large MS test data on OpenMS fileserver; pin URL_HASH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,11 +100,11 @@ endif()
 if (ENABLE_OPENTIMS_TESTS AND WITH_OPENTIMS)
   include(FetchContent)
   # Mirror of the timsrust_cpp_bridge "test-data-v1" release, hosted on the OpenMS
-  # infra fileserver. NOTE: this host currently answers only on bare-IP plain HTTP
-  # (no DNS name / HTTPS yet) and port 80 is reachable only from whitelisted
+  # infra fileserver (archive.openms.de). NOTE: this host currently answers only on
+  # plain HTTP (no HTTPS listener yet) and port 80 is reachable only from whitelisted
   # CI/build networks at the perimeter firewall. URL_HASH pins each file's
   # integrity so the weaker transport cannot corrupt a download silently.
-  set(OPENTIMS_TESTDATA_URL "http://193.196.20.95/openms/testfiles")
+  set(OPENTIMS_TESTDATA_URL "http://archive.openms.de/openms/testfiles")
   FetchContent_Declare(
     opentims_testdata_dda
     URL "${OPENTIMS_TESTDATA_URL}/DDA_HeLa_50ng_5_6min.d.zip"
@@ -137,10 +137,10 @@ if (ENABLE_THERMO_RAW_TESTS AND WITH_THERMO_RAW)
   # activation (ETD+HCD, ETD+CID) filters at precursor m/z 432.9 — exercises the
   # full activation-method switch in ThermoRawFile.cpp and MS1+MSn round-trip via
   # mzML. Served from the OpenMS infra mirror (see OPENTIMS_TESTDATA_URL note above
-  # re: bare-IP plain HTTP); URL_HASH below pins integrity/reproducibility.
+  # re: plain HTTP); URL_HASH below pins integrity/reproducibility.
   FetchContent_Declare(
     thermo_raw_testdata
-    URL "http://193.196.20.95/openms/testfiles/Angiotensin_AllScans.raw"
+    URL "http://archive.openms.de/openms/testfiles/Angiotensin_AllScans.raw"
     URL_HASH SHA256=3a0236f719e7c91e3c958f57f4e66ae422803ec3e6a997b9af4d2af395332b9f
     DOWNLOAD_NO_EXTRACT TRUE
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,20 +99,28 @@ endif()
 
 if (ENABLE_OPENTIMS_TESTS AND WITH_OPENTIMS)
   include(FetchContent)
-  set(OPENTIMS_TESTDATA_URL "https://github.com/OpenMS/timsrust_cpp_bridge/releases/download/test-data-v1")
+  # Mirror of the timsrust_cpp_bridge "test-data-v1" release, hosted on the OpenMS
+  # infra fileserver. NOTE: this host currently answers only on bare-IP plain HTTP
+  # (no DNS name / HTTPS yet) and port 80 is reachable only from whitelisted
+  # CI/build networks at the perimeter firewall. URL_HASH pins each file's
+  # integrity so the weaker transport cannot corrupt a download silently.
+  set(OPENTIMS_TESTDATA_URL "http://193.196.20.95/openms/testfiles")
   FetchContent_Declare(
     opentims_testdata_dda
     URL "${OPENTIMS_TESTDATA_URL}/DDA_HeLa_50ng_5_6min.d.zip"
+    URL_HASH SHA256=659d691e48d621edcd1fecb8448de5731147c009bda42ba6e7e5ed53e46dc15c
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
   )
   FetchContent_Declare(
     opentims_testdata_dia
     URL "${OPENTIMS_TESTDATA_URL}/DIA_HeLa_50ng_5_6min.d.zip"
+    URL_HASH SHA256=bacf98b472ed3a3cfef2c2595a726fc6c06f059a41c17d9035b2b864932b6f5d
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
   )
   FetchContent_Declare(
     opentims_testdata_fasta
     URL "${OPENTIMS_TESTDATA_URL}/human_sp.fasta"
+    URL_HASH SHA256=b205ed9970fee62413e2f192c6fb82daab86e4a5897ef521f907ecbfcd7b3e63
     DOWNLOAD_NO_EXTRACT TRUE
   )
   FetchContent_MakeAvailable(opentims_testdata_dda opentims_testdata_dia opentims_testdata_fasta)
@@ -123,15 +131,16 @@ endif()
 
 if (ENABLE_THERMO_RAW_TESTS AND WITH_THERMO_RAW)
   include(FetchContent)
-  # Angiotensin_AllScans.raw from PNNL-Comp-Mass-Spec/Thermo-Raw-File-Reader
-  # (BSD-2-Clause, (c) 2018 Battelle Memorial Institute). Pinned to a specific
-  # commit for reproducibility. Contains 87 MS1 (FTMS Full ms) plus hundreds of
-  # MS2 scans with HCD and supplemental-activation (ETD+HCD, ETD+CID) filters
-  # at precursor m/z 432.9 — exercises the full activation-method switch in
-  # ThermoRawFile.cpp and MS1+MSn round-trip via mzML.
+  # Angiotensin_AllScans.raw originally from PNNL-Comp-Mass-Spec/Thermo-Raw-File-Reader
+  # (BSD-2-Clause, (c) 2018 Battelle Memorial Institute), commit 1d8ff309. Contains
+  # 87 MS1 (FTMS Full ms) plus hundreds of MS2 scans with HCD and supplemental-
+  # activation (ETD+HCD, ETD+CID) filters at precursor m/z 432.9 — exercises the
+  # full activation-method switch in ThermoRawFile.cpp and MS1+MSn round-trip via
+  # mzML. Served from the OpenMS infra mirror (see OPENTIMS_TESTDATA_URL note above
+  # re: bare-IP plain HTTP); URL_HASH below pins integrity/reproducibility.
   FetchContent_Declare(
     thermo_raw_testdata
-    URL "https://raw.githubusercontent.com/PNNL-Comp-Mass-Spec/Thermo-Raw-File-Reader/1d8ff309f94704b850642374496c7ac28c491204/UnitTests/Docs/Angiotensin_AllScans.raw"
+    URL "http://193.196.20.95/openms/testfiles/Angiotensin_AllScans.raw"
     URL_HASH SHA256=3a0236f719e7c91e3c958f57f4e66ae422803ec3e6a997b9af4d2af395332b9f
     DOWNLOAD_NO_EXTRACT TRUE
   )


### PR DESCRIPTION
## What

Repoints the CMake `FetchContent` test-data downloads from GitHub releases / `raw.githubusercontent.com` to the OpenMS infra fileserver at `http://archive.openms.de/openms/testfiles/`:

- `DDA_HeLa_50ng_5_6min.d.zip`, `DIA_HeLa_50ng_5_6min.d.zip`, `human_sp.fasta` — opentims Bruker timsTOF test data (`OPENTIMS_TESTDATA_URL`)
- `Angiotensin_AllScans.raw` — Thermo test data

The four files (~700 MB) were uploaded to the fileserver and the `URL_HASH SHA256` values in this PR were verified against the exact bytes the mirror serves.

## Why

Moves the large vendor test data off third-party hosts (GitHub release tag + a pinned `raw.githubusercontent` commit) onto OpenMS-controlled infrastructure.

## Integrity

Added `URL_HASH SHA256` pins to the three Bruker downloads, which previously had **none** — important now that the transport is plain HTTP. The Thermo file keeps its existing hash (unchanged, still matches the original PNNL source).

## ⚠️ Reviewer note — please verify reachability from CI

This host currently has real limitations, documented in the CMake comments:

- **HTTP only** — there is no HTTPS listener on the box yet; downloads go over plain HTTP (`http://archive.openms.de/...`).
- **Perimeter-firewalled** — port 80 is reachable only from whitelisted CI/build networks; it is *not* reachable from the general internet (the server&#39;s own `ufw` allows 80/443, but the upstream cloud firewall drops it).

So an end-to-end fetch could **not** be tested from a general network. **A maintainer needs to confirm a CI build on a whitelisted runner actually downloads these** before merging. The `URL_HASH` integrity side is fully verified; only reachability is open.

If/when an HTTPS listener is set up for this host, switching to `https://` is a one-line change to `OPENTIMS_TESTDATA_URL` plus the Thermo URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Summary by CodeRabbit

* **Chores**
  * Updated test data download infrastructure to use distributed mirrors instead of direct GitHub sources, improving download reliability and speed.
  * Added SHA256 integrity verification for test data downloads to enhance security and reproducibility.