### PR TITLE
fix(ci): make macOS notarization non-blocking to prevent nightly build failure

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -394,6 +394,7 @@ jobs:
     # This step submits the signed package to Apple for notarization and staples the ticket
     - name: Notarize macOS Package
       if: steps.set-vars.outputs.pkg_type == 'pkg' && startsWith(matrix.os, 'macos')
+      continue-on-error: true
       shell: bash
       env:
         APPLE_APP_SPECIFIC_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_NOTARIZATION_PASSWORD }}


### PR DESCRIPTION
## Summary

- The nightly CI (`openms-ci-full` on the `nightly` branch) has been failing since **2026-06-08** due to Apple's notarization service returning `HTTP 403: A required agreement is missing or has expired`.
- The root cause is an **expired Apple Developer Agreement** for the OpenMS Inc. account (`C64UCGJ5PL`). This must be renewed manually at [developer.apple.com](https://developer.apple.com) — it cannot be fixed in code.
- This PR adds `continue-on-error: true` to the `Notarize macOS Package` step so the nightly build does **not** fail entirely while the agreement is being renewed. The package is still built and uploaded; only notarization/stapling is skipped.

## Error observed in nightly runs (run IDs 27178560183, 27111733509)

```
Error: HTTP status code: 403. A required agreement is missing or has expired.
This request requires an in-effect agreement that has not been signed or has expired.
Ensure your team has signed the necessary legal agreements and that they are not expired.
Error: notarytool submission failed!
##[error]Process completed with exit code 1.
```

## Action required (outside this PR)

A member of the **OpenMS Inc.** Apple Developer team (`apple@openms.de`) must log into [developer.apple.com](https://developer.apple.com/account) and re-accept the current developer program license agreement. Once that is done, the `continue-on-error` can be removed.

## Test plan

- [ ] Verify nightly build completes successfully after this change merges to `develop` → `nightly`
- [ ] After Apple agreement is renewed and notarization passes again, remove `continue-on-error: true`

https://claude.ai/code/session_01JXvZHfgszWDkxaMPFT5NWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXvZHfgszWDkxaMPFT5NWQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build workflow resilience for macOS package processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->