### PR TITLE
ProSE/FragmentIndex: precursor-prefilter SNES Phase-1 (~1.7x faster non-specific search, byte-identical)

### DIFF
--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -40,7 +40,6 @@
 #include <unordered_map>
 #include <boost/sort/sort.hpp>
 
-
 using namespace std;
 
 
@@ -1592,8 +1591,32 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
     // zeroed via .assign. Avoids per-spectrum allocation and keeps the table hot
     // in cache for large indices. Saturates at UINT16_MAX (far above any realistic
     // matched-peak count) to protect against pathological inputs without branch-on-overflow.
-    thread_local std::vector<uint16_t> score_table;
-    score_table.assign(fi_peptides_.size(), 0);
+    const size_t n_mothers = fi_peptides_.size();
+    const size_t n_words = (n_mothers + 63) / 64;
+
+    // Persistent thread-local buffers, sized once. Between spectra they are
+    // restored to all-zero by O(touched) resets (touched_ids / emitted_touched),
+    // avoiding a full-index memset per spectrum (the score_table.assign + the
+    // per-(charge,iso,sigma) std::fill(emitted) were the dominant non-scan cost
+    // at proteome scale).
+    thread_local std::vector<uint16_t> score_table;     // matched-peak count per viable mother
+    thread_local std::vector<uint64_t> viable_words;    // precursor-viability bitset, 1 bit / mother
+    thread_local std::vector<uint8_t> emitted;          // Phase-2 per-(charge,iso,sigma) dedup guard
+    thread_local std::vector<UInt32> touched_ids;       // mothers marked viable (== only ids ever written)
+    thread_local std::vector<UInt32> emitted_touched;   // ids set in emitted since its last reset
+
+    if (score_table.size() != n_mothers) score_table.assign(n_mothers, 0);
+    if (viable_words.size() != n_words)  viable_words.assign(n_words, 0);
+    if (emitted.size() != n_mothers)     emitted.assign(n_mothers, 0);
+    for (UInt32 id : touched_ids) { score_table[id] = 0; viable_words[id >> 6] &= ~(uint64_t{1} << (id & 63)); }
+    touched_ids.clear();
+    for (UInt32 id : emitted_touched) emitted[id] = 0;
+    emitted_touched.clear();
+
+    auto viable_test = [&](UInt32 id) -> bool { return (viable_words[id >> 6] >> (id & 63)) & uint64_t{1}; };
+    auto viable_set  = [&](UInt32 id) { uint64_t& w = viable_words[id >> 6]; const uint64_t b = uint64_t{1} << (id & 63);
+                                        if (!(w & b)) { w |= b; touched_ids.push_back(id); } };
+    auto emit_mark   = [&](UInt32 id) { emitted[id] = 1; emitted_touched.push_back(id); };
 
     // Fragment-charge upper bound for the byte scan. Use the max charge in the
     // `charges` list (the spectrum's known charge, or max_precursor_charge_ when
@@ -1604,6 +1627,74 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
     uint16_t byte_scan_max_frag_charge = 0;
     for (uint16_t c : charges) byte_scan_max_frag_charge = std::max(byte_scan_max_frag_charge, c);
     byte_scan_max_frag_charge = std::min(byte_scan_max_frag_charge, max_fragment_charge_);
+
+    // ===================== Pre-pass: mark precursor-viable mothers =====================
+    // The Phase-1 byte scan below only writes a count for a mother that this pre-pass
+    // marked viable. The marked set is a strict SUPERSET of the mothers Phase-2 can
+    // emit: we walk the SAME precursor-derived fragment targets (Single-N b_k,
+    // Single-C y_k) and the SAME full-length precursor_mz_ ranges, but drop the
+    // single_c / protein-anchor / score-threshold filters (over-approximation). So no
+    // mother that Phase-2 emits is ever missing its count, while the ~165M non-viable
+    // mothers no longer take a (cache-missing) random write per matched fragment.
+    // Target formulas MUST stay in sync with Phase-2 below.
+    {
+      const float water_f = static_cast<float>(Residue::getInternalToFull().getMonoWeight());
+      const bool open_mode_pp = isOpenSearchMode_();
+      const int16_t iso_lo_pp = open_mode_pp ? 0 : min_isotope_error_;
+      const int16_t iso_hi_pp = open_mode_pp ? 0 : max_isotope_error_;
+
+      std::vector<double> sigma_union = snes_sigma_delta_set_;
+      sigma_union.insert(sigma_union.end(), snes_sigma_delta_set_with_prot_nterm_.begin(), snes_sigma_delta_set_with_prot_nterm_.end());
+      sigma_union.insert(sigma_union.end(), snes_sigma_delta_set_with_prot_cterm_.begin(), snes_sigma_delta_set_with_prot_cterm_.end());
+
+      auto mark_bucket_range = [&](float target, float tol_lo, float tol_hi) {
+        auto lb = std::lower_bound(bucket_min_mz_.begin(), bucket_min_mz_.end(), target + tol_lo);
+        auto rb = std::upper_bound(bucket_min_mz_.begin(), bucket_min_mz_.end(), target + tol_hi);
+        if (lb != bucket_min_mz_.begin()) --lb;
+        const size_t jb = std::distance(bucket_min_mz_.begin(), lb);
+        const size_t je = std::distance(bucket_min_mz_.begin(), rb);
+        for (size_t j = jb; j < je; ++j)
+        {
+          const auto sb = fi_fragments_.begin() + (j * bucketsize_);
+          const auto se = ((j + 1) * bucketsize_) >= fi_fragments_.size()
+            ? fi_fragments_.end() : (fi_fragments_.begin() + ((j + 1) * bucketsize_));
+          for (auto it = sb; it != se; ++it)
+          {
+            const float d = it->fragment_mz_ - target;
+            if (d >= tol_lo && d <= tol_hi) viable_set(it->peptide_idx_);
+          }
+        }
+      };
+      auto mark_precursor_range = [&](float target, float tol_lo, float tol_hi) {
+        auto lb = std::lower_bound(fi_peptides_.begin(), fi_peptides_.end(), target + tol_lo,
+                                   [](const Peptide& a, float b) { return a.precursor_mz_ < b; });
+        auto ub = std::upper_bound(fi_peptides_.begin(), fi_peptides_.end(), target + tol_hi,
+                                   [](float b, const Peptide& a) { return b < a.precursor_mz_; });
+        for (auto it = lb; it != ub; ++it)
+          viable_set(static_cast<UInt32>(std::distance(fi_peptides_.begin(), it)));
+      };
+
+      for (uint16_t charge : charges)
+      {
+        const float mh_plus = static_cast<float>(precursor.getMZ()) * charge
+          - (charge - 1) * static_cast<float>(Constants::PROTON_MASS_U);
+        for (int16_t iso_err = iso_lo_pp; iso_err <= iso_hi_pp; ++iso_err)
+        {
+          const float shifted_mh = mh_plus
+            + static_cast<float>(iso_err) * static_cast<float>(Constants::C13C12_MASSDIFF_U);
+          const auto prec_window = computeMassWindow_(shifted_mh);
+          const float tlo = prec_window.first;   // <= 0
+          const float thi = prec_window.second;  // >= 0
+          for (double sigma : sigma_union)
+          {
+            const float s = static_cast<float>(sigma);
+            mark_bucket_range(shifted_mh - water_f - static_cast<float>(fixed_cterm_delta_) - s, tlo, thi); // Single-N b_k
+            mark_bucket_range(shifted_mh - static_cast<float>(fixed_nterm_delta_) - s, tlo, thi);           // Single-C y_k
+            mark_precursor_range(shifted_mh - s, tlo, thi);                                                 // full-length
+          }
+        }
+      }
+    }
 
     for (const Peak1D& peak : spectrum)
     {
@@ -1642,7 +1733,9 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
             if (adjusted_mass >= it->fragment_mz_ - frag_tol
                 && adjusted_mass <= it->fragment_mz_ + frag_tol)
             {
-              auto& cell = score_table[it->peptide_idx_];
+              const UInt32 id = it->peptide_idx_;
+              if (!viable_test(id)) continue;   // precursor-prefilter: skip the non-viable mothers
+              auto& cell = score_table[id];
               if (cell < std::numeric_limits<uint16_t>::max()) ++cell;
             }
           }
@@ -1662,12 +1755,9 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
     // the minimum-matched-peaks threshold.
     static const double water = Residue::getInternalToFull().getMonoWeight();
 
-    // Dedup guard (thread_local, sized once per query). The actual per-
-    // (charge, iso_err, sigma) reset happens inside the Σ loops below via
-    // std::fill — this assign() is only for size-safe initialization of
-    // the thread-local buffer when fi_peptides_.size() changes between calls.
-    thread_local std::vector<uint8_t> emitted;
-    emitted.assign(fi_peptides_.size(), 0);
+    // Dedup guard `emitted` is declared and reset (O(touched), via emitted_touched)
+    // in the setup block above. The per-(charge, iso_err, sigma) reset below is also
+    // O(touched) rather than a full-index std::fill.
 
     // Helper: compute the iso-shifted observed (M+H)+ for a given (charge, iso_err).
     // Used by the subset-enumeration post-pass to reconstruct the realization target.
@@ -1723,7 +1813,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
 
           if (score_table[id] < min_matched_peaks_) continue;
 
-          emitted[id] = 1;
+          emit_mark(id);
           SpectrumMatch sm;
           sm.peptide_idx_ = id;
           sm.num_matched_ = score_table[id];
@@ -1797,7 +1887,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
         {
           // Reset dedup per (charge, iso_err, sigma) combo so the same mother
           // can re-emit at distinct sigma values (each is a distinct match).
-          std::fill(emitted.begin(), emitted.end(), 0);
+          { for (UInt32 eid : emitted_touched) emitted[eid] = 0; emitted_touched.clear(); }
 
           const float s = static_cast<float>(sigma);
 
@@ -1842,7 +1932,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
               const UInt32 id = static_cast<UInt32>(std::distance(fi_peptides_.begin(), it));
               if (emitted[id]) continue;
               if (score_table[id] < min_matched_peaks_) continue;
-              emitted[id] = 1;
+              emit_mark(id);
               SpectrumMatch sm;
               sm.peptide_idx_ = id;
               sm.num_matched_ = score_table[id];
@@ -1859,7 +1949,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
         // are configured.
         for (double sigma : prot_nterm_extra)
         {
-          std::fill(emitted.begin(), emitted.end(), 0);
+          { for (UInt32 eid : emitted_touched) emitted[eid] = 0; emitted_touched.clear(); }
           const float s = static_cast<float>(sigma);
           collect_candidates(shifted_mh - static_cast<float>(water)
                                         - static_cast<float>(fixed_cterm_delta_) - s,
@@ -1881,7 +1971,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
               if (fi_peptides_[id].sequence_.first != 0) continue; // PROT_NTERM anchor
               if (isSingleCMother(fi_peptides_[id].mod_bitmask_)) continue; // Single-N only
               if (score_table[id] < min_matched_peaks_) continue;
-              emitted[id] = 1;
+              emit_mark(id);
               SpectrumMatch sm;
               sm.peptide_idx_ = id;
               sm.num_matched_ = score_table[id];
@@ -1896,7 +1986,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
         // Extra walks for PROTEIN_C_TERM-only Σ values.
         for (double sigma : prot_cterm_extra)
         {
-          std::fill(emitted.begin(), emitted.end(), 0);
+          { for (UInt32 eid : emitted_touched) emitted[eid] = 0; emitted_touched.clear(); }
           const float s = static_cast<float>(sigma);
           collect_candidates(shifted_mh - static_cast<float>(fixed_nterm_delta_) - s,
                              prec_tol_lo, prec_tol_hi, /*expect_single_c=*/true, iso_err, charge,
@@ -1919,7 +2009,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
               if (static_cast<uint32_t>(fi_peptides_[id].sequence_.first)
                   + fi_peptides_[id].sequence_.second != prot_len) continue;
               if (score_table[id] < min_matched_peaks_) continue;
-              emitted[id] = 1;
+              emit_mark(id);
               SpectrumMatch sm;
               sm.peptide_idx_ = id;
               sm.num_matched_ = score_table[id];

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -1605,18 +1605,44 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
     thread_local std::vector<UInt32> touched_ids;       // mothers marked viable (== only ids ever written)
     thread_local std::vector<UInt32> emitted_touched;   // ids set in emitted since its last reset
 
-    if (score_table.size() != n_mothers) score_table.assign(n_mothers, 0);
-    if (viable_words.size() != n_words)  viable_words.assign(n_words, 0);
-    if (emitted.size() != n_mothers)     emitted.assign(n_mothers, 0);
-    for (UInt32 id : touched_ids) { score_table[id] = 0; viable_words[id >> 6] &= ~(uint64_t{1} << (id & 63)); }
-    touched_ids.clear();
-    for (UInt32 id : emitted_touched) emitted[id] = 0;
-    emitted_touched.clear();
+    // Restore the buffers to all-zero for this spectrum. They persist across queries
+    // AND across different / rebuilt FragmentIndex instances on the same thread, so the
+    // index size can change between calls (e.g. a later, smaller chunk in a chunked
+    // search). On a size change we must NOT walk the stale touched lists — their ids
+    // index the previous (possibly larger) size, so they would read/write out of bounds.
+    if (score_table.size() != n_mothers || viable_words.size() != n_words || emitted.size() != n_mothers)
+    {
+      score_table.assign(n_mothers, 0);   // full zero-fill makes the touched lists redundant
+      viable_words.assign(n_words, 0);
+      emitted.assign(n_mothers, 0);
+      touched_ids.clear();
+      emitted_touched.clear();
+    }
+    else
+    {
+      // Same index as the previous query: restore only the touched entries (O(touched)
+      // instead of a full-index memset — the whole point of the optimization).
+      for (UInt32 id : touched_ids) { score_table[id] = 0; viable_words[id >> 6] &= ~(uint64_t{1} << (id & 63)); }
+      touched_ids.clear();
+      for (UInt32 id : emitted_touched) emitted[id] = 0;
+      emitted_touched.clear();
+    }
 
     auto viable_test = [&](UInt32 id) -> bool { return (viable_words[id >> 6] >> (id & 63)) & uint64_t{1}; };
     auto viable_set  = [&](UInt32 id) { uint64_t& w = viable_words[id >> 6]; const uint64_t b = uint64_t{1} << (id & 63);
                                         if (!(w & b)) { w |= b; touched_ids.push_back(id); } };
     auto emit_mark   = [&](UInt32 id) { emitted[id] = 1; emitted_touched.push_back(id); };
+    auto reset_emitted_touched = [&]() { for (UInt32 id : emitted_touched) emitted[id] = 0; emitted_touched.clear(); };
+
+    // Single source of truth for the SNES precursor-derived bin-walk targets, shared by
+    // the viability pre-pass AND Phase-2 so the two cannot drift (the superset guarantee
+    // depends on byte-identical target m/z). SNES build() emits Single-N b-ions with
+    // c_term_mod=0 and Single-C y-ions with n_term_mod=0, so for a realized (M+H)+:
+    //   b_k (Single-N) = (M+H)+ - water - fixed_cterm - Sigma ; y_k (Single-C) = (M+H)+ - fixed_nterm - Sigma
+    const float snes_water = static_cast<float>(Residue::getInternalToFull().getMonoWeight());
+    auto target_single_n = [&](float shifted_mh, float s) { return shifted_mh - snes_water - static_cast<float>(fixed_cterm_delta_) - s; };
+    auto target_single_c = [&](float shifted_mh, float s) { return shifted_mh - static_cast<float>(fixed_nterm_delta_) - s; };
+    auto target_full     = [&](float shifted_mh, float s) { return shifted_mh - s; };
 
     // Fragment-charge upper bound for the byte scan. Use the max charge in the
     // `charges` list (the spectrum's known charge, or max_precursor_charge_ when
@@ -1634,11 +1660,11 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
     // emit: we walk the SAME precursor-derived fragment targets (Single-N b_k,
     // Single-C y_k) and the SAME full-length precursor_mz_ ranges, but drop the
     // single_c / protein-anchor / score-threshold filters (over-approximation). So no
-    // mother that Phase-2 emits is ever missing its count, while the ~165M non-viable
-    // mothers no longer take a (cache-missing) random write per matched fragment.
-    // Target formulas MUST stay in sync with Phase-2 below.
+    // mother that Phase-2 emits is ever missing its count, while the non-viable mothers
+    // no longer take a (cache-missing) random write per matched fragment. The bin-walk
+    // targets come from the shared target_single_n / target_single_c / target_full
+    // helpers used by Phase-2 too, so the two paths cannot drift out of sync.
     {
-      const float water_f = static_cast<float>(Residue::getInternalToFull().getMonoWeight());
       const bool open_mode_pp = isOpenSearchMode_();
       const int16_t iso_lo_pp = open_mode_pp ? 0 : min_isotope_error_;
       const int16_t iso_hi_pp = open_mode_pp ? 0 : max_isotope_error_;
@@ -1688,9 +1714,9 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
           for (double sigma : sigma_union)
           {
             const float s = static_cast<float>(sigma);
-            mark_bucket_range(shifted_mh - water_f - static_cast<float>(fixed_cterm_delta_) - s, tlo, thi); // Single-N b_k
-            mark_bucket_range(shifted_mh - static_cast<float>(fixed_nterm_delta_) - s, tlo, thi);           // Single-C y_k
-            mark_precursor_range(shifted_mh - s, tlo, thi);                                                 // full-length
+            mark_bucket_range(target_single_n(shifted_mh, s), tlo, thi); // Single-N b_k
+            mark_bucket_range(target_single_c(shifted_mh, s), tlo, thi); // Single-C y_k
+            mark_precursor_range(target_full(shifted_mh, s), tlo, thi);  // full-length
           }
         }
       }
@@ -1752,8 +1778,8 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
     //
     // We walk the fragment buckets at each target once per (charge, iso_err) and
     // emit the dedup'd set of matching mother ids whose phase-1 byte score meets
-    // the minimum-matched-peaks threshold.
-    static const double water = Residue::getInternalToFull().getMonoWeight();
+    // the minimum-matched-peaks threshold. The target m/z are computed via the
+    // shared target_single_n / target_single_c / target_full helpers (setup block).
 
     // Dedup guard `emitted` is declared and reset (O(touched), via emitted_touched)
     // in the setup block above. The per-(charge, iso_err, sigma) reset below is also
@@ -1887,7 +1913,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
         {
           // Reset dedup per (charge, iso_err, sigma) combo so the same mother
           // can re-emit at distinct sigma values (each is a distinct match).
-          { for (UInt32 eid : emitted_touched) emitted[eid] = 0; emitted_touched.clear(); }
+          reset_emitted_touched();
 
           const float s = static_cast<float>(sigma);
 
@@ -1902,11 +1928,10 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
           // Missing the fixed-term offsets would shift the lookup target by the
           // corresponding delta and silently miss all candidates when a user
           // configures Acetyl (N-term) / Amidated (C-term) / similar.
-          collect_candidates(shifted_mh - static_cast<float>(water)
-                                        - static_cast<float>(fixed_cterm_delta_) - s,
+          collect_candidates(target_single_n(shifted_mh, s),
                              prec_tol_lo, prec_tol_hi, /*expect_single_c=*/false, iso_err, charge,
                              SnesAnchor::NONE, s);
-          collect_candidates(shifted_mh - static_cast<float>(fixed_nterm_delta_) - s,
+          collect_candidates(target_single_c(shifted_mh, s),
                              prec_tol_lo, prec_tol_hi, /*expect_single_c=*/true, iso_err, charge,
                              SnesAnchor::NONE, s);
 
@@ -1920,7 +1945,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
           // (b) proteins shorter than max_length, where every mother is at full
           // protein length.
           {
-            const float target = shifted_mh - s;
+            const float target = target_full(shifted_mh, s);
             auto lb = std::lower_bound(fi_peptides_.begin(), fi_peptides_.end(),
                                         target + prec_tol_lo,
                                         [](const Peptide& a, float b) { return a.precursor_mz_ < b; });
@@ -1949,15 +1974,14 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
         // are configured.
         for (double sigma : prot_nterm_extra)
         {
-          { for (UInt32 eid : emitted_touched) emitted[eid] = 0; emitted_touched.clear(); }
+          reset_emitted_touched();
           const float s = static_cast<float>(sigma);
-          collect_candidates(shifted_mh - static_cast<float>(water)
-                                        - static_cast<float>(fixed_cterm_delta_) - s,
+          collect_candidates(target_single_n(shifted_mh, s),
                              prec_tol_lo, prec_tol_hi, /*expect_single_c=*/false, iso_err, charge,
                              SnesAnchor::PROT_NTERM, s);
           // Supplementary full-length at this Σ, PROT_NTERM-gated.
           {
-            const float target = shifted_mh - s;
+            const float target = target_full(shifted_mh, s);
             auto lb = std::lower_bound(fi_peptides_.begin(), fi_peptides_.end(),
                                         target + prec_tol_lo,
                                         [](const Peptide& a, float b) { return a.precursor_mz_ < b; });
@@ -1986,14 +2010,14 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
         // Extra walks for PROTEIN_C_TERM-only Σ values.
         for (double sigma : prot_cterm_extra)
         {
-          { for (UInt32 eid : emitted_touched) emitted[eid] = 0; emitted_touched.clear(); }
+          reset_emitted_touched();
           const float s = static_cast<float>(sigma);
-          collect_candidates(shifted_mh - static_cast<float>(fixed_nterm_delta_) - s,
+          collect_candidates(target_single_c(shifted_mh, s),
                              prec_tol_lo, prec_tol_hi, /*expect_single_c=*/true, iso_err, charge,
                              SnesAnchor::PROT_CTERM, s);
           // Supplementary full-length at this Σ, PROT_CTERM-gated.
           {
-            const float target = shifted_mh - s;
+            const float target = target_full(shifted_mh, s);
             auto lb = std::lower_bound(fi_peptides_.begin(), fi_peptides_.end(),
                                         target + prec_tol_lo,
                                         [](const Peptide& a, float b) { return a.precursor_mz_ < b; });

--- a/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
@@ -1603,6 +1603,93 @@ START_SECTION((SNES index admits a candidate whose sub-peptide matches an observ
 }
 END_SECTION
 
+START_SECTION((SNES query is safe and correct when a smaller index is queried after a larger one on the same thread))
+{
+  // Regression for an out-of-bounds access in querySpectrumSNES_'s touched-only reset.
+  // Its score_table / viable_words / emitted scratch buffers are thread_local and persist
+  // across queries AND across different / rebuilt FragmentIndex instances on the same
+  // thread (e.g. the smaller final chunk of a chunked search). The reset must NOT walk the
+  // previous query's touched-id list after the buffers were resized to a SMALLER index, or
+  // it indexes past the new size. The defect is silent in a release build (std::vector
+  // keeps capacity on assign), but aborts under _GLIBCXX_DEBUG / _GLIBCXX_ASSERTIONS / ASan
+  // — which is where this test has teeth (run the suite under one of those to catch a
+  // regression; the assertions below also cover the result staying correct after the shrink).
+  auto make_snes = [](FragmentIndex_test& fi) {
+    Param p = fi.getParameters();
+    p.setValue("peptide:enzyme_specificity", "none");
+    p.setValue("peptide:min_size", 8);
+    p.setValue("peptide:max_size", 12);
+    p.setValue("peptide:min_mass", 0);
+    p.setValue("peptide:max_mass", 50000);
+    p.setValue("precursor:mass_tolerance_lower", 20.0);
+    p.setValue("precursor:mass_tolerance_upper", 20.0);
+    p.setValue("precursor:mass_tolerance_unit", "ppm");
+    p.setValue("fragment:mass_tolerance", 20.0);
+    p.setValue("fragment:mass_tolerance_unit", "ppm");
+    p.setValue("precursor:isotope_error_min", 0);
+    p.setValue("precursor:isotope_error_max", 0);
+    p.setValue("modifications:variable", std::vector<std::string>{});
+    p.setValue("modifications:fixed", std::vector<std::string>{});
+    p.setValue("snes_enabled", "true");
+    p.setValue("fragment:min_matched_ions", 3);
+    fi.setParameters(p);
+  };
+  auto make_spectrum = [](const std::string& seq) {
+    TheoreticalSpectrumGenerator tsg;
+    Param tsg_p = tsg.getParameters();
+    tsg_p.setValue("add_metainfo", "true");
+    tsg.setParameters(tsg_p);
+    AASequence target = AASequence::fromString(seq);
+    PeakSpectrum theo;
+    tsg.getSpectrum(theo, target, 1, 1);
+    theo.sortByPosition();
+    MSSpectrum spec;
+    for (const auto& peak : theo) spec.push_back(peak);
+    Precursor prec;
+    prec.setMZ(target.getMonoWeight() + Constants::PROTON_MASS_U); // (M+H)+ as charge-1 m/z
+    prec.setCharge(1);
+    spec.getPrecursors().push_back(prec);
+    spec.setMSLevel(2);
+    return spec;
+  };
+
+  // (1) Large index: several distinct 20-aa proteins -> a large mother set. Querying it
+  //     populates the thread_local touched-id scratch lists with large mother ids.
+  std::vector<FASTAFile::FASTAEntry> large_entries{
+    {"L0", "L0", "ACDEFGHIKLMNPQRSTVWY"}, {"L1", "L1", "WYVTSRPNMLKIHGFEDCAQ"},
+    {"L2", "L2", "GASTCVLIMPFWYHKRDENQ"}, {"L3", "L3", "MKVLAGDESTPNQRIHFYWC"},
+    {"L4", "L4", "PQRSTVWYACDEFGHIKLMN"}, {"L5", "L5", "HRKDENQSTGAVLIMPFWYC"}};
+  FragmentIndex_test fi_large;
+  make_snes(fi_large);
+  fi_large.build(large_entries);
+  TEST_EQUAL(fi_large.isSnesMode(), true)
+  const size_t large_mothers = fi_large.getPeptides().size();
+  {
+    MSSpectrum spec = make_spectrum("ACDEFGHIKL"); // 10-mer present in L0
+    FragmentIndex::SpectrumMatchesTopN sms;
+    fi_large.querySpectrum(spec, large_entries, sms); // leaves large ids in the thread_local touched lists
+  }
+
+  // (2) Small index: one short protein -> far fewer mothers. Querying it shrinks the
+  //     thread_local buffers; the buggy reset would walk the stale large ids out of bounds.
+  std::vector<FASTAFile::FASTAEntry> small_entries{{"S", "S", "ACDEFGHIKLM"}}; // 11 aa
+  FragmentIndex_test fi_small;
+  make_snes(fi_small);
+  fi_small.build(small_entries);
+  const size_t small_mothers = fi_small.getPeptides().size();
+  TEST_EQUAL(small_mothers < large_mothers, true) // the index genuinely shrank
+
+  MSSpectrum spec_small = make_spectrum("ACDEFGHIK"); // 9-mer sub-peptide of the small protein
+  FragmentIndex::SpectrumMatchesTopN sms_small;
+  fi_small.querySpectrum(spec_small, small_entries, sms_small); // <-- shrink path: must not OOB
+
+  // Correctness after the shrink: the sub-peptide is still found.
+  bool any_matched = false;
+  for (const auto& hit : sms_small.hits_) { if (hit.num_matched_ >= 3u) { any_matched = true; break; } }
+  TEST_EQUAL(any_matched, true)
+}
+END_SECTION
+
 START_SECTION((SNES matches candidates when a fixed N-terminal modification is configured))
 {
   // Build a SNES index with Acetyl (N-term) as a fixed modification and verify


### PR DESCRIPTION
## Summary

Speeds up the **SNES** (Speedy Non-specific Enzyme Search) path of ProSE / `FragmentIndex` — the mode used for non-specific / immunopeptidomics searches (`peptide:enzyme_specificity=none` + `snes_enabled`). On a large (proteome-scale) database this roughly **halves** the search wall time, with **byte-identical results**.

Change is confined to `FragmentIndex::querySpectrumSNES_`. The non-SNES path is untouched, and SNES only runs when `snes_enabled && enzyme_specificity=none`.

## Motivation (profiled)

The SNES query computed matched-peak counts for **every** mother in the index via a precursor-agnostic byte scan (Phase 1), then Phase 2 emitted only the few **precursor-viable** mothers. Profiling a human no-enzyme search showed Phase 1 was the bottleneck and **write-bound**: ~2 billion cache-missing random increments into a ~330 MB `score_table` per search, plus full-index memsets (`score_table.assign` + per-σ `std::fill(emitted)`) on every spectrum.

## What changed

1. **Viability pre-pass** — before the byte scan, mark the mothers that could realize the observed precursor by walking the *same* precursor-derived targets Phase 2 uses (Single-N `b_k`, Single-C `y_k`, and the full-length `precursor_mz_` ranges). It deliberately drops the `single_c` / protein-anchor / score-threshold filters, so the marked set is a **strict superset** of everything Phase 2 can emit — no emitted mother can ever be missing its count.
2. **Gate Phase-1 writes** by that viability bitset → the non-viable mothers no longer take a random write per matched fragment.
3. **Touched-only resets** — `score_table` / `viable` / `emitted` are sized once and restored to zero by iterating only the entries actually touched, replacing the per-spectrum full-index memsets.

## Results (3 runs each, same machine, 20 threads, `enzyme=none` 8–12mers, 3607 MS2)

**Human proteome (83,374 proteins):**

| Build | run 1 | run 2 | run 3 | median | RSS |
|---|---|---|---|---|---|
| `develop` | 122.3 s | 126.4 s | 127.1 s | **126.4 s** | 10.71 GB |
| this PR | 70.2 s | 75.1 s | 76.5 s | **75.1 s** | 10.74 GB |

→ **1.68× faster** (best run 1.74×), identical RSS.

**E. coli (1,564 proteins, control):** ~3.5 s vs ~4.0 s — within run-to-run noise. The optimization is scale-targeted: small DBs were iteration-bound, not write-bound, so there is little to gain (and the pre-pass adds a little); large DBs are where the win is.

## Correctness

- **Byte-identical idXML** vs `develop` on both human (1763 PSMs) and E. coli (1147 PSMs) — same peptide sequences and scores (md5-verified).
- `FragmentIndex_test` and `ProSEAlgorithm_test` pass.

## Notes / follow-ups

- The pre-pass duplicates Phase 2's target-m/z formulas (a `MUST stay in sync` comment marks this); a future cleanup could factor them into a shared helper.
- Phase 1 is now *iteration*-bound rather than write-bound — it still scans all bucket fragments. A larger follow-up could invert it (score viable mothers directly instead of scanning), but that needs care to reproduce the exact byte counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Faster spectrum indexing/scoring with reduced per-query work and selective buffer resets for lower CPU usage.
  * New pre-filter to skip incompatible candidates and improved per-iteration deduplication for more consistent match recovery.

* **Tests**
  * Added regression test ensuring queries remain correct and stable when switching to smaller indexes on the same thread.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->