### PR TITLE
doc/code_examples: drop stale String.h include (fixes red class-topp build on develop)

### DIFF
--- a/doc/code_examples/Tutorial_IdentificationClasses.cpp
+++ b/doc/code_examples/Tutorial_IdentificationClasses.cpp
@@ -11,7 +11,6 @@
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/PeptideHit.h>
-#include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
 

--- a/doc/code_examples/Tutorial_Logger.cpp
+++ b/doc/code_examples/Tutorial_Logger.cpp
@@ -7,7 +7,6 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/CONCEPT/ProgressLogger.h>
-#include <OpenMS/DATASTRUCTURES/String.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/doc/code_examples/Tutorial_MetaInfo.cpp
+++ b/doc/code_examples/Tutorial_MetaInfo.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/METADATA/MetaInfoInterface.h>
 #include <iostream>
 


### PR DESCRIPTION
## Problem

`develop` is red: the `build-and-test (… class-topp …)` job fails on every platform with

```
doc/code_examples/Tutorial_IdentificationClasses.cpp:14:
fatal error: OpenMS/DATASTRUCTURES/String.h: No such file or directory
```

#9468 removed the obsolete `String` / `StringConversions` / `StringUtilsSimple` shim headers, but three code-example tutorials were left still `#include`-ing the removed `<OpenMS/DATASTRUCTURES/String.h>`. The `class-topp` build compiles `doc/code_examples/`, so it dies there — on `develop` itself and on **every open PR branched after #9468** (that's how I found it: a FragmentIndex PR's CI was red purely from this, not its own changes).

## Fix

Remove the dead include from the three affected files:

- `doc/code_examples/Tutorial_IdentificationClasses.cpp`
- `doc/code_examples/Tutorial_MetaInfo.cpp`
- `doc/code_examples/Tutorial_Logger.cpp`

None of them use the `String` type (verified), so the include is simply dropped — no replacement needed. A full-repo grep confirms these are the only three files still referencing the removed header.

## Verification

All three targets build and link cleanly locally (`Tutorial_IdentificationClasses`, `Tutorial_Logger`, `Tutorial_MetaInfo`), where they failed to compile before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Cleaned up tutorial code examples to improve clarity and maintainability for developers learning from the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->