### PR TITLE
Make INIUpdater Qt-free and move it to src/topp

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -294,7 +294,7 @@ ARG TARGETARCH
 
 RUN apt-get update \ 
     && apt-get install -y --no-install-recommends --no-install-suggests \
-    # we need Xvfb to run a small subset of tests (eg. TOPP_INIUpdater)
+    # we need Xvfb to run a small subset of GUI tests (eg. TOPPView_test)
     xvfb \
     # needed for TSGDialog_test and TOPPView_test
     libqt6test6 \

--- a/src/openms/source/APPLICATIONS/ToolHandler.cpp
+++ b/src/openms/source/APPLICATIONS/ToolHandler.cpp
@@ -201,7 +201,6 @@ namespace OpenMS
     StringList GUI_tools = {
       "ExecutePipeline",
       "ImageCreator",
-      "INIUpdater",
     };
     for (const auto& tool : GUI_tools) {
       tools_map.erase(tool);

--- a/src/openms_gui/CMakeLists.txt
+++ b/src/openms_gui/CMakeLists.txt
@@ -91,12 +91,12 @@ foreach(i ${GUI_executables})
 endforeach(i)
 
 # GUI TOPP tools also need direct OpenMS link for TOPPBase etc.
-foreach(i ExecutePipeline ImageCreator INIUpdater)
+foreach(i ExecutePipeline ImageCreator)
   target_link_libraries(${i} OpenMS)
 endforeach()
 
 # Add GUI-based TOPP tools to the TOPP_TOOLS list for CWL/INI generation
-set(GUI_TOPP_TOOLS ExecutePipeline ImageCreator INIUpdater)
+set(GUI_TOPP_TOOLS ExecutePipeline ImageCreator)
 set(TOPP_TOOLS ${TOPP_TOOLS} ${GUI_TOPP_TOOLS}
     CACHE INTERNAL "OpenMS' TOPP tools" FORCE)
 

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/executables.cmake
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/executables.cmake
@@ -6,7 +6,6 @@ set(GUI_executables
 ExecutePipeline
 ImageCreator
 INIFileEditor
-INIUpdater
 TOPPAS
 TOPPView
 )

--- a/src/topp/INIUpdater.cpp
+++ b/src/topp/INIUpdater.cpp
@@ -8,17 +8,11 @@
 
 #include <OpenMS/APPLICATIONS/INIUpdater.h>
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/SYSTEM/ExternalProcess.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/ParamXMLFile.h>
-#include <OpenMS/VISUAL/TOPPASScene.h>
-#include <OpenMS/VISUAL/MISC/Qt5Port.h>
-
-
-#include <QApplication>
-#include <QFileInfo>
-#include <QFile>
-#include <QDir>
 
 using namespace OpenMS;
 using namespace std;
@@ -83,14 +77,53 @@ protected:
     setValidFormats_("out", ListUtils::create<std::string>("ini,toppas"));
   }
 
+  /// Run @p tool_name with '-write_ini' to dump its current default parameters into @p tmp_ini_file.
+  /// Returns false if the tool executable could not be found or did not finish successfully.
+  bool runWriteIni_(const std::string& tool_name, const std::string& tmp_ini_file, Int instance)
+  {
+    std::string tool_exe;
+    try
+    {
+      tool_exe = File::findSiblingTOPPExecutable(tool_name);
+    }
+    catch (Exception::FileNotFound&)
+    {
+      return false;
+    }
+
+    ExternalProcess proc;
+    std::string error_msg;
+    ExternalProcess::RETURNSTATE state = proc.run(
+      tool_exe, {"-write_ini", tmp_ini_file, "-instance", std::to_string(instance)}, "", false, error_msg);
+    return state == ExternalProcess::RETURNSTATE::SUCCESS;
+  }
+
+  /// Renames @p infile to a versioned backup "<dir>/<basename-without-extension>_v<version><extension>".
+  /// Refuses to overwrite an already existing backup (returns false and leaves @p infile untouched), matching
+  /// the original QFile::rename behavior, so a previous backup is never destroyed. On success, @p backup_name
+  /// holds the created backup path; on failure it holds the attempted path (for error reporting).
+  static bool createBackup_(const std::string& infile, const std::string& version, const std::string& extension, std::string& backup_name)
+  {
+    std::string base = File::basename(infile);
+    std::string::size_type dot = base.rfind('.');
+    if (dot != std::string::npos)
+    {
+      base = base.substr(0, dot);
+    }
+    backup_name = File::path(infile) + "/" + base + "_v" + version + extension;
+    if (File::exists(backup_name)) // never clobber an existing backup
+    {
+      return false;
+    }
+    return File::rename(infile, backup_name, false);
+  }
+
   void updateTOPPAS(const std::string& infile, const std::string& outfile)
   {
     Int this_instance = getIntOption_("instance");
     INIUpdater updater;
     std::string tmp_ini_file = File::getTempDirectory() + "/" + File::getUniqueName() + "_INIUpdater.ini";
     tmp_files_.push_back(tmp_ini_file);
-
-    std::string path = File::getExecutablePath();
 
     ParamXMLFile paramFile;
     Param p;
@@ -156,14 +189,7 @@ protected:
       p.setValue(sec_inst + "tool_type", "");
 
       // get defaults of new tool by calling it
-      QProcess pr;
-      QStringList arguments;
-      arguments << "-write_ini";
-      arguments << toQString(tmp_ini_file);
-      arguments << "-instance";
-      arguments << toQString(StringUtils::toStr(this_instance));
-      pr.start(toQString(path + "/" + new_tool), arguments);
-      if (!pr.waitForFinished(-1))
+      if (!runWriteIni_(new_tool, tmp_ini_file, this_instance))
       {
         writeLogWarn_("Update for file " + infile + " failed because the tool '" + new_tool + "' returned with an error! Check if the tool works properly.");
         update_success = false;
@@ -187,32 +213,11 @@ protected:
       return;
     }
 
-    paramFile.store(tmp_ini_file, p);
-
-    // update internal structure (e.g. edges format changed from 1.8 to 1.9)
-    int argc = 1;
-    const char* c = "IniUpdater";
-    const char** argv = &c;
-
-    QApplication app(argc, const_cast<char**>(argv), false);
-    std::string tmp_dir = File::getTempDirectory() + "/" + File::getUniqueName();
-    QDir d;
-    d.mkpath(toQString(tmp_dir));
-    {
-      TOPPASScene ts(nullptr, toQString(tmp_dir), false);
-      paramFile.store(tmp_ini_file, p);
-      ts.load(tmp_ini_file);
-      ts.store(tmp_ini_file);
-      paramFile.load(tmp_ini_file, p);
-    } // ts goes out of scope before we remove its directory
-    QDir(toQString(tmp_dir)).removeRecursively();
-
     // STORE
     if (outfile.empty()) // create a backup
     {
-      QFileInfo fi(toQString(infile));
-      std::string new_name = fromQString(fi.path()) + "/" + fromQString(fi.completeBaseName()) + "_v" + version + ".toppas";
-      if (!QFile::rename(toQString(infile), toQString(new_name)))
+      std::string new_name;
+      if (!createBackup_(infile, version, ".toppas", new_name))
       {
         OPENMS_LOG_ERROR << "Could not create backup '" << new_name << "' from '" << infile << "'. Aborting update to prevent data loss." << std::endl;
         failed_.push_back(infile);
@@ -233,8 +238,6 @@ protected:
     INIUpdater updater;
     std::string tmp_ini_file = File::getTempDirectory() + "/" + File::getUniqueName() + "_INIUpdater.ini";
     tmp_files_.push_back(tmp_ini_file);
-
-    std::string path = File::getExecutablePath();
 
     Param p;
     ParamXMLFile paramFile;
@@ -289,14 +292,7 @@ protected:
         break;
       }
       // get defaults of new tool by calling it
-      QProcess pr;
-      QStringList arguments;
-      arguments << "-write_ini";
-      arguments << toQString(tmp_ini_file);
-      arguments << "-instance";
-      arguments << toQString(StringUtils::toStr(this_instance));
-      pr.start(toQString(path + "/" + new_tool), arguments);
-      if (!pr.waitForFinished(-1))
+      if (!runWriteIni_(new_tool, tmp_ini_file, this_instance))
       {
         writeLogWarn_("Update for file '" + infile + "' failed because the tool '" + new_tool + "' returned with an error! Check if the tool works properly.");
         update_success = false;
@@ -323,9 +319,8 @@ protected:
     // STORE
     if (outfile.empty()) // create a backup
     {
-      QFileInfo fi(toQString(infile));
-      std::string backup_filename = fromQString(fi.path()) + "/" + fromQString(fi.completeBaseName()) + "_v" + version_old + ".ini";
-      if (!QFile::rename(toQString(infile), toQString(backup_filename)))
+      std::string backup_filename;
+      if (!createBackup_(infile, version_old, ".ini", backup_filename))
       {
         OPENMS_LOG_ERROR << "Could not create backup '" << backup_filename << "' from '" << infile << "'. Aborting update to prevent data loss." << std::endl;
         failed_.push_back(infile);

--- a/src/topp/executables.cmake
+++ b/src/topp/executables.cmake
@@ -55,6 +55,7 @@ IDRipper
 IDRTCalibration
 IDScoreSwitcher
 IDSplitter
+INIUpdater
 InternalCalibration
 IonMobilityBinning
 IsobaricAnalyzer


### PR DESCRIPTION
## Summary

Removes the Qt dependency from the **INIUpdater** tool and moves it from the GUI build (`openms_gui`) to the regular TOPP tools (`src/topp`). INIUpdater was the last "GUI TOPP tool" that pulled in Qt purely for utility classes (process spawning, path handling) and a `TOPPASScene` round-trip — never for an actual GUI.

After this change `INIUpdater` links only `OpenMS` (verified via `ldd` — no Qt), leaving `ExecutePipeline` and `ImageCreator` as the only remaining GUI-linked "TOPP" tools (both of which genuinely need Qt: the TOPPAS event-loop engine and raster rendering respectively).

## What changed

- **`QProcess` (`-write_ini`) → OpenMS `ExternalProcess`**
- **`QFileInfo`/`QFile`/`QDir` backup handling → OpenMS `File::` + `std::string`/`std::filesystem`**
- **Dropped the `QApplication` + `TOPPASScene` load/store round-trip** (see below)
- Moved `src/openms_gui/.../GUITOOLS/INIUpdater.cpp` → `src/topp/INIUpdater.cpp`
- CMake: removed from `GUI_executables`/`GUI_TOPP_TOOLS`, added to `TOPP_executables`
- `ToolHandler`: stop erasing `INIUpdater` from the registry in non-GUI (`-DWITH_GUI=OFF`) builds — it no longer needs the GUI lib and is now always built
- `Dockerfile`: dropped the now-stale "Xvfb needed for `TOPP_INIUpdater`" note (INIUpdater no longer needs a display)

## Why dropping the TOPPASScene round-trip is safe

The old `updateTOPPAS()` ran the parsed `Param` through a `TOPPASScene` `load()`/`store()` round-trip "to update internal structure (e.g. edge format)". Investigation shows this was **effectively dead code**: `TOPPASScene::store()` returns `false` (and its return value was ignored) whenever edges become invalid after the tool/parameter refresh, so it never actually rewrote the file. The committed reference output `INIUpdater_3_old_out.toppas` confirms this — it preserves the original **integer** edge parameters and the original vertex numbering/order, i.e. every observable change comes from plain `Param` + `ParamXMLFile`, not from TOPPAS.

## Verification

- All `TOPP_INIUpdater` tests pass unchanged, covering the three relevant paths:
  - `_1` — no-op round-trip (output == input)
  - `_2` — broken file correctly rejected (`WILL_FAIL`)
  - `_3` — 1.8 → current migration (matches reference byte-for-byte modulo the whitelisted `version`/`supported_formats`)
- `INIUpdater_test`, `TOPPWRITEINI_*`, `TOPPWRITECTD_INIUpdater` pass
- `ldd bin/INIUpdater` shows **no Qt** linkage
- The full GUI target still builds with INIUpdater removed
- Manually verified the backup-overwrite protection (see below)

## Backup safety (from adversarial review)

`createBackup_()` explicitly refuses to overwrite an existing backup, preserving the original `QFile::rename()` fail-if-exists behavior. Note: `File::rename(..., overwrite_existing=false)` does **not** currently honor that documented contract on POSIX (it falls through to `std::filesystem::rename`, which overwrites), so the existence check is done explicitly here. That underlying `File::rename` contract bug is pre-existing and worth fixing separately. Verified manually: a second in-place (`-i`) run aborts with "Aborting update to prevent data loss" and leaves the first backup untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * INIUpdater reclassified from a GUI tool to a command-line tool
  * ExecutePipeline and ImageCreator are now configured as GUI tools

* **Bug Fixes**
  * Improved in-place backup creation for INIUpdater with versioned backups to avoid overwrites
  * Switched INIUpdater to a more reliable external process approach for extracting tool defaults and writing INI data
<!-- end of auto-generated comment: release notes by coderabbit.ai -->