### PR TITLE
Fix doc/code_examples includes after String.h removal (#9468)

### DIFF
--- a/doc/code_examples/Tutorial_IdentificationClasses.cpp
+++ b/doc/code_examples/Tutorial_IdentificationClasses.cpp
@@ -11,7 +11,7 @@
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/PeptideHit.h>
-#include <OpenMS/DATASTRUCTURES/String.h>
+#include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
 

--- a/doc/code_examples/Tutorial_Logger.cpp
+++ b/doc/code_examples/Tutorial_Logger.cpp
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/CONCEPT/ProgressLogger.h>
-#include <OpenMS/DATASTRUCTURES/String.h>
+#include <OpenMS/DATASTRUCTURES/StringUtils.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/doc/code_examples/Tutorial_MetaInfo.cpp
+++ b/doc/code_examples/Tutorial_MetaInfo.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 
-#include <OpenMS/DATASTRUCTURES/String.h>
+#include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/METADATA/MetaInfoInterface.h>
 #include <iostream>
 


### PR DESCRIPTION
## Problem

The full `build-and-test` CI matrix is currently failing on `develop` with:

```
doc/code_examples/Tutorial_IdentificationClasses.cpp:14:10: fatal error:
OpenMS/DATASTRUCTURES/String.h: No such file or directory
   14 | #include <OpenMS/DATASTRUCTURES/String.h>
```

PR #9468 ("Remove obsolete String/StringConversions/StringUtilsSimple shim headers") merged `String.h` into `StringUtils.h` and rewrote all includers **across `src/`**, but three tutorials under `doc/code_examples/` were missed and still include the now-deleted `<OpenMS/DATASTRUCTURES/String.h>`.

These targets are only built when docs are enabled (`ENABLE_DOCS`), so the **wheel builds stayed green** while the full **`build-and-test`** matrix fails on every platform — which is why it slipped through (the refactor's own PR CI didn't compile the code examples).

## Fix

Point the three tutorials at `StringUtils.h`, exactly as #9468 did for the rest of the codebase:

- `doc/code_examples/Tutorial_IdentificationClasses.cpp`
- `doc/code_examples/Tutorial_Logger.cpp`
- `doc/code_examples/Tutorial_MetaInfo.cpp`

`String` now lives in `StringUtils.h`, so this is the correct, minimal replacement. After this, no `<OpenMS/DATASTRUCTURES/String.h>` includes remain in the tree.

## Notes

Discovered while bringing #8691 (psi-ms.obo update) up to date with `develop`; that PR's red `build-and-test` is caused by this pre-existing breakage, not the vocabulary change.

https://claude.ai/code/session_01YJmfkpV9FLwZg1WjcqGf2s

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJmfkpV9FLwZg1WjcqGf2s)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples with revised utility module includes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->