### PR TITLE
Factor a Qt-free TOPPASWorkflow model out of TOPPASScene

### DIFF
--- a/src/openms/include/OpenMS/APPLICATIONS/TOPPASWorkflow.h
+++ b/src/openms/include/OpenMS/APPLICATIONS/TOPPASWorkflow.h
@@ -1,0 +1,118 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/config.h>
+#include <OpenMS/DATASTRUCTURES/Param.h>
+
+#include <string>
+#include <vector>
+
+namespace OpenMS
+{
+  /**
+    @brief Qt-free in-memory representation of a TOPPAS workflow (.toppas) file.
+
+    TOPPASWorkflow holds the serialized content of a @em .toppas file -- the header
+    (version + description), the list of nodes (vertices) and the list of edges -- and
+    provides (de)serialization via ParamXMLFile (the on-disk @em .toppas format).
+
+    It is deliberately independent of Qt so that the workflow document can be read,
+    written and inspected without the GUI. The Qt-based @c TOPPASScene uses this class
+    for loading and storing, mapping between these plain structs and its visual
+    QGraphicsItem vertices/edges.
+
+    Conventions kept identical to the historical TOPPASScene serialization:
+    - Node ids are stored verbatim as strings (TOPPASScene uses the topological index).
+    - Input file names are stored verbatim (typically relative to the @em .toppas file);
+      absolutization/relativization relative to the file location is the caller's job.
+    - Edge source/target parameters are stored as strings: a parameter name, the
+      sentinel @c "__no_name__", or -- for very old (pre-1.9) files -- a numeric index.
+    - store()/toParam() always write the @em current %OpenMS version into @c info:version
+      (matching the previous behavior).
+
+    @ingroup Applications
+  */
+  class OPENMS_DLLAPI TOPPASWorkflow
+  {
+  public:
+    /// Sentinel used for an edge endpoint that is not bound to a named parameter.
+    static const std::string NO_NAME;
+
+    /// Type of a workflow node (mirrors the @c toppas_type field).
+    enum class NodeType
+    {
+      INPUT_FILE_LIST, ///< a list of input files fed into the pipeline
+      OUTPUT_FILE_LIST, ///< collects output files
+      OUTPUT_FOLDER,   ///< collects output into a folder
+      TOOL,            ///< a TOPP tool invocation
+      MERGER,          ///< merges incoming file lists
+      SPLITTER,        ///< splits an incoming file list
+      UNKNOWN          ///< unrecognized type (forward compatibility)
+    };
+
+    /// A single workflow node (vertex).
+    struct Node
+    {
+      std::string id;                ///< node id as stored in the file (TOPPASScene: topological index)
+      NodeType type = NodeType::UNKNOWN;
+      double x_pos = 0.0;            ///< canvas x position
+      double y_pos = 0.0;           ///< canvas y position
+      bool recycle_output = false;  ///< output-recycling flag (since TOPPAS 1.9)
+
+      // NodeType::TOOL
+      std::string tool_name;        ///< name of the TOPP tool
+      std::string tool_type;        ///< tool sub-type (algorithm), may be empty
+      Param parameters;             ///< the tool's parameters (without any key prefix)
+
+      // NodeType::INPUT_FILE_LIST
+      std::vector<std::string> file_names; ///< verbatim file names as stored (usually relative)
+
+      // NodeType::OUTPUT_FILE_LIST / NodeType::OUTPUT_FOLDER
+      std::string output_folder_name; ///< custom output folder name (may be empty)
+
+      // NodeType::MERGER
+      bool round_based = true;      ///< round-based vs. wait-for-all merge mode (default: round-based)
+    };
+
+    /// A directed edge connecting an output of @c source_id to an input of @c target_id.
+    struct Edge
+    {
+      std::string source_id;        ///< id of the source node
+      std::string target_id;        ///< id of the target node
+      std::string source_out_param; ///< source output parameter name (or NO_NAME, or a numeric index for very old files)
+      std::string target_in_param;  ///< target input parameter name (or NO_NAME, or a numeric index for very old files)
+    };
+
+    /// %OpenMS version string that wrote the file (empty for pre-1.9 files lacking the tag).
+    std::string version;
+    /// Free-text workflow description (CDATA wrapper removed).
+    std::string description;
+    /// All nodes, in file order.
+    std::vector<Node> nodes;
+    /// All edges, in file order.
+    std::vector<Edge> edges;
+
+    /// Convert a @c toppas_type string to a NodeType (UNKNOWN if unrecognized).
+    static NodeType typeFromString(const std::string& s);
+    /// Convert a NodeType to its @c toppas_type string (empty for UNKNOWN).
+    static std::string typeToString(NodeType t);
+
+    /// Fill this workflow from an already parsed @em .toppas Param tree.
+    void fromParam(const Param& param);
+    /// Serialize this workflow into a Param tree in the @em .toppas layout.
+    Param toParam() const;
+
+    /// Load a @em .toppas file (ParamXMLFile format). Throws on file/parse errors.
+    void load(const std::string& filename);
+    /// Store this workflow to a @em .toppas file (ParamXMLFile format).
+    void store(const std::string& filename) const;
+  };
+
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/APPLICATIONS/sources.cmake
+++ b/src/openms/include/OpenMS/APPLICATIONS/sources.cmake
@@ -10,6 +10,7 @@ OpenSwathBase.h
 ParameterInformation.h
 SearchEngineBase.h
 ToolHandler.h
+TOPPASWorkflow.h
 TOPPBase.h
 )
 

--- a/src/openms/source/APPLICATIONS/TOPPASWorkflow.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPASWorkflow.cpp
@@ -1,0 +1,224 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/APPLICATIONS/TOPPASWorkflow.h>
+
+#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/CONCEPT/VersionInfo.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/DATASTRUCTURES/StringUtils.h>
+#include <OpenMS/FORMAT/ParamXMLFile.h>
+
+namespace OpenMS
+{
+  const std::string TOPPASWorkflow::NO_NAME = "__no_name__";
+
+  namespace
+  {
+    /// Split @p s at every occurrence of @p delim (keeps empty fields; never returns an empty vector).
+    std::vector<std::string> splitStr(const std::string& s, char delim)
+    {
+      std::vector<std::string> out;
+      std::string::size_type start = 0, pos;
+      while ((pos = s.find(delim, start)) != std::string::npos)
+      {
+        out.push_back(s.substr(start, pos - start));
+        start = pos + 1;
+      }
+      out.push_back(s.substr(start));
+      return out;
+    }
+  } // namespace
+
+  TOPPASWorkflow::NodeType TOPPASWorkflow::typeFromString(const std::string& s)
+  {
+    if (s == "input file list") return NodeType::INPUT_FILE_LIST;
+    if (s == "output file list") return NodeType::OUTPUT_FILE_LIST;
+    if (s == "output folder") return NodeType::OUTPUT_FOLDER;
+    if (s == "tool") return NodeType::TOOL;
+    if (s == "merger") return NodeType::MERGER;
+    if (s == "splitter") return NodeType::SPLITTER;
+    return NodeType::UNKNOWN;
+  }
+
+  std::string TOPPASWorkflow::typeToString(NodeType t)
+  {
+    switch (t)
+    {
+      case NodeType::INPUT_FILE_LIST: return "input file list";
+      case NodeType::OUTPUT_FILE_LIST: return "output file list";
+      case NodeType::OUTPUT_FOLDER: return "output folder";
+      case NodeType::TOOL: return "tool";
+      case NodeType::MERGER: return "merger";
+      case NodeType::SPLITTER: return "splitter";
+      default: return "";
+    }
+  }
+
+  void TOPPASWorkflow::fromParam(const Param& param)
+  {
+    version.clear();
+    description.clear();
+    nodes.clear();
+    edges.clear();
+
+    if (param.exists("info:version"))
+    {
+      version = param.getValue("info:version").toString();
+    }
+    if (param.exists("info:description"))
+    {
+      std::string text = param.getValue("info:description").toString();
+      StringUtils::substitute(text, "<![CDATA[", "");
+      StringUtils::substitute(text, "]]>", "");
+      description = StringUtils::trimmed(text);
+    }
+
+    // --- nodes ---
+    Param vertices_param = param.copy("vertices:", true);
+    for (Param::ParamIterator it = vertices_param.begin(); it != vertices_param.end(); ++it)
+    {
+      std::vector<std::string> parts = splitStr(std::string(it.getName()), ':');
+      if (parts.back() != "toppas_type") // every node is introduced by its 'toppas_type' entry
+      {
+        continue;
+      }
+
+      Node n;
+      n.id = parts[0];
+      n.type = typeFromString(it->value.toString());
+      if (n.type == NodeType::UNKNOWN) // unknown/forward-compatible type: skip (as the old TOPPASScene did)
+      {
+        OPENMS_LOG_WARN << "Unknown vertex type '" << it->value.toString() << "' in TOPPAS workflow -- skipping node." << std::endl;
+        continue;
+      }
+      const std::string base = n.id + ":";
+      if (vertices_param.exists(base + "x_pos")) n.x_pos = vertices_param.getValue(base + "x_pos");
+      if (vertices_param.exists(base + "y_pos")) n.y_pos = vertices_param.getValue(base + "y_pos");
+      if (vertices_param.exists(base + "recycle_output"))
+      {
+        n.recycle_output = (vertices_param.getValue(base + "recycle_output").toString() == "true");
+      }
+
+      switch (n.type)
+      {
+        case NodeType::INPUT_FILE_LIST:
+          if (vertices_param.exists(base + "file_names"))
+          {
+            n.file_names = ListUtils::toStringList<std::string>(vertices_param.getValue(base + "file_names"));
+          }
+          break;
+        case NodeType::OUTPUT_FILE_LIST:
+        case NodeType::OUTPUT_FOLDER:
+          if (vertices_param.exists(base + "output_folder_name"))
+          {
+            n.output_folder_name = vertices_param.getValue(base + "output_folder_name").toString();
+          }
+          break;
+        case NodeType::TOOL:
+          if (vertices_param.exists(base + "tool_name")) n.tool_name = vertices_param.getValue(base + "tool_name").toString();
+          if (vertices_param.exists(base + "tool_type")) n.tool_type = vertices_param.getValue(base + "tool_type").toString();
+          n.parameters = vertices_param.copy(base + "parameters:", true);
+          break;
+        case NodeType::MERGER:
+          // default to round-based if the flag is absent
+          n.round_based = vertices_param.exists(base + "round_based")
+                            ? (vertices_param.getValue(base + "round_based").toString() == "true")
+                            : true;
+          break;
+        default:
+          break;
+      }
+      nodes.push_back(n);
+    }
+
+    // --- edges ---
+    // each edge contributes three consecutive entries: source/target, source_out_param, target_in_param
+    Param edges_param = param.copy("edges:", true);
+    for (Param::ParamIterator it = edges_param.begin(); it != edges_param.end(); ++it)
+    {
+      std::vector<std::string> st = splitStr(it->value.toString(), '/');
+      if (st.size() != 2) // malformed source/target: stop (as the old TOPPASScene did)
+      {
+        break;
+      }
+      Edge e;
+      e.source_id = st[0];
+      e.target_id = st[1];
+      if (++it == edges_param.end()) break;
+      e.source_out_param = it->value.toString();
+      if (++it == edges_param.end()) break;
+      e.target_in_param = it->value.toString();
+      edges.push_back(e);
+    }
+  }
+
+  Param TOPPASWorkflow::toParam() const
+  {
+    Param param;
+    param.setValue("info:version", VersionInfo::getVersion());
+    param.setValue("info:num_vertices", (int)nodes.size());
+    param.setValue("info:num_edges", (int)edges.size());
+    param.setValue("info:description", std::string("<![CDATA[") + description + std::string("]]>"));
+
+    for (const Node& n : nodes)
+    {
+      const std::string base = "vertices:" + n.id + ":";
+      param.setValue(base + "toppas_type", typeToString(n.type));
+      param.setValue(base + "x_pos", n.x_pos);
+      param.setValue(base + "y_pos", n.y_pos);
+      param.setValue(base + "recycle_output", n.recycle_output ? "true" : "false");
+
+      switch (n.type)
+      {
+        case NodeType::INPUT_FILE_LIST:
+          param.setValue(base + "file_names", n.file_names);
+          break;
+        case NodeType::OUTPUT_FILE_LIST:
+        case NodeType::OUTPUT_FOLDER:
+          param.setValue(base + "output_folder_name", n.output_folder_name);
+          break;
+        case NodeType::TOOL:
+          param.setValue(base + "tool_name", n.tool_name);
+          param.setValue(base + "tool_type", n.tool_type);
+          param.insert(base + "parameters:", n.parameters);
+          break;
+        case NodeType::MERGER:
+          param.setValue(base + "round_based", n.round_based ? "true" : "false");
+          break;
+        default:
+          break;
+      }
+    }
+
+    int counter = 0;
+    for (const Edge& e : edges)
+    {
+      const std::string base = "edges:" + std::to_string(counter) + ":";
+      param.setValue(base + "source/target:", e.source_id + "/" + e.target_id);
+      param.setValue(base + "source_out_param:", e.source_out_param);
+      param.setValue(base + "target_in_param:", e.target_in_param);
+      ++counter;
+    }
+
+    return param;
+  }
+
+  void TOPPASWorkflow::load(const std::string& filename)
+  {
+    Param p;
+    ParamXMLFile().load(filename, p);
+    fromParam(p);
+  }
+
+  void TOPPASWorkflow::store(const std::string& filename) const
+  {
+    ParamXMLFile().store(filename, toParam());
+  }
+
+} // namespace OpenMS

--- a/src/openms/source/APPLICATIONS/sources.cmake
+++ b/src/openms/source/APPLICATIONS/sources.cmake
@@ -9,6 +9,7 @@ ParameterInformation.cpp
 OpenSwathBase.cpp
 SearchEngineBase.cpp
 ToolHandler.cpp
+TOPPASWorkflow.cpp
 TOPPBase.cpp
 )
 

--- a/src/openms_gui/source/VISUAL/TOPPASScene.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASScene.cpp
@@ -19,6 +19,7 @@
 #include <OpenMS/VISUAL/DIALOGS/TOPPASOutputFilesDialog.h>
 #include <OpenMS/VISUAL/DIALOGS/TOPPASVertexNameDialog.h>
 
+#include <OpenMS/APPLICATIONS/TOPPASWorkflow.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/VersionInfo.h>
 #include <OpenMS/SYSTEM/File.h>
@@ -636,84 +637,65 @@ namespace OpenMS
 
   bool TOPPASScene::store(const std::string& file)
   {
-    Param save_param;
+    // build a Qt-free document model and let it handle the serialization
+    TOPPASWorkflow wf;
+    wf.description = fromQString(this->description_text_);
 
-    save_param.setValue("info:version", VersionInfo::getVersion());
-    save_param.setValue("info:num_vertices", vertices_.size());
-    save_param.setValue("info:num_edges", edges_.size());
-    save_param.setValue("info:description",std::string("<![CDATA[") + fromQString(this->description_text_) + std::string("]]>"));
-
-    // lambda function to store common parameters of all vertices
-    auto save_common_params =
-      [&save_param](const TOPPASVertex* tv, const std::string& id, const std::string& type)
-      {
-        save_param.setValue("vertices:" + id + ":toppas_type", type);
-        save_param.setValue("vertices:" + id + ":x_pos", tv->x());
-        save_param.setValue("vertices:" + id + ":y_pos", tv->y());
-        save_param.setValue("vertices:" + id + ":recycle_output", tv->isRecyclingEnabled() ? "true" : "false");
-    };
-      
-
-    // store all vertices (together with all parameters)
-    for (TOPPASVertex * tv : vertices_)
+    // all vertices (together with all parameters); node id is the topological index
+    for (TOPPASVertex* tv : vertices_)
     {
-      std::string id = StringUtils::toStr(tv->getTopoNr() - 1);
+      TOPPASWorkflow::Node n;
+      n.id = StringUtils::toStr(tv->getTopoNr() - 1);
+      n.x_pos = tv->x();
+      n.y_pos = tv->y();
+      n.recycle_output = tv->isRecyclingEnabled();
 
       // vertex subclasses
       if (auto* iflv = qobject_cast<TOPPASInputFileListVertex*>(tv); iflv)
       {
-        // store file names relative to toppas file
+        n.type = TOPPASWorkflow::NodeType::INPUT_FILE_LIST;
+        // store file names relative to the toppas file
         QDir save_dir(toQString(File::path(file)));
         const QStringList& files_qt = iflv->getFileNames();
-        std::vector<std::string> files;
-        for (const QString &file_qt : files_qt)
+        for (const QString& file_qt : files_qt)
         {
-          files.push_back(save_dir.relativeFilePath(file_qt).toStdString());
+          n.file_names.push_back(save_dir.relativeFilePath(file_qt).toStdString());
         }
-        save_common_params(iflv, id, "input file list");
-        save_param.setValue("vertices:" + id + ":file_names", files);
-        continue;
       }
-      
-      if (auto* oflv = qobject_cast<TOPPASOutputFileListVertex*>(tv); oflv)
+      else if (auto* oflv = qobject_cast<TOPPASOutputFileListVertex*>(tv); oflv)
       {
-        save_common_params(oflv, id, "output file list");
-        save_param.setValue("vertices:" + id + ":output_folder_name", oflv->getOutputFolderName().toStdString());
-        continue;
+        n.type = TOPPASWorkflow::NodeType::OUTPUT_FILE_LIST;
+        n.output_folder_name = oflv->getOutputFolderName().toStdString();
       }
-      
-      if (auto* ofv = qobject_cast<TOPPASOutputFolderVertex*>(tv); ofv)
+      else if (auto* ofv = qobject_cast<TOPPASOutputFolderVertex*>(tv); ofv)
       {
-        save_common_params(ofv, id, "output folder");
-        save_param.setValue("vertices:" + id + ":output_folder_name", ofv->getOutputFolderName().toStdString());
-        continue;
+        n.type = TOPPASWorkflow::NodeType::OUTPUT_FOLDER;
+        n.output_folder_name = ofv->getOutputFolderName().toStdString();
       }
-
-      if (auto* ttv = qobject_cast<TOPPASToolVertex*>(tv); ttv)
+      else if (auto* ttv = qobject_cast<TOPPASToolVertex*>(tv); ttv)
       {
-        save_common_params(ttv, id, "tool");
-        save_param.setValue("vertices:" + id + ":tool_name", ttv->getName());
-        save_param.setValue("vertices:" + id + ":tool_type", ttv->getType());
-        save_param.insert("vertices:" + id + ":parameters:", ttv->getParam());
-        continue;
+        n.type = TOPPASWorkflow::NodeType::TOOL;
+        n.tool_name = ttv->getName();
+        n.tool_type = ttv->getType();
+        n.parameters = ttv->getParam();
       }
-
-      if (auto* mv = qobject_cast<TOPPASMergerVertex*>(tv); mv)
+      else if (auto* mv = qobject_cast<TOPPASMergerVertex*>(tv); mv)
       {
-        save_common_params(mv, id, "merger");
-        save_param.setValue("vertices:" + id + ":round_based", mv->roundBasedMode() ? "true" : "false");
-        continue;
+        n.type = TOPPASWorkflow::NodeType::MERGER;
+        n.round_based = mv->roundBasedMode();
       }
-
-      if (auto* sv = qobject_cast<TOPPASSplitterVertex*>(tv); sv)
+      else if (auto* sv = qobject_cast<TOPPASSplitterVertex*>(tv); sv)
       {
-        save_common_params(sv, id, "splitter");
-        continue;
+        n.type = TOPPASWorkflow::NodeType::SPLITTER;
       }
+      else
+      {
+        continue; // unknown vertex type (should not happen)
+      }
+      wf.nodes.push_back(n);
     }
 
-    // store all edges
-    int counter = 0;
+    // all edges; resolve the parameter indices to their names via the live tool vertices
     for (TOPPASEdge* te : edges_)
     {
       if (!((te->getEdgeStatus() == TOPPASEdge::ES_VALID) || (te->getEdgeStatus() == TOPPASEdge::ES_NOT_READY_YET)))
@@ -726,41 +708,35 @@ namespace OpenMS
         continue;
       }
 
-      save_param.setValue("edges:" + StringUtils::toStr(counter) + ":source/target:",StringUtils::toStr(te->getSourceVertex()->getTopoNr() - 1) + "/" + StringUtils::toStr(te->getTargetVertex()->getTopoNr() - 1));
-      //save_param.setValue("edges:"+StringUtils::toStr(counter)+":source_out_param:", te->getSourceOutParam()));
-      //save_param.setValue("edges:"+StringUtils::toStr(counter)+":target_in_param:", te->getTargetInParam()));
-      std::string v = "__no_name__";
+      TOPPASWorkflow::Edge e;
+      e.source_id = StringUtils::toStr(te->getSourceVertex()->getTopoNr() - 1);
+      e.target_id = StringUtils::toStr(te->getTargetVertex()->getTopoNr() - 1);
+
+      e.source_out_param = TOPPASWorkflow::NO_NAME;
       if (te->getSourceOutParam() >= 0)
       {
-        TOPPASToolVertex* tv_src = qobject_cast<TOPPASToolVertex*>(te->getSourceVertex());
-        if (tv_src)
+        if (auto* tv_src = qobject_cast<TOPPASToolVertex*>(te->getSourceVertex()); tv_src)
         {
           QVector<TOPPASToolVertex::IOInfo> files = tv_src->getOutputParameters();
-          //std::cout << "#p: " << files.size() << " . " << te->getSourceOutParam() << "\n";
-          v = files[te->getSourceOutParam()].param_name;
+          e.source_out_param = files[te->getSourceOutParam()].param_name;
         }
       }
-      save_param.setValue("edges:" + StringUtils::toStr(counter) + ":source_out_param:", v);
 
-      v = "__no_name__";
+      e.target_in_param = TOPPASWorkflow::NO_NAME;
       if (te->getTargetInParam() >= 0)
       {
-        TOPPASToolVertex* tv_src = qobject_cast<TOPPASToolVertex*>(te->getTargetVertex());
-        if (tv_src)
+        if (auto* tv_tgt = qobject_cast<TOPPASToolVertex*>(te->getTargetVertex()); tv_tgt)
         {
-          QVector<TOPPASToolVertex::IOInfo> files = tv_src->getInputParameters();
-          //std::cout << "#p: " << files.size() << " . " << te->getTargetInParam() << "\n";
-          v = files[te->getTargetInParam()].param_name;
+          QVector<TOPPASToolVertex::IOInfo> files = tv_tgt->getInputParameters();
+          e.target_in_param = files[te->getTargetInParam()].param_name;
         }
       }
-      save_param.setValue("edges:" + StringUtils::toStr(counter) + ":target_in_param:", v);
 
-      ++counter;
+      wf.edges.push_back(e);
     }
 
     // save file
-    ParamXMLFile paramFile;
-    paramFile.store(file, save_param);
+    wf.store(file);
     setChanged(false);
     file_name_ = file;
 
@@ -841,250 +817,172 @@ namespace OpenMS
     }
 
 
-    Param vertices_param = load_param.copy("vertices:", true);
-    Param edges_param = load_param.copy("edges:", true);
+    // parse the (possibly INIUpdater-updated) document into a Qt-free workflow model
+    TOPPASWorkflow wf;
+    wf.fromParam(load_param);
 
-    bool pre_1_9_toppas = true;
-    if (load_param.exists("info:version"))
-    {
-      pre_1_9_toppas = false; // using param names instead of indices for connecting edges
-    }
+    // edges store parameter *names* since TOPPAS 1.9; older files store raw indices
+    const bool pre_1_9_toppas = !load_param.exists("info:version");
+
     if (load_param.exists("info:description"))
     {
-      std::string text =std::string(load_param.getValue("info:description").toString());
-      StringUtils::substitute(text, "<![CDATA[", "");
-      StringUtils::substitute(text, "]]>", "");
-      description_text_ = toQString(StringUtils::trim(text));
+      description_text_ = toQString(wf.description);
     }
 
-    std::string current_type, current_id;
-    TOPPASVertex* current_vertex = nullptr;
-    QVector<TOPPASVertex*> vertex_vector;
-    vertex_vector.resize((Size)(int)load_param.getValue("info:num_vertices"));
-
-    // load all vertices
-    for (Param::ParamIterator it = vertices_param.begin(); it != vertices_param.end(); ++it)
+    // create the vertices, mapping each stored node id to the created vertex
+    std::map<std::string, TOPPASVertex*> id_to_vertex;
+    for (const TOPPASWorkflow::Node& n : wf.nodes)
     {
-      StringList substrings;
-      StringUtils::split(std::string(it.getName()), ':', substrings);
-      if (substrings.back() == "toppas_type") // next node (all nodes have a "toppas_type")
+      TOPPASVertex* current_vertex = nullptr;
+      switch (n.type)
       {
-        current_vertex = nullptr;
-        current_type = (it->value).toString();
-        current_id = substrings[0];
-        Int index = StringUtils::toInt32(current_id);
-
-        if (current_type == "input file list")
+        case TOPPASWorkflow::NodeType::INPUT_FILE_LIST:
         {
-          StringList file_names = ListUtils::toStringList<std::string>(vertices_param.getValue(current_id + ":file_names"));
           QStringList file_names_qt;
-
-          for (StringList::const_iterator str_it = file_names.begin(); str_it != file_names.end(); ++str_it)
+          for (const std::string& fn : n.file_names)
           {
-            QString f = toQString(*str_it);
-            if (QDir::isRelativePath(f)) // prepend path of toppas file to relative path of the input files
+            QString f = toQString(fn);
+            if (QDir::isRelativePath(f)) // prepend path of toppas file to relative input file paths
             {
               f = toQString(File::path(file)) + "/" + f;
             }
             file_names_qt.push_back(QDir::cleanPath(f));
           }
-          TOPPASInputFileListVertex* iflv = new TOPPASInputFileListVertex(file_names_qt);
-          current_vertex = iflv;
+          current_vertex = new TOPPASInputFileListVertex(file_names_qt);
+          break;
         }
-        else if (current_type == "output file list")
+        case TOPPASWorkflow::NodeType::OUTPUT_FILE_LIST:
         {
-          TOPPASOutputFileListVertex* oflv = new TOPPASOutputFileListVertex();
-          // custom output folder
-          if (vertices_param.exists(current_id + ":output_folder_name"))
+          auto* oflv = new TOPPASOutputFileListVertex();
+          if (!n.output_folder_name.empty())
           {
-            oflv->setOutputFolderName(toQString(std::string(vertices_param.getValue(current_id + ":output_folder_name").toString())));
+            oflv->setOutputFolderName(toQString(n.output_folder_name));
           }
-          
-          connectOutputVertexSignals(oflv); // todo
-
+          connectOutputVertexSignals(oflv);
           current_vertex = oflv;
+          break;
         }
-        else if (current_type == "output folder")
+        case TOPPASWorkflow::NodeType::OUTPUT_FOLDER:
         {
           auto* ofv = new TOPPASOutputFolderVertex();
-          // custom output folder
-          if (vertices_param.exists(current_id + ":output_folder_name"))
+          if (!n.output_folder_name.empty())
           {
-            ofv->setOutputFolderName(toQString(std::string(vertices_param.getValue(current_id + ":output_folder_name").toString())));
+            ofv->setOutputFolderName(toQString(n.output_folder_name));
           }
-
           connectOutputVertexSignals(ofv);
-
           current_vertex = ofv;
+          break;
         }
-        else if (current_type == "tool")
+        case TOPPASWorkflow::NodeType::TOOL:
         {
-          std::string tool_name = vertices_param.getValue(current_id + ":tool_name").toString();
-          std::string tool_type = vertices_param.getValue(current_id + ":tool_type").toString();
-          Param param_param = vertices_param.copy(current_id + ":parameters:", true);
-          TOPPASToolVertex* tv = new TOPPASToolVertex(tool_name, tool_type);
-          tv->setParam(param_param);
-
+          auto* tv = new TOPPASToolVertex(n.tool_name, n.tool_type);
+          tv->setParam(n.parameters);
           connectToolVertexSignals(tv);
-
           current_vertex = tv;
+          break;
         }
-        else if (current_type == "merger")
+        case TOPPASWorkflow::NodeType::MERGER:
         {
-          std::string rb = "true";
-          if (vertices_param.exists(current_id + ":round_based"))
-          {
-            rb = vertices_param.getValue(current_id + ":round_based").toString();
-          }
-          TOPPASMergerVertex* mv = new TOPPASMergerVertex(rb == "true");
-
+          auto* mv = new TOPPASMergerVertex(n.round_based);
           connectMergerVertexSignals(mv);
-
           current_vertex = mv;
+          break;
         }
-        else if (current_type == "splitter")
+        case TOPPASWorkflow::NodeType::SPLITTER:
         {
-          TOPPASSplitterVertex* sv = new TOPPASSplitterVertex();
-
-          current_vertex = sv;
+          current_vertex = new TOPPASSplitterVertex();
+          break;
         }
-        else
-        {
-          std::cerr << "Unknown vertex type '" << current_type << "'" << std::endl;
-        }
-
-        if (current_vertex)
-        {
-          float x = vertices_param.getValue(current_id + ":x_pos");
-          float y = vertices_param.getValue(current_id + ":y_pos");
-
-          current_vertex->setPos(QPointF(x, y));
-
-          // vertex parameters:
-          if (vertices_param.exists(current_id + ":recycle_output")) // only since TOPPAS 1.9, so does not need to exist
-          {
-            std::string recycle = vertices_param.getValue(current_id + ":recycle_output").toString();
-            current_vertex->setRecycling(recycle == "true" ? true : false);
-          }
-
-          addVertex(current_vertex);
-
-          connectVertexSignals(current_vertex);
-
-          // temporarily block signals in order that the first topo sort does not set the changed flag
-          current_vertex->blockSignals(true);
-
-          if (index >= vertex_vector.size())
-          {
-            std::cerr << "Unexpected vertex ID!" << std::endl;
-          }
-          else
-          {
-            if (vertex_vector[index] != 0)
-            {
-              std::cerr << "Vertex occupied!" << std::endl;
-            }
-            else
-            {
-              vertex_vector[index] = current_vertex;
-            }
-          }
-        }
-        else
-        {
-          std::cerr << "Current vertex not available." << std::endl;
-        }
+        default:
+          std::cerr << "Unknown vertex type '" << TOPPASWorkflow::typeToString(n.type) << "'" << std::endl;
+          continue;
       }
-    }
 
-    // load all edges
-    for (Param::ParamIterator it = edges_param.begin(); it != edges_param.end(); ++it)
-    {
-      const std::string& edge = (it->value).toString();
-      StringList edge_substrings;
-      StringUtils::split(edge, '/', edge_substrings);
-      if (edge_substrings.size() != 2)
-      {
-        std::cerr << "Invalid edge format" << std::endl;
-        break;
-      }
-      Int index_1 = StringUtils::toInt32(edge_substrings[0]);
-      Int index_2 = StringUtils::toInt32(edge_substrings[1]);
+      current_vertex->setPos(QPointF(n.x_pos, n.y_pos));
+      current_vertex->setRecycling(n.recycle_output);
 
-      if (index_1 >= vertex_vector.size() || index_2 >= vertex_vector.size())
+      addVertex(current_vertex);
+      connectVertexSignals(current_vertex);
+      // temporarily block signals so the first topo sort does not set the changed flag
+      current_vertex->blockSignals(true);
+
+      if (id_to_vertex.count(n.id))
       {
-        std::cerr << "Invalid vertex index" << std::endl;
+        std::cerr << "Vertex occupied!" << std::endl;
       }
       else
       {
-        TOPPASVertex* tv_1 = vertex_vector[index_1];
-        TOPPASVertex* tv_2 = vertex_vector[index_2];
-        
-        // future TOPPAS files may contain new nodes, which may leave `vertex_vector[i]` empty
-        if (tv_1 == nullptr || tv_2 == nullptr)
+        id_to_vertex[n.id] = current_vertex;
+      }
+    }
+
+    // create the edges
+    for (const TOPPASWorkflow::Edge& te : wf.edges)
+    {
+      auto src_it = id_to_vertex.find(te.source_id);
+      auto tgt_it = id_to_vertex.find(te.target_id);
+      // future TOPPAS files may reference new node types that we skipped above
+      if (src_it == id_to_vertex.end() || tgt_it == id_to_vertex.end())
+      {
+        std::cerr << "Invalid edge" << std::endl;
+        continue;
+      }
+      TOPPASVertex* tv_1 = src_it->second;
+      TOPPASVertex* tv_2 = tgt_it->second;
+
+      TOPPASEdge* edge = new TOPPASEdge();
+      edge->setSourceVertex(tv_1);
+      edge->setTargetVertex(tv_2);
+      tv_1->addOutEdge(edge);
+      tv_2->addInEdge(edge);
+
+      connectEdgeSignals(edge);
+
+      addEdge(edge);
+
+      if (pre_1_9_toppas) // just indices stored - no way we can check
+      {
+        edge->setSourceOutParam(StringUtils::toInt32(te.source_out_param));
+        edge->setTargetInParam(StringUtils::toInt32(te.target_in_param));
+      }
+      else
+      {
+        Int src_index = -1;
+        Int tgt_index = -1;
+        if (auto* tv_src = qobject_cast<TOPPASToolVertex*>(tv_1); tv_src && te.source_out_param != TOPPASWorkflow::NO_NAME)
         {
-          std::cerr << "Invalid edge" << std::endl;
-          continue;
-        }
-
-        TOPPASEdge* edge = new TOPPASEdge();
-        edge->setSourceVertex(tv_1);
-        edge->setTargetVertex(tv_2);
-        tv_1->addOutEdge(edge);
-        tv_2->addInEdge(edge);
-
-        connectEdgeSignals(edge);
-
-        addEdge(edge);
-
-        std::string source_out_param = (++it)->value.toString();
-        std::string target_in_param = (++it)->value.toString();
-        if (pre_1_9_toppas) // just indices stored - no way we can check
-        {
-          edge->setSourceOutParam(StringUtils::toInt32(source_out_param));
-          edge->setTargetInParam(StringUtils::toInt32(target_in_param));
-        }
-        else
-        {
-          Int src_index = -1;
-          Int tgt_index = -1;
-          TOPPASToolVertex* tv_src = qobject_cast<TOPPASToolVertex*>(tv_1);
-          if (source_out_param != "__no_name__" && tv_src)
+          QVector<TOPPASToolVertex::IOInfo> files = tv_src->getOutputParameters();
+          // search for the name
+          for (int i = 0; i < files.size(); ++i)
           {
-            QVector<TOPPASToolVertex::IOInfo> files = tv_src->getOutputParameters();
-            // search for the name
-            for (int i = 0; i < files.size(); ++i)
+            if (files[i].param_name == te.source_out_param)
             {
-              if (files[i].param_name == source_out_param)
-              {
-                src_index = i;
-                break;
-              }
+              src_index = i;
+              break;
             }
-            if (src_index == -1)
-              logTOPPOutput(toQString(std::string("Could not find output parameter called '" + source_out_param + "'. Check edge!")));
           }
-
-          tv_src = qobject_cast<TOPPASToolVertex*>(tv_2);
-          if (target_in_param != "__no_name__" && tv_src)
-          {
-            QVector<TOPPASToolVertex::IOInfo> files = tv_src->getInputParameters();
-            // search for the name
-            for (int i = 0; i < files.size(); ++i)
-            {
-              if (files[i].param_name == target_in_param)
-              {
-                tgt_index = i;
-                break;
-              }
-            }
-            if (tgt_index == -1)
-              logTOPPOutput(toQString(std::string("Could not find input parameter called '" + target_in_param + "'. Check edge!")));
-          }
-
-          edge->setSourceOutParam(src_index);
-          edge->setTargetInParam(tgt_index);
+          if (src_index == -1)
+            logTOPPOutput(toQString(std::string("Could not find output parameter called '" + te.source_out_param + "'. Check edge!")));
         }
+
+        if (auto* tv_tgt = qobject_cast<TOPPASToolVertex*>(tv_2); tv_tgt && te.target_in_param != TOPPASWorkflow::NO_NAME)
+        {
+          QVector<TOPPASToolVertex::IOInfo> files = tv_tgt->getInputParameters();
+          // search for the name
+          for (int i = 0; i < files.size(); ++i)
+          {
+            if (files[i].param_name == te.target_in_param)
+            {
+              tgt_index = i;
+              break;
+            }
+          }
+          if (tgt_index == -1)
+            logTOPPOutput(toQString(std::string("Could not find input parameter called '" + te.target_in_param + "'. Check edge!")));
+        }
+
+        edge->setSourceOutParam(src_index);
+        edge->setTargetInParam(tgt_index);
       }
     }
     if (pre_1_9_toppas) // just indices stored - no way we can check

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -600,6 +600,7 @@ set(applications_executables_list
   INIUpdater_test
   #MapAlignerBase_test
   SearchEngineBase_test
+  TOPPASWorkflow_test
   TOPPBase_test
   ToolHandler_test
   ParameterInformation_test

--- a/src/tests/class_tests/openms/source/TOPPASWorkflow_test.cpp
+++ b/src/tests/class_tests/openms/source/TOPPASWorkflow_test.cpp
@@ -1,0 +1,218 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+#include <OpenMS/APPLICATIONS/TOPPASWorkflow.h>
+///////////////////////////
+
+using namespace OpenMS;
+using namespace std;
+
+using NodeType = TOPPASWorkflow::NodeType;
+
+// compare two workflows field-by-field (ignoring 'version', which store()/toParam() always rewrite to the current OpenMS version)
+static void compareWorkflows(const TOPPASWorkflow& a, const TOPPASWorkflow& b)
+{
+  TEST_EQUAL(a.description, b.description)
+  TEST_EQUAL(a.nodes.size(), b.nodes.size())
+  TEST_EQUAL(a.edges.size(), b.edges.size())
+  for (Size i = 0; i < a.nodes.size() && i < b.nodes.size(); ++i)
+  {
+    const TOPPASWorkflow::Node& x = a.nodes[i];
+    const TOPPASWorkflow::Node& y = b.nodes[i];
+    TEST_EQUAL(x.id, y.id)
+    TEST_EQUAL(x.type == y.type, true)
+    TEST_REAL_SIMILAR(x.x_pos, y.x_pos)
+    TEST_REAL_SIMILAR(x.y_pos, y.y_pos)
+    TEST_EQUAL(x.recycle_output, y.recycle_output)
+    TEST_EQUAL(x.tool_name, y.tool_name)
+    TEST_EQUAL(x.tool_type, y.tool_type)
+    TEST_EQUAL(x.parameters == y.parameters, true)
+    TEST_EQUAL(x.file_names == y.file_names, true)
+    TEST_EQUAL(x.output_folder_name, y.output_folder_name)
+    TEST_EQUAL(x.round_based, y.round_based)
+  }
+  for (Size i = 0; i < a.edges.size() && i < b.edges.size(); ++i)
+  {
+    const TOPPASWorkflow::Edge& x = a.edges[i];
+    const TOPPASWorkflow::Edge& y = b.edges[i];
+    TEST_EQUAL(x.source_id, y.source_id)
+    TEST_EQUAL(x.target_id, y.target_id)
+    TEST_EQUAL(x.source_out_param, y.source_out_param)
+    TEST_EQUAL(x.target_in_param, y.target_in_param)
+  }
+}
+
+START_TEST(TOPPASWorkflow, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+TOPPASWorkflow* ptr = nullptr;
+TOPPASWorkflow* null_ptr = nullptr;
+START_SECTION(TOPPASWorkflow())
+{
+  ptr = new TOPPASWorkflow();
+  TEST_NOT_EQUAL(ptr, null_ptr)
+}
+END_SECTION
+
+START_SECTION(~TOPPASWorkflow())
+{
+  delete ptr;
+}
+END_SECTION
+
+START_SECTION((static NodeType typeFromString(const std::string& s)))
+{
+  TEST_EQUAL(TOPPASWorkflow::typeFromString("input file list") == NodeType::INPUT_FILE_LIST, true)
+  TEST_EQUAL(TOPPASWorkflow::typeFromString("output file list") == NodeType::OUTPUT_FILE_LIST, true)
+  TEST_EQUAL(TOPPASWorkflow::typeFromString("output folder") == NodeType::OUTPUT_FOLDER, true)
+  TEST_EQUAL(TOPPASWorkflow::typeFromString("tool") == NodeType::TOOL, true)
+  TEST_EQUAL(TOPPASWorkflow::typeFromString("merger") == NodeType::MERGER, true)
+  TEST_EQUAL(TOPPASWorkflow::typeFromString("splitter") == NodeType::SPLITTER, true)
+  TEST_EQUAL(TOPPASWorkflow::typeFromString("nonsense") == NodeType::UNKNOWN, true)
+}
+END_SECTION
+
+START_SECTION((static std::string typeToString(NodeType t)))
+{
+  TEST_EQUAL(TOPPASWorkflow::typeToString(NodeType::INPUT_FILE_LIST), "input file list")
+  TEST_EQUAL(TOPPASWorkflow::typeToString(NodeType::TOOL), "tool")
+  TEST_EQUAL(TOPPASWorkflow::typeToString(NodeType::MERGER), "merger")
+  // string <-> enum should round-trip for all real types
+  const NodeType all[] = {NodeType::INPUT_FILE_LIST, NodeType::OUTPUT_FILE_LIST, NodeType::OUTPUT_FOLDER,
+                          NodeType::TOOL, NodeType::MERGER, NodeType::SPLITTER};
+  for (NodeType t : all)
+  {
+    TEST_EQUAL(TOPPASWorkflow::typeFromString(TOPPASWorkflow::typeToString(t)) == t, true)
+  }
+}
+END_SECTION
+
+START_SECTION((Param toParam() const) + (void fromParam(const Param& param)))
+{
+  // build a representative workflow covering all node types and named/unnamed edges
+  TOPPASWorkflow wf;
+  wf.description = "my <test> pipeline";
+
+  TOPPASWorkflow::Node in;
+  in.id = "0";
+  in.type = NodeType::INPUT_FILE_LIST;
+  in.x_pos = -140.0;
+  in.y_pos = -160.0;
+  in.recycle_output = false;
+  in.file_names = {"../a.mzML", "../b.mzML"};
+  wf.nodes.push_back(in);
+
+  TOPPASWorkflow::Node tool;
+  tool.id = "1";
+  tool.type = NodeType::TOOL;
+  tool.x_pos = 10.0;
+  tool.y_pos = 20.0;
+  tool.recycle_output = true;
+  tool.tool_name = "FileFilter";
+  tool.tool_type = "";
+  Param tp;
+  tp.setValue("in", "");
+  tp.setValue("out", "");
+  tp.setValue("threads", 1);
+  tool.parameters = tp;
+  wf.nodes.push_back(tool);
+
+  TOPPASWorkflow::Node mg;
+  mg.id = "2";
+  mg.type = NodeType::MERGER;
+  mg.x_pos = 5.0;
+  mg.y_pos = 30.0;
+  mg.round_based = false;
+  wf.nodes.push_back(mg);
+
+  TOPPASWorkflow::Node out;
+  out.id = "3";
+  out.type = NodeType::OUTPUT_FILE_LIST;
+  out.x_pos = 0.0;
+  out.y_pos = 40.0;
+  out.output_folder_name = "results";
+  wf.nodes.push_back(out);
+
+  TOPPASWorkflow::Edge e1;
+  e1.source_id = "0";
+  e1.target_id = "1";
+  e1.source_out_param = TOPPASWorkflow::NO_NAME;
+  e1.target_in_param = "in";
+  wf.edges.push_back(e1);
+
+  TOPPASWorkflow::Edge e2;
+  e2.source_id = "1";
+  e2.target_id = "2";
+  e2.source_out_param = "out";
+  e2.target_in_param = TOPPASWorkflow::NO_NAME;
+  wf.edges.push_back(e2);
+
+  // in-memory round-trip via Param
+  TOPPASWorkflow wf_param;
+  wf_param.fromParam(wf.toParam());
+  compareWorkflows(wf, wf_param);
+
+  // the serialized Param uses the documented .toppas layout
+  Param p = wf.toParam();
+  TEST_EQUAL(p.exists("info:num_vertices"), true)
+  TEST_EQUAL((int)p.getValue("info:num_vertices"), 4)
+  TEST_EQUAL((int)p.getValue("info:num_edges"), 2)
+  TEST_EQUAL(p.getValue("vertices:1:tool_name").toString(), "FileFilter")
+  TEST_EQUAL(p.getValue("vertices:2:round_based").toString(), "false")
+  TEST_EQUAL(p.getValue("edges:0:source/target:").toString(), "0/1")
+  TEST_EQUAL(p.getValue("edges:0:target_in_param:").toString(), "in")
+}
+END_SECTION
+
+START_SECTION((void store(const std::string& filename) const) + (void load(const std::string& filename)))
+{
+  TOPPASWorkflow wf;
+  wf.description = "round trip";
+  TOPPASWorkflow::Node tool;
+  tool.id = "0";
+  tool.type = NodeType::TOOL;
+  tool.tool_name = "FeatureFinderCentroided";
+  Param tp;
+  tp.setValue("in", "");
+  tp.setValue("out", "");
+  tool.parameters = tp;
+  wf.nodes.push_back(tool);
+
+  std::string tmp;
+  NEW_TMP_FILE(tmp)
+  wf.store(tmp);
+  TOPPASWorkflow wf_loaded;
+  wf_loaded.load(tmp);
+  compareWorkflows(wf, wf_loaded);
+}
+END_SECTION
+
+START_SECTION([EXTRA] load/store round-trip on a real .toppas file)
+{
+  TOPPASWorkflow wf1;
+  wf1.load(OPENMS_GET_TEST_DATA_PATH("FileHandler_toppas.toppas"));
+  TEST_EQUAL(wf1.nodes.empty(), false)
+
+  std::string tmp;
+  NEW_TMP_FILE(tmp)
+  wf1.store(tmp);
+  TOPPASWorkflow wf2;
+  wf2.load(tmp);
+  compareWorkflows(wf1, wf2);
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST


### PR DESCRIPTION
## Summary

Introduces **`OpenMS::TOPPASWorkflow`** — a Qt-free in-memory representation of a `.toppas` workflow file (header + nodes + edges) with `load()`/`store()` via `ParamXMLFile`. It lives in the **core OpenMS library**, so a TOPPAS workflow document can be read, written and inspected without the GUI.

`TOPPASScene` now **uses** this model: `load()`/`store()` delegate the `.toppas` (de)serialization to `TOPPASWorkflow`, while the Qt-specific concerns stay in the scene (the `QGraphicsItem` vertices/edges, input-file path absolutize/relativize via `QDir`, and edge-parameter index↔name resolution via the live tool vertices).

This is the **document-model** half of decoupling the TOPPAS pipeline from Qt. A follow-up can add a Qt-free `PipelineExecutor` on top of this model to make `ExecutePipeline` (and any headless `.toppas` runner) Qt-independent — the topology, parameters and data-flow routing are already plain `std`/`Param`.

## Why

- The `.toppas` format was previously only readable/writable through `TOPPASScene`, a `QGraphicsScene`. This couples a pure document format to the GUI.
- It removes **~255 lines** from `TOPPASScene.cpp` (the scene's `load`/`store` become a thin mapping over the model).
- It gives the `.toppas` format its **first unit-test coverage** (there were no TOPPAS serialization tests).

## Compatibility

- The on-disk format is **unchanged** — the serialized `Param` layout is byte-compatible with the previous `TOPPASScene` serialization.
- Behavior is preserved for all well-formed `.toppas` files. The refactor is incidentally **more robust** on malformed/future files:
  - a bad edge now drops only that edge instead of silently truncating all remaining edges (the old streaming parser could desync);
  - unknown/future node types are skipped with a warning;
  - `info:num_edges` is written as the number of actually-written edges (an informational field that no loader reads).

## Verification

- New **`TOPPASWorkflow_test`**: model round-trip, file round-trip, and a round-trip on a real `.toppas` fixture — passes.
- **`TOPP_ExecutePipeline_*`** (load **and run** real example pipelines — `ExecutePipeline_1`, `merger_tutorial`, `peakpicker_tutorial`, `Ecoli_Identification`, `FDR_NeighborSearch`, `QualityControl`) — pass through the refactored `TOPPASScene::load`.
- The OpenMS library and the full GUI target build cleanly.

The change was adversarially reviewed (serialization fidelity, scene behavioral-equivalence, build/bug dimensions); all findings were low-severity and either documented improvements or verified-equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced TOPPAS workflow file handling to improve reliability when saving and loading workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->