### PR TITLE
Add Qt-free TOPPASPipeline data-flow (round-package) engine

### DIFF
--- a/src/openms/include/OpenMS/APPLICATIONS/TOPPASPipeline.h
+++ b/src/openms/include/OpenMS/APPLICATIONS/TOPPASPipeline.h
@@ -1,0 +1,154 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/config.h>
+#include <OpenMS/CONCEPT/Types.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace OpenMS
+{
+  /**
+    @brief Qt-free data-flow ("round package") engine for TOPPAS workflows.
+
+    This class implements the round-based data-flow routing that TOPPAS uses to decide,
+    for every node and every execution round, which files arrive on which input parameter.
+    It is the Qt-free extraction of the routing logic previously living in the
+    @c TOPPAS*Vertex classes (@c buildRoundPackages, the merger/splitter/input semantics and
+    output recycling), so that a pipeline can be scheduled and executed without the GUI.
+
+    The engine operates on an explicit node/edge graph (integer parameter indices, plain
+    @c std types) and is deliberately decoupled from how nodes are parsed (from a @em .toppas
+    document) and how tools are executed (a PipelineExecutor built on top).
+
+    @par Data model
+    A node's data flow is described by RoundPackages: one RoundPackage per execution round,
+    each mapping a (signed) parameter index to the files arriving for it. The signed key
+    mirrors the historic TOPPAS convention: @c -1 means "no specific parameter" (used by
+    input/output nodes and mergers); mergers walk to @c -2, @c -3, ... when several incoming
+    edges share the @c -1 slot.
+
+    @ingroup Applications
+  */
+  class OPENMS_DLLAPI TOPPASPipeline
+  {
+  public:
+    /// File list arriving along one edge for one round.
+    using Filenames = std::vector<std::string>;
+
+    /// Files for one (node, round, parameter) plus the edge they came from.
+    struct VertexRoundPackage
+    {
+      Filenames filenames;
+      int edge_index = -1; ///< index into edges_ of the producing edge (-1 if none)
+    };
+
+    /// One round's inputs/outputs of a node: parameter index -> files. Key may be negative.
+    using RoundPackage = std::map<Int, VertexRoundPackage>;
+    /// One entry per execution round.
+    using RoundPackages = std::vector<RoundPackage>;
+
+    /// Kind of a workflow node.
+    enum class NodeKind
+    {
+      INPUT,         ///< seeds input files (one round per file)
+      TOOL,          ///< a TOPP tool invocation
+      MERGER,        ///< merges incoming file lists (round-based or collect)
+      SPLITTER,      ///< splits one round of N files into N rounds of 1 file
+      OUTPUT,        ///< collects output files
+      OUTPUT_FOLDER  ///< collects output into a folder
+    };
+
+    /// A workflow node with its topology and data-flow state.
+    struct Node
+    {
+      NodeKind kind = NodeKind::TOOL;
+      std::string id;                  ///< node id (as in the .toppas file)
+      Int topo_nr = 0;                 ///< topological number (1-based, like TOPPAS)
+      bool recycle_output = false;     ///< recycle this node's output to match downstream round counts
+      bool round_based_merge = true;   ///< merger only: round-based ("Merge") vs collect ("Collect")
+
+      Filenames input_files;           ///< INPUT node: the seed files
+
+      std::vector<int> in_edges;       ///< indices into edges_ (incoming)
+      std::vector<int> out_edges;      ///< indices into edges_ (outgoing)
+
+      // --- data-flow state (filled by the engine) ---
+      RoundPackages output_files;      ///< files this node produces, per round and output parameter
+      int round_total = -1;            ///< number of rounds this node runs
+      bool finished = false;
+    };
+
+    /// A directed edge connecting an output parameter of one node to an input parameter of another.
+    struct Edge
+    {
+      int from = -1;             ///< index into nodes_ (source)
+      int to = -1;               ///< index into nodes_ (target)
+      Int source_out_param = -1; ///< output-parameter index on the source node (-1 if none)
+      Int target_in_param = -1;  ///< input-parameter index on the target node (-1 if none)
+    };
+
+    /// Add a node and return its index.
+    int addNode(const Node& n);
+    /// Add an edge (by node indices) and wire it into both endpoints' in/out lists; returns its index.
+    int addEdge(int from, int to, Int source_out_param = -1, Int target_in_param = -1);
+
+    /// Access nodes/edges.
+    std::vector<Node>& nodes() { return nodes_; }
+    const std::vector<Node>& nodes() const { return nodes_; }
+    const std::vector<Edge>& edges() const { return edges_; }
+
+    /**
+      @brief Topologically order the nodes and assign @c topo_nr (1-based).
+      @return false if the graph contains a cycle (then @p error_msg is set).
+    */
+    bool topoSort(std::string& error_msg);
+
+    /**
+      @brief Build the per-round input packages for @p node_index from its incoming edges.
+
+      Faithful port of @c TOPPASVertex::buildRoundPackages: the round count is set by the
+      non-recycling upstream nodes (all must agree), recycling upstream nodes must tile evenly
+      into it (and are wrapped via modulo), and several incoming edges sharing the @c -1 slot
+      (mergers) are spread over @c -1, @c -2, ... .
+      @return false on an inconsistent graph (then @p error_msg is set).
+    */
+    bool buildRoundPackages(int node_index, RoundPackages& pkg, std::string& error_msg) const;
+
+    /**
+      @brief Compute the data flow for all non-tool nodes in topological order.
+
+      Seeds INPUT nodes, performs the (virtual) merge/split, and propagates recycling, filling
+      each node's @c output_files / @c round_total. TOOL nodes get their @c round_total and a
+      placeholder @c output_files (one empty RoundPackage per round); a PipelineExecutor is
+      responsible for actually producing a tool's output files. @c topoSort() must have run.
+      @return false on an inconsistent graph (then @p error_msg is set).
+    */
+    bool computeDataFlow(std::string& error_msg);
+
+    /// Files produced by @p node_index for output parameter @p param_index in @p round.
+    /// Throws Exception::IndexOverflow if the round/parameter is absent.
+    const Filenames& getFileNames(int node_index, Int param_index, int round) const;
+
+  protected:
+    /// Seed an INPUT node: one round per input file, keyed by -1.
+    void runInput_(Node& node) const;
+    /// Virtual merge of @p node from its built round packages.
+    void runMerger_(Node& node, const RoundPackages& pkg) const;
+    /// Virtual split of @p node (one round of N files becomes N rounds of one file).
+    void runSplitter_(Node& node, const RoundPackages& pkg) const;
+
+    std::vector<Node> nodes_;
+    std::vector<Edge> edges_;
+  };
+
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/APPLICATIONS/sources.cmake
+++ b/src/openms/include/OpenMS/APPLICATIONS/sources.cmake
@@ -10,6 +10,7 @@ OpenSwathBase.h
 ParameterInformation.h
 SearchEngineBase.h
 ToolHandler.h
+TOPPASPipeline.h
 TOPPBase.h
 )
 

--- a/src/openms/source/APPLICATIONS/TOPPASPipeline.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPASPipeline.cpp
@@ -1,0 +1,284 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/APPLICATIONS/TOPPASPipeline.h>
+
+#include <OpenMS/CONCEPT/Exception.h>
+
+#include <algorithm>
+
+namespace OpenMS
+{
+  int TOPPASPipeline::addNode(const Node& n)
+  {
+    nodes_.push_back(n);
+    // do not trust caller-provided edge lists for a freshly added node
+    nodes_.back().in_edges.clear();
+    nodes_.back().out_edges.clear();
+    return (int)nodes_.size() - 1;
+  }
+
+  int TOPPASPipeline::addEdge(int from, int to, Int source_out_param, Int target_in_param)
+  {
+    Edge e;
+    e.from = from;
+    e.to = to;
+    e.source_out_param = source_out_param;
+    e.target_in_param = target_in_param;
+    int idx = (int)edges_.size();
+    edges_.push_back(e);
+    nodes_[from].out_edges.push_back(idx);
+    nodes_[to].in_edges.push_back(idx);
+    return idx;
+  }
+
+  bool TOPPASPipeline::topoSort(std::string& error_msg)
+  {
+    const Size n = nodes_.size();
+    std::vector<int> indeg(n, 0);
+    for (const Edge& e : edges_)
+    {
+      if (e.to >= 0) ++indeg[e.to];
+    }
+    // process zero-indegree nodes in index order (deterministic)
+    std::vector<int> queue;
+    for (Size i = 0; i < n; ++i)
+    {
+      if (indeg[i] == 0) queue.push_back((int)i);
+    }
+    Size head = 0;
+    Int topo = 1;
+    Size processed = 0;
+    while (head < queue.size())
+    {
+      int u = queue[head++];
+      nodes_[u].topo_nr = topo++;
+      ++processed;
+      for (int ei : nodes_[u].out_edges)
+      {
+        int v = edges_[ei].to;
+        if (--indeg[v] == 0) queue.push_back(v);
+      }
+    }
+    if (processed != n)
+    {
+      error_msg = "TOPPASPipeline: workflow graph contains a cycle.";
+      return false;
+    }
+    return true;
+  }
+
+  const TOPPASPipeline::Filenames& TOPPASPipeline::getFileNames(int node_index, Int param_index, int round) const
+  {
+    const Node& node = nodes_[node_index];
+    if ((Size)round >= node.output_files.size())
+    {
+      throw Exception::IndexOverflow(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, round, node.output_files.size());
+    }
+    const RoundPackage& rp = node.output_files[round];
+    RoundPackage::const_iterator it = rp.find(param_index);
+    if (it == rp.end())
+    {
+      throw Exception::IndexOverflow(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, param_index, rp.size());
+    }
+    return it->second.filenames;
+  }
+
+  bool TOPPASPipeline::buildRoundPackages(int node_index, RoundPackages& pkg, std::string& error_msg) const
+  {
+    const Node& node = nodes_[node_index];
+    if (node.in_edges.empty())
+    {
+      error_msg = "buildRoundPackages() called on vertex with no input edges!\n";
+      return false;
+    }
+
+    // -- determine number of rounds from incoming, NON-recycling edges (they must all agree)
+    int round_common = -1;
+    int no_recycle_count = 0;
+    for (int ei : node.in_edges)
+    {
+      const Node& up = nodes_[edges_[ei].from];
+      if (up.recycle_output) continue;
+      ++no_recycle_count;
+      if (round_common == -1) round_common = up.round_total; // first non-recycler sets the pace
+      if (round_common != up.round_total)
+      {
+        error_msg = "Number of rounds for incoming edges of node #" + std::to_string(node.topo_nr) +
+                    " are not equal. No idea on how to combine them! Did you want to recycle its input?\n";
+        return false;
+      }
+    }
+
+    // -- at least one non-recycling input is required to anchor the round count
+    if (no_recycle_count == 0)
+    {
+      error_msg = "Number of rounds of node #" + std::to_string(node.topo_nr) +
+                  " cannot be determined since all input nodes have recycling enabled. Disable for at least one input!\n";
+      return false;
+    }
+
+    // -- recyclers must tile evenly into round_common
+    for (int ei : node.in_edges)
+    {
+      const Node& up = nodes_[edges_[ei].from];
+      if (!up.recycle_output) continue;
+      // (the round_total == 0 guard avoids a modulo-by-zero on a degenerate recycler that the
+      //  historical TOPPASVertex::buildRoundPackages lacked; it turns UB into a clean error)
+      if (up.round_total == 0 || round_common % up.round_total != 0)
+      {
+        error_msg = std::to_string(up.round_total) + " rounds for incoming edges of node #" + std::to_string(node.topo_nr) +
+                    " are recycled to meet a total of " + std::to_string(round_common) +
+                    " rounds. But modulo is not 0. No idea on how to combine them! Adapt the number of input files?\n";
+        return false;
+      }
+    }
+
+    if (round_common <= 0)
+    {
+      error_msg = "Number of input rounds is 0 or negative. This cannot be! Aborting!\n";
+      return false;
+    }
+
+    pkg.clear();
+    pkg.resize(round_common);
+
+    for (int ei : node.in_edges)
+    {
+      const Edge& e = edges_[ei];
+      const Node& up = nodes_[e.from];
+      Int param_index_src_out = e.source_out_param;
+      Int param_index_tgt_in = e.target_in_param;
+      for (int round = 0; round < round_common; ++round)
+      {
+        VertexRoundPackage rpg;
+        rpg.edge_index = ei;
+        int upstream_round = round;
+        if (up.recycle_output && upstream_round >= up.round_total)
+        {
+          upstream_round %= up.round_total;
+        }
+        rpg.filenames = getFileNames(e.from, param_index_src_out, upstream_round);
+
+        // mergers have several incoming edges all keyed -1: spread over -1, -2, -3, ...
+        while (pkg[round].count(param_index_tgt_in))
+        {
+          --param_index_tgt_in;
+        }
+        pkg[round][param_index_tgt_in] = rpg;
+      }
+    }
+    return true;
+  }
+
+  void TOPPASPipeline::runInput_(Node& node) const
+  {
+    // each input file becomes one round (keyed by -1)
+    node.output_files.clear();
+    node.output_files.resize(node.input_files.size());
+    for (Size f = 0; f < node.input_files.size(); ++f)
+    {
+      node.output_files[f][-1].filenames.push_back(node.input_files[f]);
+    }
+    node.round_total = (int)node.input_files.size();
+    node.finished = true;
+  }
+
+  void TOPPASPipeline::runMerger_(Node& node, const RoundPackages& pkg) const
+  {
+    const Size input_rounds = pkg.size();
+    node.round_total = node.round_based_merge ? (int)input_rounds : 1;
+    node.output_files.clear();
+    node.output_files.resize(node.round_total);
+    for (Size round = 0; round < input_rounds; ++round)
+    {
+      Filenames files;
+      for (RoundPackage::const_iterator it = pkg[round].begin(); it != pkg[round].end(); ++it)
+      {
+        files.insert(files.end(), it->second.filenames.begin(), it->second.filenames.end());
+      }
+      const Size round_index = node.round_based_merge ? round : 0;
+      Filenames& dest = node.output_files[round_index][-1].filenames;
+      dest.insert(dest.end(), files.begin(), files.end());
+    }
+    node.finished = true;
+  }
+
+  void TOPPASPipeline::runSplitter_(Node& node, const RoundPackages& pkg) const
+  {
+    // 1 round of N files becomes N rounds of 1 file
+    node.output_files.clear();
+    for (const RoundPackage& rp : pkg)
+    {
+      // there can only be one upstream (input) node
+      const Filenames& files = rp.begin()->second.filenames;
+      for (const std::string& f : files)
+      {
+        RoundPackage new_pkg;
+        new_pkg[-1].filenames.push_back(f);
+        node.output_files.push_back(new_pkg);
+      }
+    }
+    node.round_total = (int)node.output_files.size();
+    node.finished = true;
+  }
+
+  bool TOPPASPipeline::computeDataFlow(std::string& error_msg)
+  {
+    // visit nodes in topological order so every upstream is processed first
+    std::vector<int> order(nodes_.size());
+    for (Size i = 0; i < nodes_.size(); ++i) order[i] = (int)i;
+    std::sort(order.begin(), order.end(), [this](int a, int b) { return nodes_[a].topo_nr < nodes_[b].topo_nr; });
+
+    for (int ni : order)
+    {
+      Node& node = nodes_[ni];
+      switch (node.kind)
+      {
+        case NodeKind::INPUT:
+          runInput_(node);
+          break;
+        case NodeKind::MERGER:
+        {
+          RoundPackages pkg;
+          if (!buildRoundPackages(ni, pkg, error_msg)) return false;
+          runMerger_(node, pkg);
+          break;
+        }
+        case NodeKind::SPLITTER:
+        {
+          RoundPackages pkg;
+          if (!buildRoundPackages(ni, pkg, error_msg)) return false;
+          runSplitter_(node, pkg);
+          break;
+        }
+        case NodeKind::TOOL:
+        {
+          RoundPackages pkg;
+          if (!buildRoundPackages(ni, pkg, error_msg)) return false;
+          node.round_total = (int)pkg.size();
+          // placeholder: the actual output files are produced by a PipelineExecutor
+          node.output_files.assign(node.round_total, RoundPackage());
+          node.finished = true;
+          break;
+        }
+        case NodeKind::OUTPUT:
+        case NodeKind::OUTPUT_FOLDER:
+        {
+          RoundPackages pkg;
+          if (!buildRoundPackages(ni, pkg, error_msg)) return false;
+          node.round_total = (int)pkg.size();
+          node.finished = true;
+          break;
+        }
+      }
+    }
+    return true;
+  }
+
+} // namespace OpenMS

--- a/src/openms/source/APPLICATIONS/sources.cmake
+++ b/src/openms/source/APPLICATIONS/sources.cmake
@@ -9,6 +9,7 @@ ParameterInformation.cpp
 OpenSwathBase.cpp
 SearchEngineBase.cpp
 ToolHandler.cpp
+TOPPASPipeline.cpp
 TOPPBase.cpp
 )
 

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -600,6 +600,7 @@ set(applications_executables_list
   INIUpdater_test
   #MapAlignerBase_test
   SearchEngineBase_test
+  TOPPASPipeline_test
   TOPPBase_test
   ToolHandler_test
   ParameterInformation_test

--- a/src/tests/class_tests/openms/source/TOPPASPipeline_test.cpp
+++ b/src/tests/class_tests/openms/source/TOPPASPipeline_test.cpp
@@ -1,0 +1,285 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+#include <OpenMS/APPLICATIONS/TOPPASPipeline.h>
+///////////////////////////
+
+using namespace OpenMS;
+using namespace std;
+
+using NodeKind = TOPPASPipeline::NodeKind;
+using RoundPackages = TOPPASPipeline::RoundPackages;
+
+namespace
+{
+  // helper: make a node of a given kind
+  TOPPASPipeline::Node mkNode(NodeKind kind, const std::string& id)
+  {
+    TOPPASPipeline::Node n;
+    n.kind = kind;
+    n.id = id;
+    return n;
+  }
+
+  // helper: an input node seeded with the given files
+  TOPPASPipeline::Node mkInput(const std::string& id, const std::vector<std::string>& files, bool recycle = false)
+  {
+    TOPPASPipeline::Node n = mkNode(NodeKind::INPUT, id);
+    n.input_files = files;
+    n.recycle_output = recycle;
+    return n;
+  }
+
+  // collect the files of a node's output for a given round and parameter index
+  std::vector<std::string> outFiles(const TOPPASPipeline& p, int node, Int param, int round)
+  {
+    return p.getFileNames(node, param, round);
+  }
+}
+
+START_TEST(TOPPASPipeline, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+TOPPASPipeline* ptr = nullptr;
+TOPPASPipeline* null_ptr = nullptr;
+START_SECTION(TOPPASPipeline())
+{
+  ptr = new TOPPASPipeline();
+  TEST_NOT_EQUAL(ptr, null_ptr)
+}
+END_SECTION
+
+START_SECTION(~TOPPASPipeline())
+{
+  delete ptr;
+}
+END_SECTION
+
+START_SECTION([EXTRA] input node seeding: one round per file)
+{
+  TOPPASPipeline p;
+  int in = p.addNode(mkInput("0", {"a.mzML", "b.mzML", "c.mzML"}));
+  std::string err;
+  TEST_EQUAL(p.topoSort(err), true)
+  TEST_EQUAL(p.computeDataFlow(err), true)
+
+  TEST_EQUAL(p.nodes()[in].round_total, 3)
+  TEST_EQUAL(p.nodes()[in].output_files.size(), 3)
+  TEST_EQUAL(outFiles(p, in, -1, 0) == std::vector<std::string>{"a.mzML"}, true)
+  TEST_EQUAL(outFiles(p, in, -1, 1) == std::vector<std::string>{"b.mzML"}, true)
+  TEST_EQUAL(outFiles(p, in, -1, 2) == std::vector<std::string>{"c.mzML"}, true)
+}
+END_SECTION
+
+START_SECTION([EXTRA] linear input -> tool routing)
+{
+  TOPPASPipeline p;
+  int in = p.addNode(mkInput("0", {"a.mzML", "b.mzML"}));
+  int tool = p.addNode(mkNode(NodeKind::TOOL, "1"));
+  p.addEdge(in, tool, /*src_out*/ -1, /*tgt_in*/ 0); // input -> tool's input param 0
+  std::string err;
+  TEST_EQUAL(p.topoSort(err), true)
+  TEST_EQUAL(p.computeDataFlow(err), true)
+
+  // tool runs 2 rounds
+  TEST_EQUAL(p.nodes()[tool].round_total, 2)
+
+  // its input packages: each round, param 0 carries the matching input file
+  RoundPackages pkg;
+  TEST_EQUAL(p.buildRoundPackages(tool, pkg, err), true)
+  TEST_EQUAL(pkg.size(), 2)
+  TEST_EQUAL(pkg[0].count(0), 1)
+  TEST_EQUAL(pkg[0][0].filenames == std::vector<std::string>{"a.mzML"}, true)
+  TEST_EQUAL(pkg[1][0].filenames == std::vector<std::string>{"b.mzML"}, true)
+}
+END_SECTION
+
+START_SECTION([EXTRA] merger round-based combines per round and keeps the round count)
+{
+  TOPPASPipeline p;
+  int a = p.addNode(mkInput("0", {"a1", "a2"}));
+  int b = p.addNode(mkInput("1", {"b1", "b2"}));
+  int m = p.addNode(mkNode(NodeKind::MERGER, "2")); // round_based_merge defaults true
+  p.addEdge(a, m, -1, -1);
+  p.addEdge(b, m, -1, -1);
+  std::string err;
+  TEST_EQUAL(p.topoSort(err), true)
+  TEST_EQUAL(p.computeDataFlow(err), true)
+
+  TEST_EQUAL(p.nodes()[m].round_total, 2)
+  TEST_EQUAL(p.nodes()[m].output_files.size(), 2)
+  // Each round merges the matching files of both inputs. The merger keys the first incoming edge
+  // at -1 and the second at -2 (collision walk); iterating the round map in ascending key order
+  // (std::map) therefore visits -2 before -1, i.e. the SECOND edge (b) before the first (a).
+  // This faithfully reproduces the historical TOPPASMergerVertex behavior.
+  TEST_EQUAL((outFiles(p, m, -1, 0) == std::vector<std::string>{"b1", "a1"}), true)
+  TEST_EQUAL((outFiles(p, m, -1, 1) == std::vector<std::string>{"b2", "a2"}), true)
+}
+END_SECTION
+
+START_SECTION([EXTRA] merger (collect): flattens everything into a single round)
+{
+  TOPPASPipeline p;
+  int a = p.addNode(mkInput("0", {"a1", "a2"}));
+  int b = p.addNode(mkInput("1", {"b1"}));
+  TOPPASPipeline::Node mn = mkNode(NodeKind::MERGER, "2");
+  mn.round_based_merge = false; // collect
+  int m = p.addNode(mn);
+  p.addEdge(a, m, -1, -1);
+  p.addEdge(b, m, -1, -1);
+  std::string err;
+  TEST_EQUAL(p.topoSort(err), true)
+  // collect requires the non-recyclers to agree on round count -> a has 2, b has 1 -> mismatch
+  TEST_EQUAL(p.computeDataFlow(err), false)
+}
+END_SECTION
+
+START_SECTION([EXTRA] merger (collect) with equal round counts)
+{
+  TOPPASPipeline p;
+  int a = p.addNode(mkInput("0", {"a1", "a2"}));
+  int b = p.addNode(mkInput("1", {"b1", "b2"}));
+  TOPPASPipeline::Node mn = mkNode(NodeKind::MERGER, "2");
+  mn.round_based_merge = false; // collect
+  int m = p.addNode(mn);
+  p.addEdge(a, m, -1, -1);
+  p.addEdge(b, m, -1, -1);
+  std::string err;
+  TEST_EQUAL(p.topoSort(err), true)
+  TEST_EQUAL(p.computeDataFlow(err), true)
+  TEST_EQUAL(p.nodes()[m].round_total, 1)
+  // everything collapsed into round 0; per input round the second edge (b) comes before the first (a)
+  // (see ordering note above), so: round0 -> b1,a1 then round1 -> b2,a2, appended
+  TEST_EQUAL((outFiles(p, m, -1, 0) == std::vector<std::string>{"b1", "a1", "b2", "a2"}), true)
+}
+END_SECTION
+
+START_SECTION([EXTRA] splitter: 1 round of N files becomes N rounds of 1 file)
+{
+  TOPPASPipeline p;
+  int in = p.addNode(mkInput("0", {"x1", "x2", "x3"}));
+  TOPPASPipeline::Node cn = mkNode(NodeKind::MERGER, "1");
+  cn.round_based_merge = false; // collect 3 rounds into 1 round of 3 files
+  int collect = p.addNode(cn);
+  int split = p.addNode(mkNode(NodeKind::SPLITTER, "2"));
+  p.addEdge(in, collect, -1, -1);
+  p.addEdge(collect, split, -1, -1);
+  std::string err;
+  TEST_EQUAL(p.topoSort(err), true)
+  TEST_EQUAL(p.computeDataFlow(err), true)
+
+  TEST_EQUAL(p.nodes()[collect].round_total, 1)
+  TEST_EQUAL((outFiles(p, collect, -1, 0) == std::vector<std::string>{"x1", "x2", "x3"}), true)
+
+  TEST_EQUAL(p.nodes()[split].round_total, 3)
+  TEST_EQUAL((outFiles(p, split, -1, 0) == std::vector<std::string>{"x1"}), true)
+  TEST_EQUAL((outFiles(p, split, -1, 1) == std::vector<std::string>{"x2"}), true)
+  TEST_EQUAL((outFiles(p, split, -1, 2) == std::vector<std::string>{"x3"}), true)
+}
+END_SECTION
+
+START_SECTION([EXTRA] output recycling: divisible round counts wrap via modulo)
+{
+  TOPPASPipeline p;
+  int a = p.addNode(mkInput("0", {"r1", "r2"}, /*recycle*/ true)); // 2 files, recycled
+  int b = p.addNode(mkInput("1", {"f1", "f2", "f3", "f4"}));       // 4 files, sets the pace
+  int tool = p.addNode(mkNode(NodeKind::TOOL, "2"));
+  p.addEdge(a, tool, -1, 0); // recycled input on param 0
+  p.addEdge(b, tool, -1, 1); // non-recycled input on param 1
+  std::string err;
+  TEST_EQUAL(p.topoSort(err), true)
+  TEST_EQUAL(p.computeDataFlow(err), true)
+  TEST_EQUAL(p.nodes()[tool].round_total, 4)
+
+  RoundPackages pkg;
+  TEST_EQUAL(p.buildRoundPackages(tool, pkg, err), true)
+  TEST_EQUAL(pkg.size(), 4)
+  // param 1 = b straight through; param 0 = a wrapped modulo 2
+  TEST_EQUAL((pkg[0][1].filenames == std::vector<std::string>{"f1"}), true)
+  TEST_EQUAL((pkg[1][1].filenames == std::vector<std::string>{"f2"}), true)
+  TEST_EQUAL((pkg[2][1].filenames == std::vector<std::string>{"f3"}), true)
+  TEST_EQUAL((pkg[3][1].filenames == std::vector<std::string>{"f4"}), true)
+  TEST_EQUAL((pkg[0][0].filenames == std::vector<std::string>{"r1"}), true)
+  TEST_EQUAL((pkg[1][0].filenames == std::vector<std::string>{"r2"}), true)
+  TEST_EQUAL((pkg[2][0].filenames == std::vector<std::string>{"r1"}), true) // wrapped
+  TEST_EQUAL((pkg[3][0].filenames == std::vector<std::string>{"r2"}), true) // wrapped
+}
+END_SECTION
+
+START_SECTION([EXTRA] output recycling: non-divisible round counts are an error)
+{
+  TOPPASPipeline p;
+  int a = p.addNode(mkInput("0", {"r1", "r2", "r3"}, /*recycle*/ true)); // 3 files, recycled
+  int b = p.addNode(mkInput("1", {"f1", "f2", "f3", "f4"}));             // 4 files
+  int tool = p.addNode(mkNode(NodeKind::TOOL, "2"));
+  p.addEdge(a, tool, -1, 0);
+  p.addEdge(b, tool, -1, 1);
+  std::string err;
+  TEST_EQUAL(p.topoSort(err), true)
+  // 4 % 3 != 0 -> cannot recycle
+  TEST_EQUAL(p.computeDataFlow(err), false)
+  TEST_NOT_EQUAL(err.size(), 0)
+}
+END_SECTION
+
+START_SECTION([EXTRA] diamond: fan-out from one source and rejoin at a merger)
+{
+  TOPPASPipeline p;
+  int in = p.addNode(mkInput("0", {"d1", "d2"}));
+  int m1 = p.addNode(mkNode(NodeKind::MERGER, "1")); // pass-through (single input)
+  int m2 = p.addNode(mkNode(NodeKind::MERGER, "2")); // pass-through (single input)
+  int join = p.addNode(mkNode(NodeKind::MERGER, "3"));
+  p.addEdge(in, m1, -1, -1);
+  p.addEdge(in, m2, -1, -1);
+  p.addEdge(m1, join, -1, -1);
+  p.addEdge(m2, join, -1, -1);
+  std::string err;
+  TEST_EQUAL(p.topoSort(err), true)
+  TEST_EQUAL(p.computeDataFlow(err), true)
+
+  // both paths preserve 2 rounds; the join concatenates them per round (m1 before m2)
+  TEST_EQUAL(p.nodes()[join].round_total, 2)
+  TEST_EQUAL((outFiles(p, join, -1, 0) == std::vector<std::string>{"d1", "d1"}), true)
+  TEST_EQUAL((outFiles(p, join, -1, 1) == std::vector<std::string>{"d2", "d2"}), true)
+}
+END_SECTION
+
+START_SECTION([EXTRA] cycle detection)
+{
+  TOPPASPipeline p;
+  int t1 = p.addNode(mkNode(NodeKind::TOOL, "0"));
+  int t2 = p.addNode(mkNode(NodeKind::TOOL, "1"));
+  p.addEdge(t1, t2, 0, 0);
+  p.addEdge(t2, t1, 0, 0); // cycle
+  std::string err;
+  TEST_EQUAL(p.topoSort(err), false)
+  TEST_NOT_EQUAL(err.size(), 0)
+}
+END_SECTION
+
+START_SECTION((bool buildRoundPackages(int node_index, RoundPackages& pkg, std::string& error_msg) const))
+{
+  // node without input edges -> error
+  TOPPASPipeline p;
+  int tool = p.addNode(mkNode(NodeKind::TOOL, "0"));
+  RoundPackages pkg;
+  std::string err;
+  TEST_EQUAL(p.buildRoundPackages(tool, pkg, err), false)
+  TEST_NOT_EQUAL(err.size(), 0)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST


### PR DESCRIPTION
Extracts the round-based data-flow routing of TOPPAS into a new Qt-free core class OpenMS::TOPPASPipeline (input-list seeding, merger Merge/Collect, splitter, output recycling, topo-sort + cycle check). Qt-free extraction of routing that lived only in the QGraphicsItem-based TOPPAS*Vertex classes; the algorithmic core for a future Qt-free PipelineExecutor/ExecutePipeline. Ported verbatim and confirmed faithful by a line-by-line adversarial review. Because the ExecutePipeline tests only check exit codes (never diff outputs), the headline deliverable is TOPPASPipeline_test, asserting exact RoundPackages for input seeding, linear routing, both merger modes, splitter, divisible+non-divisible recycling, a diamond, and cycle detection. Follow-up: the execution layer (ExternalProcess tool invocation + rewiring ExecutePipeline off QApplication/TOPPASScene).