### PR TITLE
cmake: route openms-thermo-bridge installs to 'library' component to fix macOS notarization

### DIFF
--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -611,7 +611,14 @@ if (WITH_THERMO_RAW)
     # the CMake export set so downstream consumers resolve it via RPATH.
     set(_openms_saved_build_testing ${BUILD_TESTING})
     set(BUILD_TESTING OFF)
+    # The sub-project's install() calls have no COMPONENT, so CMake defaults them
+    # to "Unspecified". On macOS, that creates an unsigned dylib in Unspecified.pkg
+    # that fails Apple notarization. Route them to "library" instead — the same
+    # component used by install_library() below — so the existing signing step
+    # in cmake/package_mac_productbuild.cmake covers the library.
+    set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME library)
     FetchContent_MakeAvailable(OpenMSThermoBridge)
+    unset(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME)
     set(BUILD_TESTING ${_openms_saved_build_testing})
 
     # Place the bridge shared library next to libOpenMS in the build tree so


### PR DESCRIPTION
## Summary

- The nightly CI build failed because Apple notarization rejected the macOS `.pkg` with: _"The binary is not signed with a valid Developer ID certificate"_ for `libopenms_thermo_bridge.dylib`
- Root cause: `FetchContent_MakeAvailable(OpenMSThermoBridge)` includes the sub-project's own `install()` commands, which have **no `COMPONENT` specified**. CMake therefore places the library in the `Unspecified` CPack component by default.
- The code-signing step in `cmake/package_mac_productbuild.cmake` only covers the `library` and `Dependencies` components — the `Unspecified` component has no signing step, so the dylib ends up unsigned in `Unspecified.pkg`.

**Fix:** Set `CMAKE_INSTALL_DEFAULT_COMPONENT_NAME=library` around `FetchContent_MakeAvailable(OpenMSThermoBridge)` so the sub-project's unspecified `install()` rules land in the `library` component. That component already has a `codesign` step, so the library is properly signed before the `.pkg` is assembled and submitted for notarization.

## Test plan

- [ ] Nightly macOS CI build (`build-and-test (macos-15, xcode, 16.4)`) completes without notarization failure
- [ ] `libopenms_thermo_bridge.dylib` is no longer present in the `Unspecified` component package
- [ ] Apple notarization returns `status: Accepted`

https://claude.ai/code/session_01QVjiYQ6ggppnMCbGhx7E1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVjiYQ6ggppnMCbGhx7E1v)_