### PR TITLE
cmake: route openms-thermo-bridge installs to 'library' component (#9…

### DIFF
--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -611,7 +611,14 @@ if (WITH_THERMO_RAW)
     # the CMake export set so downstream consumers resolve it via RPATH.
     set(_openms_saved_build_testing ${BUILD_TESTING})
     set(BUILD_TESTING OFF)
+    # The sub-project's install() calls have no COMPONENT, so CMake defaults them
+    # to "Unspecified". On macOS, that creates an unsigned dylib in Unspecified.pkg
+    # that fails Apple notarization. Route them to "library" instead — the same
+    # component used by install_library() below — so the existing signing step
+    # in cmake/package_mac_productbuild.cmake covers the library.
+    set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME library)
     FetchContent_MakeAvailable(OpenMSThermoBridge)
+    unset(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME)
     set(BUILD_TESTING ${_openms_saved_build_testing})
 
     # Place the bridge shared library next to libOpenMS in the build tree so


### PR DESCRIPTION
…480)

The openms-thermo-bridge sub-project (via FetchContent) has install() commands with no COMPONENT specified, so CMake places them in the "Unspecified" CPack component by default. On macOS, this creates libopenms_thermo_bridge.dylib in Unspecified.pkg without any code signing, which fails Apple notarization with:

  "The binary is not signed with a valid Developer ID certificate."

Fix: set CMAKE_INSTALL_DEFAULT_COMPONENT_NAME=library around the FetchContent_MakeAvailable call so the sub-project's unspecified install() rules land in the "library" component instead. That component already has a codesign step in cmake/package_mac_productbuild.cmake, so the library is properly signed before the .pkg is assembled.

https://claude.ai/code/session_01QVjiYQ6ggppnMCbGhx7E1v

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS build and installation process for Thermo Raw support, ensuring proper component handling during the build phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->