### PR TITLE
Fix TOPP_MSGFPlusAdapter Windows CI failures

### DIFF
--- a/src/tests/topp/THIRDPARTY/third_party_tests.cmake
+++ b/src/tests/topp/THIRDPARTY/third_party_tests.cmake
@@ -112,7 +112,10 @@ if (NOT (${MSGFPLUS_BINARY} STREQUAL "MSGFPLUS_BINARY-NOTFOUND"))
   ## smoke test for the new -allow_dense_centroided_peaks flag: same input/output as test 1, only the flag differs.
   ## The flag does not change the search result for these (non-dense) spectra, so the output equals MSGFPlusAdapter_1_out
   ## except for the recorded parameter value (allow_dense_centroided_peaks=true instead of false), which is whitelisted.
+  ## Must run after test 1: both share the same proteins.fasta and spectra.mzML; MSGF+ creates temp/cache files
+  ## alongside those inputs, causing file-access conflicts on Windows when the two tests run in parallel.
   add_test("TOPP_MSGFPlusAdapter_2" ${TOPP_BIN_PATH}/MSGFPlusAdapter -test -ini ${DATA_DIR_TOPP}/THIRDPARTY/MSGFPlusAdapter_1.ini -database ${DATA_DIR_TOPP}/THIRDPARTY/proteins.fasta -in ${DATA_DIR_TOPP}/THIRDPARTY/spectra.mzML -out MSGFPlusAdapter_2_out1.tmp.idXML -mzid_out MSGFPlusAdapter_2_out2.tmp.mzid -executable "${MSGFPLUS_BINARY}" -allow_dense_centroided_peaks)
+  set_tests_properties("TOPP_MSGFPlusAdapter_2" PROPERTIES DEPENDS "TOPP_MSGFPlusAdapter_1")
   add_test("TOPP_MSGFPlusAdapter_2_out1" ${DIFF} -in1 MSGFPlusAdapter_2_out1.tmp.idXML -in2 ${DATA_DIR_TOPP}/THIRDPARTY/MSGFPlusAdapter_1_out.idXML -whitelist "IdentificationRun date" "SearchParameters id=\"SP_0\" db=" "UserParam type=\"stringList\" name=\"spectra_data\" value=" "UserParam type=\"string\" name=\"MSGFPlusAdapter:1:in\" value=" "UserParam type=\"string\" name=\"MSGFPlusAdapter:1:executable\" value=" "UserParam type=\"string\" name=\"MSGFPlusAdapter:1:database\" value=" "MSGFPlusAdapter:1:out\"" "MSGFPlusAdapter:1:mzid_out\"" "MSGFPlusAdapter:1:allow_dense_centroided_peaks")
   set_tests_properties("TOPP_MSGFPlusAdapter_2_out1" PROPERTIES DEPENDS "TOPP_MSGFPlusAdapter_2")
   add_test("TOPP_MSGFPlusAdapter_2_out2" ${DIFF} -in1 MSGFPlusAdapter_2_out2.tmp.mzid -in2 ${DATA_DIR_TOPP}/THIRDPARTY/MSGFPlusAdapter_1_out.mzid -whitelist "creationDate=" "SearchDatabase numDatabaseSequences=\"10\" location=" "SpectraData location=" "AnalysisSoftware")

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -733,7 +733,9 @@ protected:
           int scan_number = 0;
           if ((elements[2].empty()) || (elements[2] == "-1"))
           {
-            scan_number = StringUtils::toInt32(elements[1]);
+            // SpecID may be "controllerType=0 controllerNumber=1 scan=17"; extract the value after the last '='
+            auto eq_pos = elements[1].rfind('=');
+            scan_number = StringUtils::toInt32(eq_pos != std::string::npos ? elements[1].substr(eq_pos + 1) : elements[1]);
           }
           else
           {


### PR DESCRIPTION
## Summary

Fixes the 6 `TOPP_MSGFPlusAdapter` test failures on Windows introduced by PRs #9461 and #9450.

**Root cause 1 — parallel test race (main failure):**  
PR #9461 added `TOPP_MSGFPlusAdapter_2`, which uses the same `proteins.fasta` and `spectra.mzML` as test 1. MSGF+ creates temp/cache files alongside those shared inputs. On Windows, two MSGF+ processes racing for the same temp files causes file-access conflicts, making both test 1 and test 2 fail. Fix: add `DEPENDS "TOPP_MSGFPlusAdapter_1"` so test 2 is serialized after test 1.

**Root cause 2 — scan-number parsing regression:**  
PR #9450 converted `elements[1]` from `OpenMS::String` to `std::string` and replaced `elements[1].suffix('=').toInt()` with `StringUtils::toInt32(elements[1])`. For SpecIDs like `"controllerType=0 controllerNumber=1 scan=17"`, the old call extracted the integer after the last `=`; the new call throws `ConversionError` on the whole string. Fix: use `rfind('=') + substr` to restore the original behaviour. (This code path is hit when the `ScanNum` TSV column is empty or `-1`; not exercised by the existing tests, but is a real regression.)

## Test plan

- [ ] Windows CI: `TOPP_MSGFPlusAdapter_1`, `TOPP_MSGFPlusAdapter_1_out1`, `TOPP_MSGFPlusAdapter_1_out2`, `TOPP_MSGFPlusAdapter_2`, `TOPP_MSGFPlusAdapter_2_out1`, `TOPP_MSGFPlusAdapter_2_out2` should all pass
- [ ] Linux/macOS CI: no regression (tests were already passing, serialising them has no effect on correctness)

https://claude.ai/code/session_01RjUeua8ecNatvyBSSjfeGe

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjUeua8ecNatvyBSSjfeGe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated scan number extraction logic in the adapter to correctly handle alternative input formats.

* **Tests**
  * Enhanced test documentation to clarify execution order requirements and prevent conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->