### PR TITLE
Fix 3 POLS correctness bugs (MzTabBoolean::setNull, Math::absdev, QCBase::names_of_requires)

### DIFF
--- a/src/openms/include/OpenMS/MATH/StatisticFunctions.h
+++ b/src/openms/include/OpenMS/MATH/StatisticFunctions.h
@@ -579,7 +579,7 @@ namespace OpenMS
       }
       for (IteratorType iter=begin; iter!=end; ++iter)
       {
-        sum_value += *iter - mean;
+        sum_value += std::fabs(*iter - mean); // absolute deviation: accumulate the magnitude, not the signed difference
       }
       return sum_value / std::distance(begin, end);
     }

--- a/src/openms/source/FORMAT/MzTabBase.cpp
+++ b/src/openms/source/FORMAT/MzTabBase.cpp
@@ -502,10 +502,9 @@ namespace OpenMS
 
   void MzTabBoolean::setNull(bool b)
   {
-    if (!b)
-      value_ = -1;
-    else
-      value_ = 0;
+    // null is encoded as a negative value (see isNull()); a non-null boolean defaults to false (0).
+    // Note: the previous implementation had the branches inverted (setNull(true) made the value non-null).
+    value_ = b ? -1 : 0;
   }
 
   std::string MzTabBoolean::toCellString() const

--- a/src/openms/source/QC/QCBase.cpp
+++ b/src/openms/source/QC/QCBase.cpp
@@ -13,7 +13,10 @@
 
 namespace OpenMS
 {
-  const std::string QCBase::names_of_requires[] = {"fail", "raw.mzML", "postFDR.featureXML", "preFDR.featureXML", "contaminants.fasta", "trafoAlign.trafoXML"};
+  // NOTE: this array is indexed by the Requires enum value (see isRunnable()); it must have one entry per
+  // enum value up to (but excluding) SIZE_OF_REQUIRES. The trailing "id.idXML" entry corresponds to Requires::ID,
+  // which was previously missing and caused an out-of-bounds read for metrics that require protein IDs.
+  const std::string QCBase::names_of_requires[] = {"fail", "raw.mzML", "postFDR.featureXML", "preFDR.featureXML", "contaminants.fasta", "trafoAlign.trafoXML", "id.idXML"};
 
   const std::string QCBase::names_of_toleranceUnit[] = {"auto", "ppm", "da"};
 

--- a/src/tests/class_tests/openms/source/MzTab_test.cpp
+++ b/src/tests/class_tests/openms/source/MzTab_test.cpp
@@ -143,6 +143,19 @@ START_SECTION(static void addMetaInfoToOptionalColumns(const std::set<std::strin
 }
 END_SECTION
 
+START_SECTION([EXTRA] MzTabBoolean setNull / isNull polarity)
+{
+  // regression: setNull(true) must make the cell null, setNull(false) must make it not-null (the branches were inverted).
+  MzTabBoolean b(true);
+  TEST_EQUAL(b.isNull(), false)
+  b.setNull(true);
+  TEST_EQUAL(b.isNull(), true)
+  TEST_EQUAL(b.toCellString(), "null")
+  b.setNull(false);
+  TEST_EQUAL(b.isNull(), false)
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST

--- a/src/tests/class_tests/openms/source/QCBase_test.cpp
+++ b/src/tests/class_tests/openms/source/QCBase_test.cpp
@@ -79,6 +79,16 @@ START_TEST(SpectraMap, "$Id$")
   START_SECTION(QCBase::SpectraMap::size())
     NOT_TESTABLE;
   END_SECTION
-  
+
+  START_SECTION([EXTRA] names_of_requires has one entry per Requires value)
+  {
+    // regression: isRunnable() indexes names_of_requires by the Requires enum value up to SIZE_OF_REQUIRES.
+    // Requires::ID was previously missing from the array, causing an out-of-bounds read.
+    TEST_EQUAL(QCBase::names_of_requires[(Size)QCBase::Requires::NOTHING], "fail")
+    TEST_EQUAL(QCBase::names_of_requires[(Size)QCBase::Requires::TRAFOALIGN], "trafoAlign.trafoXML")
+    TEST_EQUAL(QCBase::names_of_requires[(Size)QCBase::Requires::ID], "id.idXML")
+  }
+  END_SECTION
+
 END_TEST
 

--- a/src/tests/class_tests/openms/source/StatisticFunctions_test.cpp
+++ b/src/tests/class_tests/openms/source/StatisticFunctions_test.cpp
@@ -133,6 +133,10 @@ START_SECTION([EXTRA](template <typename IteratorType> static double absdev(Iter
   // single element -> 0
   int x3[] = {-1};
   TEST_REAL_SIMILAR(Math::absdev(x3, x3 + 1, -1.0), 0.0);
+
+  // empty range -> InvalidRange (documented contract, enforced via checkIteratorsNotNULL)
+  int empty[] = {0};
+  TEST_EXCEPTION(Exception::InvalidRange, Math::absdev(empty, empty));
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/StatisticFunctions_test.cpp
+++ b/src/tests/class_tests/openms/source/StatisticFunctions_test.cpp
@@ -118,6 +118,24 @@ START_SECTION([EXTRA](template <typename IteratorType> double MeanAbsoluteDeviat
 }
 END_SECTION
 
+START_SECTION([EXTRA](template <typename IteratorType> static double absdev(IteratorType begin, IteratorType end, double mean = std::numeric_limits<double>::max())))
+{
+  // absdev is the mean absolute deviation: it must accumulate |x - mean|.
+  // (A previous bug accumulated the signed (x - mean), which sums to ~0 for the mean.)
+  int x1[] = {-1, 0, 1, 2, 3}; // mean = 1
+  TEST_REAL_SIMILAR(Math::absdev(x1, x1 + 5, 1.0), 1.2);
+  TEST_REAL_SIMILAR(Math::absdev(x1, x1 + 5), 1.2); // mean computed internally (== 1)
+
+  // symmetric data around the mean: the signed sum is exactly 0, the absolute deviation is clearly non-zero
+  DoubleList sym = ListUtils::create<double>("-2.0, -1.0, 1.0, 2.0"); // mean = 0
+  TEST_REAL_SIMILAR(Math::absdev(sym.begin(), sym.end(), 0.0), 1.5);
+
+  // single element -> 0
+  int x3[] = {-1};
+  TEST_REAL_SIMILAR(Math::absdev(x3, x3 + 1, -1.0), 0.0);
+}
+END_SECTION
+
 START_SECTION([EXTRA](template< typename IteratorType1, typename IteratorType2 > static RealType meanSquareError( IteratorType1 begin_a, const IteratorType1 end_a, IteratorType2 begin_b, const IteratorType2 end_b )))
 {
 	std::list<double> numbers1(20, 1.5);


### PR DESCRIPTION
First small fix-PR from the POLS API audit (tracking issue #9488). Three independent, verified **correctness bugs**, each with a regression test.

### 1. `MzTabBoolean::setNull(bool)` — inverted polarity
Body was `if (!b) value_ = -1; else value_ = 0;`, so `setNull(true)` made the cell **not** null and `setNull(false)` made it null — the opposite of the bool's meaning and of every sibling (`MzTabInteger`/`MzTabDouble` use `b ? NULL : DEFAULT`). Now `value_ = b ? -1 : 0;`.

This path is exercised: `MzTabBoolean::fromCellString()` calls `setNull(true)` when parsing the literal `null`, so the old inversion silently parsed a `null` boolean cell as a non-null `false` and round-tripped it back to `"0"`. OpenMS only ever *writes* `0`/`1` for the sole boolean field (`unique`), so its own output is unaffected; reading external mzTab with `null` boolean cells now behaves correctly.

### 2. `Math::absdev` — summed signed deviations
Accumulated `*iter - mean` instead of `std::fabs(*iter - mean)`, so a function named *absolute deviation* returned ≈0 for the mean. Now matches `Math::MeanAbsoluteDeviation`. (`<cmath>` already included.) Its one in-tree caller (`MRMPairFinder`) has a separate, pre-existing malformed-range bug and is intentionally left untouched here.

### 3. `QCBase::names_of_requires[]` — out-of-bounds read
The array had 6 entries but `QCBase::isRunnable()` indexes it by every `Requires` value up to `SIZE_OF_REQUIRES` (7 values, `NOTHING`…`ID`). Indexing `[Requires::ID]` read past the end for any metric requiring protein IDs. Added the `"id.idXML"` entry.

### Tests
Added regression tests to `StatisticFunctions_test`, `QCBase_test`, `MzTab_test`; all three pass locally. No reference files changed.

Part of #9488. ABI-safe (no signature changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected absolute-deviation calculation to use magnitude of deviations.
  * Fixed boolean null encoding in MzTab handling so nulls are represented correctly.
  * Restored missing QC mapping entry to prevent out-of-bounds errors in metrics.

* **Tests**
  * Added regression tests covering the above fixes to prevent regressions.
