### PR TITLE
Guard against empty/degenerate input in 3 ANALYSIS methods (crash & div-by-zero fixes)

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/NeighborSeq.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/NeighborSeq.h
@@ -168,33 +168,35 @@ namespace OpenMS
           return unfindable_peptides + findable_no_neighbors + findable_one_neighbor + findable_multiple_neighbors;
         }
 
-        /**
-          @brief @ref unfindable_peptides formatted as @c "X (Y%)".
+        /// percentage (0..100) of @p count relative to @ref total; returns 0 when @ref total is 0 (avoids integer division by zero)
+        int percentOfTotal_(int count) const
+        {
+          const int t = total();
+          return (t == 0) ? 0 : count * 100 / t;
+        }
 
-          @warning Triggers integer division by zero when @ref total is @c 0
-                   (the four counters and the formatter share an integer denominator).
-        */
+        /// @ref unfindable_peptides formatted as @c "X (Y%)"; returns @c "X (0%)" when @ref total is 0.
         std::string unfindable() const
         {
-          return StringUtils::toStr(unfindable_peptides) + " (" + unfindable_peptides * 100 / total() + "%)";
+          return StringUtils::toStr(unfindable_peptides) + " (" + StringUtils::toStr(percentOfTotal_(unfindable_peptides)) + "%)";
         }
 
-        /// @ref findable_no_neighbors formatted as @c "X (Y%)"; see @ref unfindable for the divide-by-zero caveat.
+        /// @ref findable_no_neighbors formatted as @c "X (Y%)"; returns @c "X (0%)" when @ref total is 0.
         std::string noNB() const
         {
-          return StringUtils::toStr(findable_no_neighbors) + " (" + findable_no_neighbors * 100 / total() + "%)";
+          return StringUtils::toStr(findable_no_neighbors) + " (" + StringUtils::toStr(percentOfTotal_(findable_no_neighbors)) + "%)";
         }
 
-        /// @ref findable_one_neighbor formatted as @c "X (Y%)"; see @ref unfindable for the divide-by-zero caveat.
+        /// @ref findable_one_neighbor formatted as @c "X (Y%)"; returns @c "X (0%)" when @ref total is 0.
         std::string oneNB() const
         {
-          return StringUtils::toStr(findable_one_neighbor) + " (" + findable_one_neighbor * 100 / total() + "%)";
+          return StringUtils::toStr(findable_one_neighbor) + " (" + StringUtils::toStr(percentOfTotal_(findable_one_neighbor)) + "%)";
         }
 
-        /// @ref findable_multiple_neighbors formatted as @c "X (Y%)"; see @ref unfindable for the divide-by-zero caveat.
+        /// @ref findable_multiple_neighbors formatted as @c "X (Y%)"; returns @c "X (0%)" when @ref total is 0.
         std::string multiNB() const
         {
-          return StringUtils::toStr(findable_multiple_neighbors) + " (" + findable_multiple_neighbors * 100 / total() + "%)";
+          return StringUtils::toStr(findable_multiple_neighbors) + " (" + StringUtils::toStr(percentOfTotal_(findable_multiple_neighbors)) + "%)";
         }
       };
 

--- a/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentEvaluationAlgorithmRecall.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentEvaluationAlgorithmRecall.cpp
@@ -39,16 +39,17 @@ namespace OpenMS
 
     // Guard against degenerate inputs that previously caused a division by zero below
     // (integer 'gt_i / cons_map_tool.size()' at the end of the outer loop, and '1.0 / cons_map_gt.size()').
+    if (cons_map_gt.empty())
+    {
+      // no usable ground truth -> recall is undefined regardless of the tool map (also covers both-empty)
+      throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "Recall is undefined: the ground-truth consensus map contains no consensus feature with at least two elements.");
+    }
     if (cons_map_tool.empty())
     {
       // the tool produced no consensus features -> nothing was recovered -> recall is 0
       out = 0.0;
       return;
-    }
-    if (cons_map_gt.empty())
-    {
-      throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-        "Recall is undefined: the ground-truth consensus map contains no consensus feature with at least two elements.");
     }
 
     std::vector<Size> gt_subtend_tilde_tool;        //holds the numerators of the sum

--- a/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentEvaluationAlgorithmRecall.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentEvaluationAlgorithmRecall.cpp
@@ -8,6 +8,8 @@
 
 #include <OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentEvaluationAlgorithmRecall.h>
 
+#include <OpenMS/CONCEPT/Exception.h>
+
 namespace OpenMS
 {
 
@@ -34,6 +36,20 @@ namespace OpenMS
     }
 
     ConsensusMap cons_map_tool = consensus_map_in;
+
+    // Guard against degenerate inputs that previously caused a division by zero below
+    // (integer 'gt_i / cons_map_tool.size()' at the end of the outer loop, and '1.0 / cons_map_gt.size()').
+    if (cons_map_tool.empty())
+    {
+      // the tool produced no consensus features -> nothing was recovered -> recall is 0
+      out = 0.0;
+      return;
+    }
+    if (cons_map_gt.empty())
+    {
+      throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "Recall is undefined: the ground-truth consensus map contains no consensus feature with at least two elements.");
+    }
 
     std::vector<Size> gt_subtend_tilde_tool;        //holds the numerators of the sum
     std::vector<Size> m;                //holds the denominators of the sum

--- a/src/openms/source/ANALYSIS/TOPDOWN/DeconvolvedSpectrum.cpp
+++ b/src/openms/source/ANALYSIS/TOPDOWN/DeconvolvedSpectrum.cpp
@@ -34,6 +34,13 @@ namespace OpenMS
     auto out_spec = MSSpectrum(spec_);
     out_spec.clear(false);
 
+    // An empty (e.g. default-constructed) DeconvolvedSpectrum has no peak groups; return a header-only
+    // spectrum instead of dereferencing peak_groups_[0] below (out-of-bounds access).
+    if (peak_groups_.empty())
+    {
+      return out_spec;
+    }
+
     double charge_mass_offset = (double)abs(to_charge) * FLASHHelperClasses::getChargeMass(to_charge >= 0);
     std::unordered_set<double> deconvolved_mzs;
     std::stringstream val {};

--- a/src/tests/class_tests/openms/source/DeconvolvedSpectrum_test.cpp
+++ b/src/tests/class_tests/openms/source/DeconvolvedSpectrum_test.cpp
@@ -89,6 +89,11 @@ START_SECTION((MSSpectrum toSpectrum(const int mass_charge)))
   MSSpectrum peakgroup_spec = prec_deconv_spec_1.toSpectrum(9, 1);
   TEST_EQUAL(peakgroup_spec.size(), 1);
   TEST_REAL_SIMILAR(peakgroup_spec.getRT(), 251.72280736002);
+
+  // empty (default-constructed) DeconvolvedSpectrum must not dereference peak_groups_[0] (regression): returns a header-only spectrum
+  DeconvolvedSpectrum empty_dspec;
+  MSSpectrum empty_out = empty_dspec.toSpectrum(1, 1);
+  TEST_EQUAL(empty_out.empty(), true);
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/MapAlignmentEvaluationAlgorithmRecall_test.cpp
+++ b/src/tests/class_tests/openms/source/MapAlignmentEvaluationAlgorithmRecall_test.cpp
@@ -52,6 +52,13 @@ START_SECTION((virtual void evaluate(const ConsensusMap &consensus_map_in, const
 	maea.evaluate(in, gt, 0.1, 0.1, 100, true, out);
 
 	TEST_REAL_SIMILAR(out, 0.5)
+
+	// degenerate inputs (previously a division by zero): empty tool map -> recall 0; empty ground truth -> exception
+	ConsensusMap empty_map;
+	double out_empty = -1.0;
+	maea.evaluate(empty_map, gt, 0.1, 0.1, 100, true, out_empty);
+	TEST_REAL_SIMILAR(out_empty, 0.0)
+	TEST_EXCEPTION(Exception::InvalidParameter, maea.evaluate(in, empty_map, 0.1, 0.1, 100, true, out_empty))
 END_SECTION
 
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/NeighborSeq_test.cpp
+++ b/src/tests/class_tests/openms/source/NeighborSeq_test.cpp
@@ -209,4 +209,24 @@ START_SECTION(NeighborStats getNeighborStats() const)
 }
 END_SECTION
 
+START_SECTION([EXTRA] NeighborStats percentage formatters)
+{
+  // total() == 0 must not divide by zero (regression): all formatters return "X (0%)"
+  NeighborSeq::NeighborStats s;
+  TEST_EQUAL(s.total(), 0)
+  TEST_EQUAL(s.unfindable(), "0 (0%)")
+  TEST_EQUAL(s.noNB(), "0 (0%)")
+  TEST_EQUAL(s.oneNB(), "0 (0%)")
+  TEST_EQUAL(s.multiNB(), "0 (0%)")
+
+  // non-zero total: percentages computed normally
+  NeighborSeq::NeighborStats s2;
+  s2.findable_no_neighbors = 1;
+  s2.findable_one_neighbor = 3;
+  TEST_EQUAL(s2.total(), 4)
+  TEST_EQUAL(s2.noNB(), "1 (25%)")
+  TEST_EQUAL(s2.oneNB(), "3 (75%)")
+}
+END_SECTION
+
 END_TEST


### PR DESCRIPTION
POLS audit fixes (#9488), systemic pattern: **guard degenerate/empty input**. Each change only affects input that previously crashed or returned NaN — **no valid-path output changes, no reference files touched**.

### Fixes
- **`DeconvolvedSpectrum::toSpectrum()`** dereferenced `peak_groups_[0]` before any empty check → out-of-bounds on a default-constructed/empty spectrum. Now returns a header-only spectrum when there are no peak groups.
- **`MapAlignmentEvaluationAlgorithmRecall::evaluate()`** divided by container sizes unguarded: `gt_i / cons_map_tool.size()` (integer div-by-zero/SIGFPE when the tool map is empty) and `1.0 / cons_map_gt.size()` (NaN when no ground-truth feature has ≥2 elements). Now: empty tool map → recall `0` (nothing recovered); empty ground truth → `Exception::InvalidParameter`.
- **`NeighborSeq::NeighborStats`** percentage formatters (`unfindable`/`noNB`/`oneNB`/`multiNB`) did `count * 100 / total()` → integer division by zero when `total()==0`. Now return `"X (0%)"` via a small `percentOfTotal_` helper.

### Tests
Added regression tests; `MapAlignmentEvaluationAlgorithmRecall_test` and `NeighborSeq_test` pass locally. The `DeconvolvedSpectrum` assertion was added to `DeconvolvedSpectrum_test.cpp`, which is **currently disabled in `executables.cmake`** (line 495) — so it is not exercised by CI yet, but the source fix compiles into libOpenMS and the assertion is ready for when that test is re-enabled.

Part of #9488. ABI-safe (no signature changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented division-by-zero in neighbor statistics percentage formatting, ensuring safe “count (0%)” output when totals are zero.
  * Added validation for degenerate consensus maps to avoid undefined recall calculations (returning `0.0` for empty tool consensus and throwing on invalid ground truth).
  * Prevented crashes when converting empty `DeconvolvedSpectrum` instances by safely returning an empty spectrum.

* **Tests**
  * Added/extended regression coverage for zero-total statistics, empty/degenerate recall inputs, and empty spectrum conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->