### PR TITLE
Guard against empty/degenerate input in 4 FORMAT/METADATA/FEATUREFINDER methods

### DIFF
--- a/src/openms/source/FEATUREFINDER/ElutionPeakDetection.cpp
+++ b/src/openms/source/FEATUREFINDER/ElutionPeakDetection.cpp
@@ -372,7 +372,8 @@ namespace OpenMS
       ++count_mt;
     }
 
-    std::cout << "pw low: " << filt_mtraces[0].estimateFWHM(true) << " " << " pw high: " << filt_mtraces[filt_mtraces.size() - 1].estimateFWHM(true) << '\n';
+    // (removed stray debug output that printed to std::cout and indexed filt_mtraces[0] /
+    //  filt_mtraces[size()-1] without an empty check -> out-of-bounds when no trace passed the width filter)
 
     return;
   }

--- a/src/openms/source/FEATUREFINDER/SeedListGenerator.cpp
+++ b/src/openms/source/FEATUREFINDER/SeedListGenerator.cpp
@@ -27,6 +27,12 @@ namespace OpenMS
         PeakMap::ConstIterator prec_it =
           experiment.getPrecursorSpectrum(exp_it);
         const vector<Precursor>& precursors = exp_it->getPrecursors();
+        // skip MS2 spectra without a precursor spectrum or without precursor information
+        // (dereferencing end() or indexing precursors[0] would otherwise be undefined behavior)
+        if (prec_it == experiment.end() || precursors.empty())
+        {
+          continue;
+        }
         DPosition<2> point(prec_it->getRT(), precursors[0].getMZ());
         seeds.push_back(point);
       }

--- a/src/openms/source/FORMAT/GNPSQuantificationFile.cpp
+++ b/src/openms/source/FORMAT/GNPSQuantificationFile.cpp
@@ -22,8 +22,9 @@ namespace OpenMS
     void GNPSQuantificationFile::store(const ConsensusMap& consensus_map, const std::string& output_file)
     {
         // IIMN meta values will be exported, if first feature contains mv Constants::UserParam::IIMN_ROW_ID
+        // (guard against an empty ConsensusMap: consensus_map[0] would otherwise be out of bounds)
         bool iimn = false;
-        if (consensus_map[0].metaValueExists(Constants::UserParam::IIMN_ROW_ID)) iimn = true;
+        if (!consensus_map.empty() && consensus_map[0].metaValueExists(Constants::UserParam::IIMN_ROW_ID)) iimn = true;
 
         // meta values for ion identity molecular networking
         std::vector<std::string> iimn_mvs{Constants::UserParam::IIMN_ROW_ID,

--- a/src/openms/source/METADATA/ExperimentalDesign.cpp
+++ b/src/openms/source/METADATA/ExperimentalDesign.cpp
@@ -598,11 +598,18 @@ namespace OpenMS
 
     unsigned ExperimentalDesign::getSample(unsigned fraction_group, unsigned label)
     {
-      return std::find_if(msfile_section_.begin(), msfile_section_.end(),
+      auto it = std::find_if(msfile_section_.begin(), msfile_section_.end(),
                           [&fraction_group, &label](const MSFileSectionEntry& r)
                           {
                               return r.fraction_group == fraction_group && r.label == label;
-                          })->sample;
+                          });
+      // guard against an unknown (fraction_group, label) combination: dereferencing end() would be undefined behavior
+      if (it == msfile_section_.end())
+      {
+        throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+          "No sample found for fraction group " + std::to_string(fraction_group) + " and label " + std::to_string(label));
+      }
+      return it->sample;
     }
 
     const ExperimentalDesign::SampleSection& ExperimentalDesign::getSampleSection() const

--- a/src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp
+++ b/src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp
@@ -92,6 +92,13 @@ START_SECTION((const ExperimentalDesign::SampleSection& getSampleSection() const
 }
 END_SECTION
 
+START_SECTION((unsigned getSample(unsigned fraction_group, unsigned label)))
+{
+  // an unknown (fraction_group, label) combination must throw instead of dereferencing end() (undefined behavior)
+  TEST_EXCEPTION(Exception::ElementNotFound, labelfree_unfractionated_design.getSample(99999, 99999))
+}
+END_SECTION
+
 START_SECTION((void setSampleSection(const ExperimentalDesign::SampleSection &sample_section)))
 {
   ExperimentalDesign labelfree_unfractionated_design2 = labelfree_unfractionated_design;

--- a/src/tests/class_tests/openms/source/SeedListGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/SeedListGenerator_test.cpp
@@ -57,6 +57,16 @@ START_SECTION((void generateSeedList(const PeakMap& experiment, SeedList& seeds)
 	TEST_EQUAL(seeds[2], DPosition<2>(0.5927, 678.384));
 	// ...
 	TEST_EQUAL(seeds[8], DPosition<2>(3.7572, 512.784));
+
+	// MS2 spectrum without a precursor spectrum / precursor info must be skipped, not crash
+	// (regression: previously dereferenced an end() precursor iterator and indexed precursors[0])
+	PeakMap exp_no_prec;
+	MSSpectrum ms2;
+	ms2.setMSLevel(2); // no precursor spectrum before it, and no Precursor set
+	exp_no_prec.addSpectrum(ms2);
+	SeedListGenerator::SeedList seeds_no_prec;
+	SeedListGenerator().generateSeedList(exp_no_prec, seeds_no_prec);
+	TEST_EQUAL(seeds_no_prec.empty(), true);
 }
 END_SECTION
 


### PR DESCRIPTION
POLS audit fixes (#9488), systemic pattern: **guard degenerate/empty input**. Each change only affects input that previously crashed or invoked UB — **no valid-path output changes, no reference files touched**.

### Fixes
- **`GNPSQuantificationFile::store()`** probed `consensus_map[0]` before any size check → out-of-bounds on an empty `ConsensusMap`. Guarded with `!consensus_map.empty()`.
- **`ExperimentalDesign::getSample()`** dereferenced the `std::find_if` result via `->sample` without checking `end()` → UB for an unknown `(fraction_group, label)`. Now throws `Exception::ElementNotFound`.
- **`SeedListGenerator::generateSeedList(PeakMap)`** dereferenced a possibly-`end()` precursor iterator (`getPrecursorSpectrum`) and indexed `precursors[0]` unguarded. MS2 spectra without a precursor spectrum / precursor info are now skipped.
- **`ElutionPeakDetection::filterByPeakWidth()`** printed to `std::cout` and indexed `filt_mtraces[0]`/`filt_mtraces[size()-1]` without an empty check (out-of-bounds when no trace passed the width filter). Removed the stray debug line.

### Tests
Regression tests added for `getSample` (throws on unknown combination) and `generateSeedList` (no crash / empty seeds for a precursor-less MS2 spectrum); both pass locally.

Part of #9488. ABI-safe (no signature changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved edge-case handling to prevent crashes when filtered or precursor data is empty or incomplete.
  * Enhanced error handling in sample lookup to safely detect missing fraction group/label entries and raise a clear `ElementNotFound` exception.
  * Safeguarded quantification export behavior when consensus data is absent.

* **Tests**
  * Added regression coverage for empty/invalid MS2 precursor scenarios and for out-of-range sample lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->