### PR TITLE
Doc: correct 4 misleading API doc-comments (POLS audit)

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/SimpleSearchEngineAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/SimpleSearchEngineAlgorithm.h
@@ -72,9 +72,14 @@ class OPENMS_DLLAPI SimpleSearchEngineAlgorithm :
       @brief Search the MS2 spectra in @p in_spectra against the protein database in @p in_db.
 
       Spectra and database are loaded from disk; the result is written into the two
-      output arguments. Existing contents of @p prot_ids and @p pep_ids are not
-      cleared by this call. The current parameter set (see the class brief) controls
-      tolerances, modifications, enzyme, FDR, etc.
+      output arguments. The two outputs are NOT treated symmetrically and this call is
+      NOT additive: @p prot_ids is overwritten (replaced by a single fresh
+      ProteinIdentification run for this search), whereas new PSMs are appended to
+      @p pep_ids. In addition, the run identifier of the freshly created protein run is
+      stamped onto EVERY element of @p pep_ids (including pre-existing entries), so do
+      not reuse a @p pep_ids vector that already holds PSMs from another run — pass
+      freshly constructed (empty) vectors. The current parameter set (see the class
+      brief) controls tolerances, modifications, enzyme, FDR, etc.
 
       @param[in]  in_spectra Path to the spectrum input (mzML or any format readable by @ref FileHandler).
       @param[in]  in_db      Path to the protein FASTA database to search against.

--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmUnlabeled.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmUnlabeled.h
@@ -26,7 +26,14 @@ namespace OpenMS
       - b) Call "setReference", "addToGroup" (n times), "getResultMap" in that order.
       
       The second way is more memory efficient because at all times, only the
-      reference map and the current map need to be in memory
+      reference map and the current map need to be in memory.
+
+      @note The two ways are NOT equivalent in their output. "group" performs additional
+            post-processing on the result (transfer of protein identifications, re-indexing of
+            unassigned peptide identifications, setup of column headers for all input maps, and
+            canonical sorting via sortByQuality()/sortByMaps()/sortBySize()). The incremental path
+            (b) returns the raw pairfinder result via getResultMap() without any of this
+            post-processing; callers must perform it themselves if needed (see TOPP FeatureLinkerUnlabeled).
 
       @htmlinclude OpenMS_FeatureGroupingAlgorithmUnlabeled.parameters
 
@@ -57,6 +64,10 @@ public:
 
     /**
         @brief Returns the computed consensus map (after calling addToGroup with all maps)
+
+        @note This is the @em raw incremental result. Unlike group(), it has NOT been post-processed
+              (no protein-ID transfer, no re-indexing of unassigned peptide IDs, no column headers for
+              the added maps, no canonical sorting). Perform that post-processing yourself if required.
     */
     ConsensusMap & getResultMap()
     {

--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmUnlabeled.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmUnlabeled.h
@@ -30,8 +30,8 @@ namespace OpenMS
 
       @note The two ways are NOT equivalent in their output. "group" performs additional
             post-processing on the result (transfer of protein identifications, re-indexing of
-            unassigned peptide identifications, setup of column headers for all input maps, and
-            canonical sorting via sortByQuality()/sortByMaps()/sortBySize()). The incremental path
+            unassigned peptide identifications, and canonical sorting via
+            sortByQuality()/sortByMaps()/sortBySize()). The incremental path
             (b) returns the raw pairfinder result via getResultMap() without any of this
             post-processing; callers must perform it themselves if needed (see TOPP FeatureLinkerUnlabeled).
 
@@ -66,8 +66,8 @@ public:
         @brief Returns the computed consensus map (after calling addToGroup with all maps)
 
         @note This is the @em raw incremental result. Unlike group(), it has NOT been post-processed
-              (no protein-ID transfer, no re-indexing of unassigned peptide IDs, no column headers for
-              the added maps, no canonical sorting). Perform that post-processing yourself if required.
+              (no protein-ID transfer, no re-indexing of unassigned peptide IDs, no canonical sorting).
+              Perform that post-processing yourself if required.
     */
     ConsensusMap & getResultMap()
     {

--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitation.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitation.h
@@ -124,14 +124,20 @@ public:
     /**
       @brief This function calculates the ratio between features.
 
+      The ratio is component_1 / component_2 evaluated on @p feature_name. The special name
+      @c "intensity" reads Feature::getIntensity(); any other name reads the corresponding metaValue.
+
       @param[in] component_1 component of the numerator
       @param[in] component_2 component of the denominator
       @param[in] feature_name name of the feature to calculate the ratio on
-       e.g., peak_apex, peak_area
+       e.g., "intensity", peak_apex, peak_area
 
       @return The ratio.
 
-      @exception Exception::UnableToFit
+      @note This function does NOT throw when a value is missing. If only @p component_1 carries the
+            value (no internal standard), the bare value of @p component_1 is returned; if neither
+            component carries the value, @c 0.0 is returned (only a debug message is logged). A returned
+            @c 0.0 is therefore indistinguishable from a legitimately measured zero ratio.
     */
     double calculateRatio(const Feature & component_1, const Feature & component_2, const std::string & feature_name);
 

--- a/src/openms/include/OpenMS/FEATUREFINDER/Biosaur2Algorithm.h
+++ b/src/openms/include/OpenMS/FEATUREFINDER/Biosaur2Algorithm.h
@@ -185,9 +185,13 @@ public:
     @param[out] hills Output container for all detected hills that survived filtering steps. Useful for diagnostics and quality control.
     @param[out] peptide_features Output container storing intermediate peptide feature representations before conversion to FeatureMap entries
 
-    @note The input MS data must be set via setMSData() before calling this method
-    @note All spectra with MS level != 1 will be removed from the internal MS data
-    @note If profile_mode is enabled, spectra will be centroided using PeakPickerHiRes
+    @note The input MS data must be set via setMSData() before calling this method.
+    @note <b>This method destructively consumes the stored MS data.</b> It modifies the internal
+          experiment in place (all spectra with MS level != 1 are removed; if profile_mode is enabled the
+          remaining spectra are centroided with PeakPickerHiRes; if tof_mode is enabled TOF intensity
+          filtering is applied). On data containing FAIMS compensation voltages the stored experiment is
+          additionally moved out, so getMSData() afterwards returns an emptied/moved-from experiment.
+          run() is therefore not idempotent — call setMSData() again before re-running.
   */
   void run(FeatureMap& feature_map,
            std::vector<Hill>& hills,


### PR DESCRIPTION
POLS audit fixes (#9488). **Documentation-only** — no code or behavior change, so no test changes. Each corrects a doc comment that contradicted the implementation:

- **`FeatureGroupingAlgorithmUnlabeled`** — the documented "two ways to run" are NOT equivalent: the incremental `setReference`/`addToGroup`/`getResultMap` path returns the raw pairfinder result *without* `group()`'s post-processing (protein-ID transfer, unassigned-peptide re-indexing, column headers, canonical sorting). Now documented on the class and on `getResultMap()`.
- **`SimpleSearchEngineAlgorithm::search`** — doc claimed outputs "are not cleared"; actually `prot_ids` is overwritten while `pep_ids` is appended, and the fresh run id is stamped onto every `pep_ids` element. Documented the asymmetry; advise passing fresh vectors.
- **`Biosaur2Algorithm::run`** — documented that it destructively consumes the stored MS data (`getMSData()` returns an emptied/moved-from experiment afterwards) and is not idempotent.
- **`AbsoluteQuantitation::calculateRatio`** — removed the bogus `@exception UnableToFit` (never thrown); documented that it returns the bare numerator when there is no internal standard and `0.0` when neither component carries the value (ambiguous with a real zero ratio).

Part of #9488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated search algorithm documentation to clarify output handling requirements
  * Refined feature grouping documentation regarding incremental execution behavior and post-processing needs
  * Enhanced quantitation calculation documentation for missing-value handling
  * Expanded feature finder documentation on in-place data modifications and re-execution requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->