### PR TITLE
load() replaces instead of appending: MSPFile::load and MzIdentMLFile::load

### DIFF
--- a/src/openms/source/FORMAT/MSPFile.cpp
+++ b/src/openms/source/FORMAT/MSPFile.cpp
@@ -70,6 +70,7 @@ namespace OpenMS
     const std::regex ws_rex(R"(\s{2,}|\t|\r)");
 
     exp.reset();
+    ids.clear(); // replace (not accumulate): mirror exp.reset() so a reused 'ids' vector does not silently grow across calls
 
     //set DocumentIdentifier
     exp.setLoadedFileType(filename);

--- a/src/openms/source/FORMAT/MzIdentMLFile.cpp
+++ b/src/openms/source/FORMAT/MzIdentMLFile.cpp
@@ -31,6 +31,10 @@ namespace OpenMS
 
   void MzIdentMLFile::load(const std::string& filename, std::vector<ProteinIdentification>& poid, PeptideIdentificationList& peid)
   {
+    // replace (not accumulate): the DOM handler only appends, so clear the outputs first to match the
+    // behavior of the sibling identification loaders (e.g. IdXMLFile::load) and FileHandler::loadIdentifications.
+    poid.clear();
+    peid.clear();
     Internal::MzIdentMLDOMHandler handler(poid, peid, schema_version_, *this);
     handler.readMzIdentMLFile(filename);
   }

--- a/src/tests/class_tests/openms/source/MSPFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MSPFile_test.cpp
@@ -65,6 +65,11 @@ START_SECTION(void load(const std::string &filename, std::vector< PeptideIdentif
 	TEST_EQUAL(exp.size(), 7)
 	TEST_EQUAL(ids.size(), 7)
 
+	// loading again into the same containers must replace, not accumulate (regression: 'ids' was previously appended to)
+	msp_file.load(OPENMS_GET_TEST_DATA_PATH("MSPFile_test.msp"), ids, exp);
+	TEST_EQUAL(exp.size(), 7)
+	TEST_EQUAL(ids.size(), 7)
+
 		//test DocumentIdentifier addition
 	TEST_STRING_EQUAL(exp.getLoadedFilePath(), OPENMS_GET_TEST_DATA_PATH("MSPFile_test.msp"));
   TEST_STRING_EQUAL(FileTypes::typeToName(exp.getLoadedFileType()),"msp");

--- a/src/tests/class_tests/openms/source/MzIdentMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MzIdentMLFile_test.cpp
@@ -54,6 +54,12 @@ START_SECTION(void load(const std::string& filename, std::vector<ProteinIdentifi
   TEST_EQUAL(protein_ids[0].getHits().size(),2)
   TEST_EQUAL(protein_ids[1].getHits().size(),1)
   TEST_EQUAL(peptide_ids.size(),5)
+
+  // loading again into the same containers must replace, not accumulate
+  // (regression: the DOM handler only appends; load() now clears first, matching IdXMLFile::load)
+  MzIdentMLFile().load(OPENMS_GET_TEST_DATA_PATH("MzIdentMLFile_msgf_mini.mzid"), protein_ids, peptide_ids);
+  TEST_EQUAL(protein_ids.size(),2)
+  TEST_EQUAL(peptide_ids.size(),5)
   TEST_EQUAL(peptide_ids[0].getHits().size(),1)
   TEST_EQUAL(peptide_ids[1].getHits().size(),1)
   TEST_EQUAL(peptide_ids[2].getHits().size(),1)


### PR DESCRIPTION
POLS audit fixes (#9488), systemic pattern: **`load()` clear-vs-append**. Both loaders appended to their output containers, so reusing a container across calls silently accumulated — inconsistent with the sibling identification loaders.

- **`MSPFile::load(filename, ids, exp)`** reset `exp` but only `push_back`'d onto `ids`. Now clears `ids` alongside `exp.reset()`. The 3-arg overload is only exercised by its own test (FileHandler uses `MSPGenericFile`), so no production caller is affected.
- **`MzIdentMLFile::load(filename, poid, peid)`** — the DOM handler only appends; now clears `poid`/`peid` first, matching **`IdXMLFile::load`** (which already clears) and `FileHandler::loadIdentifications`, which dispatches *both* loaders into the same containers. Since the canonical idXML path already clears, no caller could rely on cross-call accumulation for identifications.

### Tests
Regression tests added (load twice into the same containers → size unchanged). The full `MSPFile_test` and `MzIdentMLFile_test` suites pass locally — no reference files changed.

Part of #9488. ABI-safe (no signature changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data accumulation issue in file format loaders. Containers are now properly cleared before parsing, ensuring successive load operations produce clean results without accumulated data from previous calls.

* **Tests**
  * Added regression tests to verify container clearing behavior across multiple load operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->