### PR TITLE
COMPARISON: enforce binning compatibility and guard degenerate similarity scores

### DIFF
--- a/src/openms/include/OpenMS/COMPARISON/BinnedSharedPeakCount.h
+++ b/src/openms/include/OpenMS/COMPARISON/BinnedSharedPeakCount.h
@@ -52,7 +52,7 @@ public:
 
       @param[in] spec1 First spectrum given as a binned representation
       @param[in] spec2 Second spectrum given as a binned representation
-      @throw IncompatibleBinning is thrown if the binning of the two input spectra are not the same
+      @throw Exception::IllegalArgument is thrown if the binning of the two input spectra are not the same (different bin size, offset or unit)
     */
     double operator()(const BinnedSpectrum& spec1, const BinnedSpectrum& spec2) const override;
 

--- a/src/openms/include/OpenMS/COMPARISON/BinnedSpectralContrastAngle.h
+++ b/src/openms/include/OpenMS/COMPARISON/BinnedSpectralContrastAngle.h
@@ -50,7 +50,9 @@ public:
 
       @param[in] spec1 First spectrum given in a binned representation
       @param[in] spec2 Second spectrum given in a binned representation
-      @throw IncompatibleBinning is thrown if the bins of the spectra are not the same
+      @note In debug builds an OPENMS_PRECONDITION asserts that both spectra use the
+            same bin size and spread (see BinnedSpectrum::isCompatible). For an
+            empty / all-zero spectrum a defined score of 0 is returned.
     */
     double operator()(const BinnedSpectrum& spec1, const BinnedSpectrum& spec2) const override;
 

--- a/src/openms/source/COMPARISON/BinnedSharedPeakCount.cpp
+++ b/src/openms/source/COMPARISON/BinnedSharedPeakCount.cpp
@@ -49,7 +49,10 @@ namespace OpenMS
 
   double BinnedSharedPeakCount::operator()(const BinnedSpectrum& spec1, const BinnedSpectrum& spec2) const
   {
-    OPENMS_PRECONDITION(BinnedSpectrum::isCompatible(spec1, spec2), "Binned spectra have different bin size or spread");
+    if (!BinnedSpectrum::isCompatible(spec1, spec2))
+    {
+      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Binned spectra have different bin size or spread");
+    }
 
     size_t denominator(max(spec1.getBins()->nonZeros(), spec2.getBins()->nonZeros()));
 

--- a/src/openms/source/COMPARISON/BinnedSpectralContrastAngle.cpp
+++ b/src/openms/source/COMPARISON/BinnedSpectralContrastAngle.cpp
@@ -55,6 +55,14 @@ namespace OpenMS
     const double sum1 = spec1.getBins()->dot(*spec1.getBins());
     const double sum2 = spec2.getBins()->dot(*spec2.getBins());
     const double numerator = spec1.getBins()->dot(*spec2.getBins());
+
+    // guard against an empty / all-zero spectrum: sqrt(sum1 * sum2) would be 0
+    // and the division 0.0 / 0.0 would yield NaN. Return a defined score of 0.
+    if (sum1 * sum2 == 0.0)
+    {
+      return 0.0;
+    }
+
     const double score = numerator / (sqrt(sum1 * sum2));
 
     return score;

--- a/src/openms/source/COMPARISON/BinnedSumAgreeingIntensities.cpp
+++ b/src/openms/source/COMPARISON/BinnedSumAgreeingIntensities.cpp
@@ -49,7 +49,11 @@ namespace OpenMS
 
   double BinnedSumAgreeingIntensities::operator()(const BinnedSpectrum& spec1, const BinnedSpectrum& spec2) const
   {
-    OPENMS_PRECONDITION(BinnedSpectrum::isCompatible(spec1, spec2), "Binned spectra have different bin size or spread");
+    if (!BinnedSpectrum::isCompatible(spec1, spec2))
+    {
+      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "Binned spectra have different bin size or spread (incompatible binning)");
+    }
 
     const double sum1 = spec1.getBins()->sum();
     const double sum2 = spec2.getBins()->sum();

--- a/src/openms/source/COMPARISON/SpectraSTSimilarityScore.cpp
+++ b/src/openms/source/COMPARISON/SpectraSTSimilarityScore.cpp
@@ -102,7 +102,11 @@ namespace OpenMS
   {
     double numerator = (bin1.getBins()->cwiseProduct(*bin2.getBins())).norm();
     
-    if (dot_product != 0)
+    // dot_product <= 0 is the sentinel for "not supplied": recompute it.
+    // This covers the documented/default sentinel -1 as well as the legacy
+    // 0 value (which would otherwise divide by zero). A real dot product is
+    // non-negative, so only these degenerate sentinels take the recompute path.
+    if (dot_product > 0)
     {
       return (double)numerator / dot_product;
     }

--- a/src/tests/class_tests/openms/source/BinnedSharedPeakCount_test.cpp
+++ b/src/tests/class_tests/openms/source/BinnedSharedPeakCount_test.cpp
@@ -71,6 +71,10 @@ START_SECTION((double operator()(const BinnedSpectrum &spec1, const BinnedSpectr
   // compare to self
   score = (*ptr)(bs1, bs1);
   TEST_REAL_SIMILAR(score, 1)
+
+  // incompatible binning must throw (regression: the precondition was a no-op in release builds)
+  BinnedSpectrum bs3(s1, 2.0, false, 2, 0); // different bin size -> incompatible
+  TEST_EXCEPTION(Exception::IllegalArgument, (*ptr)(bs1, bs3))
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/BinnedSpectralContrastAngle_test.cpp
+++ b/src/tests/class_tests/openms/source/BinnedSpectralContrastAngle_test.cpp
@@ -67,6 +67,11 @@ START_SECTION((double operator()(const BinnedSpectrum &spec1, const BinnedSpectr
   BinnedSpectrum bs2 (s2, 1.5, false, 2, BinnedSpectrum::DEFAULT_BIN_OFFSET_LOWRES);
   double score = (*ptr)(bs1, bs2);
   TEST_REAL_SIMILAR(score,0.999985)
+
+  // empty / all-zero spectrum must yield a defined score of 0 (regression: was 0/0 = NaN)
+  PeakSpectrum empty_s;
+  BinnedSpectrum empty_bs(empty_s, 1.5, false, 2, BinnedSpectrum::DEFAULT_BIN_OFFSET_LOWRES);
+  TEST_REAL_SIMILAR((*ptr)(empty_bs, bs1), 0.0)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/BinnedSumAgreeingIntensities_test.cpp
+++ b/src/tests/class_tests/openms/source/BinnedSumAgreeingIntensities_test.cpp
@@ -71,6 +71,10 @@ START_SECTION((double operator()(const BinnedSpectrum &spec1, const BinnedSpectr
 
   score = (*ptr)(bs1, bs1);
   TEST_REAL_SIMILAR(score, 1.0)
+
+  // incompatible binning must throw (regression: the precondition was a no-op in release builds)
+  BinnedSpectrum bs3(s1, 2.0, false, 2, 0.0); // different bin size -> incompatible
+  TEST_EXCEPTION(Exception::IllegalArgument, (*ptr)(bs1, bs3))
 }
 END_SECTION
 


### PR DESCRIPTION
POLS audit fixes (#9488). The binned-spectrum comparators documented `@throw IncompatibleBinning` but only guarded with `OPENMS_PRECONDITION` (a **no-op in release builds**), so mismatched binning silently produced a garbage score. Behavior changes only on the previously-undefined degenerate path; valid (compatible) comparisons are unchanged.

- **`BinnedSharedPeakCount::operator()`**, **`BinnedSumAgreeingIntensities::operator()`** — precondition → `throw Exception::IllegalArgument` on incompatible binning.
- **`BinnedSpectralContrastAngle::operator()`** — guard `sqrt(sum1*sum2)==0` (empty/all-zero spectrum) → defined score `0` instead of `0/0 = NaN`.
- **`SpectraSTSimilarityScore::dot_bias()`** — the documented/default sentinel `dot_product=-1` now recomputes the dot product (was `if (dot_product != 0)`, which used `-1` as the divisor) and avoids divide-by-zero for the legacy `0` sentinel.

Doc comments corrected to name the real exception (the documented `IncompatibleBinning` doesn't exist). Regression tests added (incompatible binning throws; empty spectrum → 0); all four suites pass locally — no reference files changed.

Part of #9488. ABI-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for spectral binning compatibility—incompatible parameters now throw proper exceptions instead of failing silently in release builds
  * Fixed edge case where comparing empty or all-zero spectra produced undefined values

* **Documentation**
  * Updated API documentation to clarify exception behavior and edge-case handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->