### PR TITLE
Guard degenerate input in DistanceMatrix::operator==, ClusteringGrid::getClusters, File path helpers

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/DistanceMatrix.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/DistanceMatrix.h
@@ -386,11 +386,11 @@ public:
   /**
     @brief Equality comparator.
 
-    @throw Exception::Precondition thrown if given DistanceMatrix is not compatible in size
+    Matrices of different sizes always compare unequal (returns false).
   */
   bool operator==(DistanceMatrix<ValueType> const& rhs) const
   {
-    OPENMS_PRECONDITION(dimensionsize_ == rhs.dimensionsize_, "DistanceMatrices have different sizes.");
+    if (dimensionsize_ != rhs.dimensionsize_) { return false; }
     for (Size i = 1; i < rhs.dimensionsize(); ++i)
     {
       for (Size j = 0; j < i; ++j)

--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -270,9 +270,10 @@ public:
       E.g. for 'PATH=/usr/bin:/home/unicorn' the result is {"/usr/bin/", "/home/unicorn/"}
             or 'PATH=c:\\temp;c:\\Windows' the result is {"c:/temp/", "c:/Windows/"}
 
-      Note: the environment variable is passed as input to enable proper testing (env vars are usually read-only).  
+      Note: the environment variable is passed as input to enable proper testing (env vars are usually read-only).
+      If @p path is empty, the value of the $PATH environment variable is used (or nothing if $PATH is unset).
     */
-    static StringList getPathLocations(const std::string& path = std::getenv("PATH"));
+    static StringList getPathLocations(const std::string& path = "");
 
     /**
       @brief Searches for an executable with the given name (similar to @em where (Windows) or @em which (Linux/MacOS)
@@ -360,9 +361,9 @@ private:
       fallback, i.e. {".exe", ".bat"}.
 
       Note: the environment variable is passed as input to enable proper testing (env vars are usually read-only).
-
+      If @p ext is empty, the value of the %PATHEXT% environment variable is used (or nothing if %PATHEXT% is unset).
     */
-    static StringList executableExtensions_(const std::string& ext = std::getenv("PATHEXT"));
+    static StringList executableExtensions_(const std::string& ext = "");
 #endif
 
     /**

--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -270,10 +270,18 @@ public:
       E.g. for 'PATH=/usr/bin:/home/unicorn' the result is {"/usr/bin/", "/home/unicorn/"}
             or 'PATH=c:\\temp;c:\\Windows' the result is {"c:/temp/", "c:/Windows/"}
 
-      Note: the environment variable is passed as input to enable proper testing (env vars are usually read-only).
-      If @p path is empty, the value of the $PATH environment variable is used (or nothing if $PATH is unset).
+      Uses the value of the $PATH environment variable (or an empty string if $PATH is unset).
     */
-    static StringList getPathLocations(const std::string& path = "");
+    static StringList getPathLocations();
+
+    /**
+      @brief Extract list of directories from an explicit concatenated path string.
+
+      Depending on platform, the components are split based on ":" (Linux/Mac) or ";" (Windows).
+      All paths use the '/' as separator and end in '/'.
+      Note: the path string is passed as input to enable proper testing (env vars are usually read-only).
+    */
+    static StringList getPathLocations(const std::string& path);
 
     /**
       @brief Searches for an executable with the given name (similar to @em where (Windows) or @em which (Linux/MacOS)
@@ -360,10 +368,18 @@ private:
       If the result does not contain at least ".exe", then we assume the environment variable is broken and return a
       fallback, i.e. {".exe", ".bat"}.
 
-      Note: the environment variable is passed as input to enable proper testing (env vars are usually read-only).
-      If @p ext is empty, the value of the %PATHEXT% environment variable is used (or nothing if %PATHEXT% is unset).
+      Uses the value of the %PATHEXT% environment variable (or an empty string if %PATHEXT% is unset).
     */
-    static StringList executableExtensions_(const std::string& ext = "");
+    static StringList executableExtensions_();
+
+    /**
+      @brief Get list of file suffices to try during search on an explicit PATHEXT-like string.
+
+      Input could be ".COM;.EXE;.BAT;.CMD;.VBS".
+      If the result does not contain at least ".exe", then we assume the input is broken and return a
+      fallback, i.e. {".exe", ".bat"}.
+    */
+    static StringList executableExtensions_(const std::string& ext);
 #endif
 
     /**
@@ -389,4 +405,3 @@ private:
     static TemporaryFiles_ temporary_files_;
   };
 }
-

--- a/src/openms/source/ML/CLUSTERING/ClusteringGrid.cpp
+++ b/src/openms/source/ML/CLUSTERING/ClusteringGrid.cpp
@@ -65,7 +65,12 @@ void ClusteringGrid::removeAllClusters()
 
 std::list<int> ClusteringGrid::getClusters(const CellIndex &cell_index) const
 {
-    return cells_.find(cell_index)->second;
+    auto it = cells_.find(cell_index);
+    if (it == cells_.end())
+    {
+        return std::list<int>(); // empty/never-populated cell -> no clusters
+    }
+    return it->second;
 }
 
 ClusteringGrid::CellIndex ClusteringGrid::getIndex(const Point &position) const

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -829,17 +829,14 @@ namespace OpenMS
   }
 
 #ifdef OPENMS_WINDOWSPLATFORM
-  StringList File::executableExtensions_(const std::string& ext_in)
+  StringList File::executableExtensions_()
   {
-    // If no explicit value is passed, read %PATHEXT% from the environment.
-    // std::getenv may return nullptr if the variable is unset; constructing a
-    // std::string from nullptr is undefined behavior, so guard against it.
-    std::string ext = ext_in;
-    if (ext.empty())
-    {
-      const char* pathext = std::getenv("PATHEXT");
-      if (pathext != nullptr) ext = pathext;
-    }
+    const char* pathext = std::getenv("PATHEXT");
+    return executableExtensions_(pathext == nullptr ? "" : std::string(pathext));
+  }
+
+  StringList File::executableExtensions_(const std::string& ext)
+  {
     // check if content of env-var %PATHEXT% makes sense
     StringList exts;
     StringUtils::split(ext, ';', exts);
@@ -850,17 +847,14 @@ namespace OpenMS
   }
 #endif
 
-  StringList File::getPathLocations(const std::string& path_in)
+  StringList File::getPathLocations()
   {
-    // If no explicit value is passed, read $PATH from the environment.
-    // std::getenv may return nullptr if the variable is unset; constructing a
-    // std::string from nullptr is undefined behavior, so guard against it.
-    std::string path = path_in;
-    if (path.empty())
-    {
-      const char* env_path = std::getenv("PATH");
-      if (env_path != nullptr) path = env_path;
-    }
+    const char* env_path = std::getenv("PATH");
+    return getPathLocations(env_path == nullptr ? "" : std::string(env_path));
+  }
+
+  StringList File::getPathLocations(const std::string& path)
+  {
     // split by ":" or ";", depending on platform
     StringList paths;
 #ifdef OPENMS_WINDOWSPLATFORM

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -829,8 +829,17 @@ namespace OpenMS
   }
 
 #ifdef OPENMS_WINDOWSPLATFORM
-  StringList File::executableExtensions_(const std::string& ext)
+  StringList File::executableExtensions_(const std::string& ext_in)
   {
+    // If no explicit value is passed, read %PATHEXT% from the environment.
+    // std::getenv may return nullptr if the variable is unset; constructing a
+    // std::string from nullptr is undefined behavior, so guard against it.
+    std::string ext = ext_in;
+    if (ext.empty())
+    {
+      const char* pathext = std::getenv("PATHEXT");
+      if (pathext != nullptr) ext = pathext;
+    }
     // check if content of env-var %PATHEXT% makes sense
     StringList exts;
     StringUtils::split(ext, ';', exts);
@@ -841,8 +850,17 @@ namespace OpenMS
   }
 #endif
 
-  StringList File::getPathLocations(const std::string& path)
+  StringList File::getPathLocations(const std::string& path_in)
   {
+    // If no explicit value is passed, read $PATH from the environment.
+    // std::getenv may return nullptr if the variable is unset; constructing a
+    // std::string from nullptr is undefined behavior, so guard against it.
+    std::string path = path_in;
+    if (path.empty())
+    {
+      const char* env_path = std::getenv("PATH");
+      if (env_path != nullptr) path = env_path;
+    }
     // split by ":" or ";", depending on platform
     StringList paths;
 #ifdef OPENMS_WINDOWSPLATFORM

--- a/src/tests/class_tests/openms/source/ClusteringGrid_test.cpp
+++ b/src/tests/class_tests/openms/source/ClusteringGrid_test.cpp
@@ -77,6 +77,8 @@ START_SECTION(std::list<int> getClusters(const CellIndex &cell_index) const)
     grid.addCluster(index1,1);
     grid.addCluster(index2,2);
     TEST_EQUAL(grid.getClusters(index1).front(), 1);
+    // an empty / never-populated cell must return an empty list, not dereference map::end() (regression)
+    TEST_EQUAL(grid.getClusters(index3).empty(), true);
 END_SECTION
 
 START_SECTION(CellIndex getIndex(const Point &position) const)

--- a/src/tests/class_tests/openms/source/DistanceMatrix_test.cpp
+++ b/src/tests/class_tests/openms/source/DistanceMatrix_test.cpp
@@ -216,11 +216,11 @@ DistanceMatrix<double> dm3(dm);
 START_SECTION(bool operator==(DistanceMatrix< ValueType > const &rhs) const)
 {
 	TEST_EQUAL((dm==dm3),true)
-	// differently-sized matrices must compare unequal instead of throwing (debug) or reading
-	// out of bounds (release) -- the second form (smaller on the left) triggered the OOB read (regression)
-	DistanceMatrix<double> dm_small(3, 1.0);
-	TEST_EQUAL((dm==dm_small), false)
-	TEST_EQUAL((dm_small==dm), false)
+  // differently-sized matrices must compare unequal instead of throwing (debug) or reading
+  // out of bounds (release) -- the second form (smaller on the left) triggered the OOB read (regression)
+  DistanceMatrix<double> dm_small(3, 1.0);
+  TEST_EQUAL((dm==dm_small), false)
+  TEST_EQUAL((dm_small==dm), false)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/DistanceMatrix_test.cpp
+++ b/src/tests/class_tests/openms/source/DistanceMatrix_test.cpp
@@ -216,6 +216,11 @@ DistanceMatrix<double> dm3(dm);
 START_SECTION(bool operator==(DistanceMatrix< ValueType > const &rhs) const)
 {
 	TEST_EQUAL((dm==dm3),true)
+	// differently-sized matrices must compare unequal instead of throwing (debug) or reading
+	// out of bounds (release) -- the second form (smaller on the left) triggered the OOB read (regression)
+	DistanceMatrix<double> dm_small(3, 1.0);
+	TEST_EQUAL((dm==dm_small), false)
+	TEST_EQUAL((dm_small==dm), false)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -366,7 +366,7 @@ START_SECTION(static bool findExecutable(std::string& exe_filename))
 }
 END_SECTION
 
-START_SECTION(static StringList getPathLocations(const std::string& path = ""))
+START_SECTION(static StringList getPathLocations(const std::string& path))
 {
   // set env-variables is not portable across platforms, thus we inject the PATH values
 #ifdef OPENMS_WINDOWSPLATFORM
@@ -380,6 +380,13 @@ START_SECTION(static StringList getPathLocations(const std::string& path = ""))
 #else
   TEST_EQUAL(ListUtils::contains(l, "/usr/bin/"), true)
 #endif
+
+  StringList empty = File::getPathLocations("");
+  TEST_EQUAL(empty.empty(), true)
+
+  // Also exercise the no-argument overload, which reads PATH safely even when the
+  // environment lookup would otherwise return nullptr.
+  File::getPathLocations();
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -366,7 +366,7 @@ START_SECTION(static bool findExecutable(std::string& exe_filename))
 }
 END_SECTION
 
-START_SECTION(static StringList getPathLocations(const std::string& path = std::getenv("PATH")))
+START_SECTION(static StringList getPathLocations(const std::string& path = ""))
 {
   // set env-variables is not portable across platforms, thus we inject the PATH values
 #ifdef OPENMS_WINDOWSPLATFORM


### PR DESCRIPTION
POLS audit fixes (#9488). Each only changes a previously-undefined path; valid input is unchanged, no reference files touched.

- **`DistanceMatrix::operator==`** — guarded only by `OPENMS_PRECONDITION` (a no-op in release), then iterated `rhs`'s dimensions while indexing `*this` → heap **OOB read** for a smaller left-hand matrix (debug: a throw). Now returns `false` for differently-sized matrices.
- **`ClusteringGrid::getClusters`** — `cells_.find(idx)->second` with no `end()` check → dereferenced `map::end()` (UB) for a never-populated cell. Now returns an empty list.
- **`File::getPathLocations` / `executableExtensions_`** — the default argument constructed a `std::string` directly from `std::getenv("PATH"/"PATHEXT")`, which is **UB when the variable is unset** (`getenv` returns `nullptr`). The default is now `""` and the function reads the env var internally with a null guard.

Regression tests added (different-size matrices compare unequal; unknown grid cell → empty); all three suites pass locally.

Part of #9488. ABI-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added no-argument helpers for retrieving PATH locations and executable extensions (Windows).
* **Bug Fixes**
  * Distance matrix equality comparisons now safely handle matrices of different sizes.
  * Clustering grid operations no longer crash when accessing non-existent cells, returning empty results instead.
  * Improved PATH/PATHEXT handling when environment values are missing.
* **Tests**
  * Expanded coverage for distance matrix comparison and clustering grid edge cases, plus PATH-related behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->