### PR TITLE
ANALYSIS: out-of-bounds AA(char), invalid iTRAQ reference channel, missing-file SWATH windows

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/AhoCorasickAmbiguous.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AhoCorasickAmbiguous.h
@@ -58,8 +58,9 @@ namespace OpenMS
     '?', // 27 invalid AA (will usually be skipped) -- must be the last AA (AA::operator++ and others rely on it)
   };
 
-  /// Conversion table from 7-bit ASCII char to internal value representation for an amino acid (AA)
-  constexpr char const CharToAA[128] = {
+  /// Conversion table from a full 8-bit byte (unsigned char 0..255) to internal value representation for an amino acid (AA).
+  /// Indices 0..127 cover 7-bit ASCII; indices 128..255 (extended/non-ASCII bytes) all map to 27, the invalid AA ('?').
+  constexpr char const CharToAA[256] = {
     // ASCII char (7-bit Int with values from 0..127) --> amino acid 
     27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, // 0
     27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, // 1
@@ -78,6 +79,16 @@ namespace OpenMS
 
   // p,  q,  r,  s,  t,  u,  v,  w,  x,  y,  z,   ,   ,   ,   ,   ,
     14, 16, 17, 18, 19, 20, 21, 11, 25, 01, 24, 27, 27, 27, 27, 27, // 7
+
+    // bytes 128..255 (high bit set: extended ASCII / UTF-8 continuation bytes) --> invalid AA ('?')
+    27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, // 8
+    27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, // 9
+    27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, // 10
+    27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, // 11
+    27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, // 12
+    27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, // 13
+    27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, // 14
+    27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, // 15
   };
 
   /// Represents a needle found in the query.

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/SwathWindowLoader.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/SwathWindowLoader.h
@@ -99,15 +99,15 @@ window_lower window_upper
       data. No specific header text is required.
 
       @param[in]  filename         Path of the SWATH-window file. A
-                                   missing or unreadable file is not
-                                   reported as an exception; the output
-                                   vectors are left empty.
+                                   missing or unreadable file throws
+                                   Exception::FileNotFound.
       @param[out] swath_prec_lower Lower boundary of each window, in file
                                    order.
       @param[out] swath_prec_upper Upper boundary of each window, in file
                                    order; same length as
                                    @p swath_prec_lower.
 
+      @throws Exception::FileNotFound if @p filename is missing or unreadable.
       @throws Exception::InvalidValue if a row has @c lower >= @c upper.
     */
     static void readSwathWindows(const std::string& filename,

--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/ItraqEightPlexQuantitationMethod.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/ItraqEightPlexQuantitationMethod.h
@@ -60,6 +60,7 @@ public:
     void setDefaultParams_();
 
     /// implemented for DefaultParamHandler
+    /// @throw Exception::InvalidParameter if the 'reference_channel' parameter is not a valid 8-plex channel (valid: 113-119, 121; 120 is not a valid channel)
     void updateMembers_() override;
   };
 } // namespace

--- a/src/openms/source/ANALYSIS/OPENSWATH/SwathWindowLoader.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/SwathWindowLoader.cpp
@@ -91,6 +91,10 @@ namespace OpenMS
     std::vector<double> & swath_prec_upper_ )
   {
     std::ifstream data(filename.c_str());
+    if (!data)
+    {
+      throw Exception::FileNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
+    }
     std::string line;
     std::vector<std::string> headerSubstrings;
     double lower, upper;

--- a/src/openms/source/ANALYSIS/QUANTITATION/ItraqEightPlexQuantitationMethod.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/ItraqEightPlexQuantitationMethod.cpp
@@ -10,6 +10,7 @@
 
 #include <OpenMS/DATASTRUCTURES/Matrix.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 
 namespace OpenMS
@@ -114,7 +115,8 @@ namespace OpenMS
     }
     else if (ref_ch == 120)
     {
-      OPENMS_LOG_WARN << "Invalid channel selection." << std::endl;
+      throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "ItraqEightPlexQuantitationMethod: 'reference_channel' value 120 is not a valid channel for the 8-plex method (valid: 113-119, 121).");
     }
     else
     {

--- a/src/tests/class_tests/openms/source/AhoCorasickAmbiguous_test.cpp
+++ b/src/tests/class_tests/openms/source/AhoCorasickAmbiguous_test.cpp
@@ -429,6 +429,11 @@ START_SECTION(constexpr AA())
   static_assert(!AA('*').isValidForPeptide());
   static_assert(!AA('3').isValidForPeptide());
   static_assert(!AA('#').isValidForPeptide());
+
+  // extended / non-ASCII bytes (>= 128) must map to the invalid AA, not read past the table
+  // (regression: CharToAA used to have only 128 entries while AA(char) indexes it with 0..255)
+  static_assert(!AA((char)200).isValid());
+  static_assert(!AA((char)255).isValid());
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ItraqEightPlexQuantitationMethod_test.cpp
+++ b/src/tests/class_tests/openms/source/ItraqEightPlexQuantitationMethod_test.cpp
@@ -154,6 +154,11 @@ START_SECTION((Size getReferenceChannel() const ))
   quant_meth.setParameters(p);
 
   TEST_EQUAL(quant_meth.getReferenceChannel(), 7)
+
+  // 120 is within the accepted parameter range but is not a valid 8-plex channel:
+  // it must throw instead of warning and leaving a stale reference channel (regression)
+  p.setValue("reference_channel",120);
+  TEST_EXCEPTION(Exception::InvalidParameter, quant_meth.setParameters(p))
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/SwathWindowLoader_test.cpp
+++ b/src/tests/class_tests/openms/source/SwathWindowLoader_test.cpp
@@ -43,6 +43,9 @@ START_SECTION( static void readSwathWindows(const std::string& filename, std::ve
   std::vector<double> swath_prec_upper;
   SwathWindowLoader::readSwathWindows(OPENMS_GET_TEST_DATA_PATH("SwathWindowFile.txt"), swath_prec_lower, swath_prec_upper);
 
+  // a missing/unreadable file must throw instead of silently returning / undefined behavior (regression)
+  TEST_EXCEPTION(Exception::FileNotFound, SwathWindowLoader::readSwathWindows("/does/not/exist_swath_windows.txt", swath_prec_lower, swath_prec_upper))
+
   TEST_EQUAL(swath_prec_lower.size(), swath_prec_upper.size())
   TEST_REAL_SIMILAR(swath_prec_lower[0], 400)
   TEST_REAL_SIMILAR(swath_prec_lower[1], 425)


### PR DESCRIPTION
POLS audit fixes (#9488). Each only affects a previously-undefined/invalid path; valid input unchanged.

- **`AhoCorasick AA(const char)`** — `CharToAA` had 128 entries but `AA(char)` indexes it with `(unsigned char)c` (0..255), so any extended/non-ASCII byte read **past the array** (UB). `CharToAA` is now 256 entries; bytes 128..255 map to the invalid AA.
- **`ItraqEightPlexQuantitationMethod::updateMembers_`** — `reference_channel=120` is inside the accepted parameter range but is **not** a valid 8-plex channel; it only logged a warning and left a stale reference channel. Now throws `Exception::InvalidParameter`.
- **`SwathWindowLoader::readSwathWindows`** — opened the `ifstream` with no state check, so a missing/unreadable file led to **UB** (indexing an empty split result). Now throws `Exception::FileNotFound`.

Regression tests added for all three; suites pass locally.

Part of #9488. ABI-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Missing/unreadable SWATH window files now raise a clear file-not-found error.
  * Invalid reference channel for the 8-plex quantitation method now raises an error instead of a warning.
  * Extended/non-ASCII bytes are safely treated as invalid in amino-acid lookups to prevent out-of-bounds access.

* **Documentation**
  * API docs updated to state the new error behaviors.

* **Tests**
  * Added regression tests covering these behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->