### PR TITLE
StringUtils: make prefix/suffix(char) return whole string when delimiter absent

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/StringUtils.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/StringUtils.h
@@ -500,15 +500,21 @@ namespace OpenMS
       return suffix(s, static_cast<size_t>(length));
     }
 
-    /// Returns the part of @p s before the first occurrence of @p delim (excluding it).
-    /// If @p delim is not contained in @p s, the whole string is returned.
+    /**
+      @brief Returns the part of @p s before the first occurrence of @p delim (excluding it).
+
+      If @p delim is not contained in @p s, the whole string is returned.
+    */
     inline std::string prefix(const std::string& s, char delim)
     {
       return s.substr(0, s.find(delim)); // find() returns npos if absent -> substr(0, npos) -> whole string
     }
 
-    /// Returns the part of @p s after the last occurrence of @p delim (excluding it).
-    /// If @p delim is not contained in @p s, the whole string is returned.
+    /**
+      @brief Returns the part of @p s after the last occurrence of @p delim (excluding it).
+
+      If @p delim is not contained in @p s, the whole string is returned.
+    */
     inline std::string suffix(const std::string& s, char delim)
     {
       size_t pos = s.rfind(delim);

--- a/src/openms/include/OpenMS/DATASTRUCTURES/StringUtils.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/StringUtils.h
@@ -500,20 +500,19 @@ namespace OpenMS
       return suffix(s, static_cast<size_t>(length));
     }
 
+    /// Returns the part of @p s before the first occurrence of @p delim (excluding it).
+    /// If @p delim is not contained in @p s, the whole string is returned.
     inline std::string prefix(const std::string& s, char delim)
     {
-      size_t pos = s.find(delim);
-      if (pos == std::string::npos)
-        throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, std::string(1, delim));
-      return s.substr(0, pos);
+      return s.substr(0, s.find(delim)); // find() returns npos if absent -> substr(0, npos) -> whole string
     }
 
+    /// Returns the part of @p s after the last occurrence of @p delim (excluding it).
+    /// If @p delim is not contained in @p s, the whole string is returned.
     inline std::string suffix(const std::string& s, char delim)
     {
       size_t pos = s.rfind(delim);
-      if (pos == std::string::npos)
-        throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, std::string(1, delim));
-      return s.substr(pos + 1);
+      return pos == std::string::npos ? s : s.substr(pos + 1);
     }
 
     /// Wrapper around std::string::substr; clamps @p pos to [0, size]

--- a/src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp
@@ -986,15 +986,18 @@ namespace OpenMS
         OpenMS::Feature f;
         f.setUniqueId();
 
-        // parse the identifier
+        // parse the identifier: the PeptideRef is the part before the first '_'.
+        // If there is no '_', leave the PeptideRef empty (as before) rather than
+        // silently using the whole identifier (StringUtils::prefix no longer throws
+        // when the delimiter is absent).
         std::string id_f;
-        try
+        if (f_map.first.find('_') != std::string::npos)
         {
           id_f = StringUtils::prefix(f_map.first, '_');
         }
-        catch (const std::exception& e)
+        else
         {
-          OPENMS_LOG_ERROR << e.what();
+          OPENMS_LOG_ERROR << "Identifier '" << f_map.first << "' has no '_' separator; PeptideRef left empty." << std::endl;
         }
         f.setMetaValue("PeptideRef", id_f);
         f.setMZ(m);

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -2037,6 +2037,16 @@ namespace OpenMS
 
   bool TOPPBase::parseRange_(const std::string& text, double& low, double& high) const
   {
+    // The documented range syntax is "[min]:[max]"; the ':' separator is mandatory.
+    // Without it the input is malformed: since StringUtils::prefix/suffix(.,':') now
+    // return the whole string when the delimiter is absent, a colon-less "400" would
+    // otherwise be silently misread as the degenerate range 400:400. Fail loudly instead.
+    if (text.find(':') == std::string::npos)
+    {
+      throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                       "Invalid range '" + text + "': expected format '[min]:[max]' (the ':' separator is missing)");
+    }
+
     bool any_set = false;
     try
     {
@@ -2065,6 +2075,16 @@ namespace OpenMS
 
   bool TOPPBase::parseRange_(const std::string& text, Int& low, Int& high) const
   {
+    // The documented range syntax is "[min]:[max]"; the ':' separator is mandatory.
+    // Without it the input is malformed: since StringUtils::prefix/suffix(.,':') now
+    // return the whole string when the delimiter is absent, a colon-less "400" would
+    // otherwise be silently misread as the degenerate range 400:400. Fail loudly instead.
+    if (text.find(':') == std::string::npos)
+    {
+      throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                       "Invalid range '" + text + "': expected format '[min]:[max]' (the ':' separator is missing)");
+    }
+
     bool any_set = false;
     try
     {

--- a/src/openms/source/CHEMISTRY/RibonucleotideTSVDataProvider.cpp
+++ b/src/openms/source/CHEMISTRY/RibonucleotideTSVDataProvider.cpp
@@ -106,6 +106,15 @@ namespace OpenMS
             std::string msg = "10th field expected for ambiguous modification in line " + StringUtils::toStr(line_count);
             throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, row, msg);
           }
+          // the 10th field must hold two space-separated alternative codes; without the
+          // space the entry is malformed. Guard explicitly: StringUtils::prefix/suffix no
+          // longer throw on a missing ' ', so an unguarded split would silently set both
+          // alternatives to the same single value instead of skipping the bad row.
+          if (parts[9].find(' ') == std::string::npos)
+          {
+            std::string msg = "two space-separated alternative codes expected in 10th field for ambiguous modification in line " + StringUtils::toStr(line_count);
+            throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, row, msg);
+          }
           std::string code1 = StringUtils::prefix(parts[9], ' '), code2 = StringUtils::suffix(parts[9], ' ');
           entry.alternative_code_1 = code1;
           entry.alternative_code_2 = code2;

--- a/src/openms/source/FORMAT/FileHandler.cpp
+++ b/src/openms/source/FORMAT/FileHandler.cpp
@@ -268,12 +268,7 @@ namespace OpenMS
     {
       return FileTypes::SPECXML;
     }
-    try
-    {
-      tmp = StringUtils::suffix(basename, '.');
-    }
-    // no '.' => unknown type
-    catch (Exception::ElementNotFound&)
+    if (!StringUtils::has(basename, '.')) // no '.' => unknown type
     {
       // last chance, Bruker fid file
       if (basename == "fid")
@@ -282,6 +277,7 @@ namespace OpenMS
       }
       return FileTypes::UNKNOWN;
     }
+    tmp = StringUtils::suffix(basename, '.');
     StringUtils::toUpper(tmp);
     if (tmp == "BZ2" || tmp == "GZ" || tmp == "ZIP")
     {

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/ImageCreator.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/ImageCreator.cpp
@@ -235,14 +235,7 @@ protected:
     std::string format = getStringOption_("out_type");
     if (StringUtils::trim(format).empty()) // get from filename
     {
-      try
-      {
-        format = StringUtils::suffix(out, '.');
-      }
-      catch (Exception::ElementNotFound& /*e*/)
-      {
-        format = "nosuffix";
-      }
+      format = StringUtils::has(out, '.') ? StringUtils::suffix(out, '.') : "nosuffix";
       if (!ListUtils::contains(out_formats_, StringUtils::toLower(format)))
       {
         OPENMS_LOG_ERROR << "No explicit image output format was provided via 'out_type', and the suffix ('" << format << "') does not resemble a valid type. Please fix one of them." << std::endl;

--- a/src/tests/class_tests/openms/source/String_test.cpp
+++ b/src/tests/class_tests/openms/source/String_test.cpp
@@ -263,13 +263,13 @@ END_SECTION
 START_SECTION((StringUtils::prefix(char delim)))
   TEST_EQUAL(StringUtils::prefix(s, 'F'), "ACDE")
   TEST_EQUAL(StringUtils::prefix(s, 'A'), "")
-  TEST_EXCEPTION(Exception::ElementNotFound, StringUtils::prefix(s, 'Z'))
+  TEST_EQUAL(StringUtils::prefix(s, 'Z'), s) // delimiter absent -> whole string
 END_SECTION
 
 START_SECTION((StringUtils::suffix(char delim)))
   TEST_EQUAL(StringUtils::suffix(s, 'S'), "TVWY")
   TEST_EQUAL(StringUtils::suffix(s, 'Y'), "")
-  TEST_EXCEPTION(Exception::ElementNotFound, StringUtils::suffix(s, 'Z'))
+  TEST_EQUAL(StringUtils::suffix(s, 'Z'), s) // delimiter absent -> whole string
 END_SECTION
 
 START_SECTION((StringUtils::substr))

--- a/src/tests/class_tests/openms/source/TOPPBase_test.cpp
+++ b/src/tests/class_tests/openms/source/TOPPBase_test.cpp
@@ -705,6 +705,11 @@ START_SECTION(([EXTRA]void parseRange_(const std::string& text, double& low, dou
 	TEST_REAL_SIMILAR(a, 6.5);
 	TEST_REAL_SIMILAR(b, 7.5);
   TEST_EQUAL(result, true);
+
+  // a colon-less range string is malformed (documented format is "[min]:[max]") and must
+  // fail loudly, not be silently interpreted as the degenerate range value:value
+  s = "400";
+  TEST_EXCEPTION(Exception::ConversionError, topp.parseRange(s, a, b));
 }
 END_SECTION
 

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -733,9 +733,9 @@ protected:
           int scan_number = 0;
           if ((elements[2].empty()) || (elements[2] == "-1"))
           {
-            // SpecID may be "controllerType=0 controllerNumber=1 scan=17"; extract the value after the last '='
-            auto eq_pos = elements[1].rfind('=');
-            scan_number = StringUtils::toInt32(eq_pos != std::string::npos ? elements[1].substr(eq_pos + 1) : elements[1]);
+            // SpecID may be "controllerType=0 controllerNumber=1 scan=17"; take the value after the last '='
+            // (suffix() now returns the whole string when '=' is absent, matching develop's previous ternary)
+            scan_number = StringUtils::toInt32(StringUtils::suffix(elements[1], '='));
           }
           else
           {


### PR DESCRIPTION
prefix(s, delim) and suffix(s, delim) previously threw Exception::ElementNotFound
when the delimiter was not present. Throwing a container-lookup exception from a
string-slicing helper is surprising and forced callers to either guard every call
or wrap it in try/catch.

Now the missing-delimiter case returns the whole string ("nothing to cut off ->
you get the original back"), giving a simple, symmetric, no-surprises contract.
This does not change behavior for any valid input (a valid delimiter is always present).

Call sites that relied on the old throw as control flow were updated explicitly, so the
lenient contract does not silently change their behavior on malformed input:
- FileHandler::getTypeByFileName: explicit has('.') guard (preserves Bruker
  fid -> XMASS and UNKNOWN handling).
- ImageCreator: explicit has('.') guard (preserves "nosuffix" fallback).
- TOPPBase::parseRange_: now requires the documented "[min]:[max]" separator and throws
  ConversionError when ':' is missing, instead of silently reading "400" as the degenerate
  range 400:400 (affects FileFilter, IDFilter, DTAExtractor, CometAdapter, ImageCreator).
- RibonucleotideTSVDataProvider::parseRow_: a malformed ambiguity entry (10th field without
  the space separator) throws ParseError and the row is skipped, as before, instead of
  duplicating the single value into both alternative codes.
- TargetedSpectraExtractor: an identifier without '_' leaves PeptideRef empty (as the
  previous throw-and-catch did) rather than using the whole identifier.

MSGFPlusAdapter was also switched to the lenient suffix('=') for scan-number extraction;
this is equivalent to (and replaces) the rfind('=') ternary already on develop, so it is a
cosmetic refactor with no behavior change. Updated String_test and TOPPBase_test accordingly.

https://claude.ai/code/session_01TzmuvTWtGMmc5hhH8kXK7Y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * String utilities now return the original string when a requested character delimiter is missing (instead of raising an error).
  * Filenames without an extension are now consistently treated as unknown file type.
  * Image output format detection and scan number parsing are now more robust when expected separators/delimiters are absent.
  * Range parsing now validates the required `min:max` format and errors when the `:` separator is missing.
* **Tests**
  * Updated and extended tests to cover delimiter-absent and colon-missing range inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
