### PR TITLE
fix: add --mkpath to rsync for KNIME nightly update site upload

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -867,7 +867,7 @@ jobs:
           mkdir -p ~/.ssh/
           echo "$PASS" > ~/.ssh/private.key
           sudo chmod 600 ~/.ssh/private.key
-          rsync --progress -avz -e "ssh -i ~/.ssh/private.key -p $PORT -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/de.openms.update/target/repository/* "$USER@$HOST:/knime-plugin/updateSite/$folder/"
+          rsync --progress -avz --mkpath -e "ssh -i ~/.ssh/private.key -p $PORT -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/de.openms.update/target/repository/* "$USER@$HOST:/knime-plugin/updateSite/$folder/"
 
       - name: Make KNIME installer latest
         if: inputs.mark_as_latest


### PR DESCRIPTION
## Summary

The nightly CI has been failing consistently since at least June 4 in the `build-deploy-knime-updatesite` job with:

```
rsync: [Receiver] mkdir "/srv/files/openms/knime-plugin/updateSite/nightly" failed: No such file or directory (2)
rsync error: error in file IO (code 11) at main.c(800) [Receiver=3.2.7]
```

The destination directory `/knime-plugin/updateSite/nightly` does not exist on the remote server. rsync does not create missing destination directories by default.

## Fix

Add `--mkpath` to the rsync command in the "Upload KNIME update site" step. This flag (introduced in rsync 3.2.3) instructs rsync to create all missing destination path components. The remote server is already running rsync 3.2.7, so this is fully supported.

The other rsync-based upload jobs (`deploy-installer`, `deploy-docs`) were not affected — their target directories already exist on the server.

https://claude.ai/code/session_01J17NGHd7XZaDJyVq9S6aqs

---
_Generated by [Claude Code](https://claude.ai/code/session_01J17NGHd7XZaDJyVq9S6aqs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment reliability for software updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->