### PR TITLE
pyOpenMS wheels: upload built wheels to archive.openms.de

### DIFF
--- a/.github/workflows/pyopenms-wheels-cibuildwheel.yml
+++ b/.github/workflows/pyopenms-wheels-cibuildwheel.yml
@@ -554,14 +554,21 @@ jobs:
           USER: ${{ secrets.ARCHIVE_RRSYNC_USER }}
           HOST: ${{ secrets.ARCHIVE_RRSYNC_HOST }}
           PORT: ${{ secrets.ARCHIVE_RRSYNC_PORT }}
+          # Pass interpolations through env (GITHUB_REF/GITHUB_REF_NAME are runner
+          # built-ins) so they are never expanded into the shell script directly.
+          PYOPENMS_VERSION: ${{ needs.setup.outputs.pyopenms-version }}
         run: |
-          # Pick destination folder mirroring the OpenMSInstaller/Documentation layout
-          if [[ "${{ github.ref }}" == refs/tags/Release* ]]; then
-            folder="release/${{ needs.setup.outputs.pyopenms-version }}"
-          elif [[ "${{ github.ref_name }}" == "nightly" ]]; then
+          # Pick destination folder mirroring the OpenMSInstaller/Documentation layout.
+          # Sanitize externally-influenced values with a strict whitelist before
+          # using them in a path (branch/tag names may contain shell metacharacters).
+          sanitize() { printf '%s' "${1//[^a-zA-Z0-9._-]/_}"; }
+
+          if [[ "$GITHUB_REF" == refs/tags/Release* ]]; then
+            folder="release/$(sanitize "$PYOPENMS_VERSION")"
+          elif [[ "$GITHUB_REF_NAME" == "nightly" ]]; then
             folder=nightly
           else
-            folder="experimental/${{ github.ref_name }}"
+            folder="experimental/$(sanitize "$GITHUB_REF_NAME")"
           fi
           echo "Uploading wheels to: $folder"
 

--- a/.github/workflows/pyopenms-wheels-cibuildwheel.yml
+++ b/.github/workflows/pyopenms-wheels-cibuildwheel.yml
@@ -531,3 +531,41 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
+
+  publish-archive-openms:
+    name: Upload wheels to archive.openms.de
+    needs: [setup, test-wheels]
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' &&
+        (startsWith(github.ref, 'refs/heads/nightly') || startsWith(github.ref, 'refs/tags/Release')))
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist/
+
+      - name: Upload wheels to archive
+        shell: bash
+        env:
+          PASS: ${{ secrets.ARCHIVE_RRSYNC_SSH }}
+          USER: ${{ secrets.ARCHIVE_RRSYNC_USER }}
+          HOST: ${{ secrets.ARCHIVE_RRSYNC_HOST }}
+          PORT: ${{ secrets.ARCHIVE_RRSYNC_PORT }}
+        run: |
+          # Pick destination folder mirroring the OpenMSInstaller/Documentation layout
+          if [[ "${{ github.ref }}" == refs/tags/Release* ]]; then
+            folder="release/${{ needs.setup.outputs.pyopenms-version }}"
+          elif [[ "${{ github.ref_name }}" == "nightly" ]]; then
+            folder=nightly
+          else
+            folder="experimental/${{ github.ref_name }}"
+          fi
+          echo "Uploading wheels to: $folder"
+
+          mkdir -p ~/.ssh/
+          echo "$PASS" > ~/.ssh/private.key
+          chmod 600 ~/.ssh/private.key
+          rsync --progress -avz -e "ssh -i ~/.ssh/private.key -p $PORT -o StrictHostKeyChecking=no" dist/*.whl "$USER@$HOST:/pyopenms/${folder}/"


### PR DESCRIPTION
Add a publish-archive-openms job to the cibuildwheel workflow that
rsyncs the built wheels to our archive after the test stage passes,
reusing the existing ARCHIVE_RRSYNC_* SSH secrets and the
nightly/release/experimental folder convention already used for the
installer and documentation uploads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated publishing step to archive built wheel artifacts to the external archive site after wheel tests complete.
  * Upload destinations are selected automatically for release tags vs nightly builds, with path sanitization to ensure safe remote paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->