### PR TITLE
fix: update Windows CI to Visual Studio 18 2026 (windows-2025 runner update)

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -49,7 +49,7 @@ runs:
         if (-not $NPROC) { $NPROC = 4 }
         $env:CMAKE_BUILD_PARALLEL_LEVEL = $NPROC
         Set-Location "${{ github.workspace }}\contrib\build"
-        cmake -G"Visual Studio 17 2022" -Ax64 -DBUILD_TYPE=ALL "${{ github.workspace }}\contrib"
+        cmake -G"Visual Studio 18 2026" -Ax64 -DBUILD_TYPE=ALL "${{ github.workspace }}\contrib"
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     - name: Add THIRDPARTY

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -48,9 +48,10 @@ jobs:
             # clang.exe is also installed but untested (might crash with our VS specific compiler definitions)
             # clang-cl.exe might be used instead.
             compiler: cl.exe
-            # VS 2022: 14.30-14.39 (corresponds to MSVC v143)
+            # VS 2026: 14.50+ (corresponds to MSVC v145)
+            # VS 2022: 14.30-14.49 (corresponds to MSVC v143/v144)
             # VS 2019: 14.20-14.29 (corresponds to MSVC v142)
-            compiler_ver: 14.44   # Specific toolset version for VS 2022 -- must (roughly) match Qt6 compiler (see below)
+            compiler_ver: 14.51   # Approximate toolset version for VS 2026 -- must (roughly) match Qt6 compiler (see below)
 
           - os: macos-15
             # Since the appleclang version is dependent on the XCode versions that are installed


### PR DESCRIPTION
## Summary

- The `windows-2025` GitHub runner image was updated to ship **Visual Studio 18 (VS 2026)** exclusively — VS 17 (VS 2022) is no longer installed on the image (`ImageOS: win25-vs2026`, `VisualStudioVersion: 18.0`, `VCToolsVersion: 14.51.x`).
- The contrib build step in `.github/actions/dependencies/action.yml` was hard-coded to `-G"Visual Studio 17 2022"`, causing immediate CMake failure: `Generator "Visual Studio 17 2022" could not find any instance of Visual Studio.`
- This caused the entire Windows `build-and-test` job to fail at the **Install Dependencies** step, making nightly and develop CI red.

## Changes

- `.github/actions/dependencies/action.yml`: change contrib cmake generator from `Visual Studio 17 2022` → `Visual Studio 18 2026`
- `.github/workflows/openms_ci_matrix_full.yml`: update `compiler_ver` to `14.51` (actual VS 2026 toolset) and update the version range comments

**Note on Qt:** Qt remains at `win64_msvc2022_64` because MSVC maintains binary ABI compatibility within the v14x family (VS 2015 through VS 2026), so Qt 6.8.3 built with MSVC 2022 links correctly against MSVC 2026 code.

## Test plan

- [ ] Windows `build-and-test (windows-2025, cl.exe, 14.51)` job passes (contrib cmake configure with VS 18 generator succeeds)
- [ ] Other matrix jobs (Linux, macOS) unaffected

https://claude.ai/code/session_012NM7NmSi2uxwg8cxm3whrC

---
_Generated by [Claude Code](https://claude.ai/code/session_012NM7NmSi2uxwg8cxm3whrC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows build infrastructure to use Visual Studio 2026 and updated the compiler toolchain version in the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->