### PR TITLE
ci: pin Windows runner to windows-2022 (VS2022) to unblock Windows CI

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -49,14 +49,7 @@ runs:
         if (-not $NPROC) { $NPROC = 4 }
         $env:CMAKE_BUILD_PARALLEL_LEVEL = $NPROC
         Set-Location "${{ github.workspace }}\contrib\build"
-        # Do not pin the VS generator: let CMake pick the default (newest installed)
-        # Visual Studio so the contrib build follows the runner image's VS version
-        # (the windows-2025 image moved from VS 2022 to VS 2026, which broke the
-        # hardcoded "Visual Studio 17 2022" generator). -Ax64 still selects x64.
-        # contrib guards its generator to VS {14..17}; VS 2026 (18) isn't in that
-        # list yet, so pass OVERRIDE_GENERATOR=On -- safe because the chosen
-        # generator (VS 2026) matches the MSVC toolchain (no generator/toolchain mismatch).
-        cmake -Ax64 -DBUILD_TYPE=ALL -DOVERRIDE_GENERATOR=On "${{ github.workspace }}\contrib"
+        cmake -G"Visual Studio 17 2022" -Ax64 -DBUILD_TYPE=ALL "${{ github.workspace }}\contrib"
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     - name: Add THIRDPARTY

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -49,7 +49,11 @@ runs:
         if (-not $NPROC) { $NPROC = 4 }
         $env:CMAKE_BUILD_PARALLEL_LEVEL = $NPROC
         Set-Location "${{ github.workspace }}\contrib\build"
-        cmake -G"Visual Studio 17 2022" -Ax64 -DBUILD_TYPE=ALL "${{ github.workspace }}\contrib"
+        # Do not pin the VS generator: let CMake pick the default (newest installed)
+        # Visual Studio so the contrib build follows the runner image's VS version
+        # (the windows-2025 image moved from VS 2022 to VS 2026, which broke the
+        # hardcoded "Visual Studio 17 2022" generator). -Ax64 still selects x64.
+        cmake -Ax64 -DBUILD_TYPE=ALL "${{ github.workspace }}\contrib"
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     - name: Add THIRDPARTY

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -53,7 +53,10 @@ runs:
         # Visual Studio so the contrib build follows the runner image's VS version
         # (the windows-2025 image moved from VS 2022 to VS 2026, which broke the
         # hardcoded "Visual Studio 17 2022" generator). -Ax64 still selects x64.
-        cmake -Ax64 -DBUILD_TYPE=ALL "${{ github.workspace }}\contrib"
+        # contrib guards its generator to VS {14..17}; VS 2026 (18) isn't in that
+        # list yet, so pass OVERRIDE_GENERATOR=On -- safe because the chosen
+        # generator (VS 2026) matches the MSVC toolchain (no generator/toolchain mismatch).
+        cmake -Ax64 -DBUILD_TYPE=ALL -DOVERRIDE_GENERATOR=On "${{ github.workspace }}\contrib"
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     - name: Add THIRDPARTY

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -43,7 +43,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2025
+          - os: windows-2022
+            # Pinned to the VS2022 image: the windows-2025 image moved to VS2026, which the
+            # contrib build's CMake generator guard (VS {14..17}) rejects even with
+            # OVERRIDE_GENERATOR. Move back to windows-2025 once contrib supports VS2026
+            # (and bump the msvc2022 Qt arch below to match).
             # cl.exe is currently the only supported. Needs a VS shell to be set up (especially if used without VS CMake Generator)
             # clang.exe is also installed but untested (might crash with our VS specific compiler definitions)
             # clang-cl.exe might be used instead.


### PR DESCRIPTION
## Problem

The Windows `build-and-test` job fails on **every** PR at the CMake *configure* step:

```
CMake Error at CMakeLists.txt:342 (message):
  Generator  Visual Studio 17 2022  could not find any instance of Visual Studio.
```

GitHub's **`windows-2025`** runner image rolled from **Visual Studio 2022** to **Visual Studio 2026 (VS18)**, and VS2022 is no longer installed.

## Why not just update the generator

I tried that first (see this branch's earlier commits, now reverted):
1. Dropping the `-G"Visual Studio 17 2022"` pin → CMake correctly picks VS2026 (`Building for: Visual Studio 18 2026`), but the **contrib** build's own `CMakeLists.txt` allowlists only VS `{14..17}` and aborts on VS2026.
2. Adding `-DOVERRIDE_GENERATOR=On` → the contrib's override path *also* errors (`message(SEND_ERROR "...proceed with caution")`), so configure still fails.

That guard lives in the separate **`OpenMS/contrib`** submodule, and the whole Windows setup assumes VS2022 anyway (Qt is pinned to `win64_msvc2022_64`). So an `action.yml`-only fix can't work.

## Fix

Pin the Windows matrix runner to **`windows-2022`** (which still ships VS2022), keeping the toolchain self-consistent (VS2022 generator + msvc2022 Qt). Net change is one line in `openms_ci_matrix_full.yml`; the dependencies action is reverted to its original VS2022 pin.

```diff
-          - os: windows-2025
+          - os: windows-2022
```

**Revisit / proper follow-up:** move back to `windows-2025` once `OpenMS/contrib` accepts VS2026 (update its generator guard) and the `win64_msvc2022_64` Qt arch is bumped to match.

## Verification

⚠️ CI-only change, not verifiable locally — needs a CI round-trip. Note `windows-2022` is an older image and may itself be near retirement; if it's no longer offered, this approach needs rethinking (the run will say so quickly).

https://claude.ai/code/session_018EZ5DVWpC74wbXSo9utFBC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated continuous integration configuration to maintain compatibility with current development tools and ensure reliable Windows builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->