### PR TITLE
Doc: correct IndexedMzMLFileLoader::load() throw behavior (POLS audit)

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/NUXL/NuXLFDR.h
+++ b/src/openms/include/OpenMS/ANALYSIS/NUXL/NuXLFDR.h
@@ -49,20 +49,24 @@ class OPENMS_DLLAPI NuXLFDR
     explicit NuXLFDR(size_t report_top_hits);
 
     /**
-      @brief Partition @p peptide_ids into plain-peptide and cross-link PSM lists.
+      @brief Partition @p peptide_ids into plain-peptide and cross-link PSM lists by their single top hit.
 
-      For each input @c PeptideIdentification, walks its hits and keeps **only the first**
-      hit encountered for each class — even when @c report_top_hits @c >= @c 2 was passed
-      to the constructor. The classification is based on the integer meta value
-      @c "NuXL:isXL" (zero → plain peptide; anything else → cross-link). An input
-      identification contributes to @p pep_pi or @p xl_pi (or both, if it had hits of both
-      classes), but never to @p pep_pi twice.
+      For each input @c PeptideIdentification this keeps **only the single top-ranked hit**
+      (the first hit; hits are assumed sorted best-first) and assigns it to exactly one
+      output list according to the integer meta value @c "NuXL:isXL" (zero → plain peptide,
+      → @p pep_pi; anything else → cross-link, → @p xl_pi). This is a winner-takes-the-spectrum
+      class competition: a spectrum is claimed by whichever class its best hit belongs to and
+      therefore contributes to @p pep_pi @b or @p xl_pi but @b never to both. Lower-ranked hits
+      of the other class are intentionally dropped so that, e.g., a spectrum best explained as a
+      plain peptide does not also inflate the cross-link FDR pool. This single-top-hit split is
+      applied regardless of @c report_top_hits (which only toggles @c use_all_hits inside the
+      underlying @ref FalseDiscoveryRate q-value estimation, not the class split here).
 
       @p pep_pi and @p xl_pi are cleared on entry.
 
       @param[in]  peptide_ids Input mixed plain-peptide / cross-link PSMs.
-      @param[out] pep_pi      Receives the plain-peptide PSMs (one hit per PSM, the first encountered with @c NuXL:isXL @c == @c 0).
-      @param[out] xl_pi       Receives the cross-link PSMs (one hit per PSM, the first encountered with @c NuXL:isXL @c != @c 0).
+      @param[out] pep_pi      Receives the PSMs whose top hit is a plain peptide (@c NuXL:isXL @c == @c 0), one hit each.
+      @param[out] xl_pi       Receives the PSMs whose top hit is a cross-link (@c NuXL:isXL @c != @c 0), one hit each.
     */
     void splitIntoPeptidesAndXLs(const PeptideIdentificationList& peptide_ids,
       PeptideIdentificationList& pep_pi,
@@ -77,6 +81,11 @@ class OPENMS_DLLAPI NuXLFDR
           appended as a new @c PeptideIdentification;
         - if a plain-peptide entry already exists for this spectrum, the XL hits are
           appended to its hit list and that hit list is re-sorted in place.
+
+      @note For lists produced by @ref splitIntoPeptidesAndXLs the second case never occurs:
+            that split assigns each spectrum's single top hit to exactly one class, so a given
+            @c "spectrum_reference" appears in at most one of @p pep_pi / @p xl_pi. The append
+            branch only matters when merging lists assembled by other means.
 
       @p peptide_ids is cleared on entry.
 

--- a/src/openms/include/OpenMS/FORMAT/IndexedMzMLFileLoader.h
+++ b/src/openms/include/OpenMS/FORMAT/IndexedMzMLFileLoader.h
@@ -45,14 +45,29 @@ namespace OpenMS
     void setOptions(const PeakFileOptions &);
 
     /**
-      @brief Load a file 
+      @brief Load a file
 
       Tries to parse the file, success needs to be checked with the return value.
+
+      @note The return value only distinguishes a successfully parsed indexed mzML
+      from a file that exists but is @b not a valid/indexed mzML (in which case @c false
+      is returned and @p exp is left empty/invalid). It does @b not signal every error:
+      a missing or unreadable file still throws Exception::FileNotFound /
+      Exception::FileNotReadable / Exception::IOException, and a corrupt
+      @c indexListOffset throws Exception::ConversionError (both raised while reading the
+      index footer, before any value is returned). This differs from the sibling file
+      classes (MzMLFile, MzDataFile, MzXMLFile) whose load() returns @c void and reports
+      all failures via exceptions.
 
       @param[out] filename Filename determines where the file is located
       @param[out] exp Object which will contain the data after the call
 
-      @return Indicates whether parsing was successful (if it is false, the file most likely was not an mzML or not indexed).
+      @return Indicates whether parsing was successful (if it is false, the file exists but
+              most likely was not an mzML or not indexed); the return value must be checked.
+
+      @throws Exception::FileNotFound if @p filename does not exist.
+      @throws Exception::FileNotReadable if @p filename cannot be read.
+      @throws Exception::ConversionError if the index footer (indexListOffset) is corrupt.
     */
     bool load(const std::string& filename, OnDiscPeakMap& exp);
 


### PR DESCRIPTION
The proposed note in #9499 stated load() does not throw on a missing or
garbage file. That is only true for a file that exists but is not a valid
indexed mzML (returns false). A missing/unreadable file still throws
FileNotFound/FileNotReadable/IOException, and a corrupt indexListOffset
throws ConversionError, raised while reading the index footer via
IndexedMzMLDecoder::findIndexListOffset. Document the bool return vs the
exception cases accurately.

https://claude.ai/code/session_01DZJY8LSPaSqJnMjF2LMLDR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for peptide and cross-link identification processing, detailing how spectra are partitioned between output categories based on top-ranked hits.
  * Enhanced file loader API documentation to better explain return value semantics and provide comprehensive exception handling information for various failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->