### PR TITLE
CI: pin Windows build to windows-2022 runner

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -43,7 +43,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2025
+          # Pinned to windows-2022 because the windows-2025 image now ships Visual Studio 2026 (v18),
+          # which drops VS 2022 (v17). Our contrib build hardcodes the "Visual Studio 17 2022" CMake
+          # generator and the toolset/Qt below target VS 2022, so windows-2025 fails at configure time
+          # with "could not find any instance of Visual Studio". Revisit when migrating to VS 2026.
+          - os: windows-2022
             # cl.exe is currently the only supported. Needs a VS shell to be set up (especially if used without VS CMake Generator)
             # clang.exe is also installed but untested (might crash with our VS specific compiler definitions)
             # clang-cl.exe might be used instead.


### PR DESCRIPTION
The windows-2025 hosted image was updated to ship Visual Studio 2026
(v18), which removes VS 2022 (v17). The contrib build hardcodes the
"Visual Studio 17 2022" CMake generator (.github/actions/dependencies/
action.yml) and the matrix toolset (14.44) and Qt arch (win64_msvc2022_64)
target VS 2022, so the build now fails at configure with "could not find
any instance of Visual Studio". Pin the runner to windows-2022 to restore
green Windows CI until a forward migration to VS 2026 is done.

https://claude.ai/code/session_012mmCXpzAs6Xqd61XiBi44L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to use a compatible Windows runner version, ensuring stable builds and preventing potential configuration failures during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->