### PR TITLE
Enable FeatureMap move assignment and add const accessors

### DIFF
--- a/src/openms/include/OpenMS/KERNEL/FeatureMap.h
+++ b/src/openms/include/OpenMS/KERNEL/FeatureMap.h
@@ -106,7 +106,7 @@ namespace OpenMS
     FeatureMap& operator=(const FeatureMap& rhs);
 
     /// Move assignment
-    //FeatureMap& FeatureMap::operator=(FeatureMap&&);
+    FeatureMap& operator=(FeatureMap&& rhs);
 
     /// Destructor
     ~FeatureMap() override;

--- a/src/openms/include/OpenMS/KERNEL/MSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/MSExperiment.h
@@ -1240,8 +1240,14 @@ std::vector<MSChromatogram> extractXICs(
     /// returns a single chromatogram
     MSChromatogram& getChromatogram(Size id);
 
+    /// returns a single chromatogram (immutable)
+    const MSChromatogram& getChromatogram(Size id) const;
+
     /// returns a single spectrum
     MSSpectrum& getSpectrum(Size id);
+
+    /// returns a single spectrum (immutable)
+    const MSSpectrum& getSpectrum(Size id) const;
 
     /// get the total number of spectra available
     Size getNrSpectra() const;

--- a/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
+++ b/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
@@ -535,6 +535,7 @@ namespace OpenMS
       it->setHigherScoreBetter(false);
       const vector<ProteinHit>& old_hits = it->getHits();
       vector<ProteinHit> new_hits;
+      new_hits.reserve(old_hits.size());
       for (auto hit : old_hits) // NOTE: performs copy
       {
         // Add decoy proteins only if add_decoy_proteins is set

--- a/src/openms/source/KERNEL/FeatureMap.cpp
+++ b/src/openms/source/KERNEL/FeatureMap.cpp
@@ -138,7 +138,11 @@ namespace OpenMS
     return *this;
   }
 
-  //FeatureMap& FeatureMap::operator=(FeatureMap&&) = default; // TODO: cannot be defaulted since OpenMS::IdentificationData is missing operator=
+  // Can be defaulted: moving preserves the addresses of the IdentificationData
+  // objects referenced by the contained features, so (unlike the copy assignment
+  // above) no ID-reference translation is required. This mirrors the defaulted
+  // move constructor.
+  FeatureMap& FeatureMap::operator=(FeatureMap&&) = default;
 
 
   bool FeatureMap::operator==(const FeatureMap& rhs) const

--- a/src/openms/source/KERNEL/MSExperiment.cpp
+++ b/src/openms/source/KERNEL/MSExperiment.cpp
@@ -1209,8 +1209,20 @@ namespace OpenMS
     return chromatograms_[id];
   }
 
-  /// returns a single spectrum 
+  /// returns a single chromatogram (immutable)
+  const MSChromatogram & MSExperiment::getChromatogram(Size id) const
+  {
+    return chromatograms_[id];
+  }
+
+  /// returns a single spectrum
   MSSpectrum & MSExperiment::getSpectrum(Size id)
+  {
+    return spectra_[id];
+  }
+
+  /// returns a single spectrum (immutable)
+  const MSSpectrum & MSExperiment::getSpectrum(Size id) const
   {
     return spectra_[id];
   }

--- a/src/tests/class_tests/openms/source/FeatureMap_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureMap_test.cpp
@@ -227,6 +227,41 @@ START_SECTION((FeatureMap& operator = (const FeatureMap& rhs)))
 	TEST_EQUAL(map2.getUnassignedPeptideIdentifications().size(),0);
 END_SECTION
 
+START_SECTION((FeatureMap& operator=(FeatureMap&& rhs)))
+  FeatureMap map1;
+  map1.setMetaValue("meta", std::string("value"));
+  map1.push_back(feature1);
+  map1.push_back(feature2);
+  map1.push_back(feature3);
+  map1.updateRanges();
+  map1.setIdentifier("lsid");
+  map1.getDataProcessing().resize(1);
+  map1.getProteinIdentifications().resize(1);
+  map1.getUnassignedPeptideIdentifications().resize(1);
+
+  // move assignment
+  FeatureMap map2;
+  map2 = std::move(map1);
+
+  TEST_EQUAL(map2.size(), 3);
+  TEST_EQUAL(map2.getMetaValue("meta").toString(), "value")
+  TEST_REAL_SIMILAR(map2.getMaxIntensity(), 1.0)
+  TEST_STRING_EQUAL(map2.getIdentifier(), "lsid")
+  TEST_EQUAL(map2.getDataProcessing().size(), 1)
+  TEST_EQUAL(map2.getProteinIdentifications().size(), 1);
+  TEST_EQUAL(map2.getUnassignedPeptideIdentifications().size(), 1);
+
+  // move assignment of empty object
+  map2 = FeatureMap();
+
+  TEST_EQUAL(map2.size(), 0);
+  TEST_EQUAL(map2.hasRange() == HasRangeType::NONE, true)
+  TEST_STRING_EQUAL(map2.getIdentifier(), "")
+  TEST_EQUAL(map2.getDataProcessing().size(), 0)
+  TEST_EQUAL(map2.getProteinIdentifications().size(), 0);
+  TEST_EQUAL(map2.getUnassignedPeptideIdentifications().size(), 0);
+END_SECTION
+
 START_SECTION((bool operator == (const FeatureMap& rhs) const))
 	FeatureMap empty,edit;
 


### PR DESCRIPTION
Composability/speed improvements on core KERNEL types:

- FeatureMap: enable move assignment operator. It was previously
  disabled with a stale TODO ("IdentificationData is missing
  operator=") which no longer holds: IdentificationData now provides
  both copy and move assignment. Moving preserves the addresses of the
  IdentificationData objects referenced by the contained features, so
  no ID-reference translation is needed (unlike the copy assignment).
  This mirrors the already-defaulted move constructor and brings
  FeatureMap in line with ConsensusMap. Previously every
  `featureMap = std::move(other)` silently fell back to a deep copy.

- MSExperiment: add const overloads of getSpectrum(Size) and
  getChromatogram(Size). Previously only non-const versions existed,
  inconsistent with the const operator[] and getSpectra()/
  getChromatograms() accessors, blocking indexed access on a
  const MSExperiment&.

- FalseDiscoveryRate: reserve new_hits before the per-protein-hit loop
  to avoid repeated reallocations.

https://claude.ai/code/session_01JuprfiLHBucmVCMpdm52d1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added const-correct overloads for immutable access to spectra and chromatograms.
  * Exposed move assignment for `FeatureMap` as part of the public interface, with the move behavior now explicitly defaulted.
* **Performance**
  * Reduced allocations in false discovery rate processing by preallocating space for copied hits.
* **Tests**
  * Added coverage for `FeatureMap` move-assignment, including non-empty and empty scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->