### PR TITLE
[GUI] Stop cluttering home dir with eagerly-created OpenMS_Plugins folder

### DIFF
--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -228,6 +228,12 @@ public:
     /// Returns the OpenMS home path (environment variable overwrites the default home path)
     static std::string getOpenMSHomePath();
 
+    /// Returns the per-user OpenMS configuration directory (the directory that holds OpenMS.ini).
+    /// Follows the XDG base directory specification on unix-like systems
+    /// (&lt;XDG_CONFIG_HOME&gt;/OpenMS or &lt;home&gt;/.config/OpenMS) and uses &lt;home&gt;/.OpenMS otherwise.
+    /// The returned path has no trailing separator and the directory is not guaranteed to exist.
+    static std::string getOpenMSConfigDir();
+
     /// The current OpenMS temporary data path (for temporary files).
     /// Looks up the following locations, taking the first one which is non-null:
     ///   - environment variable OPENMS_TMPDIR

--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -236,13 +236,6 @@ public:
     /// @return String containing the per-user OpenMS configuration directory path
     static std::string getOpenMSConfigDir();
 
-    /// Returns the per-user OpenMS data directory for user-provided application data (e.g. plugins).
-    /// Distinct from getOpenMSDataPath() (the read-only installation share directory).
-    /// Follows the XDG base directory specification on unix-like systems
-    /// (&lt;XDG_DATA_HOME&gt;/OpenMS or &lt;home&gt;/.local/share/OpenMS) and uses &lt;home&gt;/.OpenMS otherwise.
-    /// The returned path has no trailing separator and the directory is not guaranteed to exist.
-    static std::string getOpenMSDataHome();
-
     /// The current OpenMS temporary data path (for temporary files).
     /// Looks up the following locations, taking the first one which is non-null:
     ///   - environment variable OPENMS_TMPDIR

--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -234,6 +234,13 @@ public:
     /// The returned path has no trailing separator and the directory is not guaranteed to exist.
     static std::string getOpenMSConfigDir();
 
+    /// Returns the per-user OpenMS data directory for user-provided application data (e.g. plugins).
+    /// Distinct from getOpenMSDataPath() (the read-only installation share directory).
+    /// Follows the XDG base directory specification on unix-like systems
+    /// (&lt;XDG_DATA_HOME&gt;/OpenMS or &lt;home&gt;/.local/share/OpenMS) and uses &lt;home&gt;/.OpenMS otherwise.
+    /// The returned path has no trailing separator and the directory is not guaranteed to exist.
+    static std::string getOpenMSDataHome();
+
     /// The current OpenMS temporary data path (for temporary files).
     /// Looks up the following locations, taking the first one which is non-null:
     ///   - environment variable OPENMS_TMPDIR

--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -228,10 +228,12 @@ public:
     /// Returns the OpenMS home path (environment variable overwrites the default home path)
     static std::string getOpenMSHomePath();
 
-    /// Returns the per-user OpenMS configuration directory (the directory that holds OpenMS.ini).
+    /// @brief Returns the per-user OpenMS configuration directory (the directory that holds OpenMS.ini)
+    ///
     /// Follows the XDG base directory specification on unix-like systems
     /// (&lt;XDG_CONFIG_HOME&gt;/OpenMS or &lt;home&gt;/.config/OpenMS) and uses &lt;home&gt;/.OpenMS otherwise.
     /// The returned path has no trailing separator and the directory is not guaranteed to exist.
+    /// @return String containing the per-user OpenMS configuration directory path
     static std::string getOpenMSConfigDir();
 
     /// Returns the per-user OpenMS data directory for user-provided application data (e.g. plugins).

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -765,14 +765,14 @@ namespace OpenMS
   std::string File::getOpenMSConfigDir()
   {
     // Comply with https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html on unix identifying systems
-    #ifdef __unix__
+    #ifdef OPENMS_WINDOWSPLATFORM
+      return File::getOpenMSHomePath() + "/.OpenMS";
+    #else
       if (getenv("XDG_CONFIG_HOME"))
       {
         return std::string(getenv("XDG_CONFIG_HOME")) + "/OpenMS";
       }
       return File::getOpenMSHomePath() + "/.config/OpenMS";
-    #else
-      return File::getOpenMSHomePath() + "/.OpenMS";
     #endif
   }
 

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -762,23 +762,23 @@ namespace OpenMS
     return home_path;
   }
 
-  Param File::getSystemParameters()
+  std::string File::getOpenMSConfigDir()
   {
-    std::string home_path = File::getOpenMSHomePath();
-    std::string filename;
-    //Comply with https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html on unix identifying systems
+    // Comply with https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html on unix identifying systems
     #ifdef __unix__
       if (getenv("XDG_CONFIG_HOME"))
       {
-        filename =std::string(getenv("XDG_CONFIG_HOME")) + "/OpenMS/OpenMS.ini";
+        return std::string(getenv("XDG_CONFIG_HOME")) + "/OpenMS";
       }
-      else
-      {
-        filename = File::getOpenMSHomePath() + "/.config/OpenMS/OpenMS.ini";
-      }
+      return File::getOpenMSHomePath() + "/.config/OpenMS";
     #else
-      filename = home_path + "/.OpenMS/OpenMS.ini";
+      return File::getOpenMSHomePath() + "/.OpenMS";
     #endif
+  }
+
+  Param File::getSystemParameters()
+  {
+    std::string filename = File::getOpenMSConfigDir() + "/OpenMS.ini";
 
     Param p;
     if (!File::readable(filename)) // no file, lets keep it that way

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -764,15 +764,16 @@ namespace OpenMS
 
   std::string File::getOpenMSConfigDir()
   {
-    // Comply with https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html on unix identifying systems
-    #ifdef OPENMS_WINDOWSPLATFORM
-      return File::getOpenMSHomePath() + "/.OpenMS";
-    #else
+    // Comply with https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html on unix identifying systems.
+    // This is the single source of truth for the per-user config dir (OpenMS.ini, update-check .ver files, ...).
+    #ifdef __unix__
       if (getenv("XDG_CONFIG_HOME"))
       {
         return std::string(getenv("XDG_CONFIG_HOME")) + "/OpenMS";
       }
       return File::getOpenMSHomePath() + "/.config/OpenMS";
+    #else
+      return File::getOpenMSHomePath() + "/.OpenMS";
     #endif
   }
 

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -776,6 +776,21 @@ namespace OpenMS
     #endif
   }
 
+  std::string File::getOpenMSDataHome()
+  {
+    // Per-user data directory (for user-provided application data such as plugins).
+    // Comply with https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html on unix identifying systems
+    #ifdef __unix__
+      if (getenv("XDG_DATA_HOME"))
+      {
+        return std::string(getenv("XDG_DATA_HOME")) + "/OpenMS";
+      }
+      return File::getOpenMSHomePath() + "/.local/share/OpenMS";
+    #else
+      return File::getOpenMSHomePath() + "/.OpenMS";
+    #endif
+  }
+
   Param File::getSystemParameters()
   {
     std::string filename = File::getOpenMSConfigDir() + "/OpenMS.ini";

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -776,21 +776,6 @@ namespace OpenMS
     #endif
   }
 
-  std::string File::getOpenMSDataHome()
-  {
-    // Per-user data directory (for user-provided application data such as plugins).
-    // Comply with https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html on unix identifying systems
-    #ifdef __unix__
-      if (getenv("XDG_DATA_HOME"))
-      {
-        return std::string(getenv("XDG_DATA_HOME")) + "/OpenMS";
-      }
-      return File::getOpenMSHomePath() + "/.local/share/OpenMS";
-    #else
-      return File::getOpenMSHomePath() + "/.OpenMS";
-    #endif
-  }
-
   Param File::getSystemParameters()
   {
     std::string filename = File::getOpenMSConfigDir() + "/OpenMS.ini";

--- a/src/openms/source/SYSTEM/UpdateCheck.cpp
+++ b/src/openms/source/SYSTEM/UpdateCheck.cpp
@@ -60,20 +60,8 @@ namespace OpenMS
 
     // e.g.: OpenMS_Default_Win_64_FeatureFinderCentroided_2.0.0
     std::string tool_version_string;
-    std::string config_path;
-    //Comply with https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html on unix identifying systems
-    #ifdef __unix__
-    if (getenv("XDG_CONFIG_HOME"))
-    {
-      config_path =std::string(getenv("XDG_CONFIG_HOME")) + "/OpenMS";
-    }
-    else
-    {
-      config_path = File::getOpenMSHomePath() + "/.config/OpenMS";
-    }
-    #else
-    config_path =  File::getOpenMSHomePath() + "/.OpenMS";
-    #endif
+    // resolve the per-user OpenMS config dir (same location as OpenMS.ini)
+    std::string config_path = File::getOpenMSConfigDir();
     tool_version_string =std::string("OpenMS") + "_" + "Default_" + platform + "_" + architecture + "_" + tool_name + "_" + version;
 
     std::string version_file_name = config_path + "/" + tool_name + ".ver";

--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/TOPPViewPrefDialog.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/TOPPViewPrefDialog.h
@@ -47,7 +47,6 @@ public:
 
 protected slots:
       void browseDefaultPath_();
-      void browsePluginsPath_();
 private:
       Ui::TOPPViewPrefDialogTemplate* ui_;
       mutable Param param_; ///< is updated in getParam()

--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/ToolsDialog.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/ToolsDialog.h
@@ -28,7 +28,6 @@ class QWidget;
 namespace OpenMS
 {
   class ParamEditor;
-  class TVToolDiscovery;
 
   /**
   @brief TOPP tool selection dialog
@@ -59,9 +58,8 @@ public:
       @param[in] default_dir The default directory for loading and storing INI files
       @param[in] layer_type The type of data (determines the applicable tools)
       @param[in] layer_name The name of the selected layer
-      @param[in] tool_scanner Pointer to the tool scanner for access to the plugins and to rerun the plugins detection
     */
-    ToolsDialog(QWidget * parent, const Param& params, std::string ini_file, std::string default_dir, LayerDataBase::DataType layer_type, const std::string& layer_name, TVToolDiscovery* tool_scanner);
+    ToolsDialog(QWidget * parent, const Param& params, std::string ini_file, std::string default_dir, LayerDataBase::DataType layer_type, const std::string& layer_name);
     ///Destructor
     ~ToolsDialog() override;
 
@@ -92,8 +90,6 @@ private:
     QLabel * tool_desc_;
     /// ComboBox for choosing a TOPP-tool
     QComboBox * tools_combo_;
-    /// Button to rerun the automatic plugin detection
-    QPushButton * reload_plugins_button_;
     /// for choosing an input parameter
     QComboBox * input_combo_;
     /// for choosing an output parameter
@@ -106,8 +102,6 @@ private:
     Param gui_param_;
     /// Param object containing all TOPP tool/util params
     const Param tool_params_;
-    /// Param object containing all plugin params
-    Param plugin_params_;
     /// ok-button connected with slot ok_()
     QPushButton * ok_button_;
     /// Location of the temporary INI file this dialog works on
@@ -118,9 +112,7 @@ private:
     QString filename_;
     /// Mapping of file extension to layer type to determine the type of a tool
     std::map<FileTypes::Type, LayerDataBase::DataType> tool_map_;
-    /// Pointer to the tool scanner for access to the plugins and to rerun the plugins detection
-    TVToolDiscovery * tool_scanner_;
-    /// The layer type of the current layer to determine all usable plugins
+    /// The layer type of the current layer to determine all usable tools
     LayerDataBase::DataType layer_type_;
 
     /// Disables the ok button and input/output comboboxes
@@ -131,7 +123,7 @@ private:
     std::vector<LayerDataBase::DataType> getTypesFromParam_(const Param& p) const;
     /// Fill input_combo_ and output_combo_ box with the appropriate entries from the specified param object.
     void setInputOutputCombo_(const Param& p);
-    /// Create a list of all TOPP tool/util/plugins that are compatible with the active layer type
+    /// Create a list of all TOPP tools/utils that are compatible with the active layer type
     QStringList createToolsList_();
     /// Populate and initialize thread controls
     void initializeThreadsControls_();
@@ -154,8 +146,6 @@ protected slots:
     void loadINI_();
     /// stores an ini-file from the editor
     void storeINI_();
-    /// rerun the automatic plugin detection
-    void reloadPlugins_();
     /// Slot toggling between fast and manual thread mode
     void fastModeToggled_(bool checked);
   };

--- a/src/openms_gui/include/OpenMS/VISUAL/TVToolDiscovery.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TVToolDiscovery.h
@@ -36,8 +36,7 @@ namespace OpenMS
   class OPENMS_GUI_DLLAPI TVToolDiscovery
   {
   public:
-    TVToolDiscovery() :
-      plugin_path_() {};
+    TVToolDiscovery() = default;
 
     TVToolDiscovery(const TVToolDiscovery&) = delete;
 
@@ -54,7 +53,6 @@ namespace OpenMS
        While waiting the GUI remains responsive. After waiting it is safe to access the params without further waiting.
      */
     void waitForToolParams();
-    void waitForPluginParams();
 
     /**
        @brief Returns a Param object containing the params for each tool/util.
@@ -65,67 +63,18 @@ namespace OpenMS
      */
     const Param& getToolParams();
 
-    /**
-       @brief Returns a param containing the params for each plugin.
-       @details
-       This function will ALWAYS trigger a reload of the plugins.
-    */
-    const Param& getPluginParams();
-
-    /// Returns the list of read plugin names as saved in the ini.
-    const std::vector<std::string>& getPlugins();
-
-    /**
-     * @brief Sets the path that will be searched for Plugins
-     *
-     * The configured path is always remembered, even if it does not exist on disk: plugin
-     * discovery tolerates a missing directory. The directory is only physically created when
-     * @p create is true, so users who never use plugins do not get an empty folder created.
-     *
-     * @param[in] path The new path to set
-     * @param[in] create Create the directory (including parents) if it does not already exist
-     * @returns False only if @p create is true and creating the directory failed. True otherwise.
-     */
-    [[maybe_unused]] bool setPluginPath(const std::string& path, bool create=false);
-
     /// set the verbosity level of the tool discovery for debug purposes
     void setVerbose(int verbosity_level);
 
-    /// Returns the current set path to search plugins in
-    const std::string getPluginPath();
-
-    /// Returns the path to the plugin executable or an empty string if the plugin name is unknown
-    std::string findPluginExecutable(const std::string& name);
-
   private:
-    /** Returns param for a given tool/util. This function is thread-safe. Additionally inserts names of tools into 
-        plugin list
-     */
-    static Param getParamFromIni_(const std::string& tool_path, bool plugins=false);
+    /// Returns param for a given tool/util. This function is thread-safe.
+    static Param getParamFromIni_(const std::string& tool_path);
 
-    /** Start creating params for each plugin in the set plugin path asynchronously
-     *  This should only be called from waitForPluginParams() or the names in the plugins vector are not correct
-     */
-    void loadPluginParams();
-
-    /// Returns a list of executables that are found at the plugin path
-    const StringList getPlugins_();
-
-    /// The filepath to search pugins in
-    std::string plugin_path_;
-
-    /// The futures for asyncronous loading of the tools and plugins
+    /// The futures for asyncronous loading of the tools
     std::vector<std::future<Param>> tool_param_futures_;
-    std::vector<std::future<Param>> plugin_param_futures_;
 
     /// Contains all the params of the tools/utils
     Param tool_params_;
-
-    /// Contains all the params of the plugins
-    Param plugin_params_;
-
-    /// The names of all loaded plugins, this is used to add the plugins to the list in the ToolsDialog
-    std::vector<std::string> plugins_;
 
     /// Set to value > 0 to output tool discovery debug information
     int verbosity_level_ = 0;

--- a/src/openms_gui/include/OpenMS/VISUAL/TVToolDiscovery.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TVToolDiscovery.h
@@ -77,9 +77,14 @@ namespace OpenMS
 
     /**
      * @brief Sets the path that will be searched for Plugins
+     *
+     * The configured path is always remembered, even if it does not exist on disk: plugin
+     * discovery tolerates a missing directory. The directory is only physically created when
+     * @p create is true, so users who never use plugins do not get an empty folder created.
+     *
      * @param[in] path The new path to set
-     * @param[in] create Attempt to create the directory if it does not already exist
-     * @returns False if setting/creating the path fails. True otherwise.
+     * @param[in] create Create the directory (including parents) if it does not already exist
+     * @returns False only if @p create is true and creating the directory failed. True otherwise.
      */
     [[maybe_unused]] bool setPluginPath(const std::string& path, bool create=false);
 

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -443,7 +443,7 @@ namespace OpenMS
     defaults_.setValue(user_section + "default_path", ".", "Default path for loading and storing files.");
     defaults_.setValue(user_section + "default_path_current", "true", "If the current path is preferred over the default path.");
     defaults_.setValidStrings(user_section + "default_path_current", {"true","false"});
-    defaults_.setValue(user_section + "plugins_path", File::getOpenMSConfigDir() + "/plugins", "Default path for loading Plugins");
+    defaults_.setValue(user_section + "plugins_path", File::getOpenMSDataHome() + "/plugins", "Default path for loading Plugins");
     defaults_.setValue(user_section + "intensity_cutoff", "off", "Low intensity cutoff for maps.");
     defaults_.setValidStrings(user_section + "intensity_cutoff", {"on","off"});
     defaults_.setValue(user_section + "on_file_change", "ask", "What action to take, when a data file changes. Do nothing, update automatically or ask the user.");

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -405,15 +405,10 @@ namespace OpenMS
     // set current path
     current_path_ = param_.getValue(user_section + "default_path").toString();
 
-    // remember the plugin search path; the directory is created lazily on first use
-    // (when plugins are actually scanned) instead of eagerly here at startup
     if (verbosity_ == VERBOSITY::VERBOSE)
     {
       tool_scanner_.setVerbose(1);
     }
-
-    std::string plugin_path =std::string(param_.getValue(user_section + "plugins_path").toString());
-    tool_scanner_.setPluginPath(plugin_path, false);
 
     // update the menu
     updateMenu();
@@ -443,7 +438,6 @@ namespace OpenMS
     defaults_.setValue(user_section + "default_path", ".", "Default path for loading and storing files.");
     defaults_.setValue(user_section + "default_path_current", "true", "If the current path is preferred over the default path.");
     defaults_.setValidStrings(user_section + "default_path_current", {"true","false"});
-    defaults_.setValue(user_section + "plugins_path", File::getOpenMSDataHome() + "/plugins", "Default path for loading Plugins");
     defaults_.setValue(user_section + "intensity_cutoff", "off", "Low intensity cutoff for maps.");
     defaults_.setValidStrings(user_section + "intensity_cutoff", {"on","off"});
     defaults_.setValue(user_section + "on_file_change", "ask", "What action to take, when a data file changes. Do nothing, update automatically or ask the user.");
@@ -1551,8 +1545,6 @@ namespace OpenMS
           param_.insert("tool_params:", tmp.copy("tool_params:", true));
           tool_params_added = true;
         }
-        // remember the saved plugin path (the directory is created lazily on first use)
-        tool_scanner_.setPluginPath(param_.getValue(user_section + "plugins_path").toString());
       }
     }
     else if (filename != default_ini_file)
@@ -1585,8 +1577,6 @@ namespace OpenMS
       tool_scanner_.waitForToolParams();
       param_.insert("tool_params:", tool_scanner_.getToolParams());
     }
-    // remember the plugin path (the directory is created lazily on first use)
-    tool_scanner_.setPluginPath(param_.getValue(user_section + "plugins_path").toString());
 
     // save only the subsection that begins with "preferences:" and all tool params ("tool_params:")
     try
@@ -1661,7 +1651,7 @@ namespace OpenMS
 
     ToolsDialog tools_dialog(this, param_,
                              topp_.file_name + "_ini", current_path_, layer.type,
-                             layer.getName(), &tool_scanner_);
+                             layer.getName());
 
     if (tools_dialog.exec() == QDialog::Accepted)
     {
@@ -1777,21 +1767,18 @@ namespace OpenMS
     // connect slots
     connect(topp_.process, &QProcess::readyReadStandardOutput, this, &TOPPViewBase::updateProcessLog);
     connect(topp_.process, CONNECTCAST(QProcess, finished, (int, QProcess::ExitStatus)), this, &TOPPViewBase::finishTOPPToolExecution);
-    QString tool_executable = toQString(std::string(tool_scanner_.findPluginExecutable(topp_.tool)));
-    if (tool_executable.isEmpty())
+    QString tool_executable;
+    try
     {
-      try
-      {
-        // find correct location of TOPP tool
-        tool_executable = toQString(File::findSiblingTOPPExecutable(topp_.tool));
-      }
-      catch (Exception::FileNotFound & /*ex*/)
-      {
-        log_->appendNewHeader(LogWindow::LogState::CRITICAL, "Could not locate executable!",
-                              fromQString(QString("Finding executable of TOPP tool '%1' failed. Please check your TOPP/OpenMS installation. Workaround: Add the bin/ directory to your PATH").arg(
-                                      toQString(topp_.tool))));
-        return;
-      }
+      // find correct location of TOPP tool
+      tool_executable = toQString(File::findSiblingTOPPExecutable(topp_.tool));
+    }
+    catch (Exception::FileNotFound & /*ex*/)
+    {
+      log_->appendNewHeader(LogWindow::LogState::CRITICAL, "Could not locate executable!",
+                            fromQString(QString("Finding executable of TOPP tool '%1' failed. Please check your TOPP/OpenMS installation. Workaround: Add the bin/ directory to your PATH").arg(
+                                    toQString(topp_.tool))));
+      return;
     }
 
     // update menu entries according to new state

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -405,14 +405,15 @@ namespace OpenMS
     // set current path
     current_path_ = param_.getValue(user_section + "default_path").toString();
 
-    // set plugin search path, create it if it does not already exist
-    if (verbosity_ == VERBOSITY::VERBOSE) 
+    // remember the plugin search path; the directory is created lazily on first use
+    // (when plugins are actually scanned) instead of eagerly here at startup
+    if (verbosity_ == VERBOSITY::VERBOSE)
     {
       tool_scanner_.setVerbose(1);
     }
 
     std::string plugin_path =std::string(param_.getValue(user_section + "plugins_path").toString());
-    tool_scanner_.setPluginPath(plugin_path, true);
+    tool_scanner_.setPluginPath(plugin_path, false);
 
     // update the menu
     updateMenu();
@@ -442,7 +443,7 @@ namespace OpenMS
     defaults_.setValue(user_section + "default_path", ".", "Default path for loading and storing files.");
     defaults_.setValue(user_section + "default_path_current", "true", "If the current path is preferred over the default path.");
     defaults_.setValidStrings(user_section + "default_path_current", {"true","false"});
-    defaults_.setValue(user_section + "plugins_path", File::getUserDirectory() + "OpenMS_Plugins", "Default path for loading Plugins");
+    defaults_.setValue(user_section + "plugins_path", File::getOpenMSConfigDir() + "/plugins", "Default path for loading Plugins");
     defaults_.setValue(user_section + "intensity_cutoff", "off", "Low intensity cutoff for maps.");
     defaults_.setValidStrings(user_section + "intensity_cutoff", {"on","off"});
     defaults_.setValue(user_section + "on_file_change", "ask", "What action to take, when a data file changes. Do nothing, update automatically or ask the user.");
@@ -1550,12 +1551,8 @@ namespace OpenMS
           param_.insert("tool_params:", tmp.copy("tool_params:", true));
           tool_params_added = true;
         }
-        // If the saved plugin path does not exist
-        if (!tool_scanner_.setPluginPath(param_.getValue(user_section + "plugins_path").toString()))
-        {
-          // reset it to the default
-          param_.setValue(user_section + "plugins_path", File::getUserDirectory() + "OpenMS_Plugins");
-        }
+        // remember the saved plugin path (the directory is created lazily on first use)
+        tool_scanner_.setPluginPath(param_.getValue(user_section + "plugins_path").toString());
       }
     }
     else if (filename != default_ini_file)
@@ -1588,12 +1585,8 @@ namespace OpenMS
       tool_scanner_.waitForToolParams();
       param_.insert("tool_params:", tool_scanner_.getToolParams());
     }
-    // check if the plugin path exists
-    if (!tool_scanner_.setPluginPath(param_.getValue(user_section + "plugins_path").toString()))
-    {
-      // reset if it does not
-      param_.setValue(user_section + "plugins_path", tool_scanner_.getPluginPath());
-    }
+    // remember the plugin path (the directory is created lazily on first use)
+    tool_scanner_.setPluginPath(param_.getValue(user_section + "plugins_path").toString());
 
     // save only the subsection that begins with "preferences:" and all tool params ("tool_params:")
     try

--- a/src/openms_gui/source/VISUAL/DIALOGS/TOPPViewPrefDialog.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/TOPPViewPrefDialog.cpp
@@ -136,6 +136,5 @@ namespace OpenMS
       }
     }
 
-
   }   //namespace Internal
 } //namespace OpenMS

--- a/src/openms_gui/source/VISUAL/DIALOGS/TOPPViewPrefDialog.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/TOPPViewPrefDialog.cpp
@@ -32,7 +32,6 @@ namespace OpenMS
       ui_->setupUi(this);
       ui_->param_editor_spec_gen_->load(tsg_param_);
       connect(ui_->browse_default, &QPushButton::clicked, this, &TOPPViewPrefDialog::browseDefaultPath_);
-      connect(ui_->browse_plugins, &QPushButton::clicked, this, &TOPPViewPrefDialog::browsePluginsPath_);
     }
 
     TOPPViewPrefDialog::~TOPPViewPrefDialog()
@@ -52,7 +51,6 @@ namespace OpenMS
       // general tab
       ui_->default_path->setText(toQString(std::string(param_.getValue("default_path").toString())));
       ui_->default_path_current->setChecked(param_.getValue("default_path_current").toBool());
-      ui_->plugins_path->setText(toQString(std::string(param_.getValue("plugins_path").toString())));
       ui_->use_cached_ms1->setChecked(param_.getValue("use_cached_ms1").toBool());
       ui_->use_cached_ms2->setChecked(param_.getValue("use_cached_ms2").toBool());
 
@@ -98,8 +96,6 @@ namespace OpenMS
       p.setValue("default_path", ui_->default_path->text().toStdString());
       p.setValue("default_path_current", fromCheckState(ui_->default_path_current->checkState()));
 
-      p.setValue("plugins_path", ui_->plugins_path->text().toStdString());
-
       p.setValue("use_cached_ms1", fromCheckState(ui_->use_cached_ms1->checkState()));
       p.setValue("use_cached_ms2", fromCheckState(ui_->use_cached_ms2->checkState()));
 
@@ -140,14 +136,6 @@ namespace OpenMS
       }
     }
 
-    void TOPPViewPrefDialog::browsePluginsPath_()
-    {
-      QString path = QFileDialog::getExistingDirectory(this, "Choose a directory", ui_->plugins_path->text());
-      if (!path.isEmpty())
-      {
-        ui_->plugins_path->setText(path);
-      }
-    }
 
   }   //namespace Internal
 } //namespace OpenMS

--- a/src/openms_gui/source/VISUAL/DIALOGS/TOPPViewPrefDialog.ui
+++ b/src/openms_gui/source/VISUAL/DIALOGS/TOPPViewPrefDialog.ui
@@ -203,9 +203,6 @@ p, li { white-space: pre-wrap; }
          </property>
         </widget>
        </item>
-       <item row="3" column="2">
-        <widget class="QLineEdit" name="plugins_path"/>
-       </item>
        <item row="1" column="2">
         <widget class="QCheckBox" name="default_path_current">
          <property name="toolTip">
@@ -216,20 +213,6 @@ p, li { white-space: pre-wrap; }
          </property>
          <property name="text">
           <string>use current path</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_23">
-         <property name="text">
-          <string>Plugins path:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="3">
-        <widget class="QPushButton" name="browse_plugins">
-         <property name="text">
-          <string>Browse</string>
          </property>
         </widget>
        </item>

--- a/src/openms_gui/source/VISUAL/DIALOGS/ToolsDialog.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/ToolsDialog.cpp
@@ -16,7 +16,6 @@
 #include <OpenMS/FORMAT/ParamXMLFile.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/VISUAL/ParamEditor.h>
-#include <OpenMS/VISUAL/TVToolDiscovery.h>
 #include <OpenMS/VISUAL/MISC/CommonDefs.h>
 #include <OpenMS/VISUAL/MISC/Qt5Port.h>
 
@@ -55,14 +54,12 @@ namespace OpenMS
           std::string ini_file,
           std::string default_dir,
           LayerDataBase::DataType layer_type,
-          const std::string& layer_name,
-          TVToolDiscovery* tool_scanner)
+          const std::string& layer_name)
     : QDialog(parent),
       max_threads_(std::max(1, omp_get_max_threads())),
       ini_file_(std::move(ini_file)),
       default_dir_(std::move(default_dir)),
       tool_params_(params.copy("tool_params:", true)),
-      tool_scanner_(tool_scanner),
       layer_type_(layer_type)
   {
     auto main_grid = new QGridLayout(this);
@@ -93,10 +90,6 @@ namespace OpenMS
     connect(tools_combo_, CONNECTCAST(QComboBox, activated, (int)), this, &ToolsDialog::setTool_);
 
     main_grid->addWidget(tools_combo_, 1, 1);
-
-    reload_plugins_button_ = new QPushButton("Reload Plugins");
-    connect(reload_plugins_button_, &QPushButton::clicked, this, &ToolsDialog::reloadPlugins_);
-    main_grid->addWidget(reload_plugins_button_, 0, 2);
 
     label = new QLabel("input argument:");
     const QString input_tooltip = "Select the input parameter for the tool to which the current layer's data will be forwarded to.";
@@ -241,7 +234,6 @@ namespace OpenMS
     QStringList list;
 
     const auto& tools = ToolHandler::getTOPPToolList();
-    plugin_params_ = tool_scanner_->getPluginParams();
 
     for (auto& pair : tools)
     {
@@ -249,15 +241,6 @@ namespace OpenMS
       if (std::find(tool_types.begin(), tool_types.end(), layer_type_) != tool_types.end())
       {
         list << toQString(pair.first);
-      }
-    }
-    //TODO: Plugins get added to the list just like tools and can't be differentiated in the GUI
-    for (const auto& name : tool_scanner_->getPlugins())
-    {
-      std::vector<LayerDataBase::DataType> tool_types = getTypesFromParam_(plugin_params_.copy(name + ":"));
-      if (std::find(tool_types.begin(), tool_types.end(), layer_type_) != tool_types.end())
-      {
-        list << toQString(std::string(name));
       }
     }
 
@@ -280,10 +263,6 @@ namespace OpenMS
     }
     auto tool_name = getTool();
     arg_param_ = tool_params_.copy(tool_name + ":");
-    if (arg_param_.empty())
-    {
-      arg_param_ = plugin_params_.copy(tool_name + ":");
-    }
 
     tool_desc_->setText(toQString(std::string(arg_param_.getSectionDescription(tool_name))));
     single_tool_param_ = arg_param_.copy(tool_name + ":1:", true);
@@ -429,32 +408,6 @@ namespace OpenMS
     }
   }
 
-  void ToolsDialog::reloadPlugins_()
-  {
-    QStringList list = createToolsList_();
-
-    int32_t selected_index = list.indexOf(tools_combo_->currentText());
-
-    if (selected_index < 1)
-    {
-      tool_desc_->clear();
-      arg_param_.clear();
-      single_tool_param_.clear();
-      gui_param_.clear();
-      editor_->clear();
-      input_combo_->clear();
-      output_combo_->clear();
-      disable_();
-    }
-    tools_combo_->clear();
-    tools_combo_->addItems(list);
-    if (selected_index > 0)
-    {
-      tools_combo_->setCurrentIndex(selected_index);
-      createINI_();
-    }
-  }
-
   std::string ToolsDialog::getOutput()
   {
     if (output_combo_->currentText() == "<select>")
@@ -585,7 +538,7 @@ namespace OpenMS
   {
     const int threads = threads_combo_->currentData().toInt();
 
-    if (single_tool_param_.exists("threads")) // safeguard for tools without a threads parameter (could be the case for plugins)
+    if (single_tool_param_.exists("threads")) // safeguard for tools without a threads parameter
     {
       single_tool_param_.setValue("threads", threads);
     }

--- a/src/openms_gui/source/VISUAL/TVToolDiscovery.cpp
+++ b/src/openms_gui/source/VISUAL/TVToolDiscovery.cpp
@@ -46,6 +46,12 @@ namespace OpenMS
   {
     plugin_param_futures_.clear();
     plugins_.clear();
+    // Create the plugin directory lazily, the first time plugins are actually requested
+    // (e.g. when the user opens the tool/plugin dialog), rather than eagerly at startup.
+    if (!plugin_path_.empty() && !File::exists(plugin_path_))
+    {
+      setPluginPath(plugin_path_, true);
+    }
     const auto &plugins = getPlugins_();
     for (auto& plugin : plugins)
     {
@@ -212,24 +218,15 @@ namespace OpenMS
 
   bool TVToolDiscovery::setPluginPath(const std::string& plugin_path, bool create)
   {
-    if (!File::exists(plugin_path))
+    // Only physically create the directory when explicitly requested. The configured path is
+    // always remembered: plugin discovery tolerates a missing directory (it simply finds no
+    // plugins), so there is no need to create an empty folder for users who never use plugins.
+    if (create && !File::exists(plugin_path))
     {
-      if (create)
+      // mkpath also creates intermediate directories (e.g. a not-yet-existing config dir)
+      if (!QDir().mkpath(toQString(plugin_path)))
       {
-        QDir path = QDir(toQString(plugin_path));
-        QString dir = path.dirName();
-        path.cdUp();
-
-        if (!path.mkdir(dir))
-        {
-          OPENMS_LOG_WARN << "Unable to create plugin directory " << plugin_path << std::endl;
-          //plugin_path_ = plugin_path;
-          return false;
-        }
-      }
-      else
-      {
-        OPENMS_LOG_WARN << "Unable to set plugin directory: " << plugin_path << " does not exist." << std::endl;
+        OPENMS_LOG_WARN << "Unable to create plugin directory " << plugin_path << std::endl;
         return false;
       }
     }

--- a/src/openms_gui/source/VISUAL/TVToolDiscovery.cpp
+++ b/src/openms_gui/source/VISUAL/TVToolDiscovery.cpp
@@ -73,7 +73,6 @@ namespace OpenMS
   Param TVToolDiscovery::getParamFromIni_(const std::string& tool_path)
   {
     static std::mutex io_mutex;
-    FileHandler fh;
     // Temporary file path and arguments
     std::string path = File::getTemporaryFile();
     std::string working_dir = StringUtils::prefix(path, path.find_last_of('/'));

--- a/src/openms_gui/source/VISUAL/TVToolDiscovery.cpp
+++ b/src/openms_gui/source/VISUAL/TVToolDiscovery.cpp
@@ -20,7 +20,6 @@
 #include <OpenMS/VISUAL/MISC/Qt5Port.h>
 
 #include <QCoreApplication>
-#include <QDir>
 
 #include <thread>
 
@@ -36,27 +35,10 @@ namespace OpenMS
       // Launch threads for loading tool/util params.
       for (const auto& tool : tools)
       {
-        tool_param_futures_.push_back(std::async(std::launch::async, getParamFromIni_, tool.first, false));
+        tool_param_futures_.push_back(std::async(std::launch::async, getParamFromIni_, tool.first));
       }
       return true;
     }();
-  }
-
-  void TVToolDiscovery::loadPluginParams()
-  {
-    plugin_param_futures_.clear();
-    plugins_.clear();
-    // Create the plugin directory lazily, the first time plugins are actually requested
-    // (e.g. when the user opens the tool/plugin dialog), rather than eagerly at startup.
-    if (!plugin_path_.empty() && !File::exists(plugin_path_))
-    {
-      setPluginPath(plugin_path_, true);
-    }
-    const auto &plugins = getPlugins_();
-    for (auto& plugin : plugins)
-    {
-      plugin_param_futures_.push_back(std::async(std::launch::async, getParamFromIni_, plugin, true));
-    }
   }
 
   void TVToolDiscovery::waitForToolParams()
@@ -81,27 +63,6 @@ namespace OpenMS
     }();
   }
 
-  void TVToolDiscovery::waitForPluginParams()
-  {
-    // Make sure threads have been launched before waiting
-    loadPluginParams();
-    // Wait for futures to finish
-    for (auto& param_future : plugin_param_futures_)
-    {
-      while (param_future.wait_for(std::chrono::milliseconds(10)) != std::future_status::ready)
-      {
-        // Keep GUI responsive while waiting
-        QCoreApplication::processEvents();
-      }
-      // Make future results available in plugin_params_
-      Param new_param = param_future.get();
-      // Skip if the param is empty, that means something went wrong during execution
-      if (new_param.empty()) continue;
-      plugins_.push_back(new_param.begin().getTrace().begin()->name);
-      plugin_params_.insert("", new_param);
-    }
-  }
-
   const Param& TVToolDiscovery::getToolParams()
   {
     // Make sure threads have been launched and waited for before accessing results
@@ -109,14 +70,7 @@ namespace OpenMS
     return tool_params_;
   }
 
-  const Param& TVToolDiscovery::getPluginParams()
-  {
-    plugin_params_.clear();
-    waitForPluginParams();
-    return plugin_params_;
-  }
-
-  Param TVToolDiscovery::getParamFromIni_(const std::string& tool_path, bool plugins)
+  Param TVToolDiscovery::getParamFromIni_(const std::string& tool_path)
   {
     static std::mutex io_mutex;
     FileHandler fh;
@@ -177,83 +131,16 @@ namespace OpenMS
     {
       std::scoped_lock lock(io_mutex);
       OPENMS_LOG_DEBUG << e << "\n" << "TOPP tool: " << executable <<
-        " not able to write ini. Plugins must implement -write_ini parameter. Skipping." << std::endl;
+        " not able to write ini (-write_ini failed). Skipping." << std::endl;
       return tool_param;
-    }
-    
-    if (plugins)
-    {
-      auto tool_name = tool_param.begin().getTrace().begin()->name;
-      auto filename = File::basename(tool_path);
-      tool_param.setValue(tool_name + ":filename", filename, "The filename of the plugin executable. This entry is automatically generated.");
     }
 
     return tool_param;
   }
 
-  const std::vector<std::string>& TVToolDiscovery::getPlugins()
-  {
-    return plugins_;
-  }
-
-  const StringList TVToolDiscovery::getPlugins_()
-  {
-    StringList plugins;
-
-    // here all supported file extensions can be added
-    std::vector<std::string> valid_extensions {"", ".py"};
-    const auto comparator = [valid_extensions](const std::string& plugin) -> bool
-    {
-        return !File::executable(plugin) ||
-          (std::find(valid_extensions.begin(), valid_extensions.end(), StringUtils::substr(plugin, plugin.find_last_of('.'))) == valid_extensions.end());
-    };
-
-    if (File::fileList(plugin_path_, "*", plugins, true))
-    {
-      plugins.erase(std::remove_if(plugins.begin(), plugins.end(), comparator), plugins.end());
-    }
-
-    return plugins;
-  }
-
-  bool TVToolDiscovery::setPluginPath(const std::string& plugin_path, bool create)
-  {
-    // Only physically create the directory when explicitly requested. The configured path is
-    // always remembered: plugin discovery tolerates a missing directory (it simply finds no
-    // plugins), so there is no need to create an empty folder for users who never use plugins.
-    if (create && !File::exists(plugin_path))
-    {
-      // mkpath also creates intermediate directories (e.g. a not-yet-existing config dir)
-      if (!QDir().mkpath(toQString(plugin_path)))
-      {
-        OPENMS_LOG_WARN << "Unable to create plugin directory " << plugin_path << std::endl;
-        return false;
-      }
-    }
-
-    plugin_path_ = plugin_path;
-    return true;
-  }
-
-  const std::string TVToolDiscovery::getPluginPath()
-  {
-    return plugin_path_;
-  }
-
   void TVToolDiscovery::setVerbose(int verbosity_level)
   {
     verbosity_level_ = verbosity_level;
-  }
-
-  std::string TVToolDiscovery::findPluginExecutable(const std::string& name)
-  {
-    //TODO: At the moment the usage of subdirectories in the plugin path are not possible
-    //To change that, the tool scanner has to recursively search all directories in the plugin path
-    if (!plugin_params_.exists(name + ":filename"))
-    {
-      return "";
-    }
-    return plugin_path_ + "/" + plugin_params_.getValue(name + ":filename").toString();
   }
 
 }

--- a/src/openms_gui/source/VISUAL/TVToolDiscovery.cpp
+++ b/src/openms_gui/source/VISUAL/TVToolDiscovery.cpp
@@ -84,8 +84,8 @@ namespace OpenMS
     try
     {
       std::scoped_lock lock(io_mutex);
-      // Is an executable already or has a sibling Executable
-      executable = File::exists(tool_path) ? tool_path : File::findSiblingTOPPExecutable(tool_path);
+      // tool_path is a TOPP tool name; locate the sibling executable next to the running binary
+      executable = File::findSiblingTOPPExecutable(tool_path);
     }
     catch (const Exception::FileNotFound& e)
     {

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -317,6 +317,23 @@ START_SECTION(static std::string getUserDirectory())
   // OpenMS.ini file exists at the new location.
 END_SECTION
 
+START_SECTION((static std::string getOpenMSConfigDir()))
+  std::string config_dir = File::getOpenMSConfigDir();
+  TEST_NOT_EQUAL(config_dir, std::string())
+  // every platform branch resolves to a folder named "OpenMS" with no trailing separator
+  TEST_EQUAL(StringUtils::hasSuffix(config_dir, "OpenMS"), true)
+  TEST_EQUAL(StringUtils::hasSuffix(config_dir, "/"), false)
+#ifdef __unix__
+  // on unix-like systems, XDG_CONFIG_HOME takes precedence when set
+  const char* xdg_backup = getenv("XDG_CONFIG_HOME");
+  setenv("XDG_CONFIG_HOME", "/tmp/openms_xdg_test", 1);
+  TEST_EQUAL(File::getOpenMSConfigDir(), "/tmp/openms_xdg_test/OpenMS")
+  // restore previous environment to avoid side effects on later tests
+  if (xdg_backup) { setenv("XDG_CONFIG_HOME", xdg_backup, 1); }
+  else { unsetenv("XDG_CONFIG_HOME"); }
+#endif
+END_SECTION
+
 START_SECTION(static Param getSystemParameters())
   Param p = File::getSystemParameters();
   TEST_EQUAL(!p.empty(), true)


### PR DESCRIPTION
Fixes #6233. TOPPView created a visible "OpenMS_Plugins" directory directly
in the user's home folder on every startup, even for users who never use
plugins.

Two changes:
- Move the default plugin path from ~/OpenMS_Plugins to the per-user OpenMS
  config directory (next to OpenMS.ini), via the new File::getOpenMSConfigDir()
  helper refactored out of getSystemParameters(). This puts it in the hidden,
  platform-conventional location (~/.config/OpenMS/plugins on Linux,
  ~/.OpenMS/plugins elsewhere) instead of polluting $HOME.
- Create the directory lazily, the first time plugins are actually scanned
  (i.e. when the tool/plugin dialog is opened), instead of eagerly at startup.
  setPluginPath() now always remembers the configured path but only creates the
  directory when explicitly requested; plugin discovery already tolerates a
  missing directory. mkpath() is used so intermediate dirs are created too.

Note: existing installs keep their old plugins_path saved in ~/.TOPPView.ini
until preferences are reset.

https://claude.ai/code/session_01U9L5opPn6kzMTJsD7i7VTN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OpenMS now centralizes the per-user configuration directory used for `OpenMS.ini`, applying XDG-based behavior on Unix-like systems and the correct per-user location on Windows.

* **Improvements**
  * Update checking now uses the same centralized configuration directory.
  * Plugin handling is more lazy; the default plugins location is switched to the per-user OpenMS data directory.
  * TOPP tool execution and parameter discovery were streamlined to avoid plugin-specific paths/logic.

* **UI/Removed Features**
  * Removed the “Plugins path” preference UI and the “Reload Plugins” functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->