### PR TITLE
fix(ci): update Windows build to Visual Studio 2026 (VS 18)

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -49,7 +49,7 @@ runs:
         if (-not $NPROC) { $NPROC = 4 }
         $env:CMAKE_BUILD_PARALLEL_LEVEL = $NPROC
         Set-Location "${{ github.workspace }}\contrib\build"
-        cmake -G"Visual Studio 17 2022" -Ax64 -DBUILD_TYPE=ALL "${{ github.workspace }}\contrib"
+        cmake -G"Visual Studio 18 2026" -Ax64 -DBUILD_TYPE=ALL "${{ github.workspace }}\contrib"
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     - name: Add THIRDPARTY

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -43,18 +43,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2022
-            # Pinned to the VS2022 image: the windows-2025 image moved to VS2026, which the
-            # contrib build's CMake generator guard (VS {14..17}) rejects even with
-            # OVERRIDE_GENERATOR. Move back to windows-2025 once contrib supports VS2026
-            # (and bump the msvc2022 Qt arch below to match).
+          - os: windows-2025
+            # windows-2025 ships with Visual Studio 2026 (VS 18, MSVC 14.5x).
+            # Qt is pinned to win64_msvc2022_64 (VS 2022 binaries): MSVC maintains ABI
+            # stability within the 14.x family, so VS 2026-compiled OpenMS links fine
+            # against VS 2022-compiled Qt 6.
             # cl.exe is currently the only supported. Needs a VS shell to be set up (especially if used without VS CMake Generator)
             # clang.exe is also installed but untested (might crash with our VS specific compiler definitions)
             # clang-cl.exe might be used instead.
             compiler: cl.exe
+            # VS 2026: 14.50-14.59 (corresponds to MSVC v145)
             # VS 2022: 14.30-14.39 (corresponds to MSVC v143)
-            # VS 2019: 14.20-14.29 (corresponds to MSVC v142)
-            compiler_ver: 14.44   # Specific toolset version for VS 2022 -- must (roughly) match Qt6 compiler (see below)
+            compiler_ver: 14.51   # Toolset version for VS 2026 on windows-2025 runner
 
           - os: macos-15
             # Since the appleclang version is dependent on the XCode versions that are installed


### PR DESCRIPTION
## Root Cause

The `windows-2022` GitHub Actions runner image was silently upgraded to `win25-vs2026` (Visual Studio 2026, MSVC 14.5x) on or around 2026-06-08. There is no Visual Studio 2022 installed on these runners, so the hardcoded `-G"Visual Studio 17 2022"` in the contrib build step fails immediately:

```
CMake Error at CMakeLists.txt:136 (PROJECT):
  Generator "Visual Studio 17 2022" could not find any instance of Visual Studio.
```

This broke the nightly `openms-ci-full` run (run ID 27485278482, 2026-06-14).

The previous workaround in #9506 (pin runner to `windows-2022`) no longer helps since `windows-2022` itself now maps to `win25-vs2026`.

## Changes in this PR (openms/openms)

- **`.github/actions/dependencies/action.yml`**: change contrib cmake generator from `"Visual Studio 17 2022"` to `"Visual Studio 18 2026"`
- **`.github/workflows/openms_ci_matrix_full.yml`**: switch matrix runner from `windows-2022` to `windows-2025` (explicit label for VS 2026 image), update `compiler_ver` from `14.44` to `14.51` (actual VS 2026 MSVC toolset version)

Qt stays pinned to `win64_msvc2022_64`: MSVC maintains ABI stability within the 14.x family, so VS 2026-compiled OpenMS links correctly against VS 2022-compiled Qt 6.

## Required companion change in openms/contrib

This PR **requires** a companion fix in `openms/contrib` to be merged first. The contrib `CMakeLists.txt` has a generator guard that only accepts VS 14–17 and rejects VS 18, and the `OVERRIDE_GENERATOR` escape hatch is broken (calls `FATAL_ERROR` instead of `WARNING`).

The local branch `fix/vs2026-support` in the contrib submodule (commit `fc6ccf5`) has the fix ready. The full diff to apply:

```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,11 +335,14 @@ if (MSVC)
   elseif (CMAKE_GENERATOR MATCHES ".*Visual Studio 17.*") ## VS2022
     set(TMP_VS_VERSION "17")
     set(TMP_MSVC_TOOLSET_VERSION "14.3")
+  elseif (CMAKE_GENERATOR MATCHES ".*Visual Studio 18.*") ## VS2026
+    set(TMP_VS_VERSION "18")
+    set(TMP_MSVC_TOOLSET_VERSION "14.5")
   else()
     if (OVERRIDE_GENERATOR)
-      message(FATAL_ERROR "Chosen to override the Generator check, proceed with caution.")
+      message(WARNING "Chosen to override the Generator check, proceed with caution.")
     else()
-      message(FATAL_ERROR "Please use 'Visual Studio ??' (??={14, 15, 16, 17}) as Generator ...")
+      message(FATAL_ERROR "Please use 'Visual Studio ??' (??={14, 15, 16, 17, 18}) as Generator ...")
     endif()
   endif()

diff --git a/libraries.cmake/coinor.cmake b/libraries.cmake/coinor.cmake
--- a/libraries.cmake/coinor.cmake
+++ b/libraries.cmake/coinor.cmake
@@ -37,7 +37,13 @@ MACRO( OPENMS_CONTRIB_BUILD_COINOR)
-    set(MSBUILD_ARGS_SLN "${COINOR_DIR}/CoinMP/MSVisualStudio/v${CONTRIB_VS_VERSION}/CoinMP.sln")
+    # VS 18 (2026) MSBuild can build VS 17 (2022) solution files; no v18 solutions exist yet
+    if (CONTRIB_VS_VERSION GREATER_EQUAL 18)
+      set(_COINOR_SLN_VS_DIR "v17")
+    else()
+      set(_COINOR_SLN_VS_DIR "v${CONTRIB_VS_VERSION}")
+    endif()
+    set(MSBUILD_ARGS_SLN "${COINOR_DIR}/CoinMP/MSVisualStudio/${_COINOR_SLN_VS_DIR}/CoinMP.sln")
```

## Steps to complete

- [ ] Apply contrib diff above to `openms/contrib`, open a PR there, and merge it
- [ ] Update the contrib submodule pointer in this PR to the new contrib commit
- [ ] Undraft this PR
- [ ] CI `build-and-test (windows-2025, cl.exe, 14.51)` passes

https://claude.ai/code/session_01HsZ43hGRXdr86gkocZCvxb