### PR TITLE
CI: migrate Windows build to Visual Studio 2026 (windows-2025)

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -105,12 +105,14 @@ runs:
         conda info
 
         # None of the other arrow sublibraries seemed necessary, but it's an easy addition.
-        # doxygen is installed here (conda-forge) instead of via Chocolatey: the choco
-        # 'doxygen.portable' package downloads from doxygen.nl, which intermittently returns
-        # HTTP 403 and aborts the whole job before it can build. Windows builds the docs
-        # (enable_docs=ON) to catch Doxygen errors pre-merge, so it must be available; conda-forge
-        # ships its own artifact (installed into Library/bin, already on PATH below).
-        conda install -c conda-forge libarrow libparquet libzip doxygen -y
+        # doxygen and ghostscript are installed here (conda-forge) instead of via Chocolatey:
+        #  - choco 'doxygen.portable' downloads from doxygen.nl, which intermittently returns
+        #    HTTP 403 and aborts the whole job before it can build.
+        #  - choco 'ghostscript' (Ghostscript.app) hangs its installer (gs10071w64.exe) for the
+        #    full 2700s timeout on the windows-2025 (Server 2025) image, failing the job.
+        # Both are needed for the docs (enable_docs=ON, built on Windows to catch errors
+        # pre-merge); conda-forge ships them into Library/bin (already on PATH below).
+        conda install -c conda-forge libarrow libparquet libzip doxygen ghostscript -y
 
         # Set variables required for the following steps so they
         # don't need a conda environment or login shell:
@@ -148,12 +150,11 @@ runs:
       if: inputs.os == 'Windows'
       shell: bash
       run: |
-        # NOTE: doxygen is installed via conda-forge in the Conda step above, not here, because
-        # the chocolatey 'doxygen.portable' package downloads from doxygen.nl and frequently
-        # fails with HTTP 403 (the package is also flagged "Likely broken for FOSS users").
+        # NOTE: doxygen AND ghostscript are installed via conda-forge in the Conda step above,
+        # not here: choco 'doxygen.portable' frequently 403s from doxygen.nl, and choco
+        # 'ghostscript' hangs its installer for the full 2700s timeout on windows-2025.
         choco install -y --no-progress \
           ccache \
-          ghostscript \
           graphviz
 
         # Use a custom NSIS, which provides 8-k string support and has

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -49,7 +49,9 @@ runs:
         if (-not $NPROC) { $NPROC = 4 }
         $env:CMAKE_BUILD_PARALLEL_LEVEL = $NPROC
         Set-Location "${{ github.workspace }}\contrib\build"
-        cmake -G"Visual Studio 17 2022" -Ax64 -DBUILD_TYPE=ALL "${{ github.workspace }}\contrib"
+        # windows-2025 runners ship Visual Studio 2026 (v145). The "Visual Studio 18 2026"
+        # generator needs CMake >= 4.2 (the runner image provides CMake >= 4.3).
+        cmake -G"Visual Studio 18 2026" -Ax64 -DBUILD_TYPE=ALL "${{ github.workspace }}\contrib"
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     - name: Add THIRDPARTY
@@ -135,7 +137,8 @@ runs:
       if: inputs.os == 'Windows'
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.8.3'    ## Note this version is build with win64_msvc2022_64 and should always match what we use
+        version: '6.8.3'    ## Qt 6.8.3 ships no msvc2026 build; the win64_msvc2022_64 binaries are
+                            ## ABI-compatible with the VS2026 (v145) toolchain (shared v14x ABI).
         arch: 'win64_msvc2022_64'
         cache: 'false'
         archives: 'qtsvg qtimageformats qtbase'

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -43,18 +43,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2022
-            # Pinned to the VS2022 image: the windows-2025 image moved to VS2026, which the
-            # contrib build's CMake generator guard (VS {14..17}) rejects even with
-            # OVERRIDE_GENERATOR. Move back to windows-2025 once contrib supports VS2026
-            # (and bump the msvc2022 Qt arch below to match).
+          - os: windows-2025
+            # windows-2025 ships Windows Server 2025 + Visual Studio 2026 (v145) since June 2026.
+            # The contrib build now uses the "Visual Studio 18 2026" generator (see the
+            # dependencies action); its generator guard accepts VS {14..18}.
             # cl.exe is currently the only supported. Needs a VS shell to be set up (especially if used without VS CMake Generator)
             # clang.exe is also installed but untested (might crash with our VS specific compiler definitions)
             # clang-cl.exe might be used instead.
             compiler: cl.exe
-            # VS 2022: 14.30-14.39 (corresponds to MSVC v143)
-            # VS 2019: 14.20-14.29 (corresponds to MSVC v142)
-            compiler_ver: 14.44   # Specific toolset version for VS 2022 -- must (roughly) match Qt6 compiler (see below)
+            # VS 2026: 14.50-14.5x (corresponds to MSVC v145)
+            # VS 2022: 14.30-14.4x (corresponds to MSVC v143)
+            compiler_ver: 14.51   # Toolset version for VS 2026; on Windows this only feeds the ccache key / build name (the actual compiler is cl.exe from the VS shell)
 
           - os: macos-15
             # Since the appleclang version is dependent on the XCode versions that are installed


### PR DESCRIPTION
## Why

GitHub Actions' `windows-2025` / `windows-latest` runner images migrated to **Visual Studio 2026** (MSVC v145) during June 2026, and **VS2022 is no longer installed**. `windows-2022` now also resolves to that VS2026 image, so the previous pin (#9506) no longer helps. The hardcoded `-G"Visual Studio 17 2022"` in the contrib build step fails immediately:

```
CMake Error at CMakeLists.txt:136 (PROJECT):
  Generator "Visual Studio 17 2022" could not find any instance of Visual Studio.
```

This broke the nightly `openms-ci-full` run.

## What

**This repo:**
- Run the Windows matrix job on `windows-2025`.
- Build contrib with `-G"Visual Studio 18 2026"` (the runner ships CMake ≥ 4.3, which the VS18 generator requires).
- Refresh `compiler_ver` to `14.51` (v145) — on Windows this only feeds the ccache key / build name (the compiler is `cl.exe` from the VS shell), and bumping it forces a clean rebuild on the new toolchain.
- Bump the **contrib** submodule to pick up VS2026 generator support.

**Depends on OpenMS/contrib#184** (generator guard accepts `Visual Studio 18 2026`; CoinMP `v17` solution reused with `PlatformToolset` retargeted to v145). The submodule currently points at that PR's branch commit so this PR's CI can be validated; it should be re-pointed to the contrib `master` SHA once #184 merges.

### Notes
- Qt stays on `win64_msvc2022_64` — Qt 6.8.3 ships no msvc2026 build and the v14x ABI is binary compatible with v145.
- The OpenMS build itself uses Ninja + the VS shell (`egor-tensin/vs-shell`), which picks up `cl.exe` v145 automatically — no generator change needed there.
- The pyOpenMS wheels workflow already runs on `windows-latest` with Ninja and downloads a prebuilt contrib, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Windows build setup to better align with the Visual Studio 2026 toolchain and revised related configuration.
  * Upgraded the Windows CI matrix to run on Windows 2025 with updated compiler settings.
  * Refreshed the external dependency used by the contrib component by advancing its referenced revision.
  * Improved Windows documentation tooling installation consistency by installing Doxygen and Ghostscript via conda-forge and adjusting the remaining Windows package list accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->