### PR TITLE
Fix container image tag derivation for Release* git-tag pushes

### DIFF
--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -36,30 +36,28 @@ jobs:
           sudo rm -rf "/opt/ghc"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           df -h
-      - name: Extract branch name
-        shell: bash
-        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
-        id: extract_branch
       - name: Define tag name
         shell: bash
         # Pass externally-influenced values through env so they are never
         # expanded into the shell script directly (avoids script injection).
         env:
           INPUT_TAG: ${{ github.event.inputs.tag }}
-          REF_BRANCH: ${{ steps.extract_branch.outputs.branch }}
+          REF: ${{ github.ref }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
             if [[ -n "$INPUT_TAG" ]]; then
               ## Manual run: publish under the user-provided name
               TAG="$INPUT_TAG"
-            else
-              BRANCH="$REF_BRANCH"
+            elif [[ "$REF" == refs/tags/* ]]; then
+              ## Release tag (e.g. Release3.6.0 or Release/3.6.0) -> 3.6.0
+              TAG="${REF_NAME#Release}"
+              TAG="${TAG#/}"
+            elif [[ "$REF_NAME" == "develop" || "$REF_NAME" == "nightly" || "$REF_NAME" == "feat/singularity" ]]; then
               ## use latest to follow docker conventions
-              if [[ "$BRANCH" == "develop" || "$BRANCH" == "nightly" || "$BRANCH" == "feat/singularity" ]]
-              then
-                BRANCH="latest"
-              fi
+              TAG="latest"
+            else
               ## Remove release/ from release branch name (or keep the non-release name)
-              TAG="${BRANCH#release/}"
+              TAG="${REF_NAME#release/}"
             fi
             ## Docker/OCI tags may not contain '/' and have a limited charset
             TAG="${TAG//[^a-zA-Z0-9._-]/_}"


### PR DESCRIPTION
## Description

`containerdeploy.yml` triggers on `Release*` / `Release/*` **tag** pushes, but the tag-name derivation only ever handled **branch** refs, so tagged releases never actually reached the registry.

### The bug

The old logic was:

```bash
branch=${GITHUB_REF#refs/heads/}        # only strips refs/heads/
...
echo "tag=${branch#release/}"           # only strips lowercase release/
```

For a real release tag `Release3.6.0`:

| step | value |
|------|-------|
| `GITHUB_REF` | `refs/tags/Release3.6.0` |
| `${GITHUB_REF#refs/heads/}` | `refs/tags/Release3.6.0` (prefix doesn't match → unchanged) |
| `${branch#release/}` | `refs/tags/Release3.6.0` (lowercase `release/` doesn't match `Release`) |
| **resulting image tag** | **`refs/tags/Release3.6.0`** |

That string is used both as the Docker tag (`ghcr.io/openms/openms-library:refs/tags/Release3.6.0`) and as the `OPENMS_VERSION_TAG` build-arg. A Docker/OCI tag **may not contain `/`**, so every `docker/build-push-action` push — and the downstream Singularity ORAS push that pulls those images — fails. Result: pushing a `Release*` tag produces no published containers.

### The fix

Derive the tag from `github.ref` / `github.ref_name` so tag pushes are handled explicitly:

- Release tag (`Release3.6.0` or `Release/3.6.0`) → `3.6.0`
- `develop` / `nightly` → `latest` (unchanged Docker convention)
- `release/<x>` branch → `<x>` (unchanged)

Externally-influenced values are passed via `env:` (no inline template expansion → no shell injection), and the final tag is sanitized to a valid Docker/OCI charset. The now-unused `Extract branch name` step is removed.

This matches the existing pattern in `pyopenms-wheels-cibuildwheel.yml`, which already branches on `refs/tags/Release*`.

### Note

This overlaps with #9516 (manual `workflow_dispatch` tag input) in the same `Define tag name` step. They're complementary — that PR adds an `INPUT_TAG` override branch, this PR fixes the push-trigger derivation. Whichever merges second needs a trivial conflict resolution (combine the `INPUT_TAG` branch with the `refs/tags/` branch). Happy to rebase either onto the other if you'd prefer them sequenced.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file (n/a — CI-only workflow fix)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes (n/a — CI workflow change)
- [x] Updated or added python bindings for changed or new classes (n/a)

https://claude.ai/code/session_011vX2Ntw493joYkXKrqWRqj

---
_Generated by [Claude Code](https://claude.ai/code/session_011vX2Ntw493joYkXKrqWRqj)_