### PR TITLE
[FIX] LogStream: make concurrent logging thread-safe (#9515)

### DIFF
--- a/src/openms/include/OpenMS/CONCEPT/LogStream.h
+++ b/src/openms/include/OpenMS/CONCEPT/LogStream.h
@@ -278,6 +278,12 @@ public:
 
         The default implementation is a no-op. Override in a subclass to react to log events
         (read @ref stream_ to get the formatted message body).
+
+        @warning An override MUST NOT emit any OPENMS_LOG_* message. logNotify() is invoked while
+                 the process-wide log mutex is held and while this thread's LogStreamBuf is
+                 mid-flush; re-entrant logging on the same thread reuses that buffer's
+                 incomplete_line_/cache mid-flush (a single-threaded reentrancy hazard no lock
+                 can fix) and is unsupported.
       */
       virtual void logNotify();
 
@@ -327,11 +333,11 @@ protected:
       <br>
       Which produces an error message in the log.
 
-      @note The log stream macros are thread safe and can be used in a
-      multithreaded environment, the global variables are not! The macros are
-      protected by a OPENMS_THREAD_CRITICAL directive (which translates to an
-      OpenMP critical pragma), however there may be a small performance penalty
-      to this.
+      @note The OPENMS_LOG_* macros are thread safe: each thread logs through its own
+      thread-local LogStream/LogStreamBuf (private buffer and cache), and the shared output
+      sinks/colorizer are serialized by a process-wide std::recursive_mutex inside distribute_()
+      (see issue #9515). The global LogStream variables are NOT thread safe; configure logging
+      once before spawning threads (see the thread-local accessor restrictions).
 
     */
     class OPENMS_DLLAPI LogStream :

--- a/src/openms/source/CONCEPT/LogStream.cpp
+++ b/src/openms/source/CONCEPT/LogStream.cpp
@@ -17,13 +17,12 @@
 */
 #include <limits>
 #include <string>
-#include <cstring>
 #include <cstdio>
-#include <algorithm>    // std::min
 #include <OpenMS/CONCEPT/Colorizer.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/StreamHandler.h>
 
+#include <mutex>
 #include <sstream>
 #include <iostream>
 
@@ -74,7 +73,11 @@ namespace OpenMS
 
     LogStreamBuf::~LogStreamBuf()
     {
-      // Prevent issue on OSX with OpenMP: destructors of global objects seem to be called after tearing down the OpenMP context, we therefore cannot use any locks here.
+      // ~LogStreamBuf may run during static destruction (on OSX after the OpenMP context is
+      // torn down). It flushes via syncLF_()/clearCache()/distribute_(); distribute_() takes
+      // getLogMutex_(), a process-wide std::recursive_mutex that is (a) never destroyed (leaked),
+      // so it cannot be locked-after-destruction here, and (b) a plain OS primitive, NOT an
+      // OpenMP critical section, so it is unaffected by OpenMP-runtime teardown. Safe to call.
       syncLF_();
       {
         clearCache();
@@ -213,8 +216,31 @@ namespace OpenMS
       log_time_cache_.clear();
     }
 
+    namespace
+    {
+      // Process-wide lock serializing distribute_(), the only place that writes the SHARED
+      // sink ostreams (&cerr/&cout/file streams: copied per-thread but pointing at the same
+      // objects), mutates the SHARED global Colorizer (red/yellow/magenta), and calls the
+      // user-overridable logNotify(). See issue #9515 (concurrent logging from OpenMP regions
+      // corrupted the heap on Windows; the per-thread streams alone do not make logging safe
+      // because these sinks remain shared).
+      //  - recursive_mutex: logNotify() runs while the lock is held; a same-thread override that
+      //    emits OPENMS_LOG_* re-enters distribute_() and would self-deadlock a plain mutex.
+      //  - Intentionally leaked (never destroyed): ~LogStreamBuf runs at static destruction and
+      //    reaches distribute_(); a destroyed mutex would be locked-after-destruction. A heap
+      //    object with no destructor is always lockable. It is an OS primitive, NOT an OpenMP
+      //    critical section, so it does not depend on the (possibly torn-down) OpenMP runtime.
+      std::recursive_mutex& getLogMutex_()
+      {
+        static std::recursive_mutex* m = new std::recursive_mutex(); // NOLINT: intentional leak (see above)
+        return *m;
+      }
+    }
+
     void LogStreamBuf::distribute_(const std::string& outstring)
     {
+      std::lock_guard<std::recursive_mutex> lock(getLogMutex_());
+
       // if there are any streams in our list, we
       // copy the line into that streams, too and flush them
       std::list<StreamStruct>::iterator list_it = stream_list_.begin();
@@ -252,8 +278,6 @@ namespace OpenMS
           char *line_start = pbase();
           char *line_end = pbase();
 
-          static char buf[BUFFER_LENGTH];
-
           while (line_end < pptr())
           {
             // search for the first end of line
@@ -263,31 +287,24 @@ namespace OpenMS
 
             if (line_end >= pptr())
             {
-              // Copy the incomplete line to the incomplete_line_ buffer
-              size_t length = line_end - line_start;
-              length = std::min(length, (size_t) (BUFFER_LENGTH - 1));
-              strncpy(&(buf[0]), line_start, length);
-
-              // if length was too large, we copied one byte less than BUFFER_LENGTH to have
-              // room for the final \0
-              buf[length] = '\0';
-
-              incomplete_line_ += &(buf[0]);
+              // Append the incomplete tail [line_start, line_end) directly into the
+              // per-thread buffer. No shared static buffer (issue #9515), no BUFFER_LENGTH-1
+              // truncation, embedded NULs preserved. (line_end == pptr() in this branch.)
+              incomplete_line_.append(line_start, line_end - line_start);
 
               // mark everything as read
               line_end = pptr() + 1;
             }
             else
             {
-              // note: pptr() - pbase() should be bounded by BUFFER_LENGTH, so this should always work
-              memcpy(&(buf[0]), line_start, line_end - line_start + 1);
-              buf[line_end - line_start] = '\0';
-
               // assemble the string to be written
               // (consider leftovers of the last buffer from incomplete_line_)
               std::string outstring;
               std::swap(outstring, incomplete_line_); // init outstring, while resetting incomplete_line_
-              outstring += &(buf[0]);
+              // append [line_start, line_end) WITHOUT the trailing '\n' (line_end points AT the
+              // '\n'); distribute_ re-adds the newline via std::endl. No shared static buffer
+              // (issue #9515).
+              outstring.append(line_start, line_end - line_start);
 
               // avoid adding empty lines to the cache
               if (outstring.empty())

--- a/src/tests/class_tests/openms/source/LogStream_test.cpp
+++ b/src/tests/class_tests/openms/source/LogStream_test.cpp
@@ -21,6 +21,7 @@
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 
 #include <fstream>
+#include <iostream>
 #include <boost/regex.hpp>
 
 // OpenMP support
@@ -97,6 +98,62 @@ START_SECTION(([EXTRA] OpenMP - test))
     }
     // If we get here without crashing, the test passes
     TEST_EQUAL(true, true)
+  }
+
+  // Test 3 (issue #9515): concurrent WARN logging must not crash or tear lines.
+  // This faithfully exercises the path that corrupted the heap on Windows (0xC0000374):
+  // OPENMS_LOG_WARN writes to the shared std::cerr sink through the shared 'yellow' Colorizer
+  // and (pre-fix) through a shared 'static char buf' in LogStreamBuf::syncLF_(), from inside an
+  // OpenMP parallel region. We redirect std::cerr's buffer to a temp file (the WARN sink OBJECT
+  // is unchanged, so every thread-local buffer still writes to it) to capture output and avoid
+  // console spam, then verify each captured line is an intact, well-formed message.
+  {
+    std::string tmp_filename;
+    NEW_TMP_FILE(tmp_filename)
+
+    const int N = 20000;
+    {
+      std::ofstream capture(tmp_filename.c_str());
+      std::streambuf* old_cerr = std::cerr.rdbuf(capture.rdbuf());
+
+      #ifdef _OPENMP
+      omp_set_num_threads(8);
+      #pragma omp parallel for
+      #endif
+      for (int i = 0; i < N; ++i)
+      {
+        // Unique-per-iteration: defeats the 2-slot dedup cache so every emit actually reaches
+        // distribute_() (the corrupting path). std::endl flushes each message immediately, so the
+        // per-thread LogStreamBuf retains no un-flushed tail when we restore std::cerr below
+        // (a tail would otherwise be flushed at thread exit, after the restore, and leak to cerr).
+        OPENMS_LOG_WARN << "warn_thread_msg_" << i << std::endl;
+      }
+
+      std::cerr.flush();
+      std::cerr.rdbuf(old_cerr); // restore BEFORE 'capture' is destroyed
+    } // 'capture' flushed & closed here
+
+    // Reaching here at all is the primary regression signal (pre-fix: Windows heap abort).
+    TEST_EQUAL(true, true)
+
+    // Integrity: every non-empty captured line, with any ANSI color codes stripped, must be a
+    // complete "warn_thread_msg_<n>" message. A torn/interleaved line fails the match.
+    std::ifstream in(tmp_filename.c_str());
+    std::string line;
+    Size good = 0;
+    boost::regex ansi("\033\\[[0-9;]*m");        // strip color escapes (emitted only on a TTY)
+    boost::regex msg("^warn_thread_msg_[0-9]+$");
+    while (std::getline(in, line))
+    {
+      if (line.empty()) { continue; }
+      std::string clean = boost::regex_replace(line, ansi, "");
+      TEST_EQUAL(boost::regex_match(clean, msg), true)
+      ++good;
+    }
+    // Exactly N lines must survive: messages are unique (no dedup), the default WARN config has a
+    // single sink, and std::endl flushes each line, so capture is complete and deterministic.
+    // good < N would mean silent message loss (a corruption mode short of a torn line).
+    TEST_EQUAL(good == (Size)N, true)
   }
 }
 END_SECTION


### PR DESCRIPTION
Fixes #9515.

## Problem

`OPENMS_LOG_*` macros log through **thread-local** `LogStream`s (#8620/#8596), so each thread has its own `pbuf_`, `incomplete_line_`, and message cache. But **two shared resources survived that refactor** and corrupt the heap (`0xC0000374` on Windows) when warnings are emitted from inside an OpenMP parallel region:

1. **`LogStreamBuf::syncLF_()` assembled each line in a function-local `static char buf[BUFFER_LENGTH]`** — shared across all threads, raced via `strncpy`/`memcpy`.
2. **`distribute_()` writes the shared sink ostreams (`cerr`/`cout`), mutates the shared global `Colorizer` (`red`/`yellow`/`magenta`), and calls the user-overridable `logNotify()`** — all unsynchronized.

This was hit in practice by the imzML reader (#9454): a per-array decode warning (`MzMLHandlerHelper::decodeBase64Arrays`, unconditional `OPENMS_LOG_WARN`) fires for every spectrum inside `MzMLHandler::populateSpectraWithData_()`'s `#pragma omp parallel for`. That PR worked around it locally; this PR fixes the root cause.

## Fix

- **Eliminate the shared static buffer**: append the streambuf range directly via `std::string::append(ptr, len)` into the per-thread `incomplete_line_` / a stack-local `outstring`. Also removes a latent `BUFFER_LENGTH-1` truncation and preserves embedded NULs. Drops now-unused `<algorithm>`/`<cstring>`.
- **Serialize `distribute_()`** with a process-wide, intentionally-leaked `std::recursive_mutex` (file-local `getLogMutex_()`):
  - *recursive* — `logNotify()` runs while the lock is held; a same-thread override that logs would self-deadlock a plain mutex.
  - *leaked (never destroyed)* — `~LogStreamBuf` reaches `distribute_()` during static destruction; a destroyed mutex would be locked-after-destruction. It is an OS primitive, **not** an OpenMP critical section, so it is unaffected by OpenMP-runtime teardown.
- The `syncLF_()` `stream_list_.empty()` early-out **stays lock-free**, so the default-off `OPENMS_LOG_DEBUG` hot loops take no lock.
- Docs: refresh the stale thread-safety `@note` (the referenced `OPENMS_THREAD_CRITICAL` no longer exists) and document the `logNotify()` reentrancy contract.

## Regression test

New `Test 3` in `LogStream_test`'s `[EXTRA] OpenMP` section: redirect `std::cerr`'s buffer to a temp file (the sink **object** is unchanged, so every thread-local buffer still targets it), log 20000 unique `OPENMS_LOG_WARN` messages via `std::endl` from 8 OpenMP threads, restore `cerr`, then assert every captured line (ANSI codes stripped) matches `^warn_thread_msg_[0-9]+$` **and** that exactly `N` lines survive (catches silent message loss in addition to torn lines).

## Verification (local, Linux)

- **With the fix**: passes deterministically (6/6 runs), zero stderr leak; existing caching/prefix/color/empty-line assertions intact; `Colorizer`/`StreamHandler`/`LogConfigHandler` tests pass.
- **With the source fix reverted (committed test kept)**: **fails/crashes 8/8** — 2 explicit `FAILED` at the integrity assertion (torn lines), 6 hard aborts. So the test genuinely reproduces #9515 even on Linux, not just Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified thread-safety guarantees and concurrency requirements for logging operations in multi-threaded environments.

* **Bug Fixes**
  * Enhanced thread-safety during concurrent logging and static destruction by implementing serialized access to shared logging resources.
  * Improved handling of partial log lines in multi-threaded scenarios, eliminating shared buffer race conditions.

* **Tests**
  * Added regression test verifying correct behavior of concurrent logging operations under parallel workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->