### PR TITLE
Fix ProteomicsLFQ mzTab crash on non-string spectrum_reference

### DIFF
--- a/src/openms/source/FORMAT/MzTab.cpp
+++ b/src/openms/source/FORMAT/MzTab.cpp
@@ -1994,7 +1994,7 @@ Not sure how to handle these:
     p.fromCellString("[MS,MS:1001530,mzML unique identifier,]");
     for (const auto& pid : peptide_ids)
     {
-      std::string spec_ref = pid->getMetaValue("spectrum_reference", "");
+      std::string spec_ref = pid->getSpectrumReference(); // lenient: tolerates non-string spectrum_reference DataValues
       // note: don't change order as some may contain the other terms as well. Taken from mzTab specification document
       if (StringUtils::hasSubstring(spec_ref, "controllerNumber=")) { p.fromCellString("[MS,MS:1000768,Thermo nativeID format,]"); return p; }
       if (StringUtils::hasSubstring(spec_ref, "process=")) { p.fromCellString("[MS,MS:1000769,Waters nativeID format,]"); return p; }

--- a/src/openms/source/METADATA/PeptideIdentification.cpp
+++ b/src/openms/source/METADATA/PeptideIdentification.cpp
@@ -162,7 +162,10 @@ namespace OpenMS
 
   std::string PeptideIdentification::getSpectrumReference() const
   {
-    return getMetaValue(Constants::UserParam::SPECTRUM_REFERENCE, "");
+    // spectrum_reference may be stored as a non-string DataValue (e.g. an integer scan
+    // index when loaded from idparquet/mzIdentML), so stringify leniently instead of
+    // relying on the strict DataValue::operator std::string() (which throws on Int/etc.).
+    return StringUtils::toStr(getMetaValue(Constants::UserParam::SPECTRUM_REFERENCE, ""));
   }
 
   void PeptideIdentification::setSpectrumReference(const std::string& id)
@@ -172,7 +175,8 @@ namespace OpenMS
 
   std::string PeptideIdentification::getBaseName() const
   {
-    return getMetaValue(Constants::UserParam::BASE_NAME, "");
+    // lenient stringification (see getSpectrumReference) to tolerate non-string DataValues
+    return StringUtils::toStr(getMetaValue(Constants::UserParam::BASE_NAME, ""));
   }
 
   void PeptideIdentification::setBaseName(const std::string& base_name)
@@ -192,7 +196,8 @@ namespace OpenMS
   {
     // implement as meta value in order to reduce bloat of PeptideIdentification object
     //  -> this is mostly used for pepxml at the moment which allows each peptide id to belong to a different experiment
-    return this->getMetaValue("experiment_label", "");
+    // lenient stringification (see getSpectrumReference) to tolerate non-string DataValues
+    return StringUtils::toStr(this->getMetaValue("experiment_label", ""));
   }
 
   void PeptideIdentification::setExperimentLabel(const std::string& label)

--- a/src/tests/class_tests/openms/source/PeptideIdentification_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideIdentification_test.cpp
@@ -479,6 +479,13 @@ START_SECTION((const std::string& getBaseName() const))
   // Test that it's stored as a MetaValue
   TEST_TRUE(id.metaValueExists(Constants::UserParam::BASE_NAME))
   TEST_EQUAL(id.getMetaValue(Constants::UserParam::BASE_NAME), "test_base_name")
+
+  // Regression (string refactor #9450): tolerate a non-string base_name DataValue
+  // (lenient stringification, must not throw).
+  PeptideIdentification id_int;
+  int int_base = 0;
+  id_int.setMetaValue(Constants::UserParam::BASE_NAME, int_base);
+  TEST_EQUAL(id_int.getBaseName(), "0")
 END_SECTION
 
 START_SECTION((void setBaseName(const std::string& base_name)))
@@ -500,6 +507,28 @@ START_SECTION((void setBaseName(const std::string& base_name)))
   TEST_FALSE(id.empty())
   id.setBaseName("");
   TEST_TRUE(id.empty())
+END_SECTION
+
+START_SECTION((std::string getSpectrumReference() const))
+{
+  PeptideIdentification id;
+  TEST_EQUAL(id.getSpectrumReference(), "")
+
+  // normal string round-trip
+  id.setSpectrumReference("controllerType=0 controllerNumber=1 scan=12345");
+  TEST_EQUAL(id.getSpectrumReference(), "controllerType=0 controllerNumber=1 scan=12345")
+
+  // Regression (string refactor #9450): spectrum_reference may be loaded as a non-string
+  // DataValue (e.g. an integer scan index from idparquet/mzIdentML). The accessor must
+  // stringify leniently and must NOT throw a ConversionError (which the strict
+  // DataValue::operator std::string() does for non-string types). This surfaced as a
+  // ProteomicsLFQ mzTab export crash: "Could not convert non-string DataValue of type
+  // 'Int' and value '0' to string".
+  PeptideIdentification id_int;
+  int int_ref = 0;
+  id_int.setMetaValue(Constants::UserParam::SPECTRUM_REFERENCE, int_ref);
+  TEST_EQUAL(id_int.getSpectrumReference(), "0")
+}
 END_SECTION
 
 START_SECTION((std::hash<PeptideIdentification>))


### PR DESCRIPTION
The String->std::string refactor (#9450) made DataValue::operator
std::string() strict (throws on non-string types). The PeptideIdentification
string accessors getSpectrumReference()/getBaseName()/getExperimentLabel()
do `return getMetaValue(...)`, which previously used the lenient
String(DataValue) stringification but now hit the strict operator.

When spectrum_reference is stored as an integer (e.g. a scan index loaded
from idparquet/mzIdentML), ProteomicsLFQ crashed during mzTab export with:
  "Could not convert non-string DataValue of type 'Int' and value '0' to string"

The crash originated in MzTab's CMMzTabStream constructor via
getMSRunSpectrumIdentifierType_(), which read spectrum_reference directly
into a std::string; getSpectrumReference() (used in the peptide section)
would have thrown next. A sibling site was already wrapped with
StringUtils::toStr() in #9450, but these were missed.

Restore the lenient stringification (the documented StringUtils::toStr
replacement for the old String(DataValue) behavior) in the three accessors,
and use getSpectrumReference() at the direct mzTab call site. Add a
PeptideIdentification regression test for an integer spectrum_reference /
base_name.