### PR TITLE
Fix indentation in ProSE.cpp documentation header

### DIFF
--- a/src/topp/ProSE.cpp
+++ b/src/topp/ProSE.cpp
@@ -57,17 +57,17 @@ using namespace std;
     </table>
 </CENTER>
 
-    @em This search engine is mainly for educational/benchmarking/prototyping use cases.
-    It lacks behind in speed and/or quality of results when compared to state-of-the-art search engines.
+@em This search engine is mainly for educational/benchmarking/prototyping use cases.
+It lacks behind in speed and/or quality of results when compared to state-of-the-art search engines.
 
-    @note Currently mzIdentML (mzid) is not directly supported as an input/output format of this tool. Convert mzid files to/from idXML using @ref TOPP_IDFileConverter if necessary.
-    @note Open-search mode is automatically determined by the precursor mass tolerance: enabled when tolerance exceeds 1 Da or 1000 ppm. No explicit open-search parameter is needed. This is logged at runtime and recorded in the output search parameters as UserParam 'open_search'.
-    @note Decoy handling: either enable '-Search:decoys' to generate decoys internally, or provide a FASTA database that already contains decoy proteins (e.g., from DecoyDatabase). In both cases, the decoy accession prefix must match '-Search:decoy_prefix' (default: "DECOY_").
+@note Currently mzIdentML (mzid) is not directly supported as an input/output format of this tool. Convert mzid files to/from idXML using @ref TOPP_IDFileConverter if necessary.
+@note Open-search mode is automatically determined by the precursor mass tolerance: enabled when tolerance exceeds 1 Da or 1000 ppm. No explicit open-search parameter is needed. This is logged at runtime and recorded in the output search parameters as UserParam 'open_search'.
+@note Decoy handling: either enable '-Search:decoys' to generate decoys internally, or provide a FASTA database that already contains decoy proteins (e.g., from DecoyDatabase). In both cases, the decoy accession prefix must match '-Search:decoy_prefix' (default: "DECOY_").
 
-    <B>The command line parameters of this tool are:</B>
-    @verbinclude TOPP_ProSE.cli
-    <B>INI file documentation of this tool:</B>
-    @htmlinclude TOPP_ProSE.html
+<B>The command line parameters of this tool are:</B>
+@verbinclude TOPP_ProSE.cli
+<B>INI file documentation of this tool:</B>
+@htmlinclude TOPP_ProSE.html
 */
 
 // We do not want this class to show up in the docu:


### PR DESCRIPTION
## Description

This PR fixes inconsistent indentation in the documentation header of `src/topp/ProSE.cpp`. The lines containing `@em`, `@note`, and `<B>` tags were indented with 4 spaces, while they should be aligned with the start of the comment block (no leading spaces) to match Doxygen documentation conventions.

The changes are purely formatting/whitespace adjustments to the documentation comments and do not affect any code functionality.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file (not applicable - documentation formatting only)
- [x] I have commented my code, particularly in hard-to-understand areas (not applicable - documentation fix)
- [x] New and existing unit tests pass locally with my changes (no code changes affecting tests)
- [x] Updated or added python bindings for changed or new classes (not applicable - documentation only)

https://claude.ai/code/session_0143xDMMMCMPaa3oaBLhbxCA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reformatted the ProSE tool’s documentation to improve clarity and readability by adjusting emphasis and reorganizing informational notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->