### PR TITLE
[pyOpenMS][TEST] Pin Bruker TDF frame=/MS:1002818 native ID parsing (#9460)

### DIFF
--- a/src/pyOpenMS/tests/unittests/testSpectrumNativeIDParser.py
+++ b/src/pyOpenMS/tests/unittests/testSpectrumNativeIDParser.py
@@ -79,6 +79,28 @@ def testSpectrumNativeIDParser():
         "MS:1000768"
     ) == 200
 
+    # Bruker timsTOF .d (TDF) native IDs use "frame=<F> scan=<S>" with optional trailing
+    # tokens (precursor=, windowGroup=, scanStart=/scanEnd=, merged=) emitted by the OpenMS
+    # DDA/DIA-PASEF reader (MS:1002818). The parser recognizes the frame= prefix and targets
+    # the scan=<int> token as the scan-number proxy. The accession-based cases above stop at
+    # scan=/MS:1000776 and never exercise frame=; these pin that contract on the Python side,
+    # mirroring the C++ SpectrumNativeIDParser_test "[EXTRA] Bruker TDF frame= / MS:1002818" section.
+
+    # isNativeID recognizes the frame= prefix
+    assert pyopenms.SpectrumNativeIDParser.isNativeID("frame=2 scan=529")
+    assert pyopenms.SpectrumNativeIDParser.isNativeID("frame=10 scan=42 precursor=3")
+
+    # getRegExFromNativeID targets the scan= token for the frame= format
+    assert pyopenms.SpectrumNativeIDParser.getRegExFromNativeID("frame=2 scan=529") == "scan=(?<GROUP>\\d+)"
+    assert pyopenms.SpectrumNativeIDParser.getRegExFromNativeID("frame=10 scan=42 precursor=3") == "scan=(?<GROUP>\\d+)"
+
+    # extractScanNumber via the Bruker TDF accession (MS:1002818) returns the scan= integer
+    assert pyopenms.SpectrumNativeIDParser.extractScanNumber("frame=2 scan=529", "MS:1002818") == 529
+    assert pyopenms.SpectrumNativeIDParser.extractScanNumber("frame=10 scan=42 precursor=3", "MS:1002818") == 42
+
+    # merged PASEF spectra carry multiple scan= tokens; the last one is the merged scan number
+    assert pyopenms.SpectrumNativeIDParser.extractScanNumber("frame=1 scan=5 frame=1 scan=9", "MS:1002818") == 9
+
     print("All SpectrumNativeIDParser tests passed!")
 
 


### PR DESCRIPTION
## What

Adds Bruker timsTOF `.d` (TDF) native-ID cases to the Python `testSpectrumNativeIDParser.py`, covering the `frame=<F> scan=<S>` format and its CV accession **MS:1002818**.

## Why

This closes the Python half of a `[AUTO]` task in the **OpenMS 3.6.0 pre-release testing plan** (#9460, §6 — vendor readers):

> Add SDK-free MS:1002818/`frame=` cases to **both** parser tests. **Pass:** `isNativeID("frame=2 scan=529")` is true; `extractScanNumber(..., "MS:1002818")` returns the scan.

The **C++** `SpectrumNativeIDParser_test.cpp` already has an `[EXTRA] Bruker TDF frame= / MS:1002818 native ID` section (in `develop`), but the **Python** test stopped at `scan=`/`MS:1000776` and never exercised the `frame=` path. The Bruker DDA/DIA-PASEF native-ID round-trip was therefore asserted only in the SDK-gated reader test — never on the SDK-free Python parser surface that runs on public CI.

## What it asserts (mirrors the C++ section)

- `isNativeID()` recognizes the `frame=` prefix (incl. a trailing `precursor=` token).
- `getRegExFromNativeID()` targets the `scan=<int>` token for `frame=` IDs.
- `extractScanNumber(..., "MS:1002818")` returns the `scan=` integer, including the trailing-`precursor=` and merged multi-`scan=` (last-wins) cases.

## Test plan

Tests only — no production code changed. Verified against the built nanobind bindings:

```
$ python3 src/pyOpenMS/tests/unittests/testSpectrumNativeIDParser.py
All SpectrumNativeIDParser tests passed!
```

Part of #9460.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for native spectrum ID parsing to ensure proper handling of various ID formats and scan number extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->