### PR TITLE
[TEST] PathUtils: round-trip CJK / spaces / >260-char paths through to_path (#9460)

### DIFF
--- a/src/tests/class_tests/openms/source/PathUtils_test.cpp
+++ b/src/tests/class_tests/openms/source/PathUtils_test.cpp
@@ -13,6 +13,18 @@
 
 using namespace OpenMS;
 
+namespace
+{
+  // Read a filesystem::path back as UTF-8 bytes. u8string() is UTF-8 on every
+  // platform (unlike string(), which is lossy on the Windows ANSI code page),
+  // so it is the correct cross-platform way to assert a byte-exact round-trip.
+  std::string asUtf8(const std::filesystem::path& p)
+  {
+    const std::u8string u8 = p.u8string();
+    return std::string(reinterpret_cast<const char*>(u8.data()), u8.size());
+  }
+}
+
 START_TEST(PathUtils, "$Id$")
 
 START_SECTION(std::filesystem::path to_path(const std::string& s))
@@ -24,6 +36,40 @@ START_SECTION(std::filesystem::path to_path(const std::string& s))
   const std::string utf8_ae{'\xC3', '\xA4'};
   std::filesystem::path p_utf8 = to_path(utf8_ae + ".mzML");
   TEST_FALSE(p_utf8.empty())
+  TEST_EQUAL(asUtf8(p_utf8), utf8_ae + ".mzML")
+
+  // Round-trip invariant for valid UTF-8: to_path() -> u8string() must reproduce
+  // the original bytes on every platform. All file I/O now flows through to_path()
+  // after the Qt removal, so these guard the non-ASCII path handling end to end.
+
+  // CJK (Japanese "日本語")
+  const std::string cjk{'\xE6', '\x97', '\xA5', '\xE6', '\x9C', '\xAC', '\xE8', '\xAA', '\x9E'};
+  const std::string cjk_file = cjk + ".mzML";
+  std::filesystem::path p_cjk = to_path(cjk_file);
+  TEST_FALSE(p_cjk.empty())
+  TEST_EQUAL(asUtf8(p_cjk), cjk_file)
+
+  // Embedded spaces and parentheses
+  const std::string spaced = "my data file (run 1).mzML";
+  std::filesystem::path p_spaced = to_path(spaced);
+  TEST_FALSE(p_spaced.empty())
+  TEST_EQUAL(asUtf8(p_spaced), spaced)
+
+  // Long name (well beyond the historical Windows MAX_PATH of 260): constructing
+  // the path object must not truncate or throw (the 260 limit applies to filesystem
+  // operations, not to the path object itself).
+  const std::string longname = std::string(300, 'a') + ".mzML";
+  std::filesystem::path p_long = to_path(longname);
+  TEST_FALSE(p_long.empty())
+  TEST_EQUAL(asUtf8(p_long), longname)
+  TEST_EQUAL(asUtf8(p_long).size(), longname.size())
+
+  // Mixed CJK + Latin-1 diacritics with a space ("测试 äö")
+  const std::string mixed{'\xE6', '\xB5', '\x8B', '\xE8', '\xAF', '\x95', ' ', '\xC3', '\xA4', '\xC3', '\xB6'};
+  const std::string mixed_file = mixed + ".featureXML";
+  std::filesystem::path p_mixed = to_path(mixed_file);
+  TEST_FALSE(p_mixed.empty())
+  TEST_EQUAL(asUtf8(p_mixed), mixed_file)
 
 #ifdef _WIN32
   // Windows-1252 encoded 'ä' (0xE4) — previously crashed with std::system_error


### PR DESCRIPTION
## What

Extends `PathUtils_test` with byte-exact round-trip cases for `OpenMS::to_path(const std::string&)`:

- **CJK** (Japanese `日本語.mzML`)
- **Embedded spaces / parentheses** (`my data file (run 1).mzML`)
- **>260-char name** (a 300-char filename — well past the historical Windows `MAX_PATH` of 260; constructing the path object must not truncate or throw, since that limit applies to filesystem *operations*, not to the path object)
- **Mixed CJK + Latin-1 diacritics with a space** (`测试 äö.featureXML`)

The existing `ä` case is upgraded from a non-empty check to a full round-trip.

## Why

Closes the §1 (Qt removal / infrastructure) `[AUTO]` task in the **OpenMS 3.6.0 pre-release testing plan** (#9460):

> Extend `PathUtils_test.cpp` with CJK, embedded-space, and >260-char path cases. **Pass:** `to_path` returns a non-empty path that round-trips back to the original UTF-8 bytes.

Before this, `PathUtils_test` asserted only ASCII identity plus a single non-empty `ä` case. Since the Qt removal, **all** file I/O flows through `to_path()`, so the non-ASCII handling deserves an end-to-end guard.

The round-trip is asserted via `path::u8string()`, which is UTF-8 on **every** platform — unlike `string()`, which is lossy on the Windows ANSI code page. So these cases are meaningful cross-platform, not just on Linux. (The Windows-only ANSI-codepage / UNC sub-item from the issue is a separate task and not in scope here.)

## Test plan

Tests only — no production code changed. Verified locally three ways:
- the round-trip invariant proven with a standalone `<filesystem>` snippet first;
- `-fsyntax-only` clean, then full target build green;
- the test runs **PASSED**.

Part of #9460. Follows #9524, #9525, #9526.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for UTF-8 path handling across platforms.
  * Added validation for non-ASCII character support in path round-tripping, including CJK text, spaces, parentheses, and long filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->