### PR TITLE
[TEST] DateTime: pin locale- and timezone-independent parsing/formatting (#9460)

### DIFF
--- a/src/tests/class_tests/openms/source/DateTime_test.cpp
+++ b/src/tests/class_tests/openms/source/DateTime_test.cpp
@@ -379,9 +379,11 @@ START_SECTION([EXTRA] locale- and timezone-independent parsing and formatting)
   if (had_tz) { setenv("TZ", saved_tz.c_str(), 1); }
   else        { unsetenv("TZ"); }
   tzset();
+#endif
 
-  // --- vary the C locale (guarded: unavailable locales are simply skipped, so the
-  // section still passes on minimal images that lack de_DE / tr_TR) ---
+  // --- vary the C locale (standard setlocale, so this also runs on Windows; unavailable
+  // locales are simply skipped, so the section still passes on minimal images that lack
+  // de_DE / tr_TR) ---
   const char* cur = setlocale(LC_ALL, nullptr);
   const std::string saved_loc = (cur != nullptr) ? std::string(cur) : std::string("C");
 
@@ -393,7 +395,6 @@ START_SECTION([EXTRA] locale- and timezone-independent parsing and formatting)
     }
   }
   setlocale(LC_ALL, saved_loc.c_str());
-#endif
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/DateTime_test.cpp
+++ b/src/tests/class_tests/openms/source/DateTime_test.cpp
@@ -15,6 +15,9 @@
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <iostream>
 #include <vector>
+#include <clocale>
+#include <cstdlib>
+#include <ctime>
 
 using namespace OpenMS;
 using namespace std;
@@ -322,6 +325,75 @@ END_SECTION
 START_SECTION((static DateTime now()))
 {
   TEST_EQUAL(DateTime::now().isValid(), true)
+}
+END_SECTION
+
+START_SECTION([EXTRA] locale- and timezone-independent parsing and formatting)
+{
+  // DateTime is naive: set()/get()/toString()/fromString() parse and format via
+  // sscanf("%d", ...) (locale-independent integer parsing), strncmp month matching,
+  // and timegm/gmtime (UTC) for arithmetic -- never localtime or locale-sensitive
+  // number/string functions. The output must therefore be byte-identical regardless
+  // of the C locale (e.g. tr_TR's dotted-i, de_DE's decimal comma) and the TZ
+  // environment variable. The other sections never vary either; this pins that
+  // contract. (now() is excluded -- it legitimately returns local wall-clock time.)
+  auto check_invariant = []()
+  {
+    DateTime dt;
+
+    dt.set("1999-11-24 14:24:31");
+    TEST_EQUAL(dt.get(), "1999-11-24 14:24:31")
+
+    dt.set("01.02.2000 14:24:32");           // dd.mm.yyyy
+    TEST_EQUAL(dt.get(), "2000-02-01 14:24:32")
+
+    dt.set("2005-11-13T10:58:57");           // ISO 'T' separator
+    TEST_EQUAL(dt.get(), "2005-11-13 10:58:57")
+
+    dt.set("2011-08-05T15:32:07.468+02:00"); // millisecond + timezone offset, both dropped
+    TEST_EQUAL(dt.get(), "2011-08-05 15:32:07")
+
+    dt.set("Wed Dec 14 11:59:58 2006");      // asctime-style; exercises month-name matching
+    TEST_EQUAL(dt.get(), "2006-12-14 11:59:58")
+
+    DateTime dt2 = DateTime::fromString("2020-03-09T08:07:06", "yyyy-MM-ddThh:mm:ss");
+    TEST_EQUAL(dt2.toString("yyyy-MM-dd hh:mm:ss"), "2020-03-09 08:07:06")
+  };
+
+  // Baseline: whatever locale/TZ the test process started in.
+  check_invariant();
+
+#ifndef OPENMS_WINDOWSPLATFORM
+  // --- vary TZ (POSIX setenv/tzset; tzdata is essentially always present) ---
+  const char* old_tz = std::getenv("TZ");
+  const std::string saved_tz = (old_tz != nullptr) ? std::string(old_tz) : std::string();
+  const bool had_tz = (old_tz != nullptr);
+
+  for (const char* tz : {"UTC", "America/New_York", "Asia/Kolkata", "Pacific/Chatham", "Etc/GMT-14"})
+  {
+    setenv("TZ", tz, 1);
+    tzset();
+    check_invariant();
+  }
+
+  if (had_tz) { setenv("TZ", saved_tz.c_str(), 1); }
+  else        { unsetenv("TZ"); }
+  tzset();
+
+  // --- vary the C locale (guarded: unavailable locales are simply skipped, so the
+  // section still passes on minimal images that lack de_DE / tr_TR) ---
+  const char* cur = setlocale(LC_ALL, nullptr);
+  const std::string saved_loc = (cur != nullptr) ? std::string(cur) : std::string("C");
+
+  for (const char* loc : {"C", "POSIX", "de_DE.UTF-8", "tr_TR.UTF-8", "de_DE.utf8", "tr_TR.utf8"})
+  {
+    if (setlocale(LC_ALL, loc) != nullptr)
+    {
+      check_invariant();
+    }
+  }
+  setlocale(LC_ALL, saved_loc.c_str());
+#endif
 }
 END_SECTION
 


### PR DESCRIPTION
## What

Adds a `DateTime_test` section that runs a battery of parse/format checks — ISO `T`, `dd.mm.yyyy`, millisecond + timezone-offset stripping (`2011-08-05T15:32:07.468+02:00 → 2011-08-05 15:32:07`), asctime-style month names (`Wed Dec 14 11:59:58 2006`), and `fromString → toString` — and asserts the output is **byte-identical** under:

- multiple **TZ** values (`UTC`, `America/New_York`, `Asia/Kolkata`, `Pacific/Chatham`, `Etc/GMT-14`);
- multiple **C locales** (`C`, `POSIX`, `de_DE`, `tr_TR`), each **guarded by `setlocale()` success** so the section still passes on minimal images that lack `de_DE`/`tr_TR`.

`now()` is excluded (it legitimately returns local wall-clock time). The TZ/locale process state is saved and restored; the varying block is `#ifndef OPENMS_WINDOWSPLATFORM` (POSIX `setenv`/`tzset`).

## Why

Closes the §1 (Qt removal: `QDate/QDateTime → std::chrono`) `[AUTO]` task in the **OpenMS 3.6.0 pre-release testing plan** (#9460):

> Wrap key `DateTime_test`/`Date_test` asserts in a harness that sets `setlocale(de_DE/tr_TR)` and `TZ=UTC` vs `America/New_York`. **Pass:** `get()`/parse output is byte-identical across all locale/TZ settings (`tr_TR` catches the dotted-i bug). Guard locale names by platform.

`DateTime` documents itself as naive/offset-stripping, but no test varied locale or TZ. I confirmed by reading the implementation that the parse/format path uses only locale-independent primitives — `sscanf("%d", …)` for numbers, `strncmp` for month abbreviations, `timegm`/`gmtime` for arithmetic — and that `localtime` appears **only** in `now()`. So the invariance is a real, intended contract; this pins it.

## Test plan

Tests only — no production code changed. Verified locally: `-fsyntax-only` clean, full build green, test runs **PASSED**. The TZ axis is exercised end-to-end locally (tzdata present); the `de_DE`/`tr_TR` cases run where those locales are installed (guarded-skipped otherwise). No bug surfaced — `DateTime` is confirmed TZ-independent.

Scoped to `DateTime_test` (the class with the TZ-offset / millisecond / month-name surface); the analogous `Date_test` harness can follow.

Part of #9460. Follows #9524, #9525, #9526, #9528, #9530, #9531, #9532.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an additional invariant test to verify byte-identical `DateTime` parsing and formatting across different timezones and C locale settings.
  * The test exercises multiple input formats and validates roundtrip behavior, while skipping unsupported locales and avoiding Windows where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->