### PR TITLE
[TEST] FileHandler: cover Bruker .d / .d.zip type detection (#9460)

### DIFF
--- a/src/tests/class_tests/openms/source/FileHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/FileHandler_test.cpp
@@ -78,6 +78,12 @@ TEST_EQUAL(tmp.getTypeByFileName("test.peff"), FileTypes::PEFF)
 TEST_EQUAL(tmp.getTypeByFileName("test.EDTA"), FileTypes::EDTA)
 TEST_EQUAL(tmp.getTypeByFileName("test.csv"), FileTypes::CSV)
 TEST_EQUAL(tmp.getTypeByFileName("test.txt"), FileTypes::TXT)
+// Bruker TimsTOF: a ".d" directory and its zipped ".d.zip" form both resolve by name.
+// For ".d.zip" the ".zip" compression suffix is stripped, leaving ".d" -> BRUKER_TDF.
+TEST_EQUAL(tmp.getTypeByFileName("sample.d"), FileTypes::BRUKER_TDF)
+TEST_EQUAL(tmp.getTypeByFileName("sample.d.zip"), FileTypes::BRUKER_TDF)
+TEST_EQUAL(tmp.getTypeByFileName("/data/run 1.d.zip"), FileTypes::BRUKER_TDF)
+TEST_EQUAL(tmp.getTypeByFileName("plain_archive.zip"), FileTypes::UNKNOWN) // a plain .zip is not a Bruker .d
 END_SECTION
 
 START_SECTION((static bool hasValidExtension(const std::string& filename, const FileTypes::Type type)))
@@ -129,6 +135,24 @@ START_SECTION((static FileTypes::Type getType(const std::string &filename)))
   TEST_EQUAL(tmp.getType(OPENMS_GET_TEST_DATA_PATH("TransformationXMLFile_1.trafoXML")), FileTypes::TRANSFORMATIONXML)
   TEST_EQUAL(tmp.getType(OPENMS_GET_TEST_DATA_PATH("FileHandler_toppas.toppas")), FileTypes::TOPPAS)
   TEST_EQUAL(tmp.getType(OPENMS_GET_TEST_DATA_PATH("pepnovo.txt")), FileTypes::TXT)
+
+  // .d.zip: a zipped Bruker TimsTOF .d directory. getType() resolves this to
+  // BRUKER_TDF for an existing, non-directory ".zip" whose name strips to ".d".
+  // SDK-free: only the name and the file's existence matter for type detection,
+  // not the archive contents.
+  {
+    std::string dzip_base;
+    NEW_TMP_FILE(dzip_base)
+    std::string dzip = dzip_base + ".d.zip";
+    { std::ofstream os(dzip.c_str()); os << "PK\003\004 placeholder (contents irrelevant for type detection)"; }
+    TEST_EQUAL(File::exists(dzip), true)
+#ifdef WITH_OPENTIMS
+    TEST_EQUAL(tmp.getType(dzip), FileTypes::BRUKER_TDF)
+#else
+    TEST_EQUAL(tmp.getType(dzip), FileTypes::UNKNOWN) // the .d family requires WITH_OPENTIMS
+#endif
+    File::remove(dzip);
+  }
 
   TEST_EXCEPTION(Exception::FileNotFound, tmp.getType("/bli/bla/bluff"))
 END_SECTION


### PR DESCRIPTION
## What

Adds Bruker TimsTOF `.d` / `.d.zip` cases to `FileHandler_test`:

**`getTypeByFileName` (name-only, all builds):**
- `sample.d` → `BRUKER_TDF`
- `sample.d.zip` → `BRUKER_TDF` (the `.zip` compression suffix is stripped, leaving `.d`)
- `/data/run 1.d.zip` → `BRUKER_TDF` (path + embedded spaces)
- `plain_archive.zip` → `UNKNOWN` (a plain `.zip` is **not** a Bruker `.d`)

**`getType` (existing, non-directory `.zip` whose name strips to `.d`):**
- `WITH_OPENTIMS`: an existing `*.d.zip` file → `BRUKER_TDF`
- otherwise → `UNKNOWN` (the `.d` family requires `WITH_OPENTIMS`)

## Why

Closes the §1 (Qt removal: `minizip-ng → libzip`) `[AUTO]` task in the **OpenMS 3.6.0 pre-release testing plan** (#9460):

> Test `.d.zip` type **detection** (`FileHandler::getType` → `FileTypes::BRUKER_TDF`). **Pass:** a `.d.zip` name/content resolves to `BRUKER_TDF`. (SDK-free.)

`FileHandler_test` covered many formats but never the `.d`/`.d.zip` path. Detection works in two steps that this pins: `getTypeByFileName` strips the `.zip` compression suffix and recurses on `…​.d` (→ `BRUKER_TDF`), and `getType` additionally requires the file to **exist** as a non-directory `.zip` (FileHandler.cpp:224, under `WITH_OPENTIMS`). It is SDK-free — only the name and the file's existence matter for detection, not the archive contents (a placeholder file is used).

## Test plan

Tests only — no production code changed. Verified locally: `-fsyntax-only` clean, full build green, test runs **PASSED**, and the new assertions were confirmed via verbose output (`BRUKER_TDF` = enum 69 for all `.d`/`.d.zip` cases; `UNKNOWN` for the plain `.zip`).

Part of #9460. Follows #9524, #9525, #9526, #9528, #9530, #9531, #9532, #9533.

🤖 Generated with [Claude Code](https://claude.com/claude-code)