### PR TITLE
[TEST] ZipIfstream: cover the corrupt-archive error path (#9460)

### DIFF
--- a/src/tests/class_tests/openms/source/ZipIfstream_test.cpp
+++ b/src/tests/class_tests/openms/source/ZipIfstream_test.cpp
@@ -17,6 +17,7 @@
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/SYSTEM/File.h>
 
 #include <fstream>
 #include <string>
@@ -114,6 +115,28 @@ END_SECTION
 START_SECTION([EXTRA] open nonexistent file throws FileNotFound)
   ZipIfstream zif;
   TEST_EXCEPTION(Exception::FileNotFound, zif.open("/nonexistent/path/to/file.zip"))
+END_SECTION
+
+START_SECTION([EXTRA] open corrupt ZIP throws FileNotReadable)
+{
+  // A file that exists but is not a valid ZIP archive (garbage bytes, no central
+  // directory) must raise a clear exception rather than crash or read garbage.
+  // libzip's zip_open() returns nullptr; since the file exists, ZipIfstream::open
+  // reports it as not readable (vs FileNotFound for a missing path).
+  std::string base;
+  NEW_TMP_FILE(base)
+  const std::string corrupt_zip = base + ".zip";
+  {
+    std::ofstream os(corrupt_zip.c_str(), std::ios::binary);
+    os << "This is definitely not a valid ZIP archive -- just plain text bytes.";
+  }
+  TEST_EQUAL(File::exists(corrupt_zip), true)
+
+  ZipIfstream zif;
+  TEST_EXCEPTION(Exception::FileNotReadable, zif.open(corrupt_zip.c_str()))
+
+  File::remove(corrupt_zip);
+}
 END_SECTION
 
 START_SECTION([EXTRA] FileHandler::getTypeByFileName strips .zip extension)


### PR DESCRIPTION
## What

Adds a `ZipIfstream_test` section that writes garbage (non-ZIP) bytes to a `*.zip` temp file and asserts `open()` raises **`Exception::FileNotReadable`** — a clear exception rather than a crash or a garbage read.

## Why

Closes part of the §1 (Qt removal: `minizip-ng → libzip`) `[AUTO]` task in the **OpenMS 3.6.0 pre-release testing plan** (#9460):

> Add ZIP64-awareness + empty/corrupt-archive error-path cases. **Pass:** corrupt archive raises a clear exception; empty archive handled.

`ZipIfstream_test` already pins the **empty** (`FileEmpty`), **multi-entry** (`ParseError`) and **nonexistent** (`FileNotFound`) cases, but a **corrupt** archive was untested. On garbage input, libzip's `zip_open()` returns `nullptr`; since the file exists (not missing), `ZipIfstream::open` reports `FileNotReadable` (ZipIfstream.cpp:56) — this pins exactly that contract and distinguishes it from the missing-file `FileNotFound` path.

Scope note: the **ZIP64** portion of that issue line needs a crafted ZIP64-format fixture (a >4 GB / >65535-entry archive), which isn't practical to synthesize SDK-free in a unit test, so it's left for a fixture-backed follow-up; **empty** is already covered; this PR closes the **corrupt** gap.

## Test plan

Tests only — no production code changed. Verified locally: `-fsyntax-only` clean, full build green, test runs **PASSED** (the corrupt case raises `FileNotReadable` as expected; the temp file is created and removed by the test).

Part of #9460. Follows #9524, #9525, #9526, #9528, #9530, #9531, #9532, #9533, #9534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for corrupt ZIP file handling, ensuring proper error handling when opening malformed ZIP files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->