### PR TITLE
[TEST] TheoreticalSpectrumGenerator: pin b-/a-ion neutral-loss m/z (#9460)

### DIFF
--- a/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
@@ -15,9 +15,12 @@
 
 #include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/CONCEPT/Constants.h>
+
+#include <map>
 
 ///////////////////////////
 
@@ -892,6 +895,57 @@ START_SECTION(([EXTRA] test first prefix loss))
   TEST_EQUAL(std::find(anno.begin(), anno.end(), "b1-H3N1+") == anno.end(), true)
   TEST_EQUAL(std::find(anno.begin(), anno.end(), "b1-C1H2N2+") == anno.end(), true)
   TEST_EQUAL(std::find(anno.begin(), anno.end(), "b1-C1H2N1O1+") == anno.end(), true)
+}
+END_SECTION
+
+START_SECTION([EXTRA] b-ion and a-ion neutral-loss m/z values)
+{
+  // #9078: a b/a neutral-loss ion's m/z must equal its base ion m/z minus the
+  // neutral-loss mass. The loss sections above pin x-ion loss m/z and b-loss ion
+  // *names*, but never the m/z of the b-/a-ion losses (and never a-ion losses at
+  // all). Here we assert directly that m/z(<ion>-H2O1) == m/z(<ion>) - mass(H2O)
+  // for both the b- and a-ion ladders.
+  AASequence pep = AASequence::fromString("IFSQVGK"); // contains S -> water loss
+  const double water = EmpiricalFormula("H2O").getMonoWeight();
+
+  TheoreticalSpectrumGenerator tsg;
+  Param p = tsg.getParameters();
+  p.setValue("add_a_ions", "true");
+  p.setValue("add_b_ions", "true");
+  p.setValue("add_c_ions", "false");
+  p.setValue("add_x_ions", "false");
+  p.setValue("add_y_ions", "false");
+  p.setValue("add_z_ions", "false");
+  p.setValue("add_precursor_peaks", "false");
+  p.setValue("add_losses", "true");
+  p.setValue("add_metainfo", "true");
+  tsg.setParameters(p);
+
+  PeakSpectrum spec;
+  tsg.getSpectrum(spec, pep, 1, 1);
+
+  std::map<std::string, double> mz;
+  const PeakSpectrum::StringDataArray& names = spec.getStringDataArrays().at(0);
+  for (Size i = 0; i < spec.size(); ++i) { mz[std::string(names[i])] = spec[i].getPosition()[0]; }
+
+  Size b_checked = 0, a_checked = 0;
+  for (const auto& kv : mz)
+  {
+    const std::string& name = kv.first;
+    const std::string::size_type loss_pos = name.find("-H2O1+");
+    if (loss_pos != std::string::npos && (name[0] == 'b' || name[0] == 'a'))
+    {
+      const std::string base = name.substr(0, loss_pos) + "+"; // "b3-H2O1+" -> "b3+"
+      if (mz.count(base))
+      {
+        TEST_REAL_SIMILAR(kv.second, mz[base] - water)
+        if (name[0] == 'b') { ++b_checked; } else { ++a_checked; }
+      }
+    }
+  }
+  // non-vacuous: both ladders must actually contribute water-loss ions
+  TEST_EQUAL(b_checked > 0, true)
+  TEST_EQUAL(a_checked > 0, true)
 }
 END_SECTION
 


### PR DESCRIPTION
## What

Adds a `TheoreticalSpectrumGenerator_test` section that generates a- + b-ions **with losses** for `IFSQVGK` (contains `S` → water loss) and asserts, for every `<ion>-H2O1+` peak, the neutral-loss relation:

```
m/z(<ion>-H2O1) == m/z(<ion>) - mass(H2O)
```

Both ladders are checked **non-vacuously** (4 b-loss + 4 a-loss ions verified at runtime).

## Why

Closes the §7 `[AUTO]` task in the **OpenMS 3.6.0 pre-release testing plan** (#9460):

> `TheoreticalSpectrumGenerator` b/a neutral-loss (#9078) — the test asserts loss-ion **names** (`b3-H2O1+` …) but not **m/z values**. Add a section asserting specific b-H2O/a-H2O `getPosition()[0]`. **Pass:** the exact loss m/z is checked.

I confirmed the gap by reading the existing loss sections: the m/z assertion (`result_x_losses`) covers an **x-ions-only** spectrum, and the b-ion loss section checks only ion **names** via the string data array — never the b-loss m/z. **a-ion losses weren't exercised at all.**

Rather than hard-code absolute m/z (brittle), the test asserts the **relation** `loss == base − mass(H2O)`, which is exactly the contract #9078 fixed (the loss being subtracted from the correct base ion). `mass(H2O)` is taken from `EmpiricalFormula("H2O").getMonoWeight()`.

## Test plan

Tests only — no production code changed. Verified locally: `-fsyntax-only` clean, full build green, test runs **PASSED** — 8 relational checks (4 b-loss + 4 a-loss) all hold exactly, and both `b_checked > 0` and `a_checked > 0` (non-vacuous).

Part of #9460. Follows #9524 … #9540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests for theoretical spectrum generation calculations to ensure accurate ion mass value computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->