### PR TITLE
[pyOpenMS][TEST] Prove numpy peak-data getters survive owner GC (#9460)

### DIFF
--- a/src/pyOpenMS/tests/unittests/test_numpy_getter_lifetime.py
+++ b/src/pyOpenMS/tests/unittests/test_numpy_getter_lifetime.py
@@ -1,0 +1,94 @@
+"""
+Lifetime tests for the numpy peak-data getters (OpenMS issue #9460, Section 2).
+
+MSSpectrum.get_peaks() and MSExperiment.get2DPeakData()/get2DPeakDataLong() are
+nanobind wrappers that return their peak data as numpy arrays whose buffer is
+owned by an nb::capsule (delete[]), independent of the C++ source object. They
+are safe by construction today; this pins that contract so a future change to a
+*view*-returning implementation (sharing the source buffer) is caught.
+
+test_spectrum_zerocopy.py already covers get_peaks_struct(); these cover the
+get_peaks()/get2DPeakData() getters named in the issue. The snapshot is taken
+*before* deleting the source, so the comparison cannot pass vacuously.
+"""
+
+import gc
+
+import pytest
+
+import pyopenms
+
+np = pytest.importorskip("numpy")
+
+
+def _make_spectrum():
+    spec = pyopenms.MSSpectrum()
+    spec.setRT(42.0)
+    spec.setMSLevel(1)
+    spec.set_peaks((np.array([300.0, 301.0, 302.0], dtype=np.float64),
+                    np.array([9.0, 8.0, 7.0], dtype=np.float32)))
+    return spec
+
+
+def _make_experiment():
+    exp = pyopenms.MSExperiment()
+    for i in range(3):
+        spec = pyopenms.MSSpectrum()
+        spec.setRT(10.0 + i)
+        spec.setMSLevel(1)
+        spec.set_peaks((np.array([100.0 + j for j in range(4)], dtype=np.float64),
+                        np.array([5.0 * (j + 1) for j in range(4)], dtype=np.float32)))
+        exp.addSpectrum(spec)
+    return exp
+
+
+def test_msspectrum_get_peaks_survives_owner_gc():
+    spec = _make_spectrum()
+    mz, intensity = spec.get_peaks()
+    assert len(mz) > 0
+
+    # snapshot WHILE the source spectrum is still alive
+    mz_snap, in_snap = mz.copy(), intensity.copy()
+
+    del spec
+    gc.collect()
+
+    assert np.array_equal(mz, mz_snap), "get_peaks() mz array changed after owner GC"
+    assert np.array_equal(intensity, in_snap), "get_peaks() intensity array changed after owner GC"
+
+
+def test_msexperiment_get2dpeakdata_survives_source_gc():
+    exp = _make_experiment()
+    rt, mz, intensity = exp.get2DPeakData(0.0, 1.0e9, 0.0, 1.0e9, 1)
+    assert len(rt) > 0
+
+    snap = (rt.copy(), mz.copy(), intensity.copy())
+
+    del exp
+    gc.collect()
+
+    assert np.array_equal(rt, snap[0]), "get2DPeakData() rt changed after source GC"
+    assert np.array_equal(mz, snap[1]), "get2DPeakData() mz changed after source GC"
+    assert np.array_equal(intensity, snap[2]), "get2DPeakData() intensity changed after source GC"
+
+
+def test_msexperiment_get2dpeakdatalong_survives_source_gc():
+    exp = _make_experiment()
+    rt, mz, intensity = exp.get2DPeakDataLong(0.0, 1.0e9, 0.0, 1.0e9, 1)
+    assert len(rt) > 0
+
+    snap = (rt.copy(), mz.copy(), intensity.copy())
+
+    del exp
+    gc.collect()
+
+    assert np.array_equal(rt, snap[0]), "get2DPeakDataLong() rt changed after source GC"
+    assert np.array_equal(mz, snap[1]), "get2DPeakDataLong() mz changed after source GC"
+    assert np.array_equal(intensity, snap[2]), "get2DPeakDataLong() intensity changed after source GC"
+
+
+if __name__ == "__main__":
+    test_msspectrum_get_peaks_survives_owner_gc()
+    test_msexperiment_get2dpeakdata_survives_source_gc()
+    test_msexperiment_get2dpeakdatalong_survives_source_gc()
+    print("All numpy-getter lifetime tests passed!")


### PR DESCRIPTION
## What

Adds lifetime tests (numpy `importorskip`) for the numpy peak-data getters:

- `MSSpectrum.get_peaks()` → `(mz, intensity)`
- `MSExperiment.get2DPeakData()` → `(rt, mz, intensity)`
- `MSExperiment.get2DPeakDataLong()` → `(rt, mz, intensity)`

Each test snapshots the returned arrays **while the source is still alive**, then `del`s it + `gc.collect()`, then asserts the arrays are byte-identical. Snapshot-before-delete keeps the assertion non-vacuous.

## Why

Closes the "numpy getters" part of the §2 (pyOpenMS nanobind rewrite) `[AUTO]` zero-copy task in the **OpenMS 3.6.0 pre-release testing plan** (#9460):

> For each export (`get_peaks_struct`, **numpy getters**, `spectra_to_arrow`, …): snapshot contents → `del` the source object → `gc.collect()` → re-read **every** value. **Pass:** bytes match the snapshot.

These getters return numpy arrays whose buffer is owned by an `nb::capsule` (`delete[]`), independent of the C++ source — so they're safe today, but the issue flags the "risk is a future *view*-returning edit." This pins the contract: if a getter is ever changed to return a view into the source buffer, the test fails after the source is GC'd.

`test_spectrum_zerocopy.py` already covers `get_peaks_struct()`, and #9543 (companion PR) covers the Arrow exporters; this covers the `get_peaks()`/`get2DPeakData()` getters the issue's coding-agent prompt names explicitly.

## Test plan

Tests only — no production code changed. Verified against the built nanobind bindings two ways: direct script (`All numpy-getter lifetime tests passed!`) and `pytest` (`3 passed`). `numpy` `importorskip` keeps it optional; the `spectrum`/`experiment`/`kernel` modules used are unaffected by the unrelated stale-build `_pyopenms_analysis` warning.

Part of #9460. Follows #9524 … #9543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests to verify the stability and validity of numpy arrays returned from peak data getter methods under garbage collection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->