### PR TITLE
[TEST] HydrophobicityProfile: cross-check hydrophobic moment vs published Eisenberg (#9460)

### DIFF
--- a/src/tests/class_tests/openms/source/HydrophobicityProfile_test.cpp
+++ b/src/tests/class_tests/openms/source/HydrophobicityProfile_test.cpp
@@ -13,6 +13,10 @@
 
 ///////////////////////////
 
+#include <OpenMS/CONCEPT/Constants.h>
+#include <cmath>
+#include <map>
+
 using namespace OpenMS;
 using namespace std;
 
@@ -92,6 +96,59 @@ START_SECTION(std::vector<double> computeHydrophobicMoment(const AASequence& seq
   TEST_REAL_SIMILAR(vec[2],0.734926405);
   TEST_EXCEPTION(Exception::InvalidSize,profile.computeHydrophobicMoment(seq_1,0));
   TEST_EXCEPTION(Exception::InvalidValue,profile.computeHydrophobicMoment(seq_2,3));
+}
+END_SECTION
+
+START_SECTION([EXTRA] computeHydrophobicMoment matches the published Eisenberg reference)
+{
+  // Cross-check computeHydrophobicMoment against an independent computation of the
+  // Eisenberg (1984) hydrophobic moment from the *published* Eisenberg consensus
+  // hydrophobicity scale (cf. R package R.Peptides, hmoment.R). The section above
+  // pins OpenMS's own output; this validates that output against the literature
+  // scale + formula:  moment_w = sqrt( (sum h_i sin(i*d))^2 + (sum h_i cos(i*d))^2 ) / w
+  HydrophobicityProfile profile;
+
+  // Published Eisenberg consensus hydrophobicity values (Eisenberg et al. 1984).
+  const std::map<char, double> eisenberg = {
+    {'A',  0.62}, {'R', -2.53}, {'N', -0.78}, {'D', -0.90}, {'C',  0.29},
+    {'Q', -0.85}, {'E', -0.74}, {'G',  0.48}, {'H', -0.40}, {'I',  1.38},
+    {'L',  1.06}, {'K', -1.50}, {'M',  0.64}, {'F',  1.19}, {'P',  0.12},
+    {'S', -0.18}, {'T', -0.05}, {'W',  0.81}, {'Y',  0.26}, {'V',  1.08}};
+
+  auto reference_moment = [&](const std::string& seq, Size window, double angle_deg)
+  {
+    const double a = angle_deg * Constants::PI / 180.0;
+    std::vector<double> out;
+    for (Size i = 0; i + window <= seq.size(); ++i)
+    {
+      double sum_sin = 0.0, sum_cos = 0.0;
+      for (Size pos = 0; pos < window; ++pos)
+      {
+        const double h = eisenberg.at(seq[i + pos]);
+        sum_sin += h * std::sin(a * pos);
+        sum_cos += h * std::cos(a * pos);
+      }
+      out.push_back(std::sqrt(sum_sin * sum_sin + sum_cos * sum_cos) / window);
+    }
+    return out;
+  };
+
+  struct Case { std::string pep; Size window; double angle; };
+  const std::vector<Case> cases = {
+    {"ACDEF",     3, 100.0},   // also the peptide pinned literally in the section above
+    {"FLIGKWVRP", 3, 100.0},
+    {"FLIGKWVRP", 5, 160.0}};
+
+  for (const Case& c : cases)
+  {
+    std::vector<double> got = profile.computeHydrophobicMoment(AASequence::fromString(c.pep), c.window, c.angle);
+    std::vector<double> ref = reference_moment(c.pep, c.window, c.angle);
+    TEST_EQUAL(got.size(), ref.size())
+    for (Size i = 0; i < ref.size() && i < got.size(); ++i)
+    {
+      TEST_REAL_SIMILAR(got[i], ref[i])
+    }
+  }
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/HydrophobicityProfile_test.cpp
+++ b/src/tests/class_tests/openms/source/HydrophobicityProfile_test.cpp
@@ -45,12 +45,12 @@ START_SECTION(double computeGRAVY(const AASequence& seq))
   AASequence seq("ACDE");
   HydrophobicityProfile profile;
   double gravy = profile.computeGRAVY(seq);
-  TEST_REAL_SIMILAR(gravy, -0.675); 
+  TEST_REAL_SIMILAR(gravy, -0.675);
   AASequence seq_2;
-  TEST_EXCEPTION(Exception::InvalidValue,profile.computeGRAVY(seq_2)); 
+  TEST_EXCEPTION(Exception::InvalidValue, profile.computeGRAVY(seq_2));
   AASequence seq_3("XXX");
-  TEST_EXCEPTION_WITH_MESSAGE(Exception::InvalidValue,profile.computeGRAVY(seq_3),
-  "the value 'X' was used but is not valid; No hydrophobicity value known for this residue");
+  TEST_EXCEPTION_WITH_MESSAGE(Exception::InvalidValue, profile.computeGRAVY(seq_3),
+                              "the value 'X' was used but is not valid; No hydrophobicity value known for this residue");
 }
 END_SECTION
 
@@ -60,13 +60,13 @@ START_SECTION(std::vector<double> computeProfile(const AASequence& seq, const Hy
   AASequence seq("ACDE");
   AASequence seq_2;
   AASequence seq_3("XXX");
-  std::vector<double> vec = profile.computeProfile(seq,HydrophobicityScaleMethod::KYTE_DOOLITTLE);
-  TEST_REAL_SIMILAR(vec[0],1.8);
-  TEST_REAL_SIMILAR(vec[1],2.5);
-  TEST_REAL_SIMILAR(vec[2],-3.5);
-  TEST_REAL_SIMILAR(vec[3],-3.5); 
-  TEST_REAL_SIMILAR(profile.computeProfile(seq,HydrophobicityScaleMethod::EISENBERG)[0],0.62);
-  TEST_EXCEPTION(Exception::InvalidValue,profile.computeProfile(seq_3,HydrophobicityScaleMethod::EISENBERG))
+  std::vector<double> vec = profile.computeProfile(seq, HydrophobicityScaleMethod::KYTE_DOOLITTLE);
+  TEST_REAL_SIMILAR(vec[0], 1.8);
+  TEST_REAL_SIMILAR(vec[1], 2.5);
+  TEST_REAL_SIMILAR(vec[2], -3.5);
+  TEST_REAL_SIMILAR(vec[3], -3.5);
+  TEST_REAL_SIMILAR(profile.computeProfile(seq, HydrophobicityScaleMethod::EISENBERG)[0], 0.62);
+  TEST_EXCEPTION(Exception::InvalidValue, profile.computeProfile(seq_3, HydrophobicityScaleMethod::EISENBERG))
 }
 END_SECTION
 
@@ -75,13 +75,13 @@ START_SECTION(std::vector<double> computeWindowedProfile(const AASequence& seq, 
   HydrophobicityProfile profile;
   AASequence seq("ACDEF");
   AASequence seq_2;
-  std::vector<double> vec = profile.computeWindowedProfile(seq,3);
-  TEST_REAL_SIMILAR(vec[0],0.266666666666667);
-  TEST_REAL_SIMILAR(vec[1],-1.5);
-  TEST_REAL_SIMILAR(vec[2],-1.4);
-  TEST_REAL_SIMILAR(profile.computeWindowedProfile(seq,6)[0],0.02);
-  TEST_EXCEPTION(Exception::InvalidSize,profile.computeWindowedProfile(seq,0));
-  TEST_EXCEPTION(Exception::InvalidValue,profile.computeWindowedProfile(seq_2,3));
+  std::vector<double> vec = profile.computeWindowedProfile(seq, 3);
+  TEST_REAL_SIMILAR(vec[0], 0.266666666666667);
+  TEST_REAL_SIMILAR(vec[1], -1.5);
+  TEST_REAL_SIMILAR(vec[2], -1.4);
+  TEST_REAL_SIMILAR(profile.computeWindowedProfile(seq, 6)[0], 0.02);
+  TEST_EXCEPTION(Exception::InvalidSize, profile.computeWindowedProfile(seq, 0));
+  TEST_EXCEPTION(Exception::InvalidValue, profile.computeWindowedProfile(seq_2, 3));
 }
 END_SECTION
 
@@ -90,33 +90,30 @@ START_SECTION(std::vector<double> computeHydrophobicMoment(const AASequence& seq
   HydrophobicityProfile profile;
   AASequence seq_1("ACDEF");
   AASequence seq_2;
-  std::vector<double> vec = profile.computeHydrophobicMoment(seq_1,3,100);
-  TEST_REAL_SIMILAR(vec[0],0.511576803);
-  TEST_REAL_SIMILAR(vec[1],0.435170599);
-  TEST_REAL_SIMILAR(vec[2],0.734926405);
-  TEST_EXCEPTION(Exception::InvalidSize,profile.computeHydrophobicMoment(seq_1,0));
-  TEST_EXCEPTION(Exception::InvalidValue,profile.computeHydrophobicMoment(seq_2,3));
+  std::vector<double> vec = profile.computeHydrophobicMoment(seq_1, 3, 100);
+  TEST_REAL_SIMILAR(vec[0], 0.511576803);
+  TEST_REAL_SIMILAR(vec[1], 0.435170599);
+  TEST_REAL_SIMILAR(vec[2], 0.734926405);
+  TEST_EXCEPTION(Exception::InvalidSize, profile.computeHydrophobicMoment(seq_1, 0));
+  TEST_EXCEPTION(Exception::InvalidValue, profile.computeHydrophobicMoment(seq_2, 3));
 }
 END_SECTION
 
 START_SECTION([EXTRA] computeHydrophobicMoment matches the published Eisenberg reference)
 {
   // Cross-check computeHydrophobicMoment against an independent computation of the
-  // Eisenberg (1984) hydrophobic moment from the *published* Eisenberg consensus
+  // Eisenberg (1984) hydrophobic moment from the *published* Eisenberg normalized
   // hydrophobicity scale (cf. R package R.Peptides, hmoment.R). The section above
   // pins OpenMS's own output; this validates that output against the literature
   // scale + formula:  moment_w = sqrt( (sum h_i sin(i*d))^2 + (sum h_i cos(i*d))^2 ) / w
   HydrophobicityProfile profile;
 
-  // Published Eisenberg consensus hydrophobicity values (Eisenberg et al. 1984).
-  const std::map<char, double> eisenberg = {
-    {'A',  0.62}, {'R', -2.53}, {'N', -0.78}, {'D', -0.90}, {'C',  0.29},
-    {'Q', -0.85}, {'E', -0.74}, {'G',  0.48}, {'H', -0.40}, {'I',  1.38},
-    {'L',  1.06}, {'K', -1.50}, {'M',  0.64}, {'F',  1.19}, {'P',  0.12},
-    {'S', -0.18}, {'T', -0.05}, {'W',  0.81}, {'Y',  0.26}, {'V',  1.08}};
+  // Published Eisenberg normalized hydrophobicity values (Eisenberg et al. 1984).
+  const std::map<char, double> eisenberg_normalized
+    = {{'A', 0.62}, {'R', -2.53}, {'N', -0.78}, {'D', -0.90}, {'C', 0.29}, {'Q', -0.85}, {'E', -0.74}, {'G', 0.48}, {'H', -0.40}, {'I', 1.38},
+       {'L', 1.06}, {'K', -1.50}, {'M', 0.64},  {'F', 1.19},  {'P', 0.12}, {'S', -0.18}, {'T', -0.05}, {'W', 0.81}, {'Y', 0.26},  {'V', 1.08}};
 
-  auto reference_moment = [&](const std::string& seq, Size window, double angle_deg)
-  {
+  auto reference_moment = [&](const std::string& seq, Size window, double angle_deg) {
     const double a = angle_deg * Constants::PI / 180.0;
     std::vector<double> out;
     for (Size i = 0; i + window <= seq.size(); ++i)
@@ -124,7 +121,7 @@ START_SECTION([EXTRA] computeHydrophobicMoment matches the published Eisenberg r
       double sum_sin = 0.0, sum_cos = 0.0;
       for (Size pos = 0; pos < window; ++pos)
       {
-        const double h = eisenberg.at(seq[i + pos]);
+        const double h = eisenberg_normalized.at(seq[i + pos]);
         sum_sin += h * std::sin(a * pos);
         sum_cos += h * std::cos(a * pos);
       }
@@ -133,11 +130,15 @@ START_SECTION([EXTRA] computeHydrophobicMoment matches the published Eisenberg r
     return out;
   };
 
-  struct Case { std::string pep; Size window; double angle; };
-  const std::vector<Case> cases = {
-    {"ACDEF",     3, 100.0},   // also the peptide pinned literally in the section above
-    {"FLIGKWVRP", 3, 100.0},
-    {"FLIGKWVRP", 5, 160.0}};
+  struct Case
+  {
+    std::string pep;
+    Size window;
+    double angle;
+  };
+  const std::vector<Case> cases = {{"ACDEF", 3, 100.0}, // also the peptide pinned literally in the section above
+                                   {"FLIGKWVRP", 3, 100.0},
+                                   {"FLIGKWVRP", 5, 160.0}};
 
   for (const Case& c : cases)
   {


### PR DESCRIPTION
## What

Adds a `HydrophobicityProfile_test` section that independently recomputes the Eisenberg (1984) hydrophobic moment from the **published** Eisenberg consensus hydrophobicity scale (cf. R package R.Peptides, `hmoment.R`) and asserts `computeHydrophobicMoment` matches:

```
moment_w = sqrt( (Σ h_i·sin(i·δ))² + (Σ h_i·cos(i·δ))² ) / w
```

across several peptides / window sizes / angles (`ACDEF` @w3/100°, `FLIGKWVRP` @w3/100° and @w5/160°).

## Why

Closes the §7 `[AUTO]` task in the **OpenMS 3.6.0 pre-release testing plan** (#9460):

> Add an external cross-check for `HydrophobicityProfile` hydrophobic-moment values. **Pass:** moments match a published reference.

The existing `computeHydrophobicMoment` section pinned only OpenMS's **own** output values (`0.511576803`, …) with no external anchor. This validates both the scale values (`residue.getHydrophobicity(EISENBERG)`) **and** the moment formula against the literature — not OpenMS against itself.

I confirmed beforehand (offline) that the published Eisenberg consensus values + the formula reproduce the existing pinned values to **9 digits**, so the cross-check is a true external reference rather than a re-derivation of the implementation. At runtime the 18 cross-check assertions all hold (OpenMS `got` == independent `ref`, e.g. `0.511576803058737`).

## Test plan

Tests only — no production code changed. Verified locally: `-fsyntax-only` clean, full build green, test runs **PASSED** with 18 non-vacuous cross-check assertions.

Part of #9460. Follows #9524 … #9544.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for hydrophobicity profile calculations with validation against published reference data to enhance reliability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->