### PR TITLE
[TEST] FileHandler: pin type resolution for the new parquet bundle formats (#9460)

### DIFF
--- a/src/tests/class_tests/openms/source/FileHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/FileHandler_test.cpp
@@ -78,6 +78,10 @@ TEST_EQUAL(tmp.getTypeByFileName("test.peff"), FileTypes::PEFF)
 TEST_EQUAL(tmp.getTypeByFileName("test.EDTA"), FileTypes::EDTA)
 TEST_EQUAL(tmp.getTypeByFileName("test.csv"), FileTypes::CSV)
 TEST_EQUAL(tmp.getTypeByFileName("test.txt"), FileTypes::TXT)
+// new 3.6 directory-based parquet bundle types
+TEST_EQUAL(tmp.getTypeByFileName("test.idparquet"), FileTypes::IDPARQUET)
+TEST_EQUAL(tmp.getTypeByFileName("test.featureparquet"), FileTypes::FEATUREPARQUET)
+TEST_EQUAL(tmp.getTypeByFileName("test.consensusparquet"), FileTypes::CONSENSUSPARQUET)
 END_SECTION
 
 START_SECTION((static bool hasValidExtension(const std::string& filename, const FileTypes::Type type)))
@@ -175,6 +179,15 @@ START_SECTION((FileTypes::Type FileHandler::getConsistentOutputfileType(const st
   TEST_EQUAL(FileHandler::getConsistentOutputfileType("/home/doe/file.unknown", "idxml"), FileTypes::IDXML)
   TEST_EQUAL(FileHandler::getConsistentOutputfileType("/home.with.dot/file", "mzML"), FileTypes::MZML)
   TEST_EQUAL(FileHandler::getConsistentOutputfileType("c:\\home.with.dot\\file", "mzML"), FileTypes::MZML)
+  // new 3.6 directory-based parquet bundle types: an explicit out_type fills in for a
+  // ".unknown" (or extension-less) output name, a matching extension is accepted, and a
+  // conflicting one is rejected.
+  TEST_EQUAL(FileHandler::getConsistentOutputfileType("out.unknown", "featureparquet"), FileTypes::FEATUREPARQUET)
+  TEST_EQUAL(FileHandler::getConsistentOutputfileType("out.unknown", "idparquet"), FileTypes::IDPARQUET)
+  TEST_EQUAL(FileHandler::getConsistentOutputfileType("out", "consensusparquet"), FileTypes::CONSENSUSPARQUET)
+  TEST_EQUAL(FileHandler::getConsistentOutputfileType("out.featureparquet", ""), FileTypes::FEATUREPARQUET)
+  TEST_EQUAL(FileHandler::getConsistentOutputfileType("out.featureparquet", "featureparquet"), FileTypes::FEATUREPARQUET)
+  TEST_EQUAL(FileHandler::getConsistentOutputfileType("out.featureparquet", "consensusparquet"), FileTypes::UNKNOWN) // inconsistent
 END_SECTION
 
 

--- a/src/tests/class_tests/openms/source/FileHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/FileHandler_test.cpp
@@ -165,6 +165,14 @@ START_SECTION((static std::string swapExtension(const std::string& filename, con
   TEST_STRING_EQUAL(FileHandler::swapExtension("/home.with.dot/file", FileTypes::UNKNOWN), "/home.with.dot/file.unknown")
   TEST_STRING_EQUAL(FileHandler::swapExtension("c:\\home.with.dot\\file", FileTypes::UNKNOWN), "c:\\home.with.dot\\file.unknown")
   TEST_STRING_EQUAL(FileHandler::swapExtension("./filename", FileTypes::UNKNOWN), "./filename.unknown")
+  // new 3.6 directory-based parquet bundle types
+  TEST_STRING_EQUAL(FileHandler::swapExtension("/home/doe/file.txt", FileTypes::FEATUREPARQUET), "/home/doe/file.featureparquet")
+  TEST_STRING_EQUAL(FileHandler::swapExtension("/home/doe/file.idXML", FileTypes::IDPARQUET), "/home/doe/file.idparquet")
+  TEST_STRING_EQUAL(FileHandler::swapExtension("/home/doe/file.featureparquet", FileTypes::CONSENSUSPARQUET), "/home/doe/file.consensusparquet")
+  // round-trip: a swapped-in parquet extension is recognised back as the same type
+  TEST_EQUAL(FileHandler::getTypeByFileName(FileHandler::swapExtension("x.txt", FileTypes::FEATUREPARQUET)), FileTypes::FEATUREPARQUET)
+  TEST_EQUAL(FileHandler::getTypeByFileName(FileHandler::swapExtension("x.txt", FileTypes::IDPARQUET)), FileTypes::IDPARQUET)
+  TEST_EQUAL(FileHandler::getTypeByFileName(FileHandler::swapExtension("x.txt", FileTypes::CONSENSUSPARQUET)), FileTypes::CONSENSUSPARQUET)
 END_SECTION
 
 START_SECTION((FileTypes::Type FileHandler::getConsistentOutputfileType(const std::string& output_filename, const std::string& requested_type)))


### PR DESCRIPTION
## What

Adds the new 3.6 directory-based parquet bundle types to the `getTypeByFileName` and `getConsistentOutputfileType` sections of `FileHandler_test`:

**`getTypeByFileName`** — `.idparquet → IDPARQUET`, `.featureparquet → FEATUREPARQUET`, `.consensusparquet → CONSENSUSPARQUET`.

**`getConsistentOutputfileType`** (the `.unknown` / `-out_type` fallback):
- `out.unknown` + `featureparquet`/`idparquet` → that type — the "`.unknown` adopts the single allowed type" behavior;
- extension-less `out` + `consensusparquet` → `CONSENSUSPARQUET`;
- `out.featureparquet` + `""` / matching type → `FEATUREPARQUET`;
- `out.featureparquet` + `consensusparquet` → `UNKNOWN` (inconsistent extension vs requested type).

## Why

Closes the class-level part of the §3 (native Parquet I/O) `[AUTO]` task in the **OpenMS 3.6.0 pre-release testing plan** (#9460):

> Add a `.unknown` size-1 fallback cell: `FileConverter -in x.featureXML -out out.unknown -out_type featureparquet`, then read back. **Pass:** `FileHandler` adopts the single allowed type …

`getConsistentOutputfileType` is the exact method `FileConverter` uses to resolve `-out_type` against the output filename (`FileConverter.cpp:455`). Its test (and `getTypeByFileName`'s) covered only classic file types — none of the new directory parquet bundles, even though those are the 3.6 headline formats. This pins their name-based type resolution directly at the class level (SDK-free, no tool run or data needed). The full FileConverter round-trip remains a complementary TOPP-level follow-up.

## Test plan

Tests only — no production code changed. Verified locally: `-fsyntax-only` clean, full build green, test runs **PASSED**, with the new assertions confirmed via verbose output (`IDPARQUET`=66, `FEATUREPARQUET`=67, `CONSENSUSPARQUET`=68; the inconsistent case → `UNKNOWN` with the expected error log).

Part of #9460. Follows #9524 … #9547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for handling “3.6 directory-based parquet bundle” file types, including recognizing file formats by name, validating extension swapping to parquet variants, and verifying consistent output file type resolution (including rejecting inconsistent combinations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->