### PR TITLE
[TEST] Compressed (gzip/bzip2) store→load round-trip tests for mzML and featureXML

### DIFF
--- a/src/tests/class_tests/openms/source/FeatureXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureXMLFile_test.cpp
@@ -19,6 +19,8 @@
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 
+#include <fstream>
+
 using namespace OpenMS;
 using namespace std;
 
@@ -216,6 +218,82 @@ START_SECTION((void store(const std::string &filename, const FeatureMap&feature_
   f.store(tmp_filename, map);
   WHITELIST("?xml-stylesheet")
   TEST_FILE_SIMILAR(OPENMS_GET_TEST_DATA_PATH("FeatureXMLFile_1.featureXML"), tmp_filename)
+}
+END_SECTION
+
+START_SECTION([EXTRA] store and load gzip and bzip2 compressed files - round-trip)
+{
+  // XMLFile::save_() compresses on the fly when the filename ends in
+  // ".gz"/".bz2" and load() transparently decompresses. This verifies that a
+  // store->load round-trip through a compressed file preserves the feature
+  // content (mirrors IdXMLFile_test's compressed round-trip).
+  // Note: a full FeatureMap operator== comparison is intentionally avoided
+  // because store() regenerates invalid unique ids on every call, which is
+  // unrelated to compression; instead the actual feature data is checked.
+  FeatureXMLFile f;
+
+  FeatureMap map_original;
+  f.load(OPENMS_GET_TEST_DATA_PATH("FeatureXMLFile_1.featureXML"), map_original);
+  TEST_EQUAL(map_original.size() > 0, true) // guard against a vacuous test
+
+  // read the leading bytes of a file to confirm it is really compressed
+  auto first_bytes = [](const std::string& fn, size_t n) -> std::string
+  {
+    std::ifstream is(fn.c_str(), std::ios::in | std::ios::binary);
+    std::string buf(n, '\0');
+    is.read(&buf[0], static_cast<std::streamsize>(n));
+    buf.resize(static_cast<size_t>(is.gcount()));
+    return buf;
+  };
+
+  // compare the feature content (everything except regenerated unique ids)
+  auto check_same_features = [](const FeatureMap& a, const FeatureMap& b)
+  {
+    TEST_EQUAL(a.size(), b.size())
+    for (Size i = 0; i < a.size() && i < b.size(); ++i)
+    {
+      TEST_REAL_SIMILAR(a[i].getRT(), b[i].getRT())
+      TEST_REAL_SIMILAR(a[i].getMZ(), b[i].getMZ())
+      TEST_REAL_SIMILAR(a[i].getIntensity(), b[i].getIntensity())
+      TEST_EQUAL(a[i].getCharge(), b[i].getCharge())
+      TEST_REAL_SIMILAR(a[i].getOverallQuality(), b[i].getOverallQuality())
+    }
+  };
+
+  // gzip round-trip
+  {
+    std::string tmp_gz;
+    NEW_TMP_FILE(tmp_gz);
+    tmp_gz += ".featureXML.gz";
+    f.store(tmp_gz, map_original);
+
+    // the written file must really be gzip-compressed (magic bytes 0x1f 0x8b),
+    // otherwise the round-trip could pass on a plain-text file with a .gz name
+    std::string magic = first_bytes(tmp_gz, 2);
+    TEST_EQUAL(magic.size(), 2)
+    TEST_EQUAL(static_cast<int>(static_cast<unsigned char>(magic[0])), 0x1f)
+    TEST_EQUAL(static_cast<int>(static_cast<unsigned char>(magic[1])), 0x8b)
+
+    FeatureMap map_gz;
+    f.load(tmp_gz, map_gz);
+    check_same_features(map_original, map_gz);
+  }
+
+  // bzip2 round-trip
+  {
+    std::string tmp_bz2;
+    NEW_TMP_FILE(tmp_bz2);
+    tmp_bz2 += ".featureXML.bz2";
+    f.store(tmp_bz2, map_original);
+
+    // the written file must really be bzip2-compressed (magic bytes "BZh")
+    std::string magic = first_bytes(tmp_bz2, 3);
+    TEST_STRING_EQUAL(magic, "BZh")
+
+    FeatureMap map_bz2;
+    f.load(tmp_bz2, map_bz2);
+    check_same_features(map_original, map_bz2);
+  }
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/MzMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MzMLFile_test.cpp
@@ -17,6 +17,8 @@
 #include <OpenMS/FORMAT/HANDLERS/MzMLHandler.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 
+#include <fstream>
+
 using namespace OpenMS;
 using namespace std;
 
@@ -1059,6 +1061,75 @@ START_SECTION((template <typename MapType> void store(const std::string& filenam
     TEST_EQUAL(exp == exp_original,true)
   }
 
+}
+END_SECTION
+
+START_SECTION([EXTRA] store and load gzip and bzip2 compressed files - round-trip)
+{
+  // The file format is inferred from the extension before the compression
+  // suffix; XMLFile::save_() compresses on the fly when the filename ends in
+  // ".gz"/".bz2" and load() transparently decompresses. This verifies that a
+  // store->load round-trip through a compressed file preserves the content
+  // (mirrors IdXMLFile_test's compressed round-trip).
+  MzMLFile file;
+
+  PeakMap exp_original;
+  file.load(OPENMS_GET_TEST_DATA_PATH("MzMLFile_1.mzML"), exp_original);
+
+  // uncompressed store->load result used as the reference: this isolates
+  // "does compression preserve data" from "does store/load preserve data".
+  PeakMap exp_plain;
+  {
+    std::string tmp_plain;
+    NEW_TMP_FILE(tmp_plain);
+    file.store(tmp_plain, exp_original);
+    file.load(tmp_plain, exp_plain);
+  }
+
+  // read the leading bytes of a file to confirm it is really compressed
+  auto first_bytes = [](const std::string& fn, size_t n) -> std::string
+  {
+    std::ifstream is(fn.c_str(), std::ios::in | std::ios::binary);
+    std::string buf(n, '\0');
+    is.read(&buf[0], static_cast<std::streamsize>(n));
+    buf.resize(static_cast<size_t>(is.gcount()));
+    return buf;
+  };
+
+  // gzip round-trip
+  {
+    std::string tmp_gz;
+    NEW_TMP_FILE(tmp_gz);
+    tmp_gz += ".mzML.gz";
+    file.store(tmp_gz, exp_original);
+
+    // the written file must really be gzip-compressed (magic bytes 0x1f 0x8b),
+    // otherwise the round-trip could pass on a plain-text file with a .gz name
+    std::string magic = first_bytes(tmp_gz, 2);
+    TEST_EQUAL(magic.size(), 2)
+    TEST_EQUAL(static_cast<int>(static_cast<unsigned char>(magic[0])), 0x1f)
+    TEST_EQUAL(static_cast<int>(static_cast<unsigned char>(magic[1])), 0x8b)
+
+    PeakMap exp_gz;
+    file.load(tmp_gz, exp_gz);
+    TEST_TRUE(exp_gz == exp_plain)
+  }
+
+  // bzip2 round-trip
+  {
+    std::string tmp_bz2;
+    NEW_TMP_FILE(tmp_bz2);
+    tmp_bz2 += ".mzML.bz2";
+    file.store(tmp_bz2, exp_original);
+
+    // the written file must really be bzip2-compressed (magic bytes "BZh")
+    std::string magic = first_bytes(tmp_bz2, 3);
+    TEST_STRING_EQUAL(magic, "BZh")
+
+    PeakMap exp_bz2;
+    file.load(tmp_bz2, exp_bz2);
+    TEST_TRUE(exp_bz2 == exp_plain)
+  }
 }
 END_SECTION
 


### PR DESCRIPTION
## Context

Part of the OpenMS 3.6.0 pre-release testing plan (#9460): closing a coverage gap in compressed-file I/O.

`XMLFile::save_()` transparently gzip/bzip2-compresses output when the filename ends in `.gz`/`.bz2`, and `load()` transparently decompresses. `IdXMLFile_test` already verifies a `store → .gz → load` round-trip, but:

- **`MzMLFile_test`** only *loaded* pre-existing `*.mzML.gz` / `*.mzML.bz2` fixtures — it never exercised the **store** side of compression.
- **`FeatureXMLFile_test`** had **no** compressed-file coverage at all.

## Change

Adds an `[EXTRA]` section to each test that, for both gzip and bzip2:

1. **Stores** a map to a compressed path (`*.mzML.gz`/`.bz2`, `*.featureXML.gz`/`.bz2`).
2. **Verifies the file is actually compressed** by checking the magic bytes (gzip `0x1f 0x8b`, bzip2 `"BZh"`) — so the round-trip can't pass trivially on a plain-text file that merely has a compressed-looking name.
3. **Loads it back** and checks the data is preserved.

Comparison strategy:
- **mzML** compares the full `PeakMap` against an uncompressed `store→load` reference (`MSExperiment::operator==`).
- **featureXML** compares per-feature RT / m/z / intensity / charge / overall-quality. A full `FeatureMap::operator==` is intentionally avoided here because `store()` regenerates *invalid* unique ids on every call (unrelated to compression), which would make two independent stores compare unequal.

## Notes

- **Tests only** — no production code changes.
- Both tests build and pass locally; all added assertions execute against real values (not vacuous).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Added comprehensive tests for gzip and bzip2 compressed file handling in FeatureXML and MzML data formats
* Tests validate complete round-trip store and load operations, ensuring data integrity through compressed file cycles
* Tests verify actual file compression through magic byte checking to confirm proper gzip and bzip2 encoding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->