### PR TITLE
[TEST] PercolatorInfile: validate the .pin store() header and stamped features

### DIFF
--- a/src/tests/class_tests/openms/source/PercolatorInfile_test.cpp
+++ b/src/tests/class_tests/openms/source/PercolatorInfile_test.cpp
@@ -13,6 +13,17 @@
 #include <OpenMS/FORMAT/PercolatorInfile.h>
 ///////////////////////////
 
+#include <OpenMS/METADATA/PeptideIdentification.h>
+#include <OpenMS/METADATA/PeptideHit.h>
+#include <OpenMS/METADATA/PeptideEvidence.h>
+#include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/DATASTRUCTURES/StringUtils.h>
+
+#include <algorithm>
+#include <fstream>
+#include <vector>
+
 using namespace OpenMS;
 using namespace std;
 
@@ -56,6 +67,100 @@ START_SECTION(PeptideIdentificationList PercolatorInfile::load(const std::string
   TEST_EQUAL(pids[0].getSpectrumReference(), "30381")
   TEST_EQUAL(pids[6].getSpectrumReference(), "spectrum=2041")
   TEST_EQUAL(pids[7].getHits()[0].getMetaValue("target_decoy"),"decoy") // 8th entry is annotated as target in pin file but only maps to decoy proteins with prefix "DECOY_" -> set to decoy
+}
+END_SECTION
+
+START_SECTION((static void store(const std::string& pin_file, const PeptideIdentificationList& peptide_ids, const StringList& feature_set, const std::string& enz, int min_charge, int max_charge)))
+{
+  // Validates the -out_pin output that PercolatorAdapter/ProSE/OpenNuXL emit:
+  // the header line must be the exact column contract Percolator parses
+  // (SpecId Label ScanNr ... Peptide Proteins) and store() must compute and
+  // write the standard per-PSM features (stampPinFeaturesOnHits). Build one
+  // fully-annotated target PSM so it is not skipped and a data row is written.
+  PeptideHit hit;
+  hit.setSequence(AASequence::fromString("SAMPLER"));
+  hit.setCharge(2);
+  hit.setScore(1.0);
+  hit.setTargetDecoyType(PeptideHit::TargetDecoyType::TARGET);
+  PeptideEvidence ev;
+  ev.setProteinAccession("PROT1");
+  ev.setAABefore('K'); // tryptic flanks so enzN/enzC are true
+  ev.setAAAfter('S');
+  hit.setPeptideEvidences(std::vector<PeptideEvidence>{ev});
+
+  PeptideIdentification pid;
+  pid.setMZ(500.25);
+  pid.setRT(123.4);
+  pid.setSpectrumReference("scan=529");
+  pid.setHits(std::vector<PeptideHit>{hit});
+
+  PeptideIdentificationList pids;
+  pids.push_back(pid);
+
+  // the real .pin column contract: standard features + Peptide + Proteins
+  StringList feature_set = PercolatorInfile::getStandardFeatureSet(2, 3);
+  feature_set.push_back("Peptide");
+  feature_set.push_back("Proteins");
+
+  std::string pin_file;
+  NEW_TMP_FILE(pin_file);
+  PercolatorInfile::store(pin_file, pids, feature_set, "trypsin", 2, 3);
+
+  // read the written .pin back
+  std::ifstream is(pin_file.c_str());
+  std::vector<std::string> lines;
+  std::string line;
+  while (std::getline(is, line)) lines.push_back(line);
+
+  // header + exactly one data row (the PSM must not be skipped)
+  TEST_EQUAL(lines.size(), 2)
+  ABORT_IF(lines.empty())
+
+  // --- header: column names and order Percolator expects ---
+  StringList header;
+  StringUtils::split(lines[0], '\t', header);
+  TEST_EQUAL(header.size(), feature_set.size())
+  TEST_STRING_EQUAL(header[0], "SpecId")
+  TEST_STRING_EQUAL(header[1], "Label")
+  TEST_STRING_EQUAL(header[2], "ScanNr")
+  TEST_STRING_EQUAL(header[header.size() - 2], "Peptide")
+  TEST_STRING_EQUAL(header.back(), "Proteins")
+
+  auto has = [&header](const std::string& n) {
+    return std::find(header.begin(), header.end(), n) != header.end();
+  };
+  // mass + enzyme feature columns are present
+  TEST_EQUAL(has("ExpMass"), true)
+  TEST_EQUAL(has("CalcMass"), true)
+  TEST_EQUAL(has("mass"), true)
+  TEST_EQUAL(has("peplen"), true)
+  TEST_EQUAL(has("charge2"), true)
+  TEST_EQUAL(has("charge3"), true)
+  TEST_EQUAL(has("enzN"), true)
+  TEST_EQUAL(has("enzC"), true)
+  TEST_EQUAL(has("enzInt"), true)
+  TEST_EQUAL(has("dm"), true)
+  TEST_EQUAL(has("absdm"), true)
+
+  // --- data row: same column count + the deterministic computed feature values ---
+  ABORT_IF(lines.size() < 2)
+  StringList row;
+  StringUtils::split(lines[1], '\t', row);
+  TEST_EQUAL(row.size(), header.size())
+
+  auto col = [&header](const std::string& n) -> Size {
+    return (Size)(std::find(header.begin(), header.end(), n) - header.begin());
+  };
+  TEST_STRING_EQUAL(row[col("SpecId")], "scan=529")
+  TEST_STRING_EQUAL(row[col("ScanNr")], "529")
+  TEST_STRING_EQUAL(row[col("Label")], "1")          // target -> 1
+  TEST_STRING_EQUAL(row[col("peplen")], "7")         // SAMPLER
+  TEST_STRING_EQUAL(row[col("charge2")], "1")        // charge == 2 (one-hot)
+  TEST_STRING_EQUAL(row[col("charge3")], "0")
+  TEST_STRING_EQUAL(row[col("enzN")], "1")           // tryptic N-terminus
+  TEST_STRING_EQUAL(row[col("enzC")], "1")           // tryptic C-terminus
+  TEST_STRING_EQUAL(row[col("Peptide")], "K.SAMPLER.S")
+  TEST_STRING_EQUAL(row[col("Proteins")], "PROT1")
 }
 END_SECTION
 


### PR DESCRIPTION
## Context

Part of the OpenMS 3.6.0 pre-release testing plan (#9460): a `-out_pin` header/column validation test.

`PercolatorInfile_test` only covered `load()`. The store side — `PercolatorInfile::store` → `preparePin_` → `stampPinFeaturesOnHits` (~130 lines that compute every per-PSM feature) — had **no** coverage, even though the `.pin` column layout it emits is the exact contract external Percolator parses (and the `-out_pin` output of `PercolatorAdapter` / `ProSE` / `OpenNuXL`).

## Change

Adds a `store()` section that builds one fully-annotated target PSM, writes a `.pin`, reads it back, and asserts:

- **Header** is the exact Percolator column contract: begins `SpecId Label ScanNr`, ends `Peptide Proteins`, and contains the mass/enzyme feature columns (`ExpMass`, `CalcMass`, `mass`, `peplen`, `charge2/3`, `enzN/enzC/enzInt`, `dm`, `absdm`).
- **Exactly one data row** is written (the PSM is not skipped) with the same column count as the header.
- The **computed feature values** are correct: `SpecId` (`scan=529`), `ScanNr` (529), `Label` (target → 1), `peplen` (7), charge one-hot (`charge2=1`, `charge3=0`), tryptic `enzN=enzC=1`, the bracketed `Peptide` string (`K.SAMPLER.S`), and `Proteins` (`PROT1`).

This exercises `stampPinFeaturesOnHits` end-to-end — feature computation that was previously untested.

## Notes

- **Tests only** — no production code changes.
- Builds and passes locally; all 30 assertions execute against real values (verified with `OPENMS_TEST_VERBOSE`).
- Complementary to #9536 (which validates the `getStandardFeatureSet` helper in isolation); this PR validates the actual written file and the feature stamping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for Percolator pin-file generation and parsing, including validation of tabular output formatting, header column ordering, required feature columns, and deterministic computed values (e.g., peptide charge indicators, enzyme termini, and protein accessions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->