### PR TITLE
[TEST] IsoelectricPoint: pin the EMBOSS pI scale with an external numeric cross-check

### DIFF
--- a/src/tests/class_tests/openms/source/IsoelectricPoint_test.cpp
+++ b/src/tests/class_tests/openms/source/IsoelectricPoint_test.cpp
@@ -133,6 +133,27 @@ START_SECTION(static double computePI(const AASequence& seq, ProteomicsPkaScale 
 }
 END_SECTION
 
+START_SECTION([EXTRA] computePI EMBOSS scale - external numeric cross-check)
+{
+  // Above, the EMBOSS scale is only checked for "differs from Lehninger".
+  // Pin it numerically. OpenMS uses the canonical EMBOSS Epka.dat pKa values
+  // (N-term 8.6, C-term 3.6, C 8.5, D 3.9, E 4.1, H 6.5, K 10.8, R 12.5,
+  // Y 10.1) - the same scale EMBOSS pepstats uses. The reference pI values
+  // below were produced by an independent Henderson-Hasselbalch bisection
+  // using those published EMBOSS constants (not OpenMS code); they agree with
+  // computePI() to < 1e-4 at a fine bisection tolerance.
+  TOLERANCE_ABSOLUTE(0.01)
+
+  const double tol = 1e-6; // fine bisection so the pinned reference is exact
+
+  TEST_REAL_SIMILAR(IsoelectricPoint::computePI(AASequence::fromString("ACDEFGHIK"), ProteomicsPkaScale::EMBOSS, tol), 5.4518)
+  TEST_REAL_SIMILAR(IsoelectricPoint::computePI(AASequence::fromString("PEPTIDER"), ProteomicsPkaScale::EMBOSS, tol), 3.9276)
+  TEST_REAL_SIMILAR(IsoelectricPoint::computePI(AASequence::fromString("SAMPLER"), ProteomicsPkaScale::EMBOSS, tol), 6.4101)
+  TEST_REAL_SIMILAR(IsoelectricPoint::computePI(AASequence::fromString("YGGFMR"), ProteomicsPkaScale::EMBOSS, tol), 9.3488)
+  TEST_REAL_SIMILAR(IsoelectricPoint::computePI(AASequence::fromString("DEEEAANK"), ProteomicsPkaScale::EMBOSS, tol), 3.7782)
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST


### PR DESCRIPTION
## Context

Part of the OpenMS 3.6.0 pre-release testing plan (#9460), §7: "ensure **each** pKa scale — including SILLERO — has a numeric check" against an external reference (EMBOSS `pepstats`, Expasy).

`IsoelectricPoint_test` already pins Lehninger and Bjellqvist numerically (and SILLERO via #9542). The **EMBOSS** scale, however, was only checked for "differs from Lehninger" — no numeric reference — despite EMBOSS being the `pepstats` scale the plan names as authoritative.

## Change

Adds numeric `computePI(..., EMBOSS)` checks for five realistic peptides.

OpenMS uses the canonical EMBOSS `Epka.dat` pKa values (N-term 8.6, C-term 3.6, C 8.5, D 3.9, E 4.1, H 6.5, K 10.8, R 12.5, Y 10.1). The reference pI values were produced by an **independent** Henderson-Hasselbalch bisection using those *published* EMBOSS constants (not OpenMS code), and agree with `computePI()` exactly at a fine bisection tolerance:

| peptide | EMBOSS pI |
|---|---|
| ACDEFGHIK | 5.4518 |
| PEPTIDER | 3.9276 |
| SAMPLER | 6.4101 |
| YGGFMR | 9.3488 |
| DEEEAANK | 3.7782 |

## Notes

- **Tests only** — no production code changes.
- Builds and passes locally; all five assertions execute against real `computePI()` output (verbose-confirmed).
- Complementary to #9542 (which added the SILLERO numeric check to the same file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test section for `computePI` validation using the EMBOSS scale with multiple peptides, comparing OpenMS results against externally computed reference values within specified tolerances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->