### PR TITLE
[TEST] ProForma: pin the lossy toAASequence contract for accession-less mass-delta mods

### DIFF
--- a/src/tests/class_tests/openms/source/ProFormaParser_test.cpp
+++ b/src/tests/class_tests/openms/source/ProFormaParser_test.cpp
@@ -1543,6 +1543,51 @@ START_SECTION(toAASequence - BEST_EFFORT policy ignores unsupported)
 }
 END_SECTION
 
+START_SECTION([EXTRA] toAASequence - mass-delta mods without CV accession - lossy contract)
+{
+  // A mass-delta modification (e.g. M[+15.9949]) carries no UNIMOD/PSI-MOD
+  // accession. toAASequence resolves it by mass to the matching named
+  // modification when one exists (lossless), and otherwise drops it under
+  // BEST_EFFORT (lossy) or throws under FAIL_ON_LOSS. This pins that contract.
+
+  // (1) matchable side-chain mass delta -> resolved to Oxidation
+  {
+    Peptidoform pf = ProForma::parse("EM[+15.9949]K");
+    AASequence seq = ProForma::toAASequence(pf, ConversionPolicy::BEST_EFFORT);
+    TEST_EQUAL(seq.toUnmodifiedString(), "EMK")
+    TEST_EQUAL(seq.toString(), "EM(Oxidation)K")
+    TEST_REAL_SIMILAR(seq.getMonoWeight(), AASequence::fromString("EM(Oxidation)K").getMonoWeight())
+  }
+
+  // (2) matchable mass delta on S -> Phospho
+  {
+    Peptidoform pf = ProForma::parse("PES[+79.96633]TIDE");
+    AASequence seq = ProForma::toAASequence(pf, ConversionPolicy::BEST_EFFORT);
+    TEST_EQUAL(seq.toString(), "PES(Phospho)TIDE")
+    TEST_REAL_SIMILAR(seq.getMonoWeight(), AASequence::fromString("PES(Phospho)TIDE").getMonoWeight())
+  }
+
+  // (3) matchable N-terminal mass delta -> Acetyl
+  {
+    Peptidoform pf = ProForma::parse("[+42.0106]-PEPTIDE");
+    AASequence seq = ProForma::toAASequence(pf, ConversionPolicy::BEST_EFFORT);
+    TEST_EQUAL(seq.toString(), ".(Acetyl)PEPTIDE")
+    TEST_REAL_SIMILAR(seq.getMonoWeight(), AASequence::fromString("(Acetyl)PEPTIDE").getMonoWeight())
+  }
+
+  // (4) unmatchable mass delta: BEST_EFFORT drops it (lossy); FAIL_ON_LOSS throws
+  {
+    Peptidoform pf = ProForma::parse("PEM[+0.12345]TIDE");
+    AASequence seq = ProForma::toAASequence(pf, ConversionPolicy::BEST_EFFORT);
+    TEST_EQUAL(seq.toString(), "PEMTIDE")            // mass delta dropped
+    TEST_EQUAL(seq.toUnmodifiedString(), "PEMTIDE")
+    TEST_REAL_SIMILAR(seq.getMonoWeight(), AASequence::fromString("PEMTIDE").getMonoWeight())
+    TEST_EXCEPTION(Exception::ConversionError,
+                   ProForma::toAASequence(pf, ConversionPolicy::FAIL_ON_LOSS))
+  }
+}
+END_SECTION
+
 START_SECTION(fromAASequence - simple sequence)
 {
   // Create AASequence and convert to Peptidoform


### PR DESCRIPTION
## Context

Part of the OpenMS 3.6.0 pre-release testing plan (#9460), §7 — *"the lossy BEST_EFFORT contract (mods w/o UNIMOD/PSI-MOD accession, terminal/ambiguous) is asserted."*

`ProFormaParser_test` already covers `toAASequence` for UNIMOD/named mods and the BEST_EFFORT vs FAIL_ON_LOSS policy difference on *unlocalized* mods (`[Phospho]?PEPTIDE`). What it did **not** cover is the modification-without-a-CV-accession case — a bare **mass-delta** mod (e.g. `M[+15.9949]`).

## Change

Adds a section pinning the `toAASequence` contract for accession-less mass-delta mods (behaviour verified against the built library):

- a **matchable** mass delta is resolved by mass to the named modification (lossless — mono mass matches):
  - `EM[+15.9949]K` → `EM(Oxidation)K`
  - `PES[+79.96633]TIDE` → `PES(Phospho)TIDE`
  - N-terminal `[+42.0106]-PEPTIDE` → `.(Acetyl)PEPTIDE`
- an **unmatchable** mass delta (`PEM[+0.12345]TIDE`) is **dropped** under `BEST_EFFORT` (lossy → `PEMTIDE`) and throws `Exception::ConversionError` under `FAIL_ON_LOSS`.

## Notes

- **Tests only** — no production code changes.
- Builds and passes locally; all 11 assertions execute against real values (verbose-confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for mass-delta modification handling in ProFormaParser, verifying proper resolution of named modifications and error handling across different conversion policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->