### PR TITLE
[TEST] IDFilter: cover the ConsensusMap removeDanglingProteinReferences overloads

### DIFF
--- a/src/tests/class_tests/openms/source/IDFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/IDFilter_test.cpp
@@ -18,7 +18,10 @@
 #include <OpenMS/PROCESSING/ID/IDFilter.h>
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
+#include <OpenMS/METADATA/PeptideEvidence.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/KERNEL/ConsensusMap.h>
+#include <OpenMS/KERNEL/ConsensusFeature.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
 
@@ -269,6 +272,126 @@ START_SECTION((static void removeDanglingProteinReferences(PeptideIdentification
   // remove peptide hits without any reference to an existing proteins:
   IDFilter::removeDanglingProteinReferences(peptides, proteins, true);
   TEST_EQUAL(peptide_hits.size(), 2);
+}
+END_SECTION
+
+START_SECTION((static void removeDanglingProteinReferences(ConsensusMap& cmap, bool remove_peptides_without_reference = false)))
+{
+  // Build a ConsensusMap whose run "run1" knows PROT1/PROT2 but NOT the decoys.
+  // An assigned PSM references PROT1 + DECOY_PROT1; a second assigned PSM
+  // references only DECOY_PROT1; an unassigned PSM references PROT2 + DECOY_PROT2.
+  auto make_cmap = []() {
+    ConsensusMap cmap;
+
+    ProteinIdentification prot;
+    prot.setIdentifier("run1");
+    ProteinHit ph1; ph1.setAccession("PROT1");
+    ProteinHit ph2; ph2.setAccession("PROT2");
+    prot.insertHit(ph1);
+    prot.insertHit(ph2);
+    cmap.setProteinIdentifications({prot});
+
+    // assigned PSMs on a consensus feature
+    PeptideHit hitA;
+    hitA.setSequence(AASequence::fromString("PEPTIDEA"));
+    { PeptideEvidence e; e.setProteinAccession("PROT1"); hitA.addPeptideEvidence(e); }
+    { PeptideEvidence e; e.setProteinAccession("DECOY_PROT1"); hitA.addPeptideEvidence(e); }
+    PeptideHit hitB;
+    hitB.setSequence(AASequence::fromString("PEPTIDEB"));
+    { PeptideEvidence e; e.setProteinAccession("DECOY_PROT1"); hitB.addPeptideEvidence(e); }
+    PeptideIdentification pid;
+    pid.setIdentifier("run1");
+    pid.setHits({hitA, hitB});
+
+    ConsensusFeature cf;
+    cf.setRT(1.0); cf.setMZ(100.0);
+    cf.getPeptideIdentifications().push_back(pid);
+    cmap.push_back(cf);
+
+    // unassigned PSM
+    PeptideHit hitC;
+    hitC.setSequence(AASequence::fromString("PEPTIDEC"));
+    { PeptideEvidence e; e.setProteinAccession("PROT2"); hitC.addPeptideEvidence(e); }
+    { PeptideEvidence e; e.setProteinAccession("DECOY_PROT2"); hitC.addPeptideEvidence(e); }
+    PeptideIdentification upid;
+    upid.setIdentifier("run1");
+    upid.setHits({hitC});
+    cmap.getUnassignedPeptideIdentifications().push_back(upid);
+
+    return cmap;
+  };
+
+  // (1) keep PSMs, drop the dangling (decoy) evidences only
+  {
+    ConsensusMap cmap = make_cmap();
+    IDFilter::removeDanglingProteinReferences(cmap, false);
+
+    const vector<PeptideHit>& assigned = cmap[0].getPeptideIdentifications()[0].getHits();
+    TEST_EQUAL(assigned.size(), 2);
+    TEST_EQUAL(assigned[0].getPeptideEvidences().size(), 1);
+    TEST_STRING_EQUAL(assigned[0].getPeptideEvidences()[0].getProteinAccession(), "PROT1");
+    TEST_EQUAL(assigned[1].getPeptideEvidences().size(), 0); // only DECOY_PROT1 -> removed
+
+    // unassigned PSMs are processed too (include_unassigned defaults to true)
+    const vector<PeptideHit>& unassigned = cmap.getUnassignedPeptideIdentifications()[0].getHits();
+    TEST_EQUAL(unassigned.size(), 1);
+    TEST_EQUAL(unassigned[0].getPeptideEvidences().size(), 1);
+    TEST_STRING_EQUAL(unassigned[0].getPeptideEvidences()[0].getProteinAccession(), "PROT2");
+  }
+
+  // (2) remove_peptides_without_reference: the PSM with only dangling refs is dropped
+  {
+    ConsensusMap cmap = make_cmap();
+    IDFilter::removeDanglingProteinReferences(cmap, true);
+    const vector<PeptideHit>& assigned = cmap[0].getPeptideIdentifications()[0].getHits();
+    TEST_EQUAL(assigned.size(), 1); // hitB removed (no surviving evidence)
+    TEST_STRING_EQUAL(assigned[0].getPeptideEvidences()[0].getProteinAccession(), "PROT1");
+  }
+}
+END_SECTION
+
+START_SECTION((static void removeDanglingProteinReferences(ConsensusMap& cmap, const ProteinIdentification& ref_run, bool remove_peptides_without_reference = false)))
+{
+  // Filter ALL peptides against a single reference run that knows only PROT1,
+  // so PROT2 (and both decoys) become dangling everywhere -- independent of the
+  // per-run ProteinIdentifications stored on the map.
+  ConsensusMap cmap;
+  ProteinIdentification prot; prot.setIdentifier("run1");
+  ProteinHit ph1; ph1.setAccession("PROT1");
+  ProteinHit ph2; ph2.setAccession("PROT2");
+  prot.insertHit(ph1);
+  prot.insertHit(ph2);
+  cmap.setProteinIdentifications({prot});
+
+  PeptideHit hitA;
+  hitA.setSequence(AASequence::fromString("PEPTIDEA"));
+  { PeptideEvidence e; e.setProteinAccession("PROT1"); hitA.addPeptideEvidence(e); }
+  { PeptideEvidence e; e.setProteinAccession("DECOY_PROT1"); hitA.addPeptideEvidence(e); }
+  PeptideIdentification pid; pid.setIdentifier("run1"); pid.setHits({hitA});
+  ConsensusFeature cf; cf.setRT(1.0); cf.setMZ(100.0);
+  cf.getPeptideIdentifications().push_back(pid);
+  cmap.push_back(cf);
+
+  PeptideHit hitC;
+  hitC.setSequence(AASequence::fromString("PEPTIDEC"));
+  { PeptideEvidence e; e.setProteinAccession("PROT2"); hitC.addPeptideEvidence(e); }
+  PeptideIdentification upid; upid.setIdentifier("run1"); upid.setHits({hitC});
+  cmap.getUnassignedPeptideIdentifications().push_back(upid);
+
+  ProteinIdentification ref_run;
+  ProteinHit only1; only1.setAccession("PROT1");
+  ref_run.insertHit(only1);
+
+  IDFilter::removeDanglingProteinReferences(cmap, ref_run, false);
+
+  // assigned hitA: PROT1 kept, DECOY_PROT1 removed
+  const PeptideHit& a = cmap[0].getPeptideIdentifications()[0].getHits()[0];
+  TEST_EQUAL(a.getPeptideEvidences().size(), 1);
+  TEST_STRING_EQUAL(a.getPeptideEvidences()[0].getProteinAccession(), "PROT1");
+
+  // unassigned hitC: PROT2 is NOT in ref_run -> removed (ref_run overrides per-run)
+  const PeptideHit& c = cmap.getUnassignedPeptideIdentifications()[0].getHits()[0];
+  TEST_EQUAL(c.getPeptideEvidences().size(), 0);
 }
 END_SECTION
 


### PR DESCRIPTION
## Context

Part of the OpenMS 3.6.0 pre-release testing plan (#9460), §5 — the dangling-`DECOY_`-reference concern: *"no dangling `DECOY_` `PeptideEvidence` remains (`IDFilter::removeDanglingProteinReferences`)."*

`IDFilter_test` covered `removeDanglingProteinReferences` only for the `PeptideIdentificationList` overload. The two **`ConsensusMap`** overloads — the ones the ProteomicsLFQ / consensusXML lane relies on — had **no** coverage.

## Change

Adds a dedicated section for each ConsensusMap overload (self-contained map, no fixtures):

- **`removeDanglingProteinReferences(ConsensusMap&, bool)`** — run `run1` knows `PROT1`/`PROT2` but not the decoys:
  - an assigned PSM keeps its valid `PROT1` evidence while the dangling `DECOY_PROT1` reference is removed;
  - a PSM referencing only a dangling protein ends up with zero evidences (and is **dropped** when `remove_peptides_without_reference=true`);
  - an **unassigned** PSM is filtered too (`include_unassigned` defaults to true).
- **`removeDanglingProteinReferences(ConsensusMap&, const ProteinIdentification& ref_run, bool)`** — filtering against a single reference run that knows only `PROT1` makes `PROT2` dangling everywhere, independent of the per-run protein identifications stored on the map.

## Notes

- **Tests only** — no production code changes.
- Builds and passes locally; all assertions execute against real values (verbose-confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for protein reference filtering functionality to validate handling of consensus data and protein identification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->