### PR TITLE
fix: add --mkpath to rsync to fix nightly wheel upload to archive.openms.de

### DIFF
--- a/.github/workflows/pyopenms-wheels-cibuildwheel.yml
+++ b/.github/workflows/pyopenms-wheels-cibuildwheel.yml
@@ -575,4 +575,4 @@ jobs:
           mkdir -p ~/.ssh/
           echo "$PASS" > ~/.ssh/private.key
           chmod 600 ~/.ssh/private.key
-          rsync --progress -avz -e "ssh -i ~/.ssh/private.key -p $PORT -o StrictHostKeyChecking=no" dist/*.whl "$USER@$HOST:/pyopenms/${folder}/"
+          rsync --progress -avz --mkpath -e "ssh -i ~/.ssh/private.key -p $PORT -o StrictHostKeyChecking=no" dist/*.whl "$USER@$HOST:/pyopenms/${folder}/"


### PR DESCRIPTION
## Problem

The nightly `pyopenms-wheels-cibuildwheel` CI run on 2026-06-15 failed in two upload jobs:

**1. "Upload wheels to archive.openms.de" (fixed here)**

```
rsync: [Receiver] mkdir "/srv/files/openms/pyopenms/nightly" failed: No such file or directory (2)
rsync error: error in file IO (code 11) at main.c(800) [Receiver=3.2.7]
```

The destination directory `/srv/files/openms/pyopenms/nightly` did not exist on `archive.openms.de`, causing rsync to fail with exit code 11.

**2. "Upload nightly to Tuebingen" (server-side — not fixed here)**

```
400 Bad Request
MultipartError: Memory limit reached.
```

The Tuebingen PyPI server (`pypi.cs.uni-tuebingen.de`) is hitting a memory limit when receiving wheel uploads. This is a server configuration issue that cannot be fixed in the workflow.

## Fix

Add `--mkpath` to the rsync invocation in the `publish-archive-openms` job. This flag (introduced in rsync 3.2.3) instructs the receiver to create missing destination path components. The server runs rsync 3.2.7, so this is safe.

```diff
-rsync --progress -avz -e "..." dist/*.whl "$USER@$HOST:/pyopenms/${folder}/"
+rsync --progress -avz --mkpath -e "..." dist/*.whl "$USER@$HOST:/pyopenms/${folder}/"
```

This makes the workflow robust against fresh deployments or new subdirectories (e.g. a new `nightly` or `release/x.y.z` folder) that haven't been pre-created on the server.

https://claude.ai/code/session_01Q2bkmkrpWA6pRKDJbZKPF7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2bkmkrpWA6pRKDJbZKPF7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment reliability in the build and distribution workflow by ensuring necessary directories are created during the publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->