### PR TITLE
[TEST] Tests for the OpenSWATH MSExperiment spectrum-access wrappers

### DIFF
--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -295,6 +295,8 @@ set(format_executables_list
   MSDataAggregatingConsumer_test
   SpectrumAccessQuadMZTransforming_test
   SpectrumAccessSqMass_test
+  SpectrumAccessOpenMS_test
+  SpectrumAccessOpenMSInMemory_test
   SiriusFragmentAnnotation_test
 )
 

--- a/src/tests/class_tests/openms/source/SpectrumAccessOpenMSInMemory_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumAccessOpenMSInMemory_test.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Hannes Roest $
+// $Authors: Hannes Roest $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+#include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMSInMemory.h>
+///////////////////////////
+
+#include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMS.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+
+#include <memory>
+
+using namespace OpenMS;
+using namespace std;
+
+namespace
+{
+  std::shared_ptr<MSExperiment> mkExp()
+  {
+    auto exp = std::make_shared<MSExperiment>();
+    MSSpectrum s0; s0.setRT(10.0); s0.setMSLevel(1);
+    Peak1D p; p.setMZ(100.0); p.setIntensity(500.0); s0.push_back(p);
+    Peak1D p2; p2.setMZ(200.0); p2.setIntensity(800.0); s0.push_back(p2);
+    exp->addSpectrum(s0);
+    MSSpectrum s1; s1.setRT(20.0); s1.setMSLevel(2); exp->addSpectrum(s1);
+    MSChromatogram c; c.setNativeID("chrom_42");
+    ChromatogramPeak cp; cp.setRT(5.0); cp.setIntensity(99.0); c.push_back(cp);
+    exp->addChromatogram(c);
+    return exp;
+  }
+}
+
+START_TEST(SpectrumAccessOpenMSInMemory, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+SpectrumAccessOpenMSInMemory* ptr = nullptr;
+SpectrumAccessOpenMSInMemory* null_ptr = nullptr;
+
+START_SECTION((explicit SpectrumAccessOpenMSInMemory(OpenSwath::ISpectrumAccess& origin)))
+{
+  SpectrumAccessOpenMS origin(mkExp());
+  ptr = new SpectrumAccessOpenMSInMemory(origin);
+  TEST_NOT_EQUAL(ptr, null_ptr)
+  // the in-memory copy pre-loads the same spectra/chromatograms
+  TEST_EQUAL(ptr->getNrSpectra(), 2)
+  TEST_EQUAL(ptr->getNrChromatograms(), 1)
+}
+END_SECTION
+
+START_SECTION((~SpectrumAccessOpenMSInMemory()))
+{
+  delete ptr;
+}
+END_SECTION
+
+START_SECTION((OpenSwath::SpectrumPtr getSpectrumById(int id)))
+{
+  SpectrumAccessOpenMS origin(mkExp());
+  SpectrumAccessOpenMSInMemory sa(origin);
+  OpenSwath::SpectrumPtr s = sa.getSpectrumById(0);
+  TEST_EQUAL(s->getMZArray()->data.size(), 2)
+  TEST_REAL_SIMILAR(s->getMZArray()->data[0], 100.0)
+  TEST_REAL_SIMILAR(s->getMZArray()->data[1], 200.0)
+  TEST_REAL_SIMILAR(s->getIntensityArray()->data[1], 800.0)
+}
+END_SECTION
+
+START_SECTION((OpenSwath::SpectrumMeta getSpectrumMetaById(int id) const))
+{
+  SpectrumAccessOpenMS origin(mkExp());
+  SpectrumAccessOpenMSInMemory sa(origin);
+  OpenSwath::SpectrumMeta m = sa.getSpectrumMetaById(0);
+  TEST_REAL_SIMILAR(m.RT, 10.0)
+}
+END_SECTION
+
+START_SECTION((OpenSwath::ChromatogramPtr getChromatogramById(int id)))
+{
+  SpectrumAccessOpenMS origin(mkExp());
+  SpectrumAccessOpenMSInMemory sa(origin);
+  OpenSwath::ChromatogramPtr c = sa.getChromatogramById(0);
+  TEST_EQUAL(c->getTimeArray()->data.size(), 1)
+  TEST_REAL_SIMILAR(c->getTimeArray()->data[0], 5.0)
+  TEST_REAL_SIMILAR(c->getIntensityArray()->data[0], 99.0)
+}
+END_SECTION
+
+START_SECTION((std::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const))
+{
+  SpectrumAccessOpenMS origin(mkExp());
+  SpectrumAccessOpenMSInMemory sa(origin);
+  auto clone = sa.lightClone();
+  TEST_NOT_EQUAL(clone.get(), nullptr)
+  TEST_EQUAL(clone->getNrSpectra(), 2)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST

--- a/src/tests/class_tests/openms/source/SpectrumAccessOpenMS_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumAccessOpenMS_test.cpp
@@ -1,0 +1,138 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Hannes Roest $
+// $Authors: Hannes Roest $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+#include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMS.h>
+///////////////////////////
+
+#include <OpenMS/KERNEL/MSExperiment.h>
+
+#include <memory>
+
+using namespace OpenMS;
+using namespace std;
+
+namespace
+{
+  // a 2-spectrum, 1-chromatogram experiment
+  std::shared_ptr<MSExperiment> mkExp()
+  {
+    auto exp = std::make_shared<MSExperiment>();
+    MSSpectrum s0; s0.setRT(10.0); s0.setMSLevel(1);
+    Peak1D p; p.setMZ(100.0); p.setIntensity(500.0); s0.push_back(p);
+    Peak1D p2; p2.setMZ(200.0); p2.setIntensity(800.0); s0.push_back(p2);
+    exp->addSpectrum(s0);
+    MSSpectrum s1; s1.setRT(20.0); s1.setMSLevel(2); exp->addSpectrum(s1);
+    MSChromatogram c; c.setNativeID("chrom_42");
+    ChromatogramPeak cp; cp.setRT(5.0); cp.setIntensity(99.0); c.push_back(cp);
+    exp->addChromatogram(c);
+    return exp;
+  }
+}
+
+START_TEST(SpectrumAccessOpenMS, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+SpectrumAccessOpenMS* ptr = nullptr;
+SpectrumAccessOpenMS* null_ptr = nullptr;
+
+START_SECTION((explicit SpectrumAccessOpenMS(std::shared_ptr<MSExperimentType> ms_experiment)))
+{
+  ptr = new SpectrumAccessOpenMS(mkExp());
+  TEST_NOT_EQUAL(ptr, null_ptr)
+}
+END_SECTION
+
+START_SECTION((~SpectrumAccessOpenMS()))
+{
+  delete ptr;
+}
+END_SECTION
+
+START_SECTION((size_t getNrSpectra() const))
+{
+  SpectrumAccessOpenMS sa(mkExp());
+  TEST_EQUAL(sa.getNrSpectra(), 2)
+}
+END_SECTION
+
+START_SECTION((size_t getNrChromatograms() const))
+{
+  SpectrumAccessOpenMS sa(mkExp());
+  TEST_EQUAL(sa.getNrChromatograms(), 1)
+}
+END_SECTION
+
+START_SECTION((OpenSwath::SpectrumPtr getSpectrumById(int id)))
+{
+  SpectrumAccessOpenMS sa(mkExp());
+  OpenSwath::SpectrumPtr s = sa.getSpectrumById(0);
+  TEST_EQUAL(s->getMZArray()->data.size(), 2)
+  TEST_REAL_SIMILAR(s->getMZArray()->data[0], 100.0)
+  TEST_REAL_SIMILAR(s->getMZArray()->data[1], 200.0)
+  TEST_REAL_SIMILAR(s->getIntensityArray()->data[0], 500.0)
+  TEST_REAL_SIMILAR(s->getIntensityArray()->data[1], 800.0)
+}
+END_SECTION
+
+START_SECTION((OpenSwath::SpectrumMeta getSpectrumMetaById(int id) const))
+{
+  SpectrumAccessOpenMS sa(mkExp());
+  OpenSwath::SpectrumMeta m = sa.getSpectrumMetaById(0);
+  TEST_REAL_SIMILAR(m.RT, 10.0)
+  TEST_EQUAL(m.ms_level, 1)
+}
+END_SECTION
+
+START_SECTION((std::vector<std::size_t> getSpectraByRT(double RT, double deltaRT) const))
+{
+  SpectrumAccessOpenMS sa(mkExp());
+  // exact RT, zero tolerance -> only spectrum 0 (RT 10)
+  auto hits = sa.getSpectraByRT(10.0, 0.0);
+  TEST_EQUAL(hits.size(), 1)
+  TEST_EQUAL(hits[0], 0)
+  // window covering both spectra (RT 10 and 20)
+  TEST_EQUAL(sa.getSpectraByRT(15.0, 6.0).size(), 2)
+}
+END_SECTION
+
+START_SECTION((OpenSwath::ChromatogramPtr getChromatogramById(int id)))
+{
+  SpectrumAccessOpenMS sa(mkExp());
+  OpenSwath::ChromatogramPtr c = sa.getChromatogramById(0);
+  TEST_EQUAL(c->getTimeArray()->data.size(), 1)
+  TEST_REAL_SIMILAR(c->getTimeArray()->data[0], 5.0)
+  TEST_REAL_SIMILAR(c->getIntensityArray()->data[0], 99.0)
+}
+END_SECTION
+
+START_SECTION((std::string getChromatogramNativeID(int id) const))
+{
+  SpectrumAccessOpenMS sa(mkExp());
+  TEST_STRING_EQUAL(sa.getChromatogramNativeID(0), "chrom_42")
+}
+END_SECTION
+
+START_SECTION((std::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const))
+{
+  SpectrumAccessOpenMS sa(mkExp());
+  auto clone = sa.lightClone();
+  TEST_NOT_EQUAL(clone.get(), nullptr)
+  TEST_EQUAL(clone->getNrSpectra(), 2)
+  TEST_EQUAL(clone->getNrChromatograms(), 1)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST


### PR DESCRIPTION
## Context

Part of the OpenMS 3.6.0 pre-release testing plan (#9460), §4 (OpenSwathWorkflow). **Batched PR** — two related untested data-access wrappers in one change.

`SpectrumAccessOpenMS` and `SpectrumAccessOpenMSInMemory` adapt an `MSExperiment` to the `OpenSwath::ISpectrumAccess` interface used throughout OpenSWATH; neither had a test.

## Change

Both build a small 2-spectrum / 1-chromatogram experiment and verify the interface:

- **`SpectrumAccessOpenMS`** (wraps a `shared_ptr<MSExperiment>`): `getNrSpectra` / `getNrChromatograms`, `getSpectrumById` (m/z + intensity arrays), `getSpectrumMetaById` (RT, MS level), `getSpectraByRT` (RT-window lookup), `getChromatogramById` (time + intensity arrays), `getChromatogramNativeID`, and `lightClone`.
- **`SpectrumAccessOpenMSInMemory`** (pre-loads from an `ISpectrumAccess`): the same spectrum/chromatogram counts and per-array values are reproduced from the in-memory copy, plus `getSpectrumMetaById` and `lightClone`.

## Notes

- Both registered in `executables.cmake` (`format_executables_list`, DATAACCESS section, next to the existing SpectrumAccess tests).
- **Tests only** — no production code changes.
- The OpenSwath array values were probed against the built library before pinning.
- Both build and pass locally; all assertions execute against real values (verbose-confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for spectrum access functionality, including tests for spectrum and chromatogram retrieval, metadata access, and object operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->