### PR TITLE
Add class tests for IdentifierMSRunMapper and ProteinModificationSummary

### DIFF
--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -114,6 +114,8 @@ set(metadata_executables_list
   Product_test
   ProteinHit_test
   ProteinIdentification_test
+  ProteinModificationSummary_test
+  IdentifierMSRunMapper_test
   Sample_test
   ScanWindow_test
   Software_test

--- a/src/tests/class_tests/openms/source/IdentifierMSRunMapper_test.cpp
+++ b/src/tests/class_tests/openms/source/IdentifierMSRunMapper_test.cpp
@@ -1,0 +1,213 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/METADATA/IdentifierMSRunMapper.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
+#include <OpenMS/CONCEPT/Constants.h>
+
+///////////////////////////
+
+START_TEST(IdentifierMSRunMapper, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+using namespace OpenMS;
+using namespace std;
+
+// Helper: build a small set of ProteinIdentifications with known
+// identifiers and primary MS-run-paths.
+auto makeProtIds = []() -> std::vector<ProteinIdentification>
+{
+  ProteinIdentification p1, p2;
+  p1.setIdentifier("ID_A");
+  p1.setPrimaryMSRunPath(StringList{"/data/runA.mzML"});
+  p2.setIdentifier("ID_B");
+  p2.setPrimaryMSRunPath(StringList{"/data/runB1.mzML", "/data/runB2.mzML"});
+  return std::vector<ProteinIdentification>{p1, p2};
+};
+
+IdentifierMSRunMapper* ptr = nullptr;
+IdentifierMSRunMapper* null_ptr = nullptr;
+
+START_SECTION((IdentifierMSRunMapper()))
+{
+  ptr = new IdentifierMSRunMapper();
+  TEST_NOT_EQUAL(ptr, null_ptr)
+  TEST_EQUAL(ptr->empty(), true)
+  TEST_EQUAL(ptr->size(), 0)
+}
+END_SECTION
+
+START_SECTION((~IdentifierMSRunMapper()))
+{
+  delete ptr;
+}
+END_SECTION
+
+START_SECTION((explicit IdentifierMSRunMapper(const std::vector<ProteinIdentification>& prot_ids)))
+{
+  IdentifierMSRunMapper m(makeProtIds());
+  TEST_EQUAL(m.empty(), false)
+  TEST_EQUAL(m.size(), 2)
+}
+END_SECTION
+
+START_SECTION((void create(const std::vector<ProteinIdentification>& prot_ids)))
+{
+  IdentifierMSRunMapper m;
+  m.create(makeProtIds());
+  TEST_EQUAL(m.size(), 2)
+  TEST_EQUAL(m.hasIdentifier("ID_A"), true)
+
+  // create() clears previous content
+  ProteinIdentification p;
+  p.setIdentifier("ONLY");
+  p.setPrimaryMSRunPath(StringList{"/data/only.mzML"});
+  m.create(std::vector<ProteinIdentification>{p});
+  TEST_EQUAL(m.size(), 1)
+  TEST_EQUAL(m.hasIdentifier("ID_A"), false)
+  TEST_EQUAL(m.hasIdentifier("ONLY"), true)
+
+  // Two protein IDs with the same ms-run-path must be rejected
+  ProteinIdentification d1, d2;
+  d1.setIdentifier("D1");
+  d1.setPrimaryMSRunPath(StringList{"/dup.mzML"});
+  d2.setIdentifier("D2");
+  d2.setPrimaryMSRunPath(StringList{"/dup.mzML"});
+  TEST_EXCEPTION(Exception::InvalidValue, m.create(std::vector<ProteinIdentification>{d1, d2}))
+}
+END_SECTION
+
+START_SECTION((bool empty() const))
+{
+  IdentifierMSRunMapper m;
+  TEST_EQUAL(m.empty(), true)
+  m.create(makeProtIds());
+  TEST_EQUAL(m.empty(), false)
+}
+END_SECTION
+
+START_SECTION((Size size() const))
+{
+  IdentifierMSRunMapper m(makeProtIds());
+  TEST_EQUAL(m.size(), 2)
+}
+END_SECTION
+
+START_SECTION((bool hasIdentifier(const std::string& identifier) const))
+{
+  IdentifierMSRunMapper m(makeProtIds());
+  TEST_EQUAL(m.hasIdentifier("ID_A"), true)
+  TEST_EQUAL(m.hasIdentifier("ID_B"), true)
+  TEST_EQUAL(m.hasIdentifier("ID_X"), false)
+}
+END_SECTION
+
+START_SECTION((const StringList& getMSRunPaths(const std::string& identifier) const))
+{
+  IdentifierMSRunMapper m(makeProtIds());
+  const StringList& a = m.getMSRunPaths("ID_A");
+  TEST_EQUAL(a.size(), 1)
+  TEST_STRING_EQUAL(a[0], "/data/runA.mzML")
+
+  const StringList& b = m.getMSRunPaths("ID_B");
+  TEST_EQUAL(b.size(), 2)
+  TEST_STRING_EQUAL(b[0], "/data/runB1.mzML")
+  TEST_STRING_EQUAL(b[1], "/data/runB2.mzML")
+
+  // Unknown identifier yields an empty list (no exception)
+  const StringList& none = m.getMSRunPaths("nope");
+  TEST_EQUAL(none.empty(), true)
+}
+END_SECTION
+
+START_SECTION((std::vector<std::string> getIdentifiers() const))
+{
+  IdentifierMSRunMapper m(makeProtIds());
+  std::vector<std::string> ids = m.getIdentifiers();
+  TEST_EQUAL(ids.size(), 2)
+  // std::map ordering -> sorted by key
+  TEST_STRING_EQUAL(ids[0], "ID_A")
+  TEST_STRING_EQUAL(ids[1], "ID_B")
+}
+END_SECTION
+
+START_SECTION((const std::string& getIdentifier(const StringList& ms_run_paths) const))
+{
+  IdentifierMSRunMapper m(makeProtIds());
+  TEST_STRING_EQUAL(m.getIdentifier(StringList{"/data/runA.mzML"}), "ID_A")
+  TEST_STRING_EQUAL(m.getIdentifier(StringList{"/data/runB1.mzML", "/data/runB2.mzML"}), "ID_B")
+
+  // Lookup is on the full path list: a partial match does not resolve
+  TEST_EXCEPTION(Exception::ElementNotFound, m.getIdentifier(StringList{"/data/runB1.mzML"}))
+  TEST_EXCEPTION(Exception::ElementNotFound, m.getIdentifier(StringList{"/missing.mzML"}))
+}
+END_SECTION
+
+START_SECTION((bool hasRunPath(const StringList& ms_run_paths) const))
+{
+  IdentifierMSRunMapper m(makeProtIds());
+  TEST_EQUAL(m.hasRunPath(StringList{"/data/runA.mzML"}), true)
+  TEST_EQUAL(m.hasRunPath(StringList{"/data/runB1.mzML", "/data/runB2.mzML"}), true)
+  TEST_EQUAL(m.hasRunPath(StringList{"/data/runB1.mzML"}), false)
+  TEST_EQUAL(m.hasRunPath(StringList{"/missing.mzML"}), false)
+}
+END_SECTION
+
+START_SECTION((bool tryGetIdentifier(const StringList& ms_run_paths, std::string& identifier) const))
+{
+  IdentifierMSRunMapper m(makeProtIds());
+  std::string id;
+  TEST_EQUAL(m.tryGetIdentifier(StringList{"/data/runA.mzML"}, id), true)
+  TEST_STRING_EQUAL(id, "ID_A")
+
+  std::string id2 = "unchanged";
+  TEST_EQUAL(m.tryGetIdentifier(StringList{"/missing.mzML"}, id2), false)
+  TEST_STRING_EQUAL(id2, "unchanged")
+}
+END_SECTION
+
+START_SECTION((std::string getPrimaryMSRunPath(const PeptideIdentification& pepid) const))
+{
+  IdentifierMSRunMapper m(makeProtIds());
+
+  // No merge index -> default to first path
+  PeptideIdentification pep;
+  pep.setIdentifier("ID_B");
+  TEST_STRING_EQUAL(m.getPrimaryMSRunPath(pep), "/data/runB1.mzML")
+
+  // Valid merge index -> corresponding path
+  pep.setMetaValue(Constants::UserParam::ID_MERGE_INDEX, 1);
+  TEST_STRING_EQUAL(m.getPrimaryMSRunPath(pep), "/data/runB2.mzML")
+
+  // Out-of-range merge index -> empty string
+  pep.setMetaValue(Constants::UserParam::ID_MERGE_INDEX, 5);
+  TEST_STRING_EQUAL(m.getPrimaryMSRunPath(pep), "")
+
+  // Unknown identifier -> empty string
+  PeptideIdentification pep_unknown;
+  pep_unknown.setIdentifier("DOES_NOT_EXIST");
+  TEST_STRING_EQUAL(m.getPrimaryMSRunPath(pep_unknown), "")
+
+  // Single-path identifier
+  PeptideIdentification pep_a;
+  pep_a.setIdentifier("ID_A");
+  TEST_STRING_EQUAL(m.getPrimaryMSRunPath(pep_a), "/data/runA.mzML")
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST

--- a/src/tests/class_tests/openms/source/ProteinModificationSummary_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteinModificationSummary_test.cpp
@@ -1,0 +1,136 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/METADATA/ProteinModificationSummary.h>
+#include <OpenMS/CHEMISTRY/ModificationsDB.h>
+#include <OpenMS/CHEMISTRY/ResidueModification.h>
+
+///////////////////////////
+
+START_TEST(ProteinModificationSummary, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+using namespace OpenMS;
+using namespace std;
+
+ProteinModificationSummary* ptr = nullptr;
+ProteinModificationSummary* null_ptr = nullptr;
+
+START_SECTION((ProteinModificationSummary()))
+{
+  ptr = new ProteinModificationSummary();
+  TEST_NOT_EQUAL(ptr, null_ptr)
+  TEST_EQUAL(ptr->AALevelSummary.empty(), true)
+}
+END_SECTION
+
+START_SECTION((~ProteinModificationSummary()))
+{
+  delete ptr;
+}
+END_SECTION
+
+START_SECTION(([ProteinModificationSummary::Statistics] bool operator==(const Statistics& rhs) const))
+{
+  ProteinModificationSummary::Statistics a;
+  // default-constructed values
+  TEST_EQUAL(a.count, 0)
+  TEST_REAL_SIMILAR(a.frequency, 0.0)
+  TEST_REAL_SIMILAR(a.FLR, 0.0)
+  TEST_REAL_SIMILAR(a.probability, 0.0)
+
+  ProteinModificationSummary::Statistics b;
+  TEST_EQUAL(a == b, true)
+
+  a.count = 123;
+  a.frequency = 0.5;
+  a.FLR = 0.01;
+  a.probability = 0.99;
+  TEST_EQUAL(a == b, false)
+
+  b.count = 123;
+  b.frequency = 0.5;
+  b.FLR = 0.01;
+  b.probability = 0.99;
+  TEST_EQUAL(a == b, true)
+
+  // each field participates in the comparison
+  b.count = 124;
+  TEST_EQUAL(a == b, false)
+  b.count = 123;
+  b.probability = 0.98;
+  TEST_EQUAL(a == b, false)
+}
+END_SECTION
+
+START_SECTION((bool operator==(const ProteinModificationSummary& rhs) const))
+{
+  const ResidueModification* ox = ModificationsDB::getInstance()->getModification("Oxidation", "M", ResidueModification::ANYWHERE);
+  TEST_NOT_EQUAL(ox, 0)
+
+  ProteinModificationSummary::Statistics st;
+  st.count = 42;
+  st.frequency = 0.25;
+  st.FLR = 0.05;
+  st.probability = 0.9;
+
+  ProteinModificationSummary s1, s2;
+  TEST_EQUAL(s1 == s2, true)
+
+  // position 10 carries an Oxidation observed in 42 PSMs
+  s1.AALevelSummary[10][ox] = st;
+  TEST_EQUAL(s1 == s2, false)
+
+  s2.AALevelSummary[10][ox] = st;
+  TEST_EQUAL(s1 == s2, true)
+
+  // differing statistic at the same position/modification
+  ProteinModificationSummary::Statistics st2 = st;
+  st2.count = 43;
+  s2.AALevelSummary[10][ox] = st2;
+  TEST_EQUAL(s1 == s2, false)
+
+  // differing position
+  s2.AALevelSummary[10][ox] = st;
+  TEST_EQUAL(s1 == s2, true)
+  s2.AALevelSummary[11][ox] = st;
+  TEST_EQUAL(s1 == s2, false)
+}
+END_SECTION
+
+START_SECTION([EXTRA] (nested type aliases and map semantics))
+{
+  const ResidueModification* ox = ModificationsDB::getInstance()->getModification("Oxidation", "M", ResidueModification::ANYWHERE);
+
+  ProteinModificationSummary s;
+  ProteinModificationSummary::Statistics st;
+  st.count = 7;
+  s.AALevelSummary[3][ox] = st;
+
+  // ModificationsToStatistics: modification -> statistic
+  ProteinModificationSummary::ModificationsToStatistics& at3 = s.AALevelSummary[3];
+  TEST_EQUAL(at3.size(), 1)
+  TEST_EQUAL(at3[ox].count, 7)
+
+  // AALevelSummary: position -> ModificationsToStatistics
+  TEST_EQUAL(s.AALevelSummary.size(), 1)
+  TEST_EQUAL(s.AALevelSummary.count(3), 1)
+  TEST_EQUAL(s.AALevelSummary.count(99), 0)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST


### PR DESCRIPTION
Part of the OpenMS 3.6.0 pre-release testing plan (#9460): adds class tests for two previously untested `METADATA` classes.

## `IdentifierMSRunMapper`
Two-way mapping between protein-identification identifiers and MS-run-paths (used e.g. for USI building / resolving the source file of a peptide ID). Tests cover:
- construction from `ProteinIdentification`s and `create()` (including that it clears prior content)
- `empty()`, `size()`, `hasIdentifier()`
- `getMSRunPaths()` (and empty list returned for unknown identifiers)
- `getIdentifiers()` ordering, `getIdentifier()` (full path-list match, and `Exception::ElementNotFound` on miss)
- `hasRunPath()` / `tryGetIdentifier()`
- `getPrimaryMSRunPath()` resolution via `id_merge_index` (default index 0, valid index, out-of-range → empty, unknown identifier → empty)
- duplicate ms-run-path rejection (`Exception::InvalidValue`)

## `ProteinModificationSummary`
Maps a protein position → modification → statistics. Tests cover:
- `Statistics::operator==` over all four fields (count, frequency, FLR, probability)
- `ProteinModificationSummary::operator==` across differing position / modification / statistics
- nested type aliases (`ModificationsToStatistics`, `AALevelSummary`) and map semantics

Expected values were pinned by probing the built library before writing assertions; both tests build and pass locally with no warnings (aside from the standard dtor-only "no subtests" notice).

**Tests only — no production code changes.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for IdentifierMSRunMapper, including construction, mapping lookups, and run-path resolution logic.
  * Added comprehensive unit test coverage for ProteinModificationSummary, validating construction, equality semantics, and container behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->