### PR TITLE
[TEST] Tests for IonIdentityMolecularNetworking and DDAWorkflowCommons

### DIFF
--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -514,6 +514,8 @@ set(analysis_executables_list
   IDRipper_test
   IDScoreSwitcherAlgorithm_test
   ILPDCWrapper_test
+  IonIdentityMolecularNetworking_test
+  DDAWorkflowCommons_test
   IsotopeLabelingMDVs_test
   IncludeExcludeTarget_test
   IsobaricChannelExtractor_test

--- a/src/tests/class_tests/openms/source/DDAWorkflowCommons_test.cpp
+++ b/src/tests/class_tests/openms/source/DDAWorkflowCommons_test.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/ANALYSIS/QUANTITATION/DDAWorkflowCommons.h>
+#include <OpenMS/SYSTEM/File.h>
+
+#include <map>
+#include <string>
+
+///////////////////////////
+
+START_TEST(DDAWorkflowCommons, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+using namespace OpenMS;
+using namespace std;
+
+START_SECTION((static std::map<std::string, std::string> mapId2MzMLs(const std::map<std::string, std::string>& m2i)))
+{
+  // mapId2MzMLs simply inverts the mzML->id map into an id->mzML map
+  std::map<std::string, std::string> m2i;
+  m2i["/a/runA.mzML"] = "/x/runA.idXML";
+  m2i["/b/runB.mzML"] = "/y/runB.idXML";
+
+  std::map<std::string, std::string> i2m = DDAWorkflowCommons::mapId2MzMLs(m2i);
+
+  TEST_EQUAL(i2m.size(), 2)
+  TEST_STRING_EQUAL(i2m["/x/runA.idXML"], "/a/runA.mzML")
+  TEST_STRING_EQUAL(i2m["/y/runB.idXML"], "/b/runB.mzML")
+
+  // empty input -> empty output
+  std::map<std::string, std::string> empty_in;
+  TEST_EQUAL(DDAWorkflowCommons::mapId2MzMLs(empty_in).empty(), true)
+}
+END_SECTION
+
+START_SECTION((static std::map<std::string, std::string> mapMzML2Ids(StringList& in, StringList& in_ids)))
+{
+  // Matching base names in the same order -> map of absolute mzML path -> absolute id path
+  StringList in{"dirA/sample1.mzML", "dirB/sample2.mzML"};
+  StringList ids{"idsA/sample1.idXML", "idsB/sample2.idXML"};
+
+  std::map<std::string, std::string> mz2id = DDAWorkflowCommons::mapMzML2Ids(in, ids);
+
+  TEST_EQUAL(mz2id.size(), 2)
+  TEST_STRING_EQUAL(mz2id[File::absolutePath("dirA/sample1.mzML")], File::absolutePath("idsA/sample1.idXML"))
+  TEST_STRING_EQUAL(mz2id[File::absolutePath("dirB/sample2.mzML")], File::absolutePath("idsB/sample2.idXML"))
+
+  // Different number of files -> rejected
+  StringList in_short{"a.mzML"};
+  StringList ids_long{"a.idXML", "b.idXML"};
+  TEST_EXCEPTION(Exception::IllegalArgument, DDAWorkflowCommons::mapMzML2Ids(in_short, ids_long))
+
+  // Same base names but different order -> rejected
+  StringList in_ord{"a.mzML", "b.mzML"};
+  StringList ids_ord{"b.idXML", "a.idXML"};
+  TEST_EXCEPTION(Exception::IllegalArgument, DDAWorkflowCommons::mapMzML2Ids(in_ord, ids_ord))
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST

--- a/src/tests/class_tests/openms/source/IonIdentityMolecularNetworking_test.cpp
+++ b/src/tests/class_tests/openms/source/IonIdentityMolecularNetworking_test.cpp
@@ -1,0 +1,152 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Axel Walter $
+// $Authors: Axel Walter $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/ANALYSIS/ID/IonIdentityMolecularNetworking.h>
+#include <OpenMS/KERNEL/ConsensusMap.h>
+#include <OpenMS/KERNEL/ConsensusFeature.h>
+#include <OpenMS/CONCEPT/Constants.h>
+
+#include <fstream>
+#include <vector>
+#include <string>
+
+///////////////////////////
+
+START_TEST(IonIdentityMolecularNetworking, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+using namespace OpenMS;
+using namespace std;
+
+// Helper: build a ConsensusFeature with a list of IIMN linked (adduct) groups.
+auto mkCF = [](double mz, const StringList& groups, const std::string& best_ion = "") -> ConsensusFeature
+{
+  ConsensusFeature cf;
+  cf.setMZ(mz);
+  cf.setRT(100.0);
+  if (!groups.empty())
+  {
+    cf.setMetaValue(Constants::UserParam::IIMN_LINKED_GROUPS, DataValue(groups));
+  }
+  if (!best_ion.empty())
+  {
+    cf.setMetaValue(Constants::UserParam::IIMN_BEST_ION, best_ion);
+  }
+  return cf;
+};
+
+START_SECTION((static void annotateConsensusMap(ConsensusMap& consensus_map)))
+{
+  // --- Scenario from the class documentation: two adduct partners + one separate network ---
+  // CF0 groups {1,2}, CF1 groups {2,3} -> share group 2 -> network 1
+  // CF2 groups {4,5} -> isolated -> network 2
+  {
+    ConsensusMap cm;
+    cm.push_back(mkCF(100.0, StringList{"1", "2"}));
+    cm.push_back(mkCF(122.0, StringList{"2", "3"}));
+    cm.push_back(mkCF(200.0, StringList{"4", "5"}));
+
+    IonIdentityMolecularNetworking::annotateConsensusMap(cm);
+
+    // 1-based row IDs assigned to every feature
+    TEST_EQUAL((int)cm[0].getMetaValue(Constants::UserParam::IIMN_ROW_ID), 1)
+    TEST_EQUAL((int)cm[1].getMetaValue(Constants::UserParam::IIMN_ROW_ID), 2)
+    TEST_EQUAL((int)cm[2].getMetaValue(Constants::UserParam::IIMN_ROW_ID), 3)
+
+    // network (connected-component) numbers
+    TEST_EQUAL((int)cm[0].getMetaValue(Constants::UserParam::IIMN_ANNOTATION_NETWORK_NUMBER), 1)
+    TEST_EQUAL((int)cm[1].getMetaValue(Constants::UserParam::IIMN_ANNOTATION_NETWORK_NUMBER), 1)
+    TEST_EQUAL((int)cm[2].getMetaValue(Constants::UserParam::IIMN_ANNOTATION_NETWORK_NUMBER), 2)
+
+    // adduct partners (semicolon-separated partner row IDs)
+    TEST_STRING_EQUAL(cm[0].getMetaValue(Constants::UserParam::IIMN_ADDUCT_PARTNERS).toString(), "2")
+    TEST_STRING_EQUAL(cm[1].getMetaValue(Constants::UserParam::IIMN_ADDUCT_PARTNERS).toString(), "1")
+    // CF2 has groups but no partner -> no partner annotation
+    TEST_EQUAL(cm[2].metaValueExists(Constants::UserParam::IIMN_ADDUCT_PARTNERS), false)
+
+    // linked-groups meta value is consumed/removed from every feature
+    TEST_EQUAL(cm[0].metaValueExists(Constants::UserParam::IIMN_LINKED_GROUPS), false)
+    TEST_EQUAL(cm[1].metaValueExists(Constants::UserParam::IIMN_LINKED_GROUPS), false)
+    TEST_EQUAL(cm[2].metaValueExists(Constants::UserParam::IIMN_LINKED_GROUPS), false)
+  }
+
+  // --- Chain: CF0-CF1-CF2 transitively connected -> single network, multi-partner join ---
+  {
+    ConsensusMap cm;
+    cm.push_back(mkCF(100.0, StringList{"1", "2"}));
+    cm.push_back(mkCF(120.0, StringList{"2", "3"}));
+    cm.push_back(mkCF(140.0, StringList{"3", "4"}));
+
+    IonIdentityMolecularNetworking::annotateConsensusMap(cm);
+
+    TEST_EQUAL((int)cm[0].getMetaValue(Constants::UserParam::IIMN_ANNOTATION_NETWORK_NUMBER), 1)
+    TEST_EQUAL((int)cm[1].getMetaValue(Constants::UserParam::IIMN_ANNOTATION_NETWORK_NUMBER), 1)
+    TEST_EQUAL((int)cm[2].getMetaValue(Constants::UserParam::IIMN_ANNOTATION_NETWORK_NUMBER), 1)
+
+    TEST_STRING_EQUAL(cm[0].getMetaValue(Constants::UserParam::IIMN_ADDUCT_PARTNERS).toString(), "2")
+    TEST_STRING_EQUAL(cm[1].getMetaValue(Constants::UserParam::IIMN_ADDUCT_PARTNERS).toString(), "1;3")
+    TEST_STRING_EQUAL(cm[2].getMetaValue(Constants::UserParam::IIMN_ADDUCT_PARTNERS).toString(), "2")
+  }
+
+  // --- A feature without linked groups receives only a row ID ---
+  {
+    ConsensusMap cm;
+    cm.push_back(mkCF(100.0, StringList{"1", "2"}));
+    cm.push_back(mkCF(122.0, StringList{"2", "3"}));
+    cm.push_back(mkCF(300.0, StringList{})); // no IIMN_LINKED_GROUPS
+
+    IonIdentityMolecularNetworking::annotateConsensusMap(cm);
+
+    TEST_EQUAL((int)cm[2].getMetaValue(Constants::UserParam::IIMN_ROW_ID), 3)
+    TEST_EQUAL(cm[2].metaValueExists(Constants::UserParam::IIMN_ANNOTATION_NETWORK_NUMBER), false)
+    TEST_EQUAL(cm[2].metaValueExists(Constants::UserParam::IIMN_ADDUCT_PARTNERS), false)
+  }
+}
+END_SECTION
+
+START_SECTION((static void writeSupplementaryPairTable(const ConsensusMap& consensus_map, const std::string& output_file)))
+{
+  ConsensusMap cm;
+  cm.push_back(mkCF(100.0, StringList{"1", "2"}, "[M+H]+"));
+  cm.push_back(mkCF(122.0, StringList{"2", "3"}, "[M+Na]+"));
+  cm.push_back(mkCF(200.0, StringList{"4", "5"}, "[M+H]+"));
+
+  IonIdentityMolecularNetworking::annotateConsensusMap(cm);
+
+  std::string out_file;
+  NEW_TMP_FILE(out_file)
+  IonIdentityMolecularNetworking::writeSupplementaryPairTable(cm, out_file);
+
+  std::vector<std::string> lines;
+  std::ifstream is(out_file.c_str());
+  std::string line;
+  while (std::getline(is, line))
+  {
+    if (!line.empty()) lines.push_back(line);
+  }
+  is.close();
+
+  // comma-separated table: header + exactly one edge (CF0 <-> CF1)
+  TEST_EQUAL(lines.size(), 2)
+  TEST_STRING_EQUAL(lines[0], "ID1,ID2,EdgeType,Score,Annotation")
+  // Score = (partners of CF0) + (partners of CF1) - 2 = 1 + 1 - 2 = 0
+  // Annotation = "<best ion 1> <best ion 2> dm/z=<|mz1 - mz2|>"
+  TEST_STRING_EQUAL(lines[1], "1,2,MS1 annotation,0,[M+H]+ [M+Na]+ dm/z=22.0")
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST


### PR DESCRIPTION
Part of the OpenMS 3.6.0 pre-release testing plan (#9460): adds class tests for two previously untested `ANALYSIS` workflow-helper classes.

## `IonIdentityMolecularNetworking` (ANALYSIS/ID)
Annotates a `ConsensusMap` for GNPS Ion Identity Molecular Networking by building a bipartite feature/adduct-group graph and computing connected components.

- **`annotateConsensusMap`** — verifies the three written meta values:
  - `IIMN_ROW_ID` (1-based, assigned to *every* feature, including those without group annotation)
  - `IIMN_ANNOTATION_NETWORK_NUMBER` (1-based connected-component id)
  - `IIMN_ADDUCT_PARTNERS` (semicolon-joined partner row IDs, only on features sharing a group)
  - and that the consumed `IIMN_LinkedGroups` meta value is removed.
  Scenarios: two adduct partners + one isolated network (the example documented in the source), a transitive chain (`CF0–CF1–CF2` → one network, partner string `1;3`), and a feature without linked groups (row ID only).
- **`writeSupplementaryPairTable`** — writes the GNPS supplementary pairs table to a temp file and reads it back, checking the header and the per-edge row (`Score = partners(a)+partners(b)-2`, and the `dm/z` annotation built from the best-ion meta values and the m/z difference).

## `DDAWorkflowCommons` (ANALYSIS/QUANTITATION)
- **`mapId2MzMLs`** — inverts the mzML→id map into an id→mzML map (incl. empty input).
- **`mapMzML2Ids`** — builds the absolute-path mzML→id map for matching base names, and rejects a file-count mismatch and an order mismatch with `Exception::IllegalArgument`.

Expected values (graph annotations, the exact pair-table rows, and the absolute-path mapping) were pinned by probing the built library before writing assertions. Both tests build and pass locally.

**Tests only — no production code changes.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for DDAWorkflowCommons module, covering mapping operations
  * Added comprehensive unit tests for IonIdentityMolecularNetworking module, covering feature annotation and supplementary pair table generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->