### PR TITLE
[TEST] Tests for the QC FeatureSummary and IdentificationSummary metrics

### DIFF
--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -17,8 +17,10 @@ set(concept_executables_list
 set(qc_executables_list
   Contaminants_test
   DBSuitability_test
+  FeatureSummary_test
   FragmentMassError_test
   FWHM_test
+  IdentificationSummary_test
   MissedCleavages_test
   Ms2IdentificationRate_test
   Ms2SpectrumStats_test

--- a/src/tests/class_tests/openms/source/FeatureSummary_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureSummary_test.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Axel Walter $
+// $Authors: Axel Walter $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/QC/FeatureSummary.h>
+#include <OpenMS/KERNEL/FeatureMap.h>
+
+///////////////////////////
+
+START_TEST(FeatureSummary, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+using namespace OpenMS;
+using namespace std;
+
+FeatureSummary* ptr = nullptr;
+FeatureSummary* null_ptr = nullptr;
+
+START_SECTION((FeatureSummary()))
+{
+  ptr = new FeatureSummary();
+  TEST_NOT_EQUAL(ptr, null_ptr)
+}
+END_SECTION
+
+START_SECTION((virtual ~FeatureSummary()))
+{
+  delete ptr;
+}
+END_SECTION
+
+START_SECTION((Result compute(const FeatureMap& feature_map)))
+{
+  FeatureSummary fs;
+
+  // three features, two carry an "rt_deviation" meta value (10 and 20 sec)
+  FeatureMap fm;
+  Feature f1; f1.setMetaValue("rt_deviation", 10.0); fm.push_back(f1);
+  Feature f2; f2.setMetaValue("rt_deviation", 20.0); fm.push_back(f2);
+  Feature f3; fm.push_back(f3); // no rt_deviation -> ignored in the mean
+  FeatureSummary::Result r = fs.compute(fm);
+  TEST_EQUAL(r.feature_count, 3)
+  TEST_REAL_SIMILAR(r.rt_shift_mean, 15.0) // (10 + 20) / 2
+
+  // empty map -> no features, mean defaults to 0
+  FeatureMap empty;
+  FeatureSummary::Result r0 = fs.compute(empty);
+  TEST_EQUAL(r0.feature_count, 0)
+  TEST_REAL_SIMILAR(r0.rt_shift_mean, 0.0)
+
+  // features without any rt_deviation -> count set, mean stays 0
+  FeatureMap no_dev;
+  no_dev.push_back(Feature());
+  no_dev.push_back(Feature());
+  FeatureSummary::Result rn = fs.compute(no_dev);
+  TEST_EQUAL(rn.feature_count, 2)
+  TEST_REAL_SIMILAR(rn.rt_shift_mean, 0.0)
+}
+END_SECTION
+
+START_SECTION(([FeatureSummary::Result] bool operator==(const Result& rhs) const))
+{
+  FeatureSummary::Result a, b;
+  TEST_EQUAL(a == b, true) // default-constructed: count 0, mean 0
+
+  a.feature_count = 5;
+  TEST_EQUAL(a == b, false)
+  b.feature_count = 5;
+  TEST_EQUAL(a == b, true)
+
+  a.rt_shift_mean = 3.5;
+  TEST_EQUAL(a == b, false)
+  b.rt_shift_mean = 3.5;
+  TEST_EQUAL(a == b, true)
+}
+END_SECTION
+
+START_SECTION((const std::string& getName() const override))
+{
+  FeatureSummary fs;
+  TEST_STRING_EQUAL(fs.getName(), "Summary of features from featureXML file")
+}
+END_SECTION
+
+START_SECTION((QCBase::Status requirements() const override))
+{
+  FeatureSummary fs;
+  TEST_EQUAL(fs.requirements() == QCBase::Status(QCBase::Requires::PREFDRFEAT), true)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST

--- a/src/tests/class_tests/openms/source/IdentificationSummary_test.cpp
+++ b/src/tests/class_tests/openms/source/IdentificationSummary_test.cpp
@@ -1,0 +1,167 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Axel Walter $
+// $Authors: Axel Walter $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/QC/IdentificationSummary.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
+#include <OpenMS/METADATA/PeptideIdentificationList.h>
+#include <OpenMS/METADATA/PeptideHit.h>
+#include <OpenMS/METADATA/ProteinHit.h>
+#include <OpenMS/CHEMISTRY/ProteaseDB.h>
+
+#include <vector>
+
+///////////////////////////
+
+START_TEST(IdentificationSummary, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+using namespace OpenMS;
+using namespace std;
+
+// Helper: build a PeptideIdentification with one hit of the given sequence.
+auto mkPep = [](const std::string& seq, const std::string& score_type, float sig) -> PeptideIdentification
+{
+  PeptideIdentification pid;
+  PeptideHit h;
+  h.setSequence(AASequence::fromString(seq));
+  pid.setHits({h});
+  pid.setScoreType(score_type);
+  pid.setSignificanceThreshold(sig);
+  return pid;
+};
+
+// Helper: build a single ProteinIdentification with trypsin digestion and two hits.
+auto mkProtIds = [](const std::string& score_type, float sig) -> std::vector<ProteinIdentification>
+{
+  std::vector<ProteinIdentification> prot_ids(1);
+  prot_ids[0].getSearchParameters().digestion_enzyme = *ProteaseDB::getInstance()->getEnzyme("Trypsin");
+  prot_ids[0].getSearchParameters().missed_cleavages = 4;
+  prot_ids[0].setScoreType(score_type);
+  prot_ids[0].setSignificanceThreshold(sig);
+  std::vector<ProteinHit> phs;
+  ProteinHit p1; p1.setAccession("PROT1"); p1.setScore(0.9); phs.push_back(p1);
+  ProteinHit p2; p2.setAccession("PROT2"); p2.setScore(0.5); phs.push_back(p2);
+  prot_ids[0].setHits(phs);
+  return prot_ids;
+};
+
+IdentificationSummary* ptr = nullptr;
+IdentificationSummary* null_ptr = nullptr;
+
+START_SECTION((IdentificationSummary()))
+{
+  ptr = new IdentificationSummary();
+  TEST_NOT_EQUAL(ptr, null_ptr)
+}
+END_SECTION
+
+START_SECTION((virtual ~IdentificationSummary()))
+{
+  delete ptr;
+}
+END_SECTION
+
+START_SECTION((Result compute(std::vector<ProteinIdentification>& prot_ids, PeptideIdentificationList& pep_ids)))
+{
+  // FDR score type -> fdr thresholds reported
+  {
+    std::vector<ProteinIdentification> prot_ids = mkProtIds("FDR", 0.01f);
+    PeptideIdentificationList pep_ids;
+    pep_ids.push_back(mkPep("AAAAAAAAAAAAAK", "FDR", 0.05f));  // length 14, 0 missed cleavages
+    pep_ids.push_back(mkPep("AAAAKAAAAAR", "FDR", 0.05f));     // length 11, 1 missed cleavage
+    pep_ids.push_back(mkPep("AAAKAAARAAAKAAAR", "FDR", 0.05f));// length 16, 3 missed cleavages
+
+    IdentificationSummary is;
+    IdentificationSummary::Result r = is.compute(prot_ids, pep_ids);
+
+    TEST_EQUAL(r.peptide_spectrum_matches, 3)
+    TEST_EQUAL(r.unique_peptides.count, 3)
+    TEST_EQUAL(r.unique_proteins.count, 2)
+    TEST_REAL_SIMILAR(r.unique_peptides.fdr_threshold, 0.05)
+    TEST_REAL_SIMILAR(r.unique_proteins.fdr_threshold, 0.01)
+    // (0 + 1 + 3) missed cleavages over 3 peptides
+    TEST_REAL_SIMILAR(r.missed_cleavages_mean, 4.0 / 3.0)
+    // (0.9 + 0.5) / 2 protein hits
+    TEST_REAL_SIMILAR(r.protein_hit_scores_mean, 0.7)
+    // (14 + 11 + 16) / 3 unique peptides
+    TEST_REAL_SIMILAR(r.peptide_length_mean, 41.0 / 3.0)
+  }
+
+  // Non-FDR score type -> fdr thresholds stay at the -1 sentinel
+  {
+    std::vector<ProteinIdentification> prot_ids = mkProtIds("Posterior Error Probability", 0.0f);
+    PeptideIdentificationList pep_ids;
+    pep_ids.push_back(mkPep("AAAAAAAAAAAAAK", "Posterior Error Probability", 0.0f));
+    pep_ids.push_back(mkPep("AAAAKAAAAAR", "Posterior Error Probability", 0.0f));
+
+    IdentificationSummary is;
+    IdentificationSummary::Result r = is.compute(prot_ids, pep_ids);
+
+    TEST_EQUAL(r.peptide_spectrum_matches, 2)
+    TEST_EQUAL(r.unique_peptides.count, 2)
+    TEST_REAL_SIMILAR(r.unique_peptides.fdr_threshold, -1.0)
+    TEST_REAL_SIMILAR(r.unique_proteins.fdr_threshold, -1.0)
+  }
+}
+END_SECTION
+
+START_SECTION(([IdentificationSummary::UniqueID] defaults))
+{
+  IdentificationSummary::UniqueID u;
+  TEST_EQUAL(u.count, 0)
+  TEST_REAL_SIMILAR(u.fdr_threshold, -1.0)
+}
+END_SECTION
+
+START_SECTION(([IdentificationSummary::Result] bool operator==(const Result& rhs) const))
+{
+  IdentificationSummary::Result a, b;
+  TEST_EQUAL(a == b, true)
+
+  a.peptide_spectrum_matches = 7;
+  TEST_EQUAL(a == b, false)
+  b.peptide_spectrum_matches = 7;
+  TEST_EQUAL(a == b, true)
+
+  a.unique_peptides.count = 3;
+  TEST_EQUAL(a == b, false)
+  b.unique_peptides.count = 3;
+  TEST_EQUAL(a == b, true)
+
+  a.protein_hit_scores_mean = 0.7;
+  TEST_EQUAL(a == b, false)
+  b.protein_hit_scores_mean = 0.7;
+  TEST_EQUAL(a == b, true)
+}
+END_SECTION
+
+START_SECTION((const std::string& getName() const override))
+{
+  IdentificationSummary is;
+  TEST_STRING_EQUAL(is.getName(), "Summary of detected Proteins and Peptides from idXML file")
+}
+END_SECTION
+
+START_SECTION((QCBase::Status requirements() const override))
+{
+  IdentificationSummary is;
+  TEST_EQUAL(is.requirements() == QCBase::Status(QCBase::Requires::ID), true)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST


### PR DESCRIPTION
Part of the OpenMS 3.6.0 pre-release testing plan (#9460): adds class tests for two previously untested `QC` metric classes (both `QCBase` subclasses with a `compute()` method and a `Result` struct).

## `FeatureSummary`
Summarises a `FeatureMap`:
- `compute()` — `feature_count` and `rt_shift_mean` (mean of the `rt_deviation` meta value over features that carry it); covers a mixed map, an empty map, and a map whose features have no `rt_deviation`.
- `Result::operator==`, `getName()`, and `requirements()` (`Requires::PREFDRFEAT`).

## `IdentificationSummary`
Summarises protein/peptide identifications:
- `compute()` — PSM count, unique peptide/protein counts, FDR thresholds (reported when the score type is `FDR`, `-1` sentinel otherwise), missed-cleavages mean (computed via the `MissedCleavages` metric using the trypsin search parameters), protein-hit score mean, and the mean length of the unique peptides. A second scenario verifies the non-FDR branch leaves the thresholds at `-1`.
- `UniqueID` defaults, `Result::operator==`, `getName()`, and `requirements()` (`Requires::ID`).

The identification fixture uses the same digestion setup as `MissedCleavages_test` (trypsin) with hand-checkable sequences, so the missed-cleavage and length means are exact. All expected values were pinned by probing the built library before writing the assertions; both tests build and pass locally.

**Tests only — no production code changes.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for feature and identification summary functionality to ensure reliability and correctness of data processing and aggregation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->