### PR TITLE
[TEST] Tests for LinearRegressionWithoutIntercept and SpectrumCount

### DIFF
--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -29,6 +29,7 @@ set(qc_executables_list
   PSMExplainedIonCurrent_test
   QCBase_test
   RTAlignment_test
+  SpectrumCount_test
   TIC_test
 )
 
@@ -330,6 +331,7 @@ set(math_executables_list
   LevelContextInference_test
   LinearInterpolation_test
   LinearRegression_test
+  LinearRegressionWithoutIntercept_test
   MathFunctions_test
   MultipleTesting_test
   #MSNumpress_test

--- a/src/tests/class_tests/openms/source/LinearRegressionWithoutIntercept_test.cpp
+++ b/src/tests/class_tests/openms/source/LinearRegressionWithoutIntercept_test.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Lars Nilse $
+// $Authors: Lars Nilse $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/ML/REGRESSION/LinearRegressionWithoutIntercept.h>
+
+#include <cmath>
+#include <vector>
+
+///////////////////////////
+
+START_TEST(LinearRegressionWithoutIntercept, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+using namespace OpenMS;
+using namespace OpenMS::Math;
+using namespace std;
+
+LinearRegressionWithoutIntercept* ptr = nullptr;
+LinearRegressionWithoutIntercept* null_ptr = nullptr;
+
+START_SECTION((LinearRegressionWithoutIntercept()))
+{
+  ptr = new LinearRegressionWithoutIntercept();
+  TEST_NOT_EQUAL(ptr, null_ptr)
+  // no data yet -> slope is NaN
+  TEST_EQUAL(std::isnan(ptr->getSlope()), true)
+}
+END_SECTION
+
+START_SECTION((~LinearRegressionWithoutIntercept()))
+{
+  delete ptr;
+}
+END_SECTION
+
+START_SECTION((void addData(double x, double y)))
+{
+  LinearRegressionWithoutIntercept lr;
+  // a single observation is not enough -> NaN
+  lr.addData(1.0, 2.0);
+  TEST_EQUAL(std::isnan(lr.getSlope()), true)
+
+  // perfectly collinear through the origin: y = 2x
+  lr.addData(2.0, 4.0);
+  lr.addData(3.0, 6.0);
+  // slope = sum(x*y) / sum(x*x) = 28 / 14 = 2
+  TEST_REAL_SIMILAR(lr.getSlope(), 2.0)
+}
+END_SECTION
+
+START_SECTION((void addData(std::vector<double>& x, std::vector<double>& y)))
+{
+  LinearRegressionWithoutIntercept lr;
+  std::vector<double> x{1.0, 2.0};
+  std::vector<double> y{2.1, 3.9};
+  lr.addData(x, y);
+  // slope = (1*2.1 + 2*3.9) / (1*1 + 2*2) = 9.9 / 5 = 1.98
+  TEST_REAL_SIMILAR(lr.getSlope(), 1.98)
+}
+END_SECTION
+
+START_SECTION((double getSlope() const))
+{
+  // fewer than two observations -> NaN
+  LinearRegressionWithoutIntercept lr0;
+  TEST_EQUAL(std::isnan(lr0.getSlope()), true)
+
+  LinearRegressionWithoutIntercept lr1;
+  lr1.addData(5.0, 10.0);
+  TEST_EQUAL(std::isnan(lr1.getSlope()), true)
+
+  // two observations, scaled line y = 3x
+  LinearRegressionWithoutIntercept lr2;
+  lr2.addData(1.0, 3.0);
+  lr2.addData(2.0, 6.0);
+  TEST_REAL_SIMILAR(lr2.getSlope(), 3.0)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST

--- a/src/tests/class_tests/openms/source/SpectrumCount_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumCount_test.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Axel Walter $
+// $Authors: Axel Walter $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/QC/SpectrumCount.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+
+#include <map>
+
+///////////////////////////
+
+START_TEST(SpectrumCount, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+using namespace OpenMS;
+using namespace std;
+
+SpectrumCount* ptr = nullptr;
+SpectrumCount* null_ptr = nullptr;
+
+START_SECTION((SpectrumCount()))
+{
+  ptr = new SpectrumCount();
+  TEST_NOT_EQUAL(ptr, null_ptr)
+}
+END_SECTION
+
+START_SECTION((virtual ~SpectrumCount()))
+{
+  delete ptr;
+}
+END_SECTION
+
+START_SECTION((std::map<Size, UInt> compute(const MSExperiment& exp)))
+{
+  SpectrumCount sc;
+
+  // 3 MS1, 5 MS2, 1 MS3 spectra
+  MSExperiment exp;
+  for (int i = 0; i < 3; ++i) { MSSpectrum s; s.setMSLevel(1); exp.addSpectrum(s); }
+  for (int i = 0; i < 5; ++i) { MSSpectrum s; s.setMSLevel(2); exp.addSpectrum(s); }
+  { MSSpectrum s; s.setMSLevel(3); exp.addSpectrum(s); }
+
+  std::map<Size, UInt> counts = sc.compute(exp);
+  TEST_EQUAL(counts.size(), 3)
+  TEST_EQUAL(counts[1], 3)
+  TEST_EQUAL(counts[2], 5)
+  TEST_EQUAL(counts[3], 1)
+
+  // empty experiment -> empty map
+  MSExperiment empty;
+  TEST_EQUAL(sc.compute(empty).empty(), true)
+}
+END_SECTION
+
+START_SECTION((const std::string& getName() const override))
+{
+  SpectrumCount sc;
+  TEST_STRING_EQUAL(sc.getName(), "SpectrumCount")
+}
+END_SECTION
+
+START_SECTION((QCBase::Status requirements() const override))
+{
+  SpectrumCount sc;
+  TEST_EQUAL(sc.requirements() == QCBase::Status(QCBase::Requires::RAWMZML), true)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST


### PR DESCRIPTION
Part of the OpenMS 3.6.0 pre-release testing plan (#9460): adds class tests for two previously untested classes.

## `LinearRegressionWithoutIntercept` (`ML/REGRESSION`)
Least-squares fit of a straight line through the origin.
- `addData(double, double)` and the vector overload `addData(vector, vector)`
- `getSlope()` = `sum(x*y) / sum(x*x)` — checked against hand-computed values (e.g. `(1,2),(2,4),(3,6)` → `2.0`; `(1,2.1),(2,3.9)` → `1.98`)
- fewer than two observations → `NaN`

## `SpectrumCount` (`QC`)
- `compute()` returns the number of spectra per MS level (3 MS1 / 5 MS2 / 1 MS3 → `{1:3, 2:5, 3:1}`), and an empty map for an empty experiment
- `getName()` and `requirements()` (`Requires::RAWMZML`)

All expected values were pinned by probing the built library before writing the assertions; both tests build and pass locally.

**Tests only — no production code changes.**