### PR TITLE
[TEST] Tests for the CONCEPT utilities PrecisionWrapper and RAIICleanup

### DIFF
--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -4,6 +4,8 @@ set(concept_executables_list
   Exception_Base_test
   FuzzyStringComparator_test
   #GlobalExceptionHandler_test
+  PrecisionWrapper_test
+  RAIICleanup_test
   StreamHandler_test
   Types_test
   VersionInfo_test

--- a/src/tests/class_tests/openms/source/PrecisionWrapper_test.cpp
+++ b/src/tests/class_tests/openms/source/PrecisionWrapper_test.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Marc Sturm, Clemens Groepl $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/CONCEPT/PrecisionWrapper.h>
+
+#include <sstream>
+
+///////////////////////////
+
+START_TEST(PrecisionWrapper, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+using namespace OpenMS;
+using namespace std;
+
+START_SECTION((template <typename FloatingPointType> explicit PrecisionWrapper(const FloatingPointType rhs)))
+{
+  PrecisionWrapper<double> w(3.5);
+  TEST_REAL_SIMILAR(w.ref_, 3.5)
+}
+END_SECTION
+
+START_SECTION((PrecisionWrapper(const PrecisionWrapper& rhs)))
+{
+  PrecisionWrapper<double> w(2.25);
+  PrecisionWrapper<double> copy(w);
+  TEST_REAL_SIMILAR(copy.ref_, 2.25)
+}
+END_SECTION
+
+START_SECTION((template <typename FloatingPointType> const PrecisionWrapper<FloatingPointType> precisionWrapper(const FloatingPointType rhs)))
+{
+  // the make-function deduces the type and stores the value
+  auto wd = precisionWrapper(1.5);
+  TEST_REAL_SIMILAR(wd.ref_, 1.5)
+  auto wf = precisionWrapper(0.5f);
+  TEST_REAL_SIMILAR(wf.ref_, 0.5f)
+}
+END_SECTION
+
+START_SECTION((template <typename FloatingPointType> std::ostream& operator<<(std::ostream& os, const PrecisionWrapper<FloatingPointType>& rhs)))
+{
+  // full-precision output for double
+  {
+    std::ostringstream os;
+    os << precisionWrapper(0.1234567890123456789);
+    TEST_EQUAL(os.str(), "0.123456789012346")
+  }
+  // full-precision output for float
+  {
+    std::ostringstream os;
+    os << precisionWrapper(0.1234567890123456789f);
+    TEST_EQUAL(os.str(), "0.123457")
+  }
+  // round numbers keep a decimal point (StringUtils::toStr full-precision form)
+  {
+    std::ostringstream os;
+    os << precisionWrapper(1.0);
+    TEST_EQUAL(os.str(), "1.0")
+  }
+  {
+    std::ostringstream os;
+    os << precisionWrapper(100.5);
+    TEST_EQUAL(os.str(), "100.5")
+  }
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST

--- a/src/tests/class_tests/openms/source/RAIICleanup_test.cpp
+++ b/src/tests/class_tests/openms/source/RAIICleanup_test.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Chris Bielow $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/CONCEPT/RAIICleanup.h>
+
+#include <functional>
+
+///////////////////////////
+
+START_TEST(RAIICleanup, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+using namespace OpenMS;
+using namespace std;
+
+START_SECTION((RAIICleanup(std::function<void()> l)))
+{
+  // the cleanup lambda must not run before destruction
+  bool ran = false;
+  {
+    RAIICleanup c([&]() { ran = true; });
+    TEST_EQUAL(ran, false)
+  } // c goes out of scope here -> lambda runs
+  TEST_EQUAL(ran, true)
+}
+END_SECTION
+
+START_SECTION((~RAIICleanup()))
+{
+  // lambda runs exactly once per instance, at end of scope
+  int counter = 0;
+  {
+    RAIICleanup c([&]() { counter += 5; });
+  }
+  TEST_EQUAL(counter, 5)
+
+  {
+    RAIICleanup c([&]() { counter += 5; });
+  }
+  TEST_EQUAL(counter, 10)
+
+  // the lambda can capture and mutate arbitrary state
+  std::string s = "start";
+  {
+    RAIICleanup c([&]() { s = "cleaned"; });
+    TEST_STRING_EQUAL(s, "start")
+  }
+  TEST_STRING_EQUAL(s, "cleaned")
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST


### PR DESCRIPTION
Part of the OpenMS 3.6.0 pre-release testing plan (#9460): adds class tests for two previously untested `CONCEPT` utility classes.

## `PrecisionWrapper`
Stream-output helper that prints a floating-point value with full precision.
- the `PrecisionWrapper` constructor / copy constructor (stored `ref_`)
- the `precisionWrapper()` make-function (type deduction from the argument)
- `operator<<` full-precision output — `double` `0.1234567890123456789` → `0.123456789012346`, `float` → `0.123457`, and the full-precision form of round numbers (`1.0`, `100.5`)

## `RAIICleanup`
Exception-safe scope guard that runs a lambda on destruction.
- the cleanup lambda does **not** run before destruction and runs exactly once at end of scope (verified via a counter accumulated across instances)
- the lambda can capture and mutate arbitrary state

The exact output strings were pinned by probing the built library before writing the assertions; both tests build and pass locally.

**Tests only — no production code changes.**