### PR TITLE
[TEST] Add BuildInfo_test (OpenMSOSInfo OS/arch/SIMD reporting)

### DIFF
--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -125,6 +125,7 @@ set(metadata_executables_list
   )
 
 set(system_executables_list
+  BuildInfo_test
   ExternalProcess_test
   File_test
   Network_test

--- a/src/tests/class_tests/openms/source/BuildInfo_test.cpp
+++ b/src/tests/class_tests/openms/source/BuildInfo_test.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Chris Bielow $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/SYSTEM/BuildInfo.h>
+
+#include <set>
+#include <string>
+
+///////////////////////////
+
+START_TEST(OpenMSOSInfo, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+using namespace OpenMS;
+using namespace OpenMS::Internal;
+using namespace std;
+
+OpenMSOSInfo* ptr = nullptr;
+OpenMSOSInfo* null_ptr = nullptr;
+
+START_SECTION((OpenMSOSInfo()))
+{
+  ptr = new OpenMSOSInfo();
+  TEST_NOT_EQUAL(ptr, null_ptr)
+  // a freshly constructed instance reports everything as "unknown"
+  TEST_STRING_EQUAL(ptr->getOSAsString(), "unknown")
+  TEST_STRING_EQUAL(ptr->getArchAsString(), "unknown")
+  TEST_STRING_EQUAL(ptr->getOSVersionAsString(), "unknown")
+}
+END_SECTION
+
+START_SECTION((~OpenMSOSInfo()))
+{
+  delete ptr;
+}
+END_SECTION
+
+START_SECTION((std::string getOSAsString() const))
+{
+  TEST_STRING_EQUAL(OpenMSOSInfo().getOSAsString(), "unknown")
+}
+END_SECTION
+
+START_SECTION((std::string getArchAsString() const))
+{
+  TEST_STRING_EQUAL(OpenMSOSInfo().getArchAsString(), "unknown")
+}
+END_SECTION
+
+START_SECTION((std::string getOSVersionAsString() const))
+{
+  TEST_STRING_EQUAL(OpenMSOSInfo().getOSVersionAsString(), "unknown")
+}
+END_SECTION
+
+START_SECTION((static std::string getBinaryArchitecture()))
+{
+  // derived from sizeof(size_t); platform-independent expectation
+  std::string expected = (sizeof(size_t) == 8) ? "64 bit"
+                       : (sizeof(size_t) == 4) ? "32 bit"
+                       : "unknown";
+  TEST_STRING_EQUAL(OpenMSOSInfo::getBinaryArchitecture(), expected)
+}
+END_SECTION
+
+START_SECTION((static OpenMSOSInfo getOSInfo()))
+{
+  OpenMSOSInfo info = OpenMSOSInfo::getOSInfo();
+
+  // the architecture is derived from the pointer width, so it must agree with
+  // getBinaryArchitecture()
+  TEST_STRING_EQUAL(info.getArchAsString(), OpenMSOSInfo::getBinaryArchitecture())
+
+  // the running OS must be recognised on any supported build platform
+  std::set<std::string> supported_os = {"Windows", "MacOS", "Linux"};
+  TEST_EQUAL(supported_os.count(info.getOSAsString()) == 1, true)
+  TEST_NOT_EQUAL(info.getOSAsString(), "unknown")
+
+  // a version string is always reported (at worst the "unknown" fallback)
+  TEST_EQUAL(info.getOSVersionAsString().empty(), false)
+}
+END_SECTION
+
+START_SECTION((static std::string getActiveSIMDExtensions()))
+{
+  // build-dependent content, but a stable (deterministic) string per binary
+  std::string simd = OpenMSOSInfo::getActiveSIMDExtensions();
+  TEST_EQUAL(simd == OpenMSOSInfo::getActiveSIMDExtensions(), true)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST


### PR DESCRIPTION
Part of the OpenMS 3.6.0 pre-release testing plan (#9460): adds a class test for the previously untested `OpenMSOSInfo` (`SYSTEM/BuildInfo`), which reports the running OS, architecture, OS version, and the SIMD extensions compiled into the binary.

All assertions are deliberately **platform-independent** so the test is correct on every CI host:

- default construction reports `"unknown"` OS / architecture / version
- `getBinaryArchitecture()` matches `sizeof(size_t)` (`"32 bit"` / `"64 bit"`)
- `getOSInfo()`: the reported architecture agrees with `getBinaryArchitecture()`, the OS is one of the supported platforms (`Windows` / `MacOS` / `Linux`, never `"unknown"` on a real build host), and a non-empty version string is reported
- `getActiveSIMDExtensions()`: returns a deterministic string per binary (the content is build-dependent, so it is not pinned — only stability across calls is checked)

Behaviour was pinned by probing the built library before writing the assertions; the test builds and passes locally (only the standard dtor-only "no subtests" notice).

**Tests only — no production code changes.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for system information detection, validating correct reporting of operating system, binary architecture, and active SIMD extensions across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->