### PR TITLE
[TEST] Add NuXLFragmentAdductDefinition_test (mass-ignored ==/hash contract)

### DIFF
--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -576,6 +576,7 @@ set(analysis_executables_list
   PrecursorPurity_test
   QTClusterFinder_test
   ReactionMonitoringTransition_test
+  NuXLFragmentAdductDefinition_test
   NuXLModificationsGenerator_test
   NuXLParameterParsing_test
   ProSEAlgorithm_test

--- a/src/tests/class_tests/openms/source/NuXLFragmentAdductDefinition_test.cpp
+++ b/src/tests/class_tests/openms/source/NuXLFragmentAdductDefinition_test.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/ANALYSIS/NUXL/NuXLFragmentAdductDefinition.h>
+#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
+
+#include <unordered_set>
+
+///////////////////////////
+
+START_TEST(NuXLFragmentAdductDefinition, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+using namespace OpenMS;
+using namespace std;
+
+NuXLFragmentAdductDefinition* ptr = nullptr;
+NuXLFragmentAdductDefinition* null_ptr = nullptr;
+
+START_SECTION((NuXLFragmentAdductDefinition()))
+{
+  ptr = new NuXLFragmentAdductDefinition();
+  TEST_NOT_EQUAL(ptr, null_ptr)
+  TEST_STRING_EQUAL(ptr->name, "")
+  TEST_REAL_SIMILAR(ptr->mass, 0.0)
+  TEST_EQUAL(ptr->formula.isEmpty(), true)
+}
+END_SECTION
+
+START_SECTION((~NuXLFragmentAdductDefinition()))
+{
+  delete ptr;
+}
+END_SECTION
+
+START_SECTION((NuXLFragmentAdductDefinition(const EmpiricalFormula& f, const std::string& n, double m)))
+{
+  NuXLFragmentAdductDefinition fad(EmpiricalFormula("C5H10"), "adductA", 70.078);
+  TEST_STRING_EQUAL(fad.name, "adductA")
+  TEST_REAL_SIMILAR(fad.mass, 70.078)
+  TEST_EQUAL(fad.formula == EmpiricalFormula("C5H10"), true)
+}
+END_SECTION
+
+START_SECTION((NuXLFragmentAdductDefinition(const NuXLFragmentAdductDefinition&)))
+{
+  NuXLFragmentAdductDefinition fad(EmpiricalFormula("C5H10"), "adductA", 70.078);
+  NuXLFragmentAdductDefinition copy(fad);
+  TEST_STRING_EQUAL(copy.name, "adductA")
+  TEST_REAL_SIMILAR(copy.mass, 70.078)
+  TEST_EQUAL(copy.formula == EmpiricalFormula("C5H10"), true)
+}
+END_SECTION
+
+START_SECTION((bool operator==(const NuXLFragmentAdductDefinition& other) const))
+{
+  EmpiricalFormula f("C5H10");
+  NuXLFragmentAdductDefinition a(f, "adductA", 70.0);
+
+  // equality is defined over (formula, name) only -- the mass is intentionally ignored
+  NuXLFragmentAdductDefinition same_diff_mass(f, "adductA", 999.0);
+  TEST_EQUAL(a == same_diff_mass, true)
+
+  // different formula or name -> not equal
+  NuXLFragmentAdductDefinition diff_formula(EmpiricalFormula("C6H12"), "adductA", 70.0);
+  TEST_EQUAL(a == diff_formula, false)
+  NuXLFragmentAdductDefinition diff_name(f, "adductD", 70.0);
+  TEST_EQUAL(a == diff_name, false)
+
+  // identical definition compares equal
+  NuXLFragmentAdductDefinition copy(f, "adductA", 70.0);
+  TEST_EQUAL(a == copy, true)
+}
+END_SECTION
+
+START_SECTION((bool operator<(const NuXLFragmentAdductDefinition& other) const))
+{
+  EmpiricalFormula f("C5H10");
+
+  // ordering is primarily by mass
+  NuXLFragmentAdductDefinition lo(f, "x", 10.0);
+  NuXLFragmentAdductDefinition hi(f, "x", 20.0);
+  TEST_EQUAL(lo < hi, true)
+  TEST_EQUAL(hi < lo, false)
+
+  // note: two definitions equal under operator== (same formula+name) can still be
+  // ordered by operator< if their masses differ (operator< also considers mass)
+  NuXLFragmentAdductDefinition a(f, "adductA", 70.0);
+  NuXLFragmentAdductDefinition b(f, "adductA", 999.0);
+  TEST_EQUAL(a == b, true)
+  TEST_EQUAL(a < b, true)
+  TEST_EQUAL(b < a, false)
+
+  // strict ordering: exactly one direction holds for these distinct masses
+  TEST_EQUAL((a < b) != (b < a), true)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] std::hash<NuXLFragmentAdductDefinition> is consistent with operator==))
+{
+  EmpiricalFormula f("C5H10");
+  std::hash<NuXLFragmentAdductDefinition> H;
+
+  NuXLFragmentAdductDefinition a(f, "adductA", 70.0);
+  NuXLFragmentAdductDefinition b(f, "adductA", 999.0); // == a (mass ignored)
+  // equal objects must hash equally
+  TEST_EQUAL(H(a) == H(b), true)
+
+  // usable as an unordered_set key: a and b collapse to one entry, a different
+  // formula adds a second
+  std::unordered_set<NuXLFragmentAdductDefinition> s;
+  s.insert(a);
+  s.insert(b);
+  TEST_EQUAL(s.size(), 1)
+  s.insert(NuXLFragmentAdductDefinition(EmpiricalFormula("C6H12"), "adductA", 70.0));
+  TEST_EQUAL(s.size(), 2)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST


### PR DESCRIPTION
Part of the OpenMS 3.6.0 pre-release testing plan (#9460): adds a class test for the previously untested `NuXLFragmentAdductDefinition` (`ANALYSIS/NUXL`), the `(formula, name, mass)` record describing an RNA/DNA cross-link fragment adduct.

Covers, with emphasis on the subtle equality/ordering contract:

- default and `(formula, name, mass)` construction, and copy construction
- **`operator==`**: equality is defined over `(formula, name)` **only** — the mass is intentionally ignored, so two definitions with the same formula+name compare equal even with different masses
- **`operator<`**: ordering is primarily by mass, then formula string, then name. A notable consequence (pinned by the test): two definitions that are *equal* under `operator==` can still be *ordered* by `operator<` when their masses differ
- **`std::hash` specialization**: consistent with `operator==` (equal objects hash equally, mass ignored) and usable as an `unordered_set` key (a and b with same formula+name collapse to one entry; a different formula adds a second)

The mass-ignored `==` / hash contract was pinned by probing the built library before writing the assertions; the test builds and passes locally (only the standard dtor-only "no subtests" notice).

**Tests only — no production code changes.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for fragment adduct definition functionality to enhance code quality and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->