### PR TITLE
[DOC] Correct AUTHORS ordering

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,8 +23,8 @@ the authors tag in the respective file header.
  - Chirag Dave
  - Chris Bauer
  - Chris Bielow
- - Christie Mathews
  - Christian Ehrlich
+ - Christie Mathews
  - Clemens Groepl
  - Cornelia Friedle
  - Daniel Jameson


### PR DESCRIPTION
## Summary

Correct the alphabetical order of `Christian Ehrlich` and `Christie Mathews` in `AUTHORS`.

## Impact

Documentation-only change. No code behavior is affected.

## Validation

- `git diff --check`

No build was run because this only reorders one entry in `AUTHORS`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated author listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->