### PR TITLE
[TEST] Algorithms (§7): scipy KDE cross-check, USI well-formedness, FFP tolerance-swap (#9460)

### DIFF
--- a/src/tests/class_tests/openms/source/FeatureFinderAlgorithmPicked_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureFinderAlgorithmPicked_test.cpp
@@ -93,9 +93,8 @@ END_SECTION
 START_SECTION(([EXTRA] isotopic_pattern:mz_tolerance and mass_trace:mz_tolerance are not interchangeable (#9247)))
 {
   // PR #9247 fixed a swap in updateMembers_(): pattern_tolerance_ <- isotopic_pattern:mz_tolerance and
-  // trace_tolerance_ <- mass_trace:mz_tolerance. This pins that the two MZ tolerances are NOT
-  // interchangeable -- feeding asymmetric values in one assignment order vs the swapped order yields a
-  // different feature set. If the assignment is ever swapped again, the two runs would converge.
+  // trace_tolerance_ <- mass_trace:mz_tolerance. Pin both asymmetric configurations directionally, so a
+  // repeated assignment swap exchanges the outcomes and fails the test.
   MzMLFile mzml_file;
   mzml_file.getOptions().addMSLevel(1);
   PeakMap input_template;
@@ -129,21 +128,21 @@ START_SECTION(([EXTRA] isotopic_pattern:mz_tolerance and mass_trace:mz_tolerance
     ff.run(std::move(in), out2, p2, FeatureMap());
   }
 
-  // the two parameterizations must produce a different feature set
-  bool differs = (out1.size() != out2.size());
-  if (!differs)
+  TEST_EQUAL(out1.size(), 1)
+  TEST_EQUAL(out2.size(), 0)
+
+  if (out1.size() == 1)
   {
-    for (Size i = 0; i < out1.size(); ++i)
-    {
-      if (std::fabs(out1[i].getIntensity() - out2[i].getIntensity()) > 1.0 ||
-          std::fabs(out1[i].getOverallQuality() - out2[i].getOverallQuality()) > 1e-4)
-      {
-        differs = true;
-        break;
-      }
-    }
+    TEST_EQUAL(out1[0].getMetaValue(Constants::UserParam::NUM_OF_DATAPOINTS), 33)
+
+    TOLERANCE_ABSOLUTE(0.001);
+    TEST_REAL_SIMILAR(out1[0].getRT(), 4278.1601)
+    TEST_REAL_SIMILAR(out1[0].getMZ(), 653.7722)
+    TEST_REAL_SIMILAR(out1[0].getOverallQuality(), 0.9609)
+
+    TOLERANCE_ABSOLUTE(20.0);
+    TEST_REAL_SIMILAR(out1[0].getIntensity(), 18467.8)
   }
-  TEST_EQUAL(differs, true)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/FeatureFinderAlgorithmPicked_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureFinderAlgorithmPicked_test.cpp
@@ -90,6 +90,63 @@ START_SECTION((virtual void run()))
 
 END_SECTION
 
+START_SECTION(([EXTRA] isotopic_pattern:mz_tolerance and mass_trace:mz_tolerance are not interchangeable (#9247)))
+{
+  // PR #9247 fixed a swap in updateMembers_(): pattern_tolerance_ <- isotopic_pattern:mz_tolerance and
+  // trace_tolerance_ <- mass_trace:mz_tolerance. This pins that the two MZ tolerances are NOT
+  // interchangeable -- feeding asymmetric values in one assignment order vs the swapped order yields a
+  // different feature set. If the assignment is ever swapped again, the two runs would converge.
+  MzMLFile mzml_file;
+  mzml_file.getOptions().addMSLevel(1);
+  PeakMap input_template;
+  mzml_file.load(OPENMS_GET_TEST_DATA_PATH("FeatureFinderAlgorithmPicked.mzML"), input_template);
+  input_template.updateRanges();
+
+  Param base;
+  ParamXMLFile paramFile;
+  paramFile.load(OPENMS_GET_TEST_DATA_PATH("FeatureFinderAlgorithmPicked.ini"), base);
+  base = base.copy("FeatureFinder:1:algorithm:", true);
+
+  // tight isotope-pattern tolerance, loose mass-trace tolerance
+  Param p1 = base;
+  p1.setValue("isotopic_pattern:mz_tolerance", 0.005);
+  p1.setValue("mass_trace:mz_tolerance", 0.5);
+  FeatureMap out1;
+  {
+    PeakMap in = input_template;
+    FFPP ff;
+    ff.run(std::move(in), out1, p1, FeatureMap());
+  }
+
+  // swapped assignment: loose isotope-pattern tolerance, tight mass-trace tolerance
+  Param p2 = base;
+  p2.setValue("isotopic_pattern:mz_tolerance", 0.5);
+  p2.setValue("mass_trace:mz_tolerance", 0.005);
+  FeatureMap out2;
+  {
+    PeakMap in = input_template;
+    FFPP ff;
+    ff.run(std::move(in), out2, p2, FeatureMap());
+  }
+
+  // the two parameterizations must produce a different feature set
+  bool differs = (out1.size() != out2.size());
+  if (!differs)
+  {
+    for (Size i = 0; i < out1.size(); ++i)
+    {
+      if (std::fabs(out1[i].getIntensity() - out2[i].getIntensity()) > 1.0 ||
+          std::fabs(out1[i].getOverallQuality() - out2[i].getOverallQuality()) > 1e-4)
+      {
+        differs = true;
+        break;
+      }
+    }
+  }
+  TEST_EQUAL(differs, true)
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 

--- a/src/tests/class_tests/openms/source/KernelDensityEstimation_test.cpp
+++ b/src/tests/class_tests/openms/source/KernelDensityEstimation_test.cpp
@@ -496,7 +496,38 @@ START_SECTION("kde reference (statsmodels) regression")
       total_tests++;
     }
   }
-  
+
+}
+END_SECTION
+
+START_SECTION("kde density vs scipy.stats.gaussian_kde reference")
+{
+  // Cross-check kdeFFTEval against scipy.stats.gaussian_kde (issue #9460 §7, L291). The companion
+  // statsmodels section above pins the bandwidth rule + FFT KDE; this pins the density values against
+  // a second, independent reference (scipy). Reference computed offline with a *fixed* bandwidth so the
+  // comparison isolates the density evaluation from the bandwidth rule:
+  //   import numpy as np; from scipy.stats import gaussian_kde
+  //   data = [0,1,2,3,4,5,6,7,8,9,2.5,3.5,3.0,4.5]; sd = np.std(data, ddof=1)
+  //   bw = 1.2298580108  # R nrd0 bandwidth for this data
+  //   kde = gaussian_kde(data, bw_method=bw/sd); dens = kde(data)
+  // scipy evaluates an exact Gaussian sum while OpenMS uses an FFT grid, so a modest tolerance is used.
+  std::vector<double> data = {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 2.5, 3.5, 3.0, 4.5};
+  const double bw = 1.2298580108;
+  std::vector<double> scipy_density = {
+    0.05184986, 0.08447517, 0.12205155, 0.14815310, 0.14174787, 0.11287841, 0.08684046,
+    0.07360770, 0.06438698, 0.04732923, 0.13832075, 0.14919717, 0.14815310, 0.12843312};
+
+  // the fixed bandwidth is the nrd0 bandwidth OpenMS computes for this data (ties it to the rule)
+  double our_bw = KernelDensityEstimation::bwNrd0(data);
+  TEST_EQUAL(std::fabs(our_bw - bw) / bw <= 0.05, true)
+
+  auto our_density = KernelDensityEstimation::kdeFFTEval(data, bw);
+  TEST_EQUAL(our_density.size(), scipy_density.size())
+  for (std::size_t i = 0; i < scipy_density.size(); ++i)
+  {
+    double rel = std::fabs(our_density[i] - scipy_density[i]) / std::fabs(scipy_density[i]);
+    TEST_EQUAL(rel <= 0.10 || std::fabs(our_density[i] - scipy_density[i]) <= 0.01, true)
+  }
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/PeptideIdentification_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideIdentification_test.cpp
@@ -720,6 +720,39 @@ START_SECTION(([EXTRA] buildUSI().toString() convenience pattern))
 }
 END_SECTION
 
+START_SECTION(([EXTRA] buildUSI().toString() is well-formed mzspec accepted by USI::isValidUSI))
+{
+  // issue #9460 §7, L299: pin that the generator (buildUSI) and the static validator (isValidUSI) agree.
+  // Every USI string buildUSI emits for a referenced spectrum must begin with the "mzspec:" scheme and be
+  // accepted by USI::isValidUSI; the empty string from an unreferenced ID must be rejected.
+  PeptideIdentification id;
+  id.setSpectrumReference("controllerType=0 controllerNumber=1 scan=12345");
+  PeptideHit hit;
+  hit.setSequence(AASequence::fromString("EM(Oxidation)K"));
+  hit.setCharge(2);
+  id.insertHit(hit);
+  id.sort();
+
+  // scan-based, with and without ProForma interpretation
+  std::string s_plain = id.buildUSI("sample.mzML", "PXD000561", false).toString();
+  std::string s_interp = id.buildUSI("sample.mzML", "PXD000561", true).toString();
+  TEST_EQUAL(s_plain.rfind("mzspec:", 0) == 0, true) // begins with the mzspec: scheme
+  TEST_EQUAL(USI::isValidUSI(s_plain), true)
+  TEST_EQUAL(USI::isValidUSI(s_interp), true)
+  TEST_STRING_EQUAL(s_interp, "mzspec:PXD000561:sample.mzML:scan:12345:EM[UNIMOD:35]K/2")
+
+  // nativeID fallback path (scan number not extractable)
+  PeptideIdentification id_nat;
+  id_nat.setSpectrumReference("custom_format_123");
+  std::string s_nat = id_nat.buildUSI("data.mzML", "PXD000563", false).toString();
+  TEST_EQUAL(USI::isValidUSI(s_nat), true)
+
+  // empty reference -> empty string -> NOT a valid USI
+  PeptideIdentification id_empty;
+  TEST_EQUAL(USI::isValidUSI(id_empty.buildUSI("x.mzML", "PXD0", false).toString()), false)
+}
+END_SECTION
+
 // Additional tests for file path handling in buildUSI
 START_SECTION(([EXTRA] buildUSI with file paths and basenames))
 {


### PR DESCRIPTION
## Context

Closes the remaining **§7 (scientific algorithms & parsers)** `[AUTO]` gaps of the OpenMS 3.6.0 pre-release testing plan (#9460). **Tests only.**

## Changes

| Item | Test | Verified |
|---|---|---|
| **L291** | `KernelDensityEstimation_test` — a **scipy.stats.gaussian_kde** density cross-check, complementing the existing statsmodels section. A fixed `nrd0` bandwidth isolates the density evaluation from the bandwidth rule; OpenMS's FFT KDE is compared to scipy's exact Gaussian sum within a documented tolerance (`bwNrd0` is additionally tied to the fixed bandwidth). | ✅ green |
| **L299** | `PeptideIdentification_test` — pin that `buildUSI()` and the static validator agree: every USI string `buildUSI` emits begins with `mzspec:` and is accepted by `USI::isValidUSI` (scan / ProForma interpretation / nativeID-fallback paths); an unreferenced ID yields an empty, invalid string. | ✅ green |
| **L304** | `FeatureFinderAlgorithmPicked_test` — a regression for the **#9247** tolerance swap: running with `isotopic_pattern:mz_tolerance` and `mass_trace:mz_tolerance` asymmetric vs swapped yields a different feature set, proving the two MZ tolerances are not interchangeable. (Confirmed the existing fixture is swap-sensitive.) | ✅ green |

## Notes

- L291's "cross-validate KDE against an external stats library" intent is **already** met on develop by the statsmodels reference section (#8524); this PR adds the literal **scipy** cross-check the plan called for.
- L299's other half (the `TextExporter id:add_usi` column) is covered at its source — `TextExporter` emits exactly `PeptideIdentification::buildUSI(...).toString()`, which is what this test now validates against `USI::isValidUSI`.

## Test plan

`ctest -R '^(KernelDensityEstimation_test|PeptideIdentification_test|FeatureFinderAlgorithmPicked_test)$'` — all pass locally.

Part of #9460 (§7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression test ensuring `isotopic_pattern:mz_tolerance` and `mass_trace:mz_tolerance` are directionally non-interchangeable, with expected feature counts and detailed checks on the remaining result.
  * Added a regression test validating KDE evaluation accuracy by comparing against a precomputed SciPy reference dataset.
  * Added tests verifying generated USI strings are well-formed and validated correctly, including expected prefixes, ProForma suffixes, fallback behavior, and rejection of empty spectrum references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->