### PR TITLE
[FIX] DistanceMatrix::setValue keeps the cached minimum correct (#9488 DATA-24)

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/DistanceMatrix.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/DistanceMatrix.h
@@ -226,7 +226,13 @@ public:
     if (i != j)
     {
       if (i < j) { std::swap(i, j); }
-      if (i != min_element_.first && j != min_element_.second)
+      // Fast path whenever (i,j) is NOT the current minimum cell: writing into any
+      // other cell can only introduce a new (smaller) minimum, never invalidate the
+      // existing one. Using '||' (i.e. "not the min cell") instead of '&&' is required:
+      // with '&&' a cell that shares exactly one index with the min coordinate fell into
+      // the else-branch, which never refreshes min_element_ when the new value is smaller,
+      // leaving a stale cached minimum (issue #9488, DATA-24).
+      if (i != min_element_.first || j != min_element_.second)
       {
         matrix_[i][j] = value;
         if (value < matrix_[min_element_.first][min_element_.second]) // keep min_element_ up-to-date

--- a/src/tests/class_tests/openms/source/DistanceMatrix_test.cpp
+++ b/src/tests/class_tests/openms/source/DistanceMatrix_test.cpp
@@ -83,6 +83,18 @@ START_SECTION((void setValue(SizeType i, SizeType j, ValueType value)))
 	TEST_EQUAL(dm.getValue(dm.getMinElementCoordinates().first, dm.getMinElementCoordinates().second),0.5)
 	dm.setValue(3,4,1);
 	TEST_EQUAL(dm.getValue(dm.getMinElementCoordinates().first, dm.getMinElementCoordinates().second),1.0)
+	// regression (issue #9488, DATA-24): writing a value smaller than the current minimum
+	// into a cell that shares exactly ONE index with the min coordinate must update the
+	// cached minimum. Cell (2,4) shares column 4 with the current min cell (3,4).
+	dm.setValue(2,4,0.1);
+	// the cached minimum must now reflect the new smaller value at cell (2,4); with the
+	// stale-min bug getMinElementCoordinates() would still point at (3,4)=1.0
+	TEST_REAL_SIMILAR(dm.getValue(dm.getMinElementCoordinates().first, dm.getMinElementCoordinates().second),0.1)
+	TEST_REAL_SIMILAR(dm.getValue(2,4),0.1)
+	// restore the matrix to the state the following sections expect
+	dm.setValue(2,4,2);
+	TEST_EQUAL(dm.getValue(dm.getMinElementCoordinates().first, dm.getMinElementCoordinates().second),1.0)
+	TEST_EQUAL(dm.getValue(2,4),2)
 	//more tested below
 }
 END_SECTION


### PR DESCRIPTION
Part of #9488 (POLS high-severity checklist — **CONCEPT / DATASTRUCTURES / KERNEL**).

### [DATA-24] `DistanceMatrix::setValue` — stale cached minimum
`setValue()` keeps a cached minimum coordinate (`min_element_`) up to date on the fast path. The guard for that fast path used `&&`:

```cpp
if (i != min_element_.first && j != min_element_.second)   // before
```

so a cell that shares **exactly one** index with the current min coordinate (e.g. same column) skipped the fast path and fell into the `else` branch, which never refreshes `min_element_` when the new value is *smaller*. Writing a new minimum into such a cell left `getMinElementCoordinates()` pointing at a stale (larger) cell.

**Fix:** one-character change to `||` — i.e. "take the fast path whenever `(i,j)` is **not** the min cell". Writing into any non-min cell can only introduce a new (smaller) minimum, never invalidate the existing one, so the fast path is always correct there; the `else` branch now fires only when `(i,j)` *is* the min cell (where a recompute may be needed).

**ABI:** source-compatible (inline template body only).
**Test:** `DistanceMatrix_test` — writing a smaller value into a cell sharing one index with the min now updates the cached min coordinate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a bug in distance matrix operations where minimum value coordinates could become stale and fail to update correctly under certain conditions, potentially affecting downstream computations.

* **Tests**
  * Added regression test to verify distance matrix minimum value tracking updates properly in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->