### PR TITLE
[FIX] FragmentMassError: make both compute() overloads agree (#9488 QC-3)

### DIFF
--- a/src/openms/source/QC/FragmentMassError.cpp
+++ b/src/openms/source/QC/FragmentMassError.cpp
@@ -288,10 +288,10 @@ namespace OpenMS
     bool print_warning {false};
 
     // computation of ppms
-    // issue #9488, QC-3: mirror the FeatureMap overload's two-pass computation so both overloads
-    // compute the average/variance consistently (variance must be accumulated against the FINAL
-    // average over all ppm errors, not a moving/partial average inside the loop).
-    // computes the FragmentMassError (first pass: accumulate all ppm errors)
+    // Both overloads use the same two-pass computation so their average/variance agree:
+    // variance must be accumulated against the FINAL average over all ppm errors, not a
+    // moving/partial average inside the loop.
+    // first pass: accumulate all ppm errors
     for (auto& pep_id : pep_ids)
     {
       calculateFME_(pep_id, exp, map_to_spectrum, print_warning, tolerance, tolerance_unit, accumulator_ppm, counter_ppm, window_mower_filter);

--- a/src/openms/source/QC/FragmentMassError.cpp
+++ b/src/openms/source/QC/FragmentMassError.cpp
@@ -288,20 +288,28 @@ namespace OpenMS
     bool print_warning {false};
 
     // computation of ppms
-    // computes the FragmentMassError
+    // issue #9488, QC-3: mirror the FeatureMap overload's two-pass computation so both overloads
+    // compute the average/variance consistently (variance must be accumulated against the FINAL
+    // average over all ppm errors, not a moving/partial average inside the loop).
+    // computes the FragmentMassError (first pass: accumulate all ppm errors)
     for (auto& pep_id : pep_ids)
     {
       calculateFME_(pep_id, exp, map_to_spectrum, print_warning, tolerance, tolerance_unit, accumulator_ppm, counter_ppm, window_mower_filter);
+    }
 
-      // if there are no matching peaks, the counter is zero and it is not possible to find ppms
-      if (counter_ppm == 0)
-      {
-        results_.push_back(result);
-        return;
-      }
-      // computes average
-      result.average_ppm = accumulator_ppm / counter_ppm;
+    // if there are no matching peaks, the counter is zero and it is not possible to find ppms
+    if (counter_ppm == 0)
+    {
+      results_.push_back(result);
+      return;
+    }
 
+    // computes average
+    result.average_ppm = accumulator_ppm / counter_ppm;
+
+    // computes variance (second pass: against the final average)
+    for (const auto& pep_id : pep_ids)
+    {
       calculateVariance_(result, pep_id, counter_ppm);
     }
 

--- a/src/tests/class_tests/openms/source/FragmentMassError_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentMassError_test.cpp
@@ -303,6 +303,65 @@ START_SECTION(void compute(PeptideIdentificationList& pep_ids, const ProteinIden
   TEST_REAL_SIMILAR(result[0].variance_ppm, 0.0) // offset is constant, i.e. no variance
 
   //--------------------------------------------------------------------
+  // regression for issue #9488, QC-3: the PeptideIdentificationList and FeatureMap
+  // overloads must compute the average/variance identically. The constant-offset data
+  // above always yields variance 0, which cannot distinguish the (old, buggy)
+  // moving-average accumulation from the correct two-pass computation. Here we feed
+  // NON-constant per-spectrum errors (+2 ppm for HIMALAYA, +8 ppm for ALABAMA) through
+  // BOTH overloads using the exact same spectra/peptides and assert that the resulting
+  // average_ppm and variance_ppm match. With the buggy list overload the variance was
+  // accumulated against a moving/partial average and differed from the FeatureMap result.
+  {
+    // build MSExperiment whose peaks carry two different ppm offsets
+    PeakSpectrum himalaya_var = createMSSpectrum(2, 3.7, "XTandem::1");
+    TheoreticalSpectrumGenerator theo_gen_hi_var;
+    theo_gen_hi_var.getSpectrum(himalaya_var, AASequence::fromString("HIMALAYA"), 1, 1);
+    for (Peak1D& peak : himalaya_var)
+      peak.setMZ(Math::ppmToMass(peak.getMZ(), 2.0) + peak.getMZ()); // +2 ppm
+
+    PeakSpectrum alabama_var = createMSSpectrum(2, 2, "XTandem::2", Precursor::ActivationMethod::ECD);
+    TheoreticalSpectrumGenerator theo_gen_al_var;
+    Param theo_gen_settings_al_var = theo_gen_al_var.getParameters();
+    theo_gen_settings_al_var.setValue("add_c_ions", "true");
+    theo_gen_settings_al_var.setValue("add_z_ions", "true");
+    theo_gen_settings_al_var.setValue("add_b_ions", "false");
+    theo_gen_settings_al_var.setValue("add_y_ions", "false");
+    theo_gen_al_var.setParameters(theo_gen_settings_al_var);
+    theo_gen_al_var.getSpectrum(alabama_var, AASequence::fromString("ALABAMA"), 2, 2);
+    for (Peak1D& peak : alabama_var)
+      peak.setMZ(Math::ppmToMass(peak.getMZ(), 8.0) + peak.getMZ()); // +8 ppm
+
+    MSExperiment exp_var;
+    exp_var.setSpectra({MSSpectrum(), alabama_var, himalaya_var});
+    QCBase::SpectraMap spectra_map_var(exp_var);
+
+    // run the PeptideIdentificationList overload
+    PeptideIdentificationList pep_ids_var = {createPeptideIdentification("XTandem::1", "HIMALAYA", 1, 888),
+                                             createPeptideIdentification("XTandem::2", "ALABAMA", 2, 264)};
+    FragmentMassError frag_ma_err_list_var;
+    frag_ma_err_list_var.compute(pep_ids_var, param, exp_var, spectra_map_var);
+    const FragmentMassError::Statistics list_result = frag_ma_err_list_var.getResults()[0];
+
+    // run the FeatureMap overload (already-correct reference) on the SAME data
+    FeatureMap fmap_var;
+    fmap_var.setUnassignedPeptideIdentifications({createPeptideIdentification("XTandem::1", "HIMALAYA", 1, 888),
+                                                  createPeptideIdentification("XTandem::2", "ALABAMA", 2, 264)});
+    fmap_var.push_back(Feature());
+    ProteinIdentification protId_var;
+    protId_var.setSearchParameters(param);
+    fmap_var.setProteinIdentifications({protId_var});
+    FragmentMassError frag_ma_err_fmap_var;
+    frag_ma_err_fmap_var.compute(fmap_var, exp_var, spectra_map_var);
+    const FragmentMassError::Statistics fmap_result = frag_ma_err_fmap_var.getResults()[0];
+
+    // non-constant errors => non-zero variance (guards against the data being degenerate)
+    TEST_EQUAL(list_result.variance_ppm > 0.0, true)
+    // the two overloads must agree on both average and variance
+    TEST_REAL_SIMILAR(list_result.average_ppm, fmap_result.average_ppm)
+    TEST_REAL_SIMILAR(list_result.variance_ppm, fmap_result.variance_ppm)
+  }
+
+  //--------------------------------------------------------------------
   // test with valid input - ToleranceUnit PPM
   //--------------------------------------------------------------------
 

--- a/src/tests/class_tests/openms/source/FragmentMassError_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentMassError_test.cpp
@@ -303,14 +303,13 @@ START_SECTION(void compute(PeptideIdentificationList& pep_ids, const ProteinIden
   TEST_REAL_SIMILAR(result[0].variance_ppm, 0.0) // offset is constant, i.e. no variance
 
   //--------------------------------------------------------------------
-  // regression for issue #9488, QC-3: the PeptideIdentificationList and FeatureMap
-  // overloads must compute the average/variance identically. The constant-offset data
-  // above always yields variance 0, which cannot distinguish the (old, buggy)
-  // moving-average accumulation from the correct two-pass computation. Here we feed
-  // NON-constant per-spectrum errors (+2 ppm for HIMALAYA, +8 ppm for ALABAMA) through
+  // The PeptideIdentificationList and FeatureMap overloads must compute the average/variance
+  // identically. The constant-offset data above always yields variance 0, which cannot
+  // distinguish a moving-average accumulation from the correct two-pass computation. Here we
+  // feed NON-constant per-spectrum errors (+2 ppm for HIMALAYA, +8 ppm for ALABAMA) through
   // BOTH overloads using the exact same spectra/peptides and assert that the resulting
-  // average_ppm and variance_ppm match. With the buggy list overload the variance was
-  // accumulated against a moving/partial average and differed from the FeatureMap result.
+  // average_ppm and variance_ppm match. A moving/partial average in the list overload would
+  // accumulate variance against a shifting mean and differ from the FeatureMap result.
   {
     // build MSExperiment whose peaks carry two different ppm offsets
     PeakSpectrum himalaya_var = createMSSpectrum(2, 3.7, "XTandem::1");
@@ -355,7 +354,7 @@ START_SECTION(void compute(PeptideIdentificationList& pep_ids, const ProteinIden
     const FragmentMassError::Statistics fmap_result = frag_ma_err_fmap_var.getResults()[0];
 
     // non-constant errors => non-zero variance (guards against the data being degenerate)
-    TEST_EQUAL(list_result.variance_ppm > 0.0, true)
+    TEST_TRUE(list_result.variance_ppm > 0.0)
     // the two overloads must agree on both average and variance
     TEST_REAL_SIMILAR(list_result.average_ppm, fmap_result.average_ppm)
     TEST_REAL_SIMILAR(list_result.variance_ppm, fmap_result.variance_ppm)


### PR DESCRIPTION
Part of #9488 (POLS high-severity checklist — **QC / SYSTEM / APPLICATIONS**).

### [QC-3] `FragmentMassError::compute` — two overloads computed average/variance differently
The `PeptideIdentificationList` overload accumulated ppm errors, computed the average, and called `calculateVariance_` **inside** the per-ID loop, so the variance was accumulated against a *moving/partial* average. The `FeatureMap` overload already did it correctly in two passes, so the two overloads produced different results for the same data.

**Fix:** make the list overload mirror the `FeatureMap` overload — first pass accumulates all ppm errors and computes the final average; second pass computes the variance against that final average.

**ABI:** none (implementation only).
**Test:** `FragmentMassError_test` — both overloads now produce identical `average_ppm` / `variance_ppm` for the same input (non-constant errors so the variance is non-degenerate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected fragment mass error statistics to compute average and variance consistently across the full set of peptide identifications.
  * Improved robustness for scenarios where fragment mass error varies between spectra, preventing incorrect variance outcomes.

* **Tests**
  * Added a regression test for a real-world QC scenario with non-constant ppm offsets, verifying results align between analysis paths and that variance is non-zero when expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->