### PR TITLE
[FIX] ProSE/SimpleSearchEngine: don't abort on low-res data; gate deisotoping via Deisotoper::isToleranceSupported (#9619)

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
@@ -364,7 +364,7 @@ class OPENMS_DLLAPI ProSEAlgorithm :
     };
 
     /// @brief filter, deisotope, decharge spectra
-    static void preprocessSpectra_(PeakMap& exp, double fragment_mass_tolerance, bool fragment_mass_tolerance_unit_ppm, const std::string& deisotope_mode);
+    static void preprocessSpectra_(PeakMap& exp, double fragment_mass_tolerance, bool fragment_mass_tolerance_unit_ppm, bool deisotope_requested);
 
     /**
      * @brief Build a decoy-augmented copy of the input FASTA.
@@ -486,8 +486,11 @@ class OPENMS_DLLAPI ProSEAlgorithm :
 
     std::string fragment_mass_tolerance_unit_;
 
-    /// MS2 deisotoping mode (param fragment:deisotope): "auto" | "true" | "false".
-    std::string deisotope_;
+    /// Resolved MS2 deisotoping request (param fragment:deisotope != "false").
+    /// preprocessSpectra_ still gates on Deisotoper::isToleranceSupported() so the
+    /// deisotoper is never called out of range (it would throw -> terminate in the
+    /// OpenMP region). See OpenMS#9619.
+    bool deisotope_requested_{true};
 
     StringList modifications_fixed_;
 

--- a/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
@@ -364,7 +364,7 @@ class OPENMS_DLLAPI ProSEAlgorithm :
     };
 
     /// @brief filter, deisotope, decharge spectra
-    static void preprocessSpectra_(PeakMap& exp, double fragment_mass_tolerance, bool fragment_mass_tolerance_unit_ppm);
+    static void preprocessSpectra_(PeakMap& exp, double fragment_mass_tolerance, bool fragment_mass_tolerance_unit_ppm, const std::string& deisotope_mode);
 
     /**
      * @brief Build a decoy-augmented copy of the input FASTA.
@@ -485,6 +485,9 @@ class OPENMS_DLLAPI ProSEAlgorithm :
     double fragment_mass_tolerance_;
 
     std::string fragment_mass_tolerance_unit_;
+
+    /// MS2 deisotoping mode (param fragment:deisotope): "auto" | "true" | "false".
+    std::string deisotope_;
 
     StringList modifications_fixed_;
 

--- a/src/openms/include/OpenMS/PROCESSING/DEISOTOPING/Deisotoper.h
+++ b/src/openms/include/OpenMS/PROCESSING/DEISOTOPING/Deisotoper.h
@@ -183,6 +183,20 @@ class OPENMS_DLLAPI Deisotoper
                                          unsigned int start_intensity_check = 2,
                                          bool add_up_intensity = false,
                                          bool annotate_features = false);
+
+    /**
+      @brief Whether deisotopeAndSingleCharge() supports this fragment tolerance.
+
+      deisotopeAndSingleCharge() throws Exception::IllegalArgument for a fragment
+      tolerance greater than 100 ppm or 0.1 Da (isotope spacing cannot be resolved
+      at lower resolution). This non-throwing predicate exposes that same limit so
+      callers can choose to skip deisotoping (e.g. for low-resolution ion-trap CID
+      data) instead of triggering the throw -- important when the call sits inside
+      an OpenMP region, where an escaping exception calls std::terminate() (OpenMS#9619).
+
+      @return true iff (fragment_unit_ppm ? fragment_tolerance <= 100 : fragment_tolerance <= 0.1)
+    */
+    static bool isToleranceSupported(double fragment_tolerance, bool fragment_unit_ppm);
 };
 
 }

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -262,21 +262,29 @@ namespace OpenMS
 
     fragment_mass_tolerance_unit_ = param_.getValue("fragment:mass_tolerance_unit").toString();
 
-    deisotope_ = param_.getValue("fragment:deisotope").toString();
-    // Fail fast if deisotoping is forced on with a low-resolution fragment tolerance
-    // the deisotoper cannot handle (> 0.1 Da / > 100 ppm); otherwise the search would
-    // only crash later, inside preprocessSpectra_'s OpenMP region (OpenMS#9619).
-    // "auto" and "false" are always safe.
-    if (deisotope_ == "true")
+    // Resolve the MS2 deisotoping mode (fragment:deisotope = auto|true|false) ONCE.
+    // The Deisotoper supports a fragment tolerance <= 100 ppm / <= 0.1 Da and throws
+    // otherwise; consult its non-throwing predicate so the limit lives in one place
+    // (OpenMS#9619). 'false' never deisotopes; 'true'/'auto' deisotope only when the
+    // tolerance is supported -- 'true' fails fast here with a clear parameter error
+    // rather than aborting later inside preprocessSpectra_'s OpenMP region, while
+    // 'auto' silently skips deisotoping for low-resolution data.
+    const std::string deisotope_mode = param_.getValue("fragment:deisotope").toString();
+    const bool deisotope_supported =
+      Deisotoper::isToleranceSupported(fragment_mass_tolerance_, fragment_mass_tolerance_unit_ == "ppm");
+    deisotope_requested_ = (deisotope_mode != "false");
+    if (deisotope_mode == "true" && !deisotope_supported)
     {
-      const bool unit_ppm = (fragment_mass_tolerance_unit_ == "ppm");
-      const bool in_range = (unit_ppm && fragment_mass_tolerance_ <= 100.0) || (!unit_ppm && fragment_mass_tolerance_ <= 0.1);
-      if (!in_range)
-      {
-        throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-          "fragment:deisotope=true requires a high-resolution fragment tolerance (<= 0.1 Da or <= 100 ppm). "
-          "Use 'auto' (deisotopes only for high-resolution data) or 'false' for low-resolution data.");
-      }
+      throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "fragment:deisotope=true requires a high-resolution fragment tolerance (<= 0.1 Da or <= 100 ppm). "
+        "Use 'auto' (deisotopes only for high-resolution data) or 'false' for low-resolution data.");
+    }
+    if (deisotope_mode == "auto" && !deisotope_supported)
+    {
+      OPENMS_LOG_WARN << "[ProSE] Fragment tolerance " << fragment_mass_tolerance_
+                      << (fragment_mass_tolerance_unit_ == "ppm" ? " ppm" : " Da")
+                      << " exceeds the deisotoping limit (100 ppm / 0.1 Da); skipping MS2 "
+                      << "deisotoping (expected for low-resolution data)." << endl;
     }
 
     modifications_fixed_ = ListUtils::toStringList<std::string>(param_.getValue("modifications:fixed"));
@@ -331,7 +339,7 @@ namespace OpenMS
   }
 
   // static
-  void ProSEAlgorithm::preprocessSpectra_(PeakMap& exp, double fragment_mass_tolerance, bool fragment_mass_tolerance_unit_ppm, const std::string& deisotope_mode)
+  void ProSEAlgorithm::preprocessSpectra_(PeakMap& exp, double fragment_mass_tolerance, bool fragment_mass_tolerance_unit_ppm, bool deisotope_requested)
   {
     // filter MS2 map
     // remove 0 intensities
@@ -354,29 +362,13 @@ namespace OpenMS
 
     NLargest nlargest_filter = NLargest(400);
 
-    // Whether to deisotope is an explicit, instrument-aware choice (param
-    // fragment:deisotope), mirroring how data-driven engines gate single-charge
-    // deconvolution per instrument class (off for low-resolution models). The
-    // Deisotoper requires a fragment tolerance <= 100 ppm / <= 0.1 Da and THROWS
-    // otherwise, so we decide ONCE here, before the OpenMP region: an exception
-    // escaping a parallel region calls std::terminate() (OpenMS#9619). The
-    // tol_in_range guard makes the Deisotoper call below unable to throw
-    // regardless of mode; "true" with an out-of-range tolerance is rejected up
-    // front in updateMembers_().
-    //   - "false": never deisotope.
-    //   - "auto"/"true": deisotope only for high-resolution tolerances; for
-    //     low-resolution data "auto" skips it (with a warning) so the search runs.
-    const bool tol_in_range =
-      (fragment_mass_tolerance_unit_ppm && fragment_mass_tolerance <= 100.0) ||
-      (!fragment_mass_tolerance_unit_ppm && fragment_mass_tolerance <= 0.1);
-    const bool do_deisotope = (deisotope_mode != "false") && tol_in_range;
-    if (deisotope_mode == "auto" && !tol_in_range)
-    {
-      OPENMS_LOG_WARN << "[ProSE] Fragment tolerance " << fragment_mass_tolerance
-                      << (fragment_mass_tolerance_unit_ppm ? " ppm" : " Da")
-                      << " exceeds the deisotoping limit (100 ppm / 0.1 Da); skipping MS2 "
-                      << "deisotoping (expected for low-resolution data)." << endl;
-    }
+    // Deisotope only when requested (param fragment:deisotope, resolved in
+    // updateMembers_) AND the tolerance is in the Deisotoper's supported range.
+    // The range guard keeps the Deisotoper call below from ever throwing, so no
+    // exception can escape the OpenMP region (OpenMS#9619). Mode resolution and the
+    // low-resolution warning are handled once, in updateMembers_.
+    const bool do_deisotope = deisotope_requested &&
+      Deisotoper::isToleranceSupported(fragment_mass_tolerance, fragment_mass_tolerance_unit_ppm);
 
 #pragma omp parallel for default(none) shared(exp, do_deisotope, fragment_mass_tolerance, fragment_mass_tolerance_unit_ppm, window_mower_filter, nlargest_filter)
     for (SignedSize exp_index = 0; exp_index < (SignedSize)exp.size(); ++exp_index)
@@ -1110,7 +1102,7 @@ namespace OpenMS
 
     bool fragment_mass_tolerance_unit_ppm = (fragment_mass_tolerance_unit_ == "ppm");
     bool open_search_mode = isOpenSearchMode_();
-    preprocessSpectra_(spectra, fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm, deisotope_);
+    preprocessSpectra_(spectra, fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm, deisotope_requested_);
 
     // Effective tolerances — may be narrowed by calibration below. Kept asymmetric
     // (lower / upper separately) so the FragmentIndex query can exploit the full
@@ -1349,7 +1341,7 @@ namespace OpenMS
                     << precursor_mass_tolerance_unit_ << ")" << std::endl;
 
     startProgress(0, 1, "Filtering spectra...");
-    preprocessSpectra_(spectra, fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm, deisotope_);
+    preprocessSpectra_(spectra, fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm, deisotope_requested_);
     endProgress();
 
     // Reference the prepared (decoy-augmented) database and prebuilt fragment index from the context.
@@ -1784,7 +1776,7 @@ namespace OpenMS
         f.getOptions() = options;
         f.loadExperiment(in_spectra_files[i], all_spectra[i], {FileTypes::MZML, FileTypes::BRUKER_TDF, FileTypes::RAW});
         all_spectra[i].sortSpectra(true);
-        preprocessSpectra_(all_spectra[i], fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm, deisotope_);
+        preprocessSpectra_(all_spectra[i], fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm, deisotope_requested_);
       }
 
       // Per-file calibration: build a strided calibration FI once, run calibration per file.

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -334,19 +334,41 @@ namespace OpenMS
 
     NLargest nlargest_filter = NLargest(400);
 
-#pragma omp parallel for default(none) shared(exp, fragment_mass_tolerance, fragment_mass_tolerance_unit_ppm, window_mower_filter, nlargest_filter)
+    // Deisotoping (Deisotoper::deisotopeAndSingleCharge) requires a fragment
+    // tolerance within its supported range (<= 100 ppm or <= 0.1 Da) and THROWS
+    // otherwise. Low-resolution data (e.g. ion-trap CID) legitimately needs a
+    // wider fragment tolerance, where deisotoping is both unsupported and
+    // unreliable. Decide ONCE here, before the OpenMP region: an exception that
+    // escapes a parallel region calls std::terminate(). When the tolerance is out
+    // of range we skip deisotoping rather than abort, so ProSE can still search
+    // low-resolution spectra (see OpenMS#9619).
+    const bool do_deisotope =
+      (fragment_mass_tolerance_unit_ppm && fragment_mass_tolerance <= 100.0) ||
+      (!fragment_mass_tolerance_unit_ppm && fragment_mass_tolerance <= 0.1);
+    if (!do_deisotope)
+    {
+      OPENMS_LOG_WARN << "[ProSE] Fragment tolerance " << fragment_mass_tolerance
+                      << (fragment_mass_tolerance_unit_ppm ? " ppm" : " Da")
+                      << " exceeds the deisotoping limit (100 ppm / 0.1 Da); skipping MS2 "
+                      << "deisotoping (expected for low-resolution data)." << endl;
+    }
+
+#pragma omp parallel for default(none) shared(exp, do_deisotope, fragment_mass_tolerance, fragment_mass_tolerance_unit_ppm, window_mower_filter, nlargest_filter)
     for (SignedSize exp_index = 0; exp_index < (SignedSize)exp.size(); ++exp_index)
     {
       // sort by mz
       exp[exp_index].sortByPosition();
 
-      // deisotope
-      Deisotoper::deisotopeAndSingleCharge(exp[exp_index], 
-        fragment_mass_tolerance, fragment_mass_tolerance_unit_ppm, 
-        1, 3,   // min / max charge 
-        false,  // keep only deisotoped
-        3, 10,  // min / max isopeaks 
-        true);  // convert fragment m/z to mono-charge
+      // deisotope (skipped for low-resolution data; see do_deisotope above)
+      if (do_deisotope)
+      {
+        Deisotoper::deisotopeAndSingleCharge(exp[exp_index],
+          fragment_mass_tolerance, fragment_mass_tolerance_unit_ppm,
+          1, 3,   // min / max charge
+          false,  // keep only deisotoped
+          3, 10,  // min / max isopeaks
+          true);  // convert fragment m/z to mono-charge
+      }
 
       // remove noise
       window_mower_filter.filterPeakSpectrum(exp[exp_index]);

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -94,6 +94,9 @@ namespace OpenMS
     defaults_.setValue("fragment:mass_tolerance_unit", "ppm", "Unit of fragment m");
     defaults_.setValidStrings("fragment:mass_tolerance_unit", fragment_mass_tolerance_unit_valid_strings);
 
+    defaults_.setValue("fragment:deisotope", "auto", "MS2 deisotoping (single-charge deconvolution) before searching. 'auto' deisotopes only when the fragment tolerance is within the high-resolution deisotoper range (<= 0.1 Da / <= 100 ppm) and skips it for low-resolution (e.g. ion-trap CID) data; 'true' always deisotopes (requires a high-resolution fragment tolerance); 'false' never deisotopes.");
+    defaults_.setValidStrings("fragment:deisotope", {"auto", "true", "false"});
+
 
     defaults_.setValue("fragment:min_mz", 150, "Minimal fragment mz for database");
     defaults_.setValue("fragment:max_mz", 2000, "Maximal fragment mz for database");
@@ -259,6 +262,23 @@ namespace OpenMS
 
     fragment_mass_tolerance_unit_ = param_.getValue("fragment:mass_tolerance_unit").toString();
 
+    deisotope_ = param_.getValue("fragment:deisotope").toString();
+    // Fail fast if deisotoping is forced on with a low-resolution fragment tolerance
+    // the deisotoper cannot handle (> 0.1 Da / > 100 ppm); otherwise the search would
+    // only crash later, inside preprocessSpectra_'s OpenMP region (OpenMS#9619).
+    // "auto" and "false" are always safe.
+    if (deisotope_ == "true")
+    {
+      const bool unit_ppm = (fragment_mass_tolerance_unit_ == "ppm");
+      const bool in_range = (unit_ppm && fragment_mass_tolerance_ <= 100.0) || (!unit_ppm && fragment_mass_tolerance_ <= 0.1);
+      if (!in_range)
+      {
+        throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+          "fragment:deisotope=true requires a high-resolution fragment tolerance (<= 0.1 Da or <= 100 ppm). "
+          "Use 'auto' (deisotopes only for high-resolution data) or 'false' for low-resolution data.");
+      }
+    }
+
     modifications_fixed_ = ListUtils::toStringList<std::string>(param_.getValue("modifications:fixed"));
     set<std::string> fixed_unique(modifications_fixed_.begin(), modifications_fixed_.end());
     if (fixed_unique.size() != modifications_fixed_.size())
@@ -311,7 +331,7 @@ namespace OpenMS
   }
 
   // static
-  void ProSEAlgorithm::preprocessSpectra_(PeakMap& exp, double fragment_mass_tolerance, bool fragment_mass_tolerance_unit_ppm)
+  void ProSEAlgorithm::preprocessSpectra_(PeakMap& exp, double fragment_mass_tolerance, bool fragment_mass_tolerance_unit_ppm, const std::string& deisotope_mode)
   {
     // filter MS2 map
     // remove 0 intensities
@@ -334,18 +354,23 @@ namespace OpenMS
 
     NLargest nlargest_filter = NLargest(400);
 
-    // Deisotoping (Deisotoper::deisotopeAndSingleCharge) requires a fragment
-    // tolerance within its supported range (<= 100 ppm or <= 0.1 Da) and THROWS
-    // otherwise. Low-resolution data (e.g. ion-trap CID) legitimately needs a
-    // wider fragment tolerance, where deisotoping is both unsupported and
-    // unreliable. Decide ONCE here, before the OpenMP region: an exception that
-    // escapes a parallel region calls std::terminate(). When the tolerance is out
-    // of range we skip deisotoping rather than abort, so ProSE can still search
-    // low-resolution spectra (see OpenMS#9619).
-    const bool do_deisotope =
+    // Whether to deisotope is an explicit, instrument-aware choice (param
+    // fragment:deisotope), mirroring how data-driven engines gate single-charge
+    // deconvolution per instrument class (off for low-resolution models). The
+    // Deisotoper requires a fragment tolerance <= 100 ppm / <= 0.1 Da and THROWS
+    // otherwise, so we decide ONCE here, before the OpenMP region: an exception
+    // escaping a parallel region calls std::terminate() (OpenMS#9619). The
+    // tol_in_range guard makes the Deisotoper call below unable to throw
+    // regardless of mode; "true" with an out-of-range tolerance is rejected up
+    // front in updateMembers_().
+    //   - "false": never deisotope.
+    //   - "auto"/"true": deisotope only for high-resolution tolerances; for
+    //     low-resolution data "auto" skips it (with a warning) so the search runs.
+    const bool tol_in_range =
       (fragment_mass_tolerance_unit_ppm && fragment_mass_tolerance <= 100.0) ||
       (!fragment_mass_tolerance_unit_ppm && fragment_mass_tolerance <= 0.1);
-    if (!do_deisotope)
+    const bool do_deisotope = (deisotope_mode != "false") && tol_in_range;
+    if (deisotope_mode == "auto" && !tol_in_range)
     {
       OPENMS_LOG_WARN << "[ProSE] Fragment tolerance " << fragment_mass_tolerance
                       << (fragment_mass_tolerance_unit_ppm ? " ppm" : " Da")
@@ -1085,7 +1110,7 @@ namespace OpenMS
 
     bool fragment_mass_tolerance_unit_ppm = (fragment_mass_tolerance_unit_ == "ppm");
     bool open_search_mode = isOpenSearchMode_();
-    preprocessSpectra_(spectra, fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm);
+    preprocessSpectra_(spectra, fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm, deisotope_);
 
     // Effective tolerances — may be narrowed by calibration below. Kept asymmetric
     // (lower / upper separately) so the FragmentIndex query can exploit the full
@@ -1324,7 +1349,7 @@ namespace OpenMS
                     << precursor_mass_tolerance_unit_ << ")" << std::endl;
 
     startProgress(0, 1, "Filtering spectra...");
-    preprocessSpectra_(spectra, fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm);
+    preprocessSpectra_(spectra, fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm, deisotope_);
     endProgress();
 
     // Reference the prepared (decoy-augmented) database and prebuilt fragment index from the context.
@@ -1759,7 +1784,7 @@ namespace OpenMS
         f.getOptions() = options;
         f.loadExperiment(in_spectra_files[i], all_spectra[i], {FileTypes::MZML, FileTypes::BRUKER_TDF, FileTypes::RAW});
         all_spectra[i].sortSpectra(true);
-        preprocessSpectra_(all_spectra[i], fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm);
+        preprocessSpectra_(all_spectra[i], fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm, deisotope_);
       }
 
       // Per-file calibration: build a strided calibration FI once, run calibration per file.

--- a/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
@@ -220,19 +220,35 @@ namespace OpenMS
 
     NLargest nlargest_filter = NLargest(400);
 
-#pragma omp parallel for default(none) shared(exp, fragment_mass_tolerance, fragment_mass_tolerance_unit_ppm, window_mower_filter, nlargest_filter)
+    // Deisotoping requires a fragment tolerance the Deisotoper supports (<= 100 ppm
+    // / <= 0.1 Da); it throws otherwise, and an exception escaping the OpenMP region
+    // below would call std::terminate(). Decide once here and skip deisotoping for
+    // low-resolution (e.g. ion-trap CID) data instead of aborting (OpenMS#9619).
+    const bool do_deisotope = Deisotoper::isToleranceSupported(fragment_mass_tolerance, fragment_mass_tolerance_unit_ppm);
+    if (!do_deisotope)
+    {
+      OPENMS_LOG_WARN << "[SimpleSearchEngine] Fragment tolerance " << fragment_mass_tolerance
+                      << (fragment_mass_tolerance_unit_ppm ? " ppm" : " Da")
+                      << " exceeds the deisotoping limit (100 ppm / 0.1 Da); skipping MS2 "
+                      << "deisotoping (expected for low-resolution data)." << endl;
+    }
+
+#pragma omp parallel for default(none) shared(exp, do_deisotope, fragment_mass_tolerance, fragment_mass_tolerance_unit_ppm, window_mower_filter, nlargest_filter)
     for (SignedSize exp_index = 0; exp_index < (SignedSize)exp.size(); ++exp_index)
     {
       // sort by mz
       exp[exp_index].sortByPosition();
 
-      // deisotope
-      Deisotoper::deisotopeAndSingleCharge(exp[exp_index], 
-        fragment_mass_tolerance, fragment_mass_tolerance_unit_ppm, 
-        1, 3,   // min / max charge 
-        false,  // keep only deisotoped
-        3, 10,  // min / max isopeaks 
-        true);  // convert fragment m/z to mono-charge
+      // deisotope (skipped for low-resolution data; see do_deisotope above)
+      if (do_deisotope)
+      {
+        Deisotoper::deisotopeAndSingleCharge(exp[exp_index],
+          fragment_mass_tolerance, fragment_mass_tolerance_unit_ppm,
+          1, 3,   // min / max charge
+          false,  // keep only deisotoped
+          3, 10,  // min / max isopeaks
+          true);  // convert fragment m/z to mono-charge
+      }
 
       // remove noise
       window_mower_filter.filterPeakSpectrum(exp[exp_index]);

--- a/src/openms/source/PROCESSING/DEISOTOPING/Deisotoper.cpp
+++ b/src/openms/source/PROCESSING/DEISOTOPING/Deisotoper.cpp
@@ -20,6 +20,15 @@ namespace OpenMS
 {
 
 // static
+bool Deisotoper::isToleranceSupported(double fragment_tolerance, bool fragment_unit_ppm)
+{
+  // Mirror of the precondition enforced by deisotopeAndSingleCharge(): isotope
+  // spacing is only resolvable up to 100 ppm / 0.1 Da. Single source of truth for
+  // that limit so callers can gate on it instead of replicating the constants.
+  return fragment_unit_ppm ? (fragment_tolerance <= 100.0) : (fragment_tolerance <= 0.1);
+}
+
+// static
 void Deisotoper::deisotopeWithAveragineModel(MSSpectrum& spec,
   double fragment_tolerance,
   bool fragment_unit_ppm,
@@ -36,7 +45,7 @@ void Deisotoper::deisotopeWithAveragineModel(MSSpectrum& spec,
 {
   OPENMS_PRECONDITION(spec.isSorted(), "Spectrum must be sorted.");
 
-    if ((fragment_unit_ppm && fragment_tolerance > 100) || (!fragment_unit_ppm && fragment_tolerance > 0.1))
+    if (!isToleranceSupported(fragment_tolerance, fragment_unit_ppm))
     {
         throw Exception::IllegalArgument(
                 __FILE__,
@@ -344,7 +353,7 @@ void Deisotoper::deisotopeAndSingleCharge(MSSpectrum& spec,
 {
   OPENMS_PRECONDITION(spec.isSorted(), "Spectrum must be sorted.");
 
-    if ((fragment_unit_ppm && fragment_tolerance > 100) || (!fragment_unit_ppm && fragment_tolerance > 0.1))
+    if (!isToleranceSupported(fragment_tolerance, fragment_unit_ppm))
     {
         throw Exception::IllegalArgument(
                 __FILE__,

--- a/src/tests/class_tests/openms/source/Deisotoper_test.cpp
+++ b/src/tests/class_tests/openms/source/Deisotoper_test.cpp
@@ -341,6 +341,22 @@ START_SECTION(static void deisotopeWithAveragineModel(MSSpectrum& spectrum,
 }
 END_SECTION
 
+START_SECTION((static bool isToleranceSupported(double fragment_tolerance, bool fragment_unit_ppm)))
+{
+  // Non-throwing mirror of the deisotopeAndSingleCharge() precondition (<= 100 ppm / <= 0.1 Da).
+  // ppm: supported iff tolerance <= 100
+  TEST_EQUAL(Deisotoper::isToleranceSupported(100.0, true), true)
+  TEST_EQUAL(Deisotoper::isToleranceSupported(20.0, true), true)
+  TEST_EQUAL(Deisotoper::isToleranceSupported(100.0001, true), false)
+  TEST_EQUAL(Deisotoper::isToleranceSupported(150.0, true), false)
+  // Da: supported iff tolerance <= 0.1
+  TEST_EQUAL(Deisotoper::isToleranceSupported(0.1, false), true)
+  TEST_EQUAL(Deisotoper::isToleranceSupported(0.02, false), true)
+  TEST_EQUAL(Deisotoper::isToleranceSupported(0.10001, false), false)
+  TEST_EQUAL(Deisotoper::isToleranceSupported(0.5, false), false)
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 

--- a/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
@@ -52,6 +52,7 @@ public:
   using ProSEAlgorithm::last_calibration_result_;
   using ProSEAlgorithm::last_mod_match_tolerance_used_;
   using ProSEAlgorithm::CalibrationResult_;
+  using ProSEAlgorithm::preprocessSpectra_;
 };
 
 // --- Shared calibration fixture -------------------------------------------------
@@ -1380,6 +1381,65 @@ START_SECTION(([EXTRA] computeModMatchTolerance_ returns min(lower, upper)))
   p.setValue("precursor:mass_tolerance_upper", 2.0);
   algo.setParameters(p);
   TEST_REAL_SIMILAR(algo.computeModMatchTolerance_(), 0.5)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] preprocessSpectra_ skips deisotoping for low-res fragment tolerance (OpenMS#9619)))
+{
+  // Regression for OpenMS#9619: a fragment tolerance above the Deisotoper limit
+  // (>0.1 Da / >100 ppm) -- as needed for low-resolution ion-trap CID data --
+  // must NOT abort ProSE. preprocessSpectra_ decides whether to deisotope once,
+  // before its OpenMP region, and skips deisotoping (rather than throwing, which
+  // would call std::terminate from inside the parallel region) when out of range.
+  auto make_exp = []()
+  {
+    PeakMap exp;
+    MSSpectrum s;
+    s.setMSLevel(2);
+    s.setRT(1.0);
+    Precursor prec;
+    prec.setMZ(500.0);
+    prec.setCharge(2);
+    s.getPrecursors().push_back(prec);
+    for (double mz : {110.07, 120.08, 130.10, 200.10, 201.10, 300.20, 350.25, 500.30})
+    {
+      Peak1D p;
+      p.setMZ(mz);
+      p.setIntensity(1000.0f);
+      s.push_back(p);
+    }
+    exp.addSpectrum(s);
+    return exp;
+  };
+
+  // Low-res: 0.5 Da > 0.1 Da. Before the fix this threw IllegalArgument inside the
+  // OpenMP region -> std::terminate. Now it completes with deisotoping skipped.
+  {
+    PeakMap exp = make_exp();
+    ProSEAlgorithm_test::preprocessSpectra_(exp, 0.5, false);
+    TEST_EQUAL(exp.size(), 1)
+    TEST_EQUAL(exp[0].empty(), false)
+  }
+
+  // 150 ppm > 100 ppm likewise skips deisotoping (no throw / abort).
+  {
+    PeakMap exp = make_exp();
+    ProSEAlgorithm_test::preprocessSpectra_(exp, 150.0, true);
+    TEST_EQUAL(exp.size(), 1)
+    TEST_EQUAL(exp[0].empty(), false)
+  }
+
+  // High-resolution tolerances still deisotope (<=0.1 Da / <=100 ppm path unchanged).
+  {
+    PeakMap exp = make_exp();
+    ProSEAlgorithm_test::preprocessSpectra_(exp, 0.05, false);
+    TEST_EQUAL(exp.size(), 1)
+  }
+  {
+    PeakMap exp = make_exp();
+    ProSEAlgorithm_test::preprocessSpectra_(exp, 20.0, true);
+    TEST_EQUAL(exp.size(), 1)
+  }
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
@@ -1384,14 +1384,14 @@ START_SECTION(([EXTRA] computeModMatchTolerance_ returns min(lower, upper)))
 }
 END_SECTION
 
-START_SECTION(([EXTRA] preprocessSpectra_ deisotope modes incl. low-res skip (OpenMS#9619)))
+START_SECTION(([EXTRA] preprocessSpectra_ never aborts; gates deisotoping on the Deisotoper limit (OpenMS#9619)))
 {
-  // Regression for OpenMS#9619 + the fragment:deisotope mode. A fragment tolerance
-  // above the Deisotoper limit (>0.1 Da / >100 ppm) -- needed for low-resolution
-  // ion-trap CID data -- must NOT abort ProSE: deisotoping is decided once, before
-  // preprocessSpectra_'s OpenMP region (an exception escaping it calls
-  // std::terminate). "auto" skips deisotoping for low-res, "false" never deisotopes,
-  // and high-res tolerances still run the deisotoping path.
+  // Regression for OpenMS#9619: preprocessSpectra_ must never let Deisotoper throw
+  // inside its OpenMP region (an escaping exception calls std::terminate). It gates
+  // the Deisotoper call on Deisotoper::isToleranceSupported(), so even
+  // deisotope_requested=true with a low-resolution (out-of-range) tolerance is a
+  // safe no-op rather than an abort. Mode resolution (auto/true/false) is covered
+  // via the param in the next section.
   auto make_exp = []()
   {
     PeakMap exp;
@@ -1413,36 +1413,35 @@ START_SECTION(([EXTRA] preprocessSpectra_ deisotope modes incl. low-res skip (Op
     return exp;
   };
 
-  // "auto" + low-res (0.5 Da / 150 ppm): skip deisotoping, no throw/abort.
+  // Low-resolution tolerance: requested true OR false -> never throws (deisotoping
+  // is skipped because the tolerance is out of the Deisotoper's supported range).
   {
     PeakMap exp = make_exp();
-    ProSEAlgorithm_test::preprocessSpectra_(exp, 0.5, false, "auto");
+    ProSEAlgorithm_test::preprocessSpectra_(exp, 0.5, false, true);
     TEST_EQUAL(exp.size(), 1)
     TEST_EQUAL(exp[0].empty(), false)
   }
   {
     PeakMap exp = make_exp();
-    ProSEAlgorithm_test::preprocessSpectra_(exp, 150.0, true, "auto");
+    ProSEAlgorithm_test::preprocessSpectra_(exp, 150.0, true, true);
     TEST_EQUAL(exp.size(), 1)
-    TEST_EQUAL(exp[0].empty(), false)
   }
-
-  // "false": never deisotope, even for an out-of-range tolerance (no throw).
   {
     PeakMap exp = make_exp();
-    ProSEAlgorithm_test::preprocessSpectra_(exp, 0.5, false, "false");
+    ProSEAlgorithm_test::preprocessSpectra_(exp, 0.5, false, false);
     TEST_EQUAL(exp.size(), 1)
   }
 
-  // High-resolution tolerances still run the deisotoping path ("auto" and "true").
+  // High-resolution tolerance: requested true -> deisotoping path runs (no throw);
+  // requested false -> skipped.
   {
     PeakMap exp = make_exp();
-    ProSEAlgorithm_test::preprocessSpectra_(exp, 0.05, false, "auto");
+    ProSEAlgorithm_test::preprocessSpectra_(exp, 0.05, false, true);
     TEST_EQUAL(exp.size(), 1)
   }
   {
     PeakMap exp = make_exp();
-    ProSEAlgorithm_test::preprocessSpectra_(exp, 20.0, true, "true");
+    ProSEAlgorithm_test::preprocessSpectra_(exp, 20.0, true, false);
     TEST_EQUAL(exp.size(), 1)
   }
 }

--- a/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
@@ -1384,13 +1384,14 @@ START_SECTION(([EXTRA] computeModMatchTolerance_ returns min(lower, upper)))
 }
 END_SECTION
 
-START_SECTION(([EXTRA] preprocessSpectra_ skips deisotoping for low-res fragment tolerance (OpenMS#9619)))
+START_SECTION(([EXTRA] preprocessSpectra_ deisotope modes incl. low-res skip (OpenMS#9619)))
 {
-  // Regression for OpenMS#9619: a fragment tolerance above the Deisotoper limit
-  // (>0.1 Da / >100 ppm) -- as needed for low-resolution ion-trap CID data --
-  // must NOT abort ProSE. preprocessSpectra_ decides whether to deisotope once,
-  // before its OpenMP region, and skips deisotoping (rather than throwing, which
-  // would call std::terminate from inside the parallel region) when out of range.
+  // Regression for OpenMS#9619 + the fragment:deisotope mode. A fragment tolerance
+  // above the Deisotoper limit (>0.1 Da / >100 ppm) -- needed for low-resolution
+  // ion-trap CID data -- must NOT abort ProSE: deisotoping is decided once, before
+  // preprocessSpectra_'s OpenMP region (an exception escaping it calls
+  // std::terminate). "auto" skips deisotoping for low-res, "false" never deisotopes,
+  // and high-res tolerances still run the deisotoping path.
   auto make_exp = []()
   {
     PeakMap exp;
@@ -1412,34 +1413,69 @@ START_SECTION(([EXTRA] preprocessSpectra_ skips deisotoping for low-res fragment
     return exp;
   };
 
-  // Low-res: 0.5 Da > 0.1 Da. Before the fix this threw IllegalArgument inside the
-  // OpenMP region -> std::terminate. Now it completes with deisotoping skipped.
+  // "auto" + low-res (0.5 Da / 150 ppm): skip deisotoping, no throw/abort.
   {
     PeakMap exp = make_exp();
-    ProSEAlgorithm_test::preprocessSpectra_(exp, 0.5, false);
+    ProSEAlgorithm_test::preprocessSpectra_(exp, 0.5, false, "auto");
+    TEST_EQUAL(exp.size(), 1)
+    TEST_EQUAL(exp[0].empty(), false)
+  }
+  {
+    PeakMap exp = make_exp();
+    ProSEAlgorithm_test::preprocessSpectra_(exp, 150.0, true, "auto");
     TEST_EQUAL(exp.size(), 1)
     TEST_EQUAL(exp[0].empty(), false)
   }
 
-  // 150 ppm > 100 ppm likewise skips deisotoping (no throw / abort).
+  // "false": never deisotope, even for an out-of-range tolerance (no throw).
   {
     PeakMap exp = make_exp();
-    ProSEAlgorithm_test::preprocessSpectra_(exp, 150.0, true);
+    ProSEAlgorithm_test::preprocessSpectra_(exp, 0.5, false, "false");
     TEST_EQUAL(exp.size(), 1)
-    TEST_EQUAL(exp[0].empty(), false)
   }
 
-  // High-resolution tolerances still deisotope (<=0.1 Da / <=100 ppm path unchanged).
+  // High-resolution tolerances still run the deisotoping path ("auto" and "true").
   {
     PeakMap exp = make_exp();
-    ProSEAlgorithm_test::preprocessSpectra_(exp, 0.05, false);
+    ProSEAlgorithm_test::preprocessSpectra_(exp, 0.05, false, "auto");
     TEST_EQUAL(exp.size(), 1)
   }
   {
     PeakMap exp = make_exp();
-    ProSEAlgorithm_test::preprocessSpectra_(exp, 20.0, true);
+    ProSEAlgorithm_test::preprocessSpectra_(exp, 20.0, true, "true");
     TEST_EQUAL(exp.size(), 1)
   }
+}
+END_SECTION
+
+START_SECTION(([EXTRA] fragment:deisotope parameter + validation (OpenMS#9619)))
+{
+  ProSEAlgorithm_test algo;
+  // Default is the instrument-aware "auto".
+  TEST_EQUAL(algo.getParameters().getValue("fragment:deisotope").toString(), "auto")
+
+  // deisotope=true with a low-resolution (Da > 0.1) tolerance is rejected up front,
+  // rather than aborting later inside the search.
+  Param p = algo.getParameters();
+  p.setValue("fragment:deisotope", "true");
+  p.setValue("fragment:mass_tolerance", 0.5);
+  p.setValue("fragment:mass_tolerance_unit", "Da");
+  TEST_EXCEPTION(Exception::InvalidParameter, algo.setParameters(p))
+
+  // deisotope=true with a high-resolution tolerance is accepted.
+  p.setValue("fragment:mass_tolerance", 0.02);
+  p.setValue("fragment:mass_tolerance_unit", "Da");
+  algo.setParameters(p);
+  TEST_EQUAL(algo.getParameters().getValue("fragment:deisotope").toString(), "true")
+
+  // "auto" and "false" accept any tolerance (incl. low-res).
+  p.setValue("fragment:deisotope", "auto");
+  p.setValue("fragment:mass_tolerance", 0.5);
+  p.setValue("fragment:mass_tolerance_unit", "Da");
+  algo.setParameters(p);
+  p.setValue("fragment:deisotope", "false");
+  algo.setParameters(p);
+  TEST_EQUAL(algo.getParameters().getValue("fragment:deisotope").toString(), "false")
 }
 END_SECTION
 


### PR DESCRIPTION
## What

Fixes #9619.

OpenMS aborts (signal 6, uncaught `Exception::IllegalArgument`) when a fragment-index search engine is given a fragment tolerance appropriate for low-resolution (ion-trap CID) MS2 data. `Deisotoper::deisotopeAndSingleCharge` throws for a fragment tolerance > 100 ppm / 0.1 Da, and ProSE / SimpleSearchEngine call it **inside an `#pragma omp parallel for`** — an exception escaping a parallel region calls `std::terminate()`, after the fragment index has already been built.

## Fix

**Single source of truth.** New `static bool Deisotoper::isToleranceSupported(tol, ppm)` exposes the deisotoper's own limit (non-throwing). Both `deisotopeAndSingleCharge()` precondition throws now use it, and external callers consult it instead of re-hardcoding `0.1 Da / 100 ppm`.

**ProSE.** New `fragment:deisotope` parameter (`auto` | `true` | `false`, default `auto`), modelled on how data-driven engines gate single-charge deconvolution per instrument class (off for low-res). Resolved **once** in `updateMembers_`: `false` never deisotopes; `auto` deisotopes only for high-res tolerances and skips low-res (with a one-time warning) so the search runs; `true` always deisotopes and is rejected up front (`ILLEGAL_PARAMETERS`) on a low-res tolerance. `preprocessSpectra_` now takes a plain bool and gates the `Deisotoper` call on `isToleranceSupported()`, so it is self-safe regardless of caller and no exception can escape the OpenMP region.

**SimpleSearchEngine.** The sibling `SimpleSearchEngineAlgorithm::preprocessSpectra_` had the identical latent abort; it now gates its deisotope call on `isToleranceSupported()` too — low-res input skips deisotoping instead of aborting.

## Behaviour

- High-res runs unchanged — incl. the existing `ProSE_1/2/4` TOPP tests (fragment tolerance `0.1 Da`) and SimpleSearchEngine's normal ppm path.
- Low-res CID runs complete (deisotoping skipped) instead of aborting.

## Tests

- `Deisotoper_test`: `isToleranceSupported` boundary values (ppm/Da).
- `ProSEAlgorithm_test`: `preprocessSpectra_` self-safety (never aborts out-of-range) + `fragment:deisotope` resolution / validation.

## Verification (PRIDE PXD001819 `UPS1_50amol_R1`, low-res ion-trap CID)

- ProSE default `auto` + `0.5 Da`: warns, completes, writes a valid `.pin` (before: abort).
- ProSE `-Search:fragment:deisotope true` + low-res: clean `ILLEGAL_PARAMETERS` (before: abort).
- SimpleSearchEngine + `0.5 Da`: warns, completes (82 MB idXML, 11 s), **0 aborts** (before: abort).

## Note

This generalizes the original per-tool fix after code review (the `0.1 Da / 100 ppm` limit was duplicated, and the sibling SimpleSearchEngine retained the same latent abort). The other `deisotopeAndSingleCharge` callers (`TargetedSpectraExtractor`, `OPXLSpectrumProcessingAlgorithms`, `SwathQC`) are left unchanged but can now adopt `Deisotoper::isToleranceSupported()` to gate safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable MS2 deisotoping mode (`auto`, enabled, disabled) to control whether deisotoping runs during preprocessing.

* **Bug Fixes**
  * Improved handling of unsupported fragment tolerances: deisotoping is now safely skipped (with a warning) instead of failing during parallel preprocessing.

* **Tests**
  * Added regression tests covering deisotoping mode behavior and preprocessing safety across supported and unsupported tolerance ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->