### PR TITLE
CHANGELOG: document 8 recently merged PRs for 3.6.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -63,6 +63,7 @@ General:
   - Fix: SwathMapMassCorrection: removed null-pointer dereference and memory leak in correctMZ/correctIM when fetchSpectrumSwath returns an empty spectrum; empty-spectrum iterations are now skipped cleanly via continue or a null-pointer guard (#9386)
   - Fix: SimpleSearchEngineAlgorithm: removed default(none) from the OpenMP parallel-for pragma that unconditionally listed annotated_hits_lock in its shared() clause; on macOS/Xcode where _OPENMP is not defined, this caused "use of undeclared identifier" compile errors and prevented building on those platforms (#9388)
   - New ThermoRawFile class for native reading of Thermo .raw files into MSExperiment via the openms-thermo-bridge (.NET managed DLL bridge); fetched automatically via CMake FetchContent; controlled by WITH_THERMO_RAW CMake option (ON by default, except on Linux/aarch64); registered in FileHandler and FileTypes (#9389)
+  - ThermoRawFile: now extracts full mzML-equivalent metadata — per-spectrum TIC (MS:1000285), base peak m/z and intensity, lowest/highest observed m/z, scan filter string, scan window, ion injection time (MS:1000927), polarity (previously missing/incorrect), and instrument source/analyzer/detector info with file-level FileDescription; output now matches msconvert/ProteoWizard mzML conversion; pyOpenMS bindings updated (#9623)
   - Optimized MzIdentML parser performance by caching CV lookups and added mzIdentML 1.3 schema support (#8764)
   - New IsoelectricPoint class in CHEMISTRY for peptide pI and charge-at-pH calculation: IsoelectricPoint::computeCharge(AASequence, pH, ProteomicsPkaScale=EMBOSS) returns the net charge via Henderson-Hasselbalch; IsoelectricPoint::computePI(AASequence, ProteomicsPkaScale=EMBOSS, tolerance=1e-6) finds the isoelectric point by bisection in pH range [0, 14]; supports four pKa scales via the ProteomicsPkaScale enum (LEHNINGER, EMBOSS, SILLERO, BJELLQVIST); the Bjellqvist scale uses per-N-terminal-residue pKa values; pyOpenMS bindings included (#9419)
   - BREAKING: the immutable singleton databases now return a const pointer from getInstance(), reflecting that they are read-only after construction: RibonucleotideDB::getInstance(), MonosaccharideDB::getInstance(), ElementDB::getInstance(), and (via the DigestionEnzymeDB CRTP base) ProteaseDB::getInstance() and RNaseDB::getInstance() now return const T* instead of T*. Downstream code that stored the result in a non-const pointer (e.g. ProteaseDB* db = ProteaseDB::getInstance();) must switch to const T* or auto. As a consequence, RibonucleotideDB's lookup methods (getRibonucleotide, getRibonucleotidePrefix, getRibonucleotideAlternatives) and ProteaseDB::writeTSV are now const-qualified. ResidueDB returns const as well (via a logical-const cache).
@@ -124,6 +125,7 @@ PyOpenMS:
     - MZTrafoModel.setRANSACSeed(seed) for reproducible RANSAC-based m/z calibration (#9407)
     - EmpiricalFormula.getNumberOf(Element), EmpiricalFormula.getLightestIsotopeWeight(), Residue.getHydrophobicity(HydrophobicityScaleMethod) + new HydrophobicityScaleMethod enum, TheoreticalSpectrumGenerator.getPrefixAndSuffixIonsMZ(peptide, charge) returning a numpy float array, and SpectralMatch CCS accessors (getCCS/setFoundCCS) added (#9415, #9412)
     - IsoelectricPoint.computeCharge(AASequence, pH, ProteomicsPkaScale=EMBOSS) and IsoelectricPoint.computePI(AASequence, ProteomicsPkaScale=EMBOSS, tolerance=1e-6) for peptide net-charge and isoelectric point calculation; ProteomicsPkaScale enum (LEHNINGER/EMBOSS/SILLERO/BJELLQVIST) (#9419)
+    - FileInfo: new wrapper for programmatic file inspection; FileInfo().runAll(filename) returns typed fields (file type, feature/spectrum counts, m/z ranges, etc.); FileInfo.toText(result) reproduces the CLI text output; replaces the need to shell out to the FileInfo TOPP tool (#9602)
   - String handling: Functions now accept both str and bytes via libcpp_utf8_string (#8602, #8604)
   - Backward compatibility restored for file I/O methods in IdXMLFile, PepXMLFile, MzIdentMLFile (#8553)
   - Static methods modernized using @staticmethod decorator (#8562)
@@ -405,6 +407,7 @@ OpenMS Library:
     - TMTThirtyTwoPlexQuantitationMethod, TMTThirtyFivePlexQuantitationMethod: new classes for TMT 32-plex and 35-plex isobaric quantitation; isotope correction matrix defaults to identity until calibrated values are provided (#9003)
     - IMPeakType enum (IM_PROFILE, IM_CENTROIDED, UNKNOWN) added to SpectrumSettings to track per-peak ion mobility processing state independently of data layout (IMFormat); IMFormat::CENTROIDED deprecated (#9007)
     - IsoelectricPoint: new CHEMISTRY class for computing the isoelectric point (pI) and net charge of peptides via the Henderson-Hasselbalch equation; supports four pKa scales (ProteomicsPkaScale enum: LEHNINGER, EMBOSS, SILLERO, BJELLQVIST); pI found by bisection in pH range [0, 14]; pyOpenMS bindings included (#9419)
+    - FileInfo: new FORMAT/ class providing programmatic file inspection equivalent to the FileInfo TOPP tool but callable from C++ library code and pyOpenMS; FileInfo().runAll(filename) returns a structured result with file type, feature/spectrum counts, m/z ranges, and other metadata; FileInfo::toText(result) reproduces the CLI text output; pyOpenMS bindings included (#9602)
   Changes:
     - BREAKING: Matrix<T> no longer inherits from Eigen; uses std::vector<T> for storage (#8511)
     - BREAKING: Eigen moved from PUBLIC to PRIVATE linking - downstream users no longer need Eigen headers (#8511)
@@ -465,7 +468,8 @@ OpenMS Library:
       - OpenSwathParquetExporter: writes per-feature score tables to Parquet format via Apache Arrow
       - OpenSwathResultsExporter: exports combined results in TSV and Parquet formats; reads gene-decoy and transition-annotation columns from OSWFile
       - OSWFile: extended SQL queries to include gene decoy flags and transition annotation fields required by the new export classes
-  - IMAGING: multi-region support - new MSImagingRegion class (axis-aligned rectangle or bbox-local bitmask footprint in global pixel coordinates) and a decoupled region overlay on MSImagingGeometry (addRegion/removeRegion/regionOf/getRegionPixels/getRegionSpectrumIndices); regions form a disjoint partition of acquired pixels with membership derived on demand (not cached). MSImagingExperiment gains a per-region extractIonImage(mz, tolerance_ppm, region_id) overload. pyOpenMS bindings included.
+    - Deisotoper: new static method isToleranceSupported(tolerance, ppm) returns true if the given tolerance is within the supported range for deisotoping (≤ 100 ppm or ≤ 0.1 Da); used by ProSE and SimpleSearchEngine to guard the deisotoping step and avoid std::terminate on low-resolution data (#9620)
+  - IMAGING: multi-region support - new MSImagingRegion class (axis-aligned rectangle or bbox-local bitmask footprint in global pixel coordinates) and a decoupled region overlay on MSImagingGeometry (addRegion/removeRegion/regionOf/getRegionPixels/getRegionSpectrumIndices); regions form a disjoint partition of acquired pixels with membership derived on demand (not cached). MSImagingExperiment gains a per-region extractIonImage(mz, tolerance_ppm, region_id) overload. pyOpenMS bindings included. (#9521)
 
 Fixes:
   - Fix inverted use_all_hits logic causing NucleicAcidSearchEngine crash with multiple hits per spectrum (#8542)
@@ -494,6 +498,10 @@ Fixes:
   - Fix TOPPView performance regression when right-clicking in large mzML files (#8997)
   - Fix: TOPPView: prevent segfault on extreme zoom in 1D view in SNAP intensity mode; when the visible m/z range contains no peaks the intensity range collapsed to [0, 0], causing divide-by-zero in dataToWidget_ and a crash in Qt's painter; now falls back to the layer's overall intensity range (#9206, #9263)
   - Fix: ChromatogramExtractor::prepare_coordinates (TargetedExperiment overload) now honours the ms1_isotopes parameter; a `&& false` guard introduced in 2018 silently disabled the isotope-coordinate block, so callers passing ms1=true with ms1_isotopes > 0 received fewer chromatograms than requested; the LightTargetedExperiment overload was unaffected (#7284, #9270)
+  - Fix: DistanceMatrix::setValue: the fast-path cache-invalidation guard used && instead of ||, causing the cached minimum to go stale when a smaller value was written to a cell sharing one index with the current cached-minimum cell (#9610, #9488)
+  - Fix: DistanceMatrix::operator== performed an out-of-bounds heap read and returned incorrect results when comparing matrices of different sizes; now returns false early. ClusteringGrid::getClusters no longer dereferences map::end() for unpopulated cells and instead returns an empty list. File path helpers guarded against degenerate inputs (#9497, #9488)
+  - Fix: LogStreamBuf thread-safety: three shared resources (static buffer, sink list, Colorizer) were not protected against concurrent access from OpenMP parallel regions; heap corruption could occur (e.g. in the imzML reader's populateSpectraWithData_() on Windows, reported as STATUS_HEAP_CORRUPTION 0xC0000374); all three resources are now properly synchronized (#9583, fixes #9515)
+  - Fix: ProSE and SimpleSearchEngine no longer crash (SIGABRT / std::terminate from an unhandled exception escaping an OpenMP parallel region) when the fragment tolerance exceeds the range supported by deisotoping (> 100 ppm or > 0.1 Da); the deisotoping step is now guarded by Deisotoper::isToleranceSupported() and skipped when the tolerance is too large (#9620, fixes #9619)
 
 Documentation:
   - Comprehensive documentation for Targeted Quantitation algorithms (#8588)
@@ -532,6 +540,7 @@ Build System:
   - Qt6 find_package guarded by WITH_GUI block; Qt is no longer needed for non-GUI TOPP tool builds (#9041)
   - yaml-cpp bumped to 0.9.0 in tool_description_lib; fixes broken hash/map type parsing in YAML CTD config files (#9056)
   - OpenMP SIMD: when the OpenMP runtime is absent (e.g. on macOS without libomp), CMake now falls back to -fopenmp-simd so that `#pragma omp simd` directives still enable auto-vectorisation; the flag is applied PRIVATE to all OpenMS targets (#9267)
+  - CI: Windows build migrated from Visual Studio 2022 to Visual Studio 2026 (windows-2025 runner, MSVC v145 toolset, CMake generator "Visual Studio 18 2026") (#9514)
 
 
 ------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds CHANGELOG entries for 8 substantive PRs merged since the last changelog update, all targeting OpenMS 3.6.0 (under development).

**New features / additions:**
- **#9623** `ThermoRawFile`: full mzML-equivalent metadata extraction + polarity fix (General + PyOpenMS sections)
- **#9602** `FileInfo`: new FORMAT/ library class callable from C++ and pyOpenMS; equivalent to the FileInfo TOPP tool but usable programmatically (OpenMS Library Added + PyOpenMS New wrappers sections)
- **#9521** `IMAGING` multi-region support — PR reference was missing from the existing entry added by the PR itself

**Bug fixes:**
- **#9620** `Deisotoper::isToleranceSupported()` — new guard method + ProSE/SimpleSearchEngine crash fix on low-resolution data (Fixes + OpenMS Library Changes sections)
- **#9610** `DistanceMatrix::setValue` cached-minimum stale guard (`&&` → `||`)
- **#9497** `DistanceMatrix::operator==` OOB heap read, `ClusteringGrid::getClusters` null-deref, `File` path guards
- **#9583** `LogStreamBuf` thread-safety (heap corruption from OpenMP parallel regions)

**Build system:**
- **#9514** Windows CI migrated from Visual Studio 2022 to Visual Studio 2026

## Test plan
- [ ] Diff is pure CHANGELOG text; no code changed
- [ ] All 8 PR numbers appear in the changelog: `grep -c "#9623\|#9602\|#9521\|#9610\|#9497\|#9583\|#9620\|#9514" CHANGELOG` → 10 (some PRs appear in multiple sections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLg6pWyjyTxpWAU6mgrDzC

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLg6pWyjyTxpWAU6mgrDzC)_