### PR TITLE
[pyOpenMS] Fix docutils errors in nanobind docstrings (#9460)

### DIFF
--- a/src/pyOpenMS/bindings/bind_analysis.cpp
+++ b/src/pyOpenMS/bindings/bind_analysis.cpp
@@ -767,7 +767,7 @@ A node of the kD-tree with pointer to corresponding data and index
         .def("__copy__", [](const OpenMS::KDTreeFeatureNode& self) { return OpenMS::KDTreeFeatureNode(self); })
         .def("__deepcopy__", [](const OpenMS::KDTreeFeatureNode& self, nb::dict) { return OpenMS::KDTreeFeatureNode(self); }, "memo"_a)
         .def("__getitem__", [](OpenMS::KDTreeFeatureNode& self, size_t i) { return self[i]; })
-        .def("getIndex", [](const OpenMS::KDTreeFeatureNode& self) { return self.getIndex(); }, "Returns index of corresponding feature in data_")
+        .def("getIndex", [](const OpenMS::KDTreeFeatureNode& self) { return self.getIndex(); }, "Returns index of corresponding feature in ``data_``")
         ;
 
     // -----------------------------------------------------------------------
@@ -1212,8 +1212,8 @@ private
         .def(nb::init<size_t, OpenMS::Param>())
         .def("__copy__", [](const OpenMS::MapAlignmentAlgorithmKD& self) { return OpenMS::MapAlignmentAlgorithmKD(self); })
         .def("__deepcopy__", [](const OpenMS::MapAlignmentAlgorithmKD& self, nb::dict) { return OpenMS::MapAlignmentAlgorithmKD(self); }, "memo"_a)
-        .def("addRTFitData", [](OpenMS::MapAlignmentAlgorithmKD& self, const OpenMS::KDTreeFeatureMaps& kd_data) { return self.addRTFitData(kd_data); }, "kd_data"_a, "Compute data points needed for RT transformation in the current `kd_data`, add to `fit_data_`")
-        .def("fitLOWESS", [](OpenMS::MapAlignmentAlgorithmKD& self) { return self.fitLOWESS(); }, "Fit LOWESS to fit_data_, store final models in `transformations_`")
+        .def("addRTFitData", [](OpenMS::MapAlignmentAlgorithmKD& self, const OpenMS::KDTreeFeatureMaps& kd_data) { return self.addRTFitData(kd_data); }, "kd_data"_a, "Compute data points needed for RT transformation in the current ``kd_data``, add to ``fit_data_``")
+        .def("fitLOWESS", [](OpenMS::MapAlignmentAlgorithmKD& self) { return self.fitLOWESS(); }, "Fit LOWESS to ``fit_data_``, store final models in ``transformations_``")
         .def("transform", [](const OpenMS::MapAlignmentAlgorithmKD& self, OpenMS::KDTreeFeatureMaps& kd_data) { return self.transform(kd_data); }, "kd_data"_a, "Transform RTs for `kd_data`")
         ;
 

--- a/src/pyOpenMS/bindings/bind_datastructures.cpp
+++ b/src/pyOpenMS/bindings/bind_datastructures.cpp
@@ -1010,7 +1010,7 @@ which is a key parameter in FDR estimation.
 Attributes:
 pi0: Estimated proportion of true null hypotheses (0-1)
 pi0_lambda: Vector of pi0 estimates at each lambda threshold
-lambda_: Vector of lambda threshold values used
+``lambda_``: Vector of lambda threshold values used
 pi0_smooth: Whether smoothing was successfully applied
 )doc")
         .def(nb::init<>())

--- a/src/pyOpenMS/bindings/bind_featurefinder.cpp
+++ b/src/pyOpenMS/bindings/bind_featurefinder.cpp
@@ -289,11 +289,13 @@ estimated for arbitrary m/z using a spline interpolation.
         R"doc(
 Represents one target compound in the assay library for FeatureFinderAlgorithmMetaboIdent.
 
-Constructor:
+Constructor::
+
     FeatureFinderMetaboIdentCompound(name, formula, mass, charges, rts, rt_ranges,
                                      iso_distrib, ion_mobilities=[], adduct="")
 
-Arguments:
+Arguments::
+
     name           Unique target name.
     formula        Sum formula (e.g. 'C6H12O6'); may be empty if mass > 0.
     mass           Neutral mass; <= 0 means "derive from formula".


### PR DESCRIPTION
## What

Fixes the **6 docutils `ERROR`s** the pyOpenMS readthedocs/Sphinx build emits from nanobind binding docstrings. The build still *succeeded* (these are non-fatal), but the errors pollute the log and break cross-references in the rendered API docs.

## Root cause

Two distinct RST-parsing issues:

1. **Trailing-underscore member names leak into docstrings.** OpenMS' C++ private-member convention (`data_`, `fit_data_`, `transformations_`, `lambda_`) appears verbatim in docstrings, where RST reads a word ending in `_` at a word boundary as a hyperlink reference → `ERROR: Unknown target name: "..."`. Affected: `KDTreeFeatureNode.getIndex`, `MapAlignmentAlgorithmKD.addRTFitData`, `MapAlignmentAlgorithmKD.fitLOWESS`, `Pi0Result`.
2. **`FeatureFinderMetaboIdentCompound`** — the `Constructor:`/`Arguments:` blocks parse as block quotes, so the deeper-indented continuation line trips `ERROR: Unexpected indentation`.

## Fix

- Wrap the member-name references in **double-backtick inline literals** (``` ``data_`` ```), so RST treats them as code and renders them monospace.
- Convert the `Constructor:`/`Arguments:` blocks to **literal blocks** (`::`) so the indented text is taken verbatim.

No behavioral change — docstrings only.

## Verification

Clean Sphinx rebuild against the freshly-built bindings:

| | before | after |
|---|---|---|
| docutils ERRORs | 6 | **0** |
| build | succeeded | succeeded |

Remaining warnings are unrelated (missing `intersphinx_mapping`, hoverxref glossary noise) and out of scope here.

Part of #9460 (pyOpenMS readthedocs build task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Python API documentation formatting for consistency across binding modules. Updated docstring formatting for analysis, data structure, and feature finder classes to improve readability and standardization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->