### PR TITLE
[ProSE] Auto decoy mode (detect-or-generate, prefix/suffix aware)

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
@@ -103,6 +103,15 @@ class OPENMS_DLLAPI ProSEAlgorithm :
     {
       std::vector<SearchResult> per_file;
       SearchResult aggregate;
+
+      /// Effective decoy marker resolved from the shared database, for a
+      /// caller-side merged-PSM protein-FDR step (e.g. the ProSE TOPP tool's
+      /// -out_merged path). Empty when the search was target-only (decoys=ignore).
+      std::string decoy_string;
+      /// Position of @c decoy_string (true = prefix, false = suffix).
+      bool decoy_is_prefix = true;
+      /// True when the searched databases contained decoys (FDR possible).
+      bool have_decoys = false;
     };
 
     /**
@@ -128,6 +137,17 @@ class OPENMS_DLLAPI ProSEAlgorithm :
       /// for callers that built ctx via prepareContext() and want to
       /// run multiple search() calls against it.
       bool release_fragment_index_after_scoring = false;
+
+      /// Effective decoy marker carried by `db` (auto-detected for external
+      /// decoys, or the configured prefix for internally generated ones).
+      /// Empty when the search is target-only. Feeds PeptideIndexing and the
+      /// protein-level FDR so they recognise the same decoys that were searched.
+      std::string decoy_string;
+      /// Position of `decoy_string` (true = prefix, false = suffix).
+      bool decoy_is_prefix = true;
+      /// True when `db` contains decoy entries (generated or external), i.e.
+      /// target-decoy FDR is possible.
+      bool have_decoys = false;
     };
 
     /**
@@ -366,36 +386,64 @@ class OPENMS_DLLAPI ProSEAlgorithm :
     /// @brief filter, deisotope, decharge spectra
     static void preprocessSpectra_(PeakMap& exp, double fragment_mass_tolerance, bool fragment_mass_tolerance_unit_ppm, bool deisotope_requested);
 
+    /// How decoys are obtained/recognised for a search (parameter "decoys").
+    enum class DecoyMode_
+    {
+      AUTO,     ///< ensure decoys: use those already present, otherwise generate
+      GENERATE, ///< always (re)generate decoys from the targets (strip existing first)
+      IGNORE    ///< search targets only; remove any decoys present in the database
+    };
+
     /**
-     * @brief Build a decoy-augmented copy of the input FASTA.
+     * @brief Resolved decoy handling for one concrete input database.
      *
-     * Used by prepareContext() and the chunked search path. Produces FASTA
-     * entries only — does not construct a FragmentIndex. If decoys_ is false
-     * the input is returned unchanged.
+     * Produced by resolveDecoyStrategy_() and consumed by
+     * buildDecoyAugmentedDB_() and the downstream PeptideIndexing / FDR steps,
+     * so the same decoys that are searched are also the ones scored.
+     */
+    struct DecoyStrategy_
+    {
+      bool generate{false};       ///< reverse target proteins to synthesise decoys
+      bool strip_existing{false}; ///< drop pre-existing decoy entries before searching
+      bool have_decoys{false};    ///< searched DB will contain decoys (FDR possible)
+      std::string decoy_string;   ///< effective marker for PeptideIndexing + protein FDR
+      bool is_prefix{true};       ///< position of decoy_string
+      std::string strip_string;   ///< marker of pre-existing decoys to strip
+      bool strip_is_prefix{true}; ///< position of strip_string
+    };
+
+    /**
+     * @brief Decide how to obtain/recognise decoys for @p db.
+     *
+     * Detects pre-existing decoys via the common-marker heuristic
+     * (OpenMS::DecoyHelper), falling back to the configured decoy_prefix for
+     * custom markers, then maps the "decoys" mode (auto/generate/ignore) onto a
+     * concrete DecoyStrategy_.
+     */
+    DecoyStrategy_ resolveDecoyStrategy_(
+        const std::vector<FASTAFile::FASTAEntry>& db) const;
+
+    /**
+     * @brief ProSE parameters made safe to hand to a FragmentIndex.
+     *
+     * FragmentIndex declares its own (unused) boolean "decoys" flag with
+     * restrictions {true,false}. ProSE's "decoys" parameter is the richer
+     * auto/generate/ignore enum and manages decoys at the database level, so
+     * forwarding it verbatim would trip FragmentIndex's validation. This returns
+     * getParameters() with "decoys" overridden to "false".
+     */
+    Param fragmentIndexParameters_() const;
+
+    /**
+     * @brief Build the searched database according to @p strategy.
+     *
+     * Optionally strips pre-existing decoys and/or generates fresh decoys by
+     * reversing the target proteins. Produces FASTA entries only — does not
+     * construct a FragmentIndex.
      */
     std::vector<FASTAFile::FASTAEntry> buildDecoyAugmentedDB_(
-        const std::vector<FASTAFile::FASTAEntry>& fasta_db) const;
-
-    /**
-     * @brief Test whether an accession carries the decoy marker.
-     *
-     * Matches decoy_prefix_ as either a prefix or a suffix of the accession,
-     * so databases that tag decoys at the end (e.g. "PROT_DECOY") are detected
-     * as well as the conventional leading "DECOY_PROT". No extra parameter is
-     * required; both orientations of the same marker string are accepted.
-     */
-    bool isDecoyAccession_(const std::string& accession) const;
-
-    /**
-     * @brief Detect whether decoys are tagged by prefix or suffix in @p db.
-     *
-     * Returns "suffix" only when the decoy marker is found exclusively at the
-     * end of accessions (i.e. some accession ends with it and none begins with
-     * it); otherwise returns "prefix". The result feeds PeptideIndexing's
-     * "decoy_string_position", which accepts a single orientation.
-     */
-    std::string detectDecoyStringPosition_(
-        const std::vector<FASTAFile::FASTAEntry>& db) const;
+        const std::vector<FASTAFile::FASTAEntry>& fasta_db,
+        const DecoyStrategy_& strategy) const;
 
     /**
      * @brief Build a strided protein sample for chunked calibration.
@@ -418,9 +466,10 @@ class OPENMS_DLLAPI ProSEAlgorithm :
      *
      * Splits full_db into chunks of database_chunk_size_ proteins, builds a
      * FragmentIndex per chunk, scores all spectra against each chunk, and
-     * accumulates hits before a single post-processing pass. full_db must
-     * already contain decoys if decoys_ is true. Taken by non-const reference
-     * because PeptideIndexing::run() mutates it.
+     * accumulates hits before a single post-processing pass. full_db is the
+     * already-resolved database (decoys generated/stripped per @p strategy);
+     * @p strategy carries the effective decoy marker for PeptideIndexing and
+     * FDR. Taken by non-const reference because PeptideIndexing::run() mutates it.
      *
      * @return EXECUTION_OK on success; INPUT_FILE_EMPTY / UNEXPECTED_RESULT /
      *         UNKNOWN_ERROR on PeptideIndexing failure.
@@ -428,6 +477,7 @@ class OPENMS_DLLAPI ProSEAlgorithm :
     ExitCodes searchChunked_(
         PeakMap& spectra,
         std::vector<FASTAFile::FASTAEntry>& full_db,
+        const DecoyStrategy_& strategy,
         std::vector<ProteinIdentification>& protein_ids,
         PeptideIdentificationList& peptide_ids) const;
 
@@ -521,7 +571,7 @@ class OPENMS_DLLAPI ProSEAlgorithm :
 
     std::string enzyme_;
 
-    bool decoys_;
+    DecoyMode_ decoy_mode_{DecoyMode_::AUTO};
     std::string decoy_prefix_;
 
     double fdr_psm_{0.0};

--- a/src/openms/include/OpenMS/DATASTRUCTURES/FASTAContainer.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/FASTAContainer.h
@@ -364,9 +364,15 @@ public:
     For tested decoy strings see DecoyHelper::affixes.
     Both prefix and suffix is tested and if one of the candidates above is found in at least 40% of all proteins,
     it is returned as the winner (see DecoyHelper::Result).
+
+    @param proteins The protein accessions to inspect.
+    @param quiet If true, suppress the ERROR/WARN log messages emitted when no
+                 decoy string can be determined. Useful for callers that treat a
+                 negative result as a normal outcome (e.g. a target-only database)
+                 and handle it themselves.
   */
   template<typename T>
-  static Result findDecoyString(FASTAContainer<T>& proteins)
+  static Result findDecoyString(FASTAContainer<T>& proteins, bool quiet = false)
   {
     // calls function to search for decoys in input data
     DecoyStatistics decoy_stats = countDecoys(proteins);
@@ -381,13 +387,13 @@ public:
     // return default values
     if (static_cast<double>(decoy_stats.all_prefix_occur + decoy_stats.all_suffix_occur) < 0.4 * static_cast<double>(decoy_stats.all_proteins_count))
     {
-      OPENMS_LOG_ERROR << "Unable to determine decoy string (not enough occurrences; <40%)!" << std::endl;
+      if (!quiet) OPENMS_LOG_ERROR << "Unable to determine decoy string (not enough occurrences; <40%)!" << std::endl;
       return {false, "?", true};
     }
 
     if (decoy_stats.all_prefix_occur == decoy_stats.all_suffix_occur)
     {
-      OPENMS_LOG_ERROR << "Unable to determine decoy string (prefix and suffix occur equally often)!" << std::endl;
+      if (!quiet) OPENMS_LOG_ERROR << "Unable to determine decoy string (prefix and suffix occur equally often)!" << std::endl;
       return {false, "?", true};
     }
 
@@ -401,7 +407,7 @@ public:
 
       if (freq_prefix >= 0.8 && freq_prefix_in_proteins >= 0.4)
       {
-        if (prefix_suffix_counts.first != decoy_stats.all_prefix_occur)
+        if (!quiet && prefix_suffix_counts.first != decoy_stats.all_prefix_occur)
         {
           OPENMS_LOG_WARN << "More than one decoy prefix observed!" << std::endl;
           OPENMS_LOG_WARN << "Using most frequent decoy prefix (" << (int)(freq_prefix * 100) << "%)" << std::endl;
@@ -421,7 +427,7 @@ public:
 
       if (freq_suffix >= 0.8 && freq_suffix_in_proteins >= 0.4)
       {
-        if (prefix_suffix_counts.second != decoy_stats.all_suffix_occur)
+        if (!quiet && prefix_suffix_counts.second != decoy_stats.all_suffix_occur)
         {
           OPENMS_LOG_WARN << "More than one decoy suffix observed!" << std::endl;
           OPENMS_LOG_WARN << "Using most frequent decoy suffix (" << (int)(freq_suffix * 100) << "%)" << std::endl;
@@ -431,7 +437,7 @@ public:
       }
     }
 
-    OPENMS_LOG_ERROR << "Unable to determine decoy string and its position. Please provide a decoy string and its position as parameters." << std::endl;
+    if (!quiet) OPENMS_LOG_ERROR << "Unable to determine decoy string and its position. Please provide a decoy string and its position as parameters." << std::endl;
     return {false, "?", true};
   }
 

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -25,6 +25,7 @@
 #include <OpenMS/IONMOBILITY/IMTypes.h>
 #include <OpenMS/CONCEPT/VersionInfo.h>
 #include <OpenMS/DATASTRUCTURES/Param.h>
+#include <OpenMS/DATASTRUCTURES/FASTAContainer.h>
 #include <OpenMS/FORMAT/FASTAFile.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/CONCEPT/LogStream.h>
@@ -121,10 +122,16 @@ namespace OpenMS
     defaults_.setValue("enzyme", "Trypsin", "The enzyme used for peptide digestion.");
     defaults_.setValidStrings("enzyme", ListUtils::create<std::string>(all_enzymes));
 
-    defaults_.setValue("decoys", "false", "Should decoys be generated?");
-    defaults_.setValidStrings("decoys", {"true","false"} );
+    defaults_.setValue("decoys", "auto",
+      "Decoy handling for target-decoy FDR. "
+      "'auto': ensure decoys are available — reuse decoys already present in the database "
+      "(marker auto-detected, prefix or suffix) or generate them if none are found. "
+      "'generate': always (re)generate decoys from the target proteins (any pre-existing "
+      "decoys are removed first to avoid decoy-of-decoy entries). "
+      "'ignore': search the target proteins only — any decoys present in the database are removed.");
+    defaults_.setValidStrings("decoys", {"auto","generate","ignore"} );
 
-    defaults_.setValue("decoy_prefix", "DECOY_", "Accession marker used for decoy proteins. When decoy generation is enabled (-decoys), this string is prepended to generated decoy accessions. When decoy generation is disabled, the FASTA database may already contain decoy proteins tagged with this string and FDR can still be applied; existing decoys are recognised whether the marker is a prefix or a suffix of the accession (e.g. 'DECOY_PROT' or 'PROT_DECOY').", {"advanced"});
+    defaults_.setValue("decoy_prefix", "DECOY_", "Accession prefix prepended to decoy proteins when ProSE generates them (modes 'auto' without existing decoys, and 'generate'). Pre-existing decoys in the database are detected automatically (any common marker, used as prefix or suffix) and do not require this setting.", {"advanced"});
 
     defaults_.setValue("annotate:PSM",  std::vector<std::string>{"ALL"}, "Annotations added to each PSM.");
     defaults_.setValidStrings("annotate:PSM",
@@ -316,7 +323,10 @@ namespace OpenMS
 
     report_top_hits_ = param_.getValue("report:top_hits");
 
-    decoys_ = param_.getValue("decoys") == "true";
+    const std::string decoy_mode_str = param_.getValue("decoys").toString();
+    if (decoy_mode_str == "generate")   { decoy_mode_ = DecoyMode_::GENERATE; }
+    else if (decoy_mode_str == "ignore") { decoy_mode_ = DecoyMode_::IGNORE; }
+    else                                 { decoy_mode_ = DecoyMode_::AUTO; }
     decoy_prefix_ = param_.getValue("decoy_prefix").toString();
     annotate_psm_ = ListUtils::toStringList<std::string>(param_.getValue("annotate:PSM"));
     fdr_psm_ = param_.getValue("FDR:PSM");
@@ -793,14 +803,112 @@ namespace OpenMS
   // Hoisted out of the in-memory search() body so callers can build the
   // index once and reuse it across many spectrum files.
   // =====================================================================
-  // Build a decoy-augmented copy of a FASTA database without building a
-  // FragmentIndex. Used by prepareContext() and the chunked search path.
+  Param ProSEAlgorithm::fragmentIndexParameters_() const
+  {
+    Param p = getParameters();
+    // FragmentIndex has its own boolean 'decoys' flag {true,false}; ProSE's enum
+    // value (auto/generate/ignore) would fail its validation. ProSE builds the
+    // decoy-augmented database itself, so the FragmentIndex must never generate.
+    p.remove("decoys");
+    p.setValue("decoys", "false");
+    return p;
+  }
+
+  ProSEAlgorithm::DecoyStrategy_
+  ProSEAlgorithm::resolveDecoyStrategy_(const std::vector<FASTAFile::FASTAEntry>& db) const
+  {
+    // Detect pre-existing decoys. First the common-marker heuristic
+    // (DecoyHelper: "decoy", "rev", "xxx", ... as prefix or suffix), then a
+    // literal fall-back to the configured decoy_prefix so custom markers
+    // outside the vocabulary are still recognised.
+    FASTAContainer<TFI_Vector> container(db);
+    const DecoyHelper::Result det = DecoyHelper::findDecoyString(container);
+
+    bool existing = det.success;
+    std::string ext_string = det.success ? det.name : decoy_prefix_;
+    bool ext_is_prefix = det.success ? det.is_prefix : true;
+
+    if (!existing && !decoy_prefix_.empty())
+    {
+      bool any_prefix = false, any_suffix = false;
+      for (const FASTAFile::FASTAEntry& e : db)
+      {
+        if (StringUtils::hasPrefix(e.identifier, decoy_prefix_)) { any_prefix = true; break; }
+        if (StringUtils::hasSuffix(e.identifier, decoy_prefix_)) { any_suffix = true; }
+      }
+      if (any_prefix || any_suffix)
+      {
+        existing = true;
+        ext_string = decoy_prefix_;
+        ext_is_prefix = any_prefix; // prefer prefix when both orientations occur
+      }
+    }
+
+    DecoyStrategy_ s;
+    switch (decoy_mode_)
+    {
+      case DecoyMode_::AUTO:
+        if (existing)
+        {
+          // Reuse the decoys already in the database; never double-generate.
+          s.generate = false; s.strip_existing = false; s.have_decoys = true;
+          s.decoy_string = ext_string; s.is_prefix = ext_is_prefix;
+        }
+        else
+        {
+          // No decoys present: synthesise them so target-decoy FDR is possible.
+          s.generate = true; s.strip_existing = false; s.have_decoys = true;
+          s.decoy_string = decoy_prefix_; s.is_prefix = true;
+        }
+        break;
+
+      case DecoyMode_::GENERATE:
+        if (existing)
+        {
+          OPENMS_LOG_WARN << "[ProSE] decoys=generate: removing pre-existing decoys (marker '"
+                          << ext_string << "') and regenerating from the target proteins.\n";
+        }
+        s.generate = true; s.strip_existing = existing; s.have_decoys = true;
+        s.decoy_string = decoy_prefix_; s.is_prefix = true;
+        s.strip_string = ext_string; s.strip_is_prefix = ext_is_prefix;
+        break;
+
+      case DecoyMode_::IGNORE:
+        if (existing)
+        {
+          OPENMS_LOG_WARN << "[ProSE] decoys=ignore: removing pre-existing decoys (marker '"
+                          << ext_string << "'); searching the target proteins only.\n";
+        }
+        s.generate = false; s.strip_existing = existing; s.have_decoys = false;
+        s.decoy_string.clear(); s.is_prefix = true;
+        s.strip_string = ext_string; s.strip_is_prefix = ext_is_prefix;
+        break;
+    }
+    return s;
+  }
+
+  // Build the searched database according to @p strategy: optionally strip
+  // pre-existing decoys, optionally generate fresh decoys from the targets.
+  // Produces FASTA entries only — does not build a FragmentIndex.
   std::vector<FASTAFile::FASTAEntry>
   ProSEAlgorithm::buildDecoyAugmentedDB_(
-      const std::vector<FASTAFile::FASTAEntry>& fasta_db) const
+      const std::vector<FASTAFile::FASTAEntry>& fasta_db,
+      const DecoyStrategy_& strategy) const
   {
-    std::vector<FASTAFile::FASTAEntry> db = fasta_db;
-    if (decoys_)
+    std::vector<FASTAFile::FASTAEntry> db;
+    db.reserve(fasta_db.size() * (strategy.generate ? 2 : 1));
+
+    // 1. Copy targets, dropping pre-existing decoys when requested.
+    for (const FASTAFile::FASTAEntry& e : fasta_db)
+    {
+      const bool is_existing_decoy = strategy.strip_existing &&
+        (strategy.strip_is_prefix ? StringUtils::hasPrefix(e.identifier, strategy.strip_string)
+                                  : StringUtils::hasSuffix(e.identifier, strategy.strip_string));
+      if (!is_existing_decoy) { db.push_back(e); }
+    }
+
+    // 2. Generate decoys by reversing the (remaining) target proteins.
+    if (strategy.generate)
     {
       DecoyGenerator decoy_generator;
       const size_t old_size = db.size();
@@ -812,34 +920,13 @@ namespace OpenMS
           e.sequence = decoy_generator.reverseProtein(AASequence::fromString(e.sequence)).toString();
         else
           e.sequence = decoy_generator.reversePeptides(AASequence::fromString(e.sequence), enzyme_).toString();
-        e.identifier = decoy_prefix_ + e.identifier;
+        e.identifier = strategy.decoy_string + e.identifier;  // decoy_string is the prefix to add
         db.push_back(std::move(e));
       }
       Math::RandomShuffler shuffler(42);  // fixed seed for reproducible decoy ordering across runs/files
       shuffler.portable_random_shuffle(db.begin(), db.end());
     }
     return db;
-  }
-
-  bool ProSEAlgorithm::isDecoyAccession_(const std::string& accession) const
-  {
-    return StringUtils::hasPrefix(accession, decoy_prefix_) ||
-           StringUtils::hasSuffix(accession, decoy_prefix_);
-  }
-
-  std::string ProSEAlgorithm::detectDecoyStringPosition_(
-      const std::vector<FASTAFile::FASTAEntry>& db) const
-  {
-    bool any_prefix = false;
-    bool any_suffix = false;
-    for (const FASTAFile::FASTAEntry& e : db)
-    {
-      if (StringUtils::hasPrefix(e.identifier, decoy_prefix_)) any_prefix = true;
-      else if (StringUtils::hasSuffix(e.identifier, decoy_prefix_)) any_suffix = true;
-      if (any_prefix) break; // prefix is the conventional default; stop once seen
-    }
-    // Only report "suffix" when the marker appears exclusively at the end.
-    return (any_suffix && !any_prefix) ? "suffix" : "prefix";
   }
 
   // =====================================================================
@@ -901,12 +988,16 @@ namespace OpenMS
     SearchContext ctx;
 
     startProgress(0, 1, "Generate decoys...");
-    ctx.db = buildDecoyAugmentedDB_(fasta_db);
+    const DecoyStrategy_ strategy = resolveDecoyStrategy_(fasta_db);
+    ctx.db = buildDecoyAugmentedDB_(fasta_db, strategy);
+    ctx.decoy_string = strategy.decoy_string;
+    ctx.decoy_is_prefix = strategy.is_prefix;
+    ctx.have_decoys = strategy.have_decoys;
     endProgress();
 
     // build fragment index
     startProgress(0, 1, "Building fragment index...");
-    auto this_params = getParameters();
+    Param this_params = fragmentIndexParameters_();
     ctx.fragment_index.setParameters(this_params);
     ctx.fragment_index.build(ctx.db);
     endProgress();
@@ -1088,21 +1179,25 @@ namespace OpenMS
     // and chunk_size is 5000 with decoys enabled, the augmented DB (6000)
     // still exceeds chunk_size — decide-before-augment would have skipped
     // chunking and built a full FI 2× the user's declared memory budget.
-    auto full_db = buildDecoyAugmentedDB_(fasta_db);
+    const DecoyStrategy_ strategy = resolveDecoyStrategy_(fasta_db);
+    auto full_db = buildDecoyAugmentedDB_(fasta_db, strategy);
     if (full_db.size() <= database_chunk_size_)
     {
       // Augmented DB fits in one chunk — use the single-context path but skip
       // prepareContext's internal decoy re-generation by building ctx inline.
       SearchContext ctx;
       ctx.db = std::move(full_db);
+      ctx.decoy_string = strategy.decoy_string;
+      ctx.decoy_is_prefix = strategy.is_prefix;
+      ctx.have_decoys = strategy.have_decoys;
       ctx.release_fragment_index_after_scoring = true; // single-use ctx (M1)
       startProgress(0, 1, "Building fragment index...");
-      ctx.fragment_index.setParameters(getParameters());
+      ctx.fragment_index.setParameters(fragmentIndexParameters_());
       ctx.fragment_index.build(ctx.db);
       endProgress();
       return search(spectra, ctx, protein_ids, peptide_ids);
     }
-    return searchChunked_(spectra, full_db, protein_ids, peptide_ids);
+    return searchChunked_(spectra, full_db, strategy, protein_ids, peptide_ids);
   }
 
   // =====================================================================
@@ -1113,6 +1208,7 @@ namespace OpenMS
   ProSEAlgorithm::ExitCodes ProSEAlgorithm::searchChunked_(
       PeakMap& spectra,
       std::vector<FASTAFile::FASTAEntry>& full_db,
+      const DecoyStrategy_& strategy,
       vector<ProteinIdentification>& protein_ids,
       PeptideIdentificationList& peptide_ids) const
   {
@@ -1146,7 +1242,7 @@ namespace OpenMS
     {
       std::vector<FASTAFile::FASTAEntry> cal_db = buildCalibrationSample_(full_db);
       FragmentIndex cal_fi;
-      cal_fi.setParameters(getParameters());
+      cal_fi.setParameters(fragmentIndexParameters_());
       cal_fi.build(cal_db);
 
       CalibrationResult_ cal = runCalibrationPass_(spectra, cal_fi, cal_db);
@@ -1207,7 +1303,7 @@ namespace OpenMS
       std::vector<FASTAFile::FASTAEntry> chunk_db(full_db.begin() + start, full_db.begin() + end);
       FragmentIndex chunk_fi;
       {
-        Param fi_params = getParameters();
+        Param fi_params = fragmentIndexParameters_();
         // Apply calibrated tolerances (if calibration succeeded above). Asymmetric
         // lower/upper preserved — collapsing to max() would re-open the tight side
         // of the calibrated window and admit spurious decoy candidates.
@@ -1273,8 +1369,11 @@ namespace OpenMS
     // 7. PeptideIndexing against the FULL database (not per-chunk).
     PeptideIndexing indexer;
     Param param_pi = indexer.getParameters();
-    param_pi.setValue("decoy_string", decoy_prefix_);
-    param_pi.setValue("decoy_string_position", detectDecoyStringPosition_(full_db));
+    // Use the effective decoy marker/position that was actually searched. A
+    // non-empty string (decoy_prefix_ when target-only) avoids PeptideIndexing's
+    // own auto-detection; missing_decoy_action=silent keeps it quiet when none match.
+    param_pi.setValue("decoy_string", strategy.decoy_string.empty() ? decoy_prefix_ : strategy.decoy_string);
+    param_pi.setValue("decoy_string_position", strategy.is_prefix ? "prefix" : "suffix");
     param_pi.setValue("enzyme:name", enzyme_);
     param_pi.setValue("enzyme:specificity",
                       EnzymaticDigestion::NamesOfSpecificity[peptide_enzyme_specificity_]);
@@ -1311,8 +1410,7 @@ namespace OpenMS
     //    (matching the non-chunked search(spectra, ctx, ...) semantics — that
     //    method also does PSM FDR only; the multi-file wrapper and file-based
     //    searchWithModificationAnalysis apply protein FDR post-call).
-    bool has_decoys = std::any_of(full_db.begin(), full_db.end(),
-        [this](const FASTAFile::FASTAEntry& e) { return isDecoyAccession_(e.identifier); });
+    const bool has_decoys = strategy.have_decoys;
 
     if (fdr_psm_ > 0.0 && has_decoys)
     {
@@ -1330,8 +1428,8 @@ namespace OpenMS
     }
     else if (fdr_psm_ > 0.0 && !has_decoys)
     {
-      OPENMS_LOG_WARN << "FDR:PSM is set but no decoys found (decoy_prefix='" << decoy_prefix_
-                      << "'). Provide a FASTA with decoy proteins or enable '-decoys'. Skipping FDR filtering." << std::endl;
+      OPENMS_LOG_WARN << "FDR:PSM is set but the search has no decoys (decoys=ignore). "
+                         "Use decoys=auto to search/generate decoys and enable FDR. Skipping FDR filtering." << std::endl;
     }
 
     restore_tolerances();
@@ -1540,8 +1638,10 @@ namespace OpenMS
     // semi-specific / non-specific PSMs would be silently filtered out here.
     PeptideIndexing indexer;
     Param param_pi = indexer.getParameters();
-    param_pi.setValue("decoy_string", decoy_prefix_);
-    param_pi.setValue("decoy_string_position", detectDecoyStringPosition_(db));
+    // Use the effective decoy marker/position recorded in the context (the same
+    // decoys that were searched), avoiding PeptideIndexing's own auto-detection.
+    param_pi.setValue("decoy_string", ctx.decoy_string.empty() ? decoy_prefix_ : ctx.decoy_string);
+    param_pi.setValue("decoy_string_position", ctx.decoy_is_prefix ? "prefix" : "suffix");
     param_pi.setValue("enzyme:name", enzyme_);
     param_pi.setValue("enzyme:specificity",
                       EnzymaticDigestion::NamesOfSpecificity[peptide_enzyme_specificity_]);
@@ -1582,11 +1682,9 @@ namespace OpenMS
       }
     }
 
-    // PSM-level FDR filtering.
-    // Decoys may be generated internally (decoys_=true) or present in the
-    // input FASTA (external, identified by decoy_prefix_).
-    bool has_decoys = std::any_of(db.begin(), db.end(),
-        [this](const FASTAFile::FASTAEntry& e) { return isDecoyAccession_(e.identifier); });
+    // PSM-level FDR filtering. The context records whether decoys are present
+    // (generated internally, or external decoys reused from the input FASTA).
+    const bool has_decoys = ctx.have_decoys;
 
     if (fdr_psm_ > 0.0 && has_decoys)
     {
@@ -1604,8 +1702,8 @@ namespace OpenMS
     }
     else if (fdr_psm_ > 0.0 && !has_decoys)
     {
-      OPENMS_LOG_WARN << "FDR:PSM is set but no decoys found (decoy_prefix='" << decoy_prefix_
-                      << "'). Provide a FASTA with decoy proteins or enable '-decoys'. Skipping FDR filtering." << endl;
+      OPENMS_LOG_WARN << "FDR:PSM is set but the search has no decoys (decoys=ignore). "
+                         "Use decoys=auto to search/generate decoys and enable FDR. Skipping FDR filtering." << endl;
     }
 
     restore_fi_params();
@@ -1647,16 +1745,16 @@ namespace OpenMS
 
     // Protein inference + picked-protein FDR for single-file search.
     // Must run before decoy removal so both target and decoy proteins
-    // receive aggregated scores from BPIA.
-    bool has_decoys_single = std::any_of(fasta_db.begin(), fasta_db.end(),
-        [this](const FASTAFile::FASTAEntry& e) { return isDecoyAccession_(e.identifier); });
-    if (fdr_protein_ > 0.0 && (decoys_ || has_decoys_single))
+    // receive aggregated scores from BPIA. Resolve the decoy strategy from the
+    // same input FASTA the search used so the marker/position match.
+    const DecoyStrategy_ strategy = resolveDecoyStrategy_(fasta_db);
+    if (fdr_protein_ > 0.0 && strategy.have_decoys)
     {
       BasicProteinInferenceAlgorithm bpia;
       bpia.run(peptide_ids, protein_ids);
 
       FalseDiscoveryRate fdr;
-      fdr.applyPickedProteinFDR(protein_ids[0], decoy_prefix_, true);
+      fdr.applyPickedProteinFDR(protein_ids[0], strategy.decoy_string, strategy.is_prefix);
       IDFilter::filterHitsByScore(protein_ids, fdr_protein_);
 
       // Now safe to remove decoys (deferred from search() above)
@@ -1757,15 +1855,24 @@ namespace OpenMS
       return mfres;
     }
 
-    // Decide chunking on the decoy-augmented DB size (#9180): if decoys_ doubles
-    // the target DB, a 3000-protein target against chunk_size=5000 should still
-    // chunk because the augmented DB is 6000 — otherwise the resulting FI would
-    // exceed the user's memory budget by 2×.
+    // Resolve decoy handling once from the shared input FASTA; reused for the
+    // chunk-major path, the single-context path, and the downstream FDR steps.
+    const DecoyStrategy_ strategy = resolveDecoyStrategy_(fasta_db);
+    // Surface the effective marker so a caller doing merged-PSM protein FDR
+    // (e.g. ProSE -out_merged) recognises the same decoys that were searched.
+    mfres.decoy_string = strategy.decoy_string;
+    mfres.decoy_is_prefix = strategy.is_prefix;
+    mfres.have_decoys = strategy.have_decoys;
+
+    // Decide chunking on the decoy-augmented DB size (#9180): if decoy generation
+    // doubles the target DB, a 3000-protein target against chunk_size=5000 should
+    // still chunk because the augmented DB is 6000 — otherwise the resulting FI
+    // would exceed the user's memory budget by 2×.
     std::vector<FASTAFile::FASTAEntry> full_db;
     bool use_chunked = false;
     if (database_chunk_size_ > 0)
     {
-      full_db = buildDecoyAugmentedDB_(fasta_db);
+      full_db = buildDecoyAugmentedDB_(fasta_db, strategy);
       use_chunked = (full_db.size() > database_chunk_size_);
     }
 
@@ -1828,7 +1935,7 @@ namespace OpenMS
         // Build a strided-sample calibration FI once, reused across files.
         std::vector<FASTAFile::FASTAEntry> cal_db = buildCalibrationSample_(full_db);
         FragmentIndex cal_fi;
-        cal_fi.setParameters(getParameters());
+        cal_fi.setParameters(fragmentIndexParameters_());
         cal_fi.build(cal_db);
 
         for (Size i = 0; i < in_spectra_files.size(); ++i)
@@ -1915,7 +2022,7 @@ namespace OpenMS
 
         std::vector<FASTAFile::FASTAEntry> chunk_db(full_db.begin() + start, full_db.begin() + end);
         FragmentIndex chunk_fi;
-        chunk_fi.setParameters(getParameters());
+        chunk_fi.setParameters(fragmentIndexParameters_());
         chunk_fi.build(chunk_db);
 
         // Score ALL files against this chunk's index.
@@ -1989,8 +2096,8 @@ namespace OpenMS
 
         PeptideIndexing indexer;
         Param param_pi = indexer.getParameters();
-        param_pi.setValue("decoy_string", decoy_prefix_);
-        param_pi.setValue("decoy_string_position", detectDecoyStringPosition_(full_db));
+        param_pi.setValue("decoy_string", strategy.decoy_string.empty() ? decoy_prefix_ : strategy.decoy_string);
+        param_pi.setValue("decoy_string_position", strategy.is_prefix ? "prefix" : "suffix");
         param_pi.setValue("enzyme:name", enzyme_);
         param_pi.setValue("enzyme:specificity",
                           EnzymaticDigestion::NamesOfSpecificity[peptide_enzyme_specificity_]);
@@ -2015,8 +2122,7 @@ namespace OpenMS
         }
 
         // PSM-level FDR only (matching non-chunked search semantics).
-        bool has_decoys = std::any_of(full_db.begin(), full_db.end(),
-            [this](const FASTAFile::FASTAEntry& e) { return isDecoyAccession_(e.identifier); });
+        const bool has_decoys = strategy.have_decoys;
         if (fdr_psm_ > 0.0 && has_decoys)
         {
           FalseDiscoveryRate fdr;
@@ -2063,8 +2169,11 @@ namespace OpenMS
         // already-built decoy-augmented DB instead of re-augmenting inside
         // prepareContext.
         ctx.db = std::move(full_db);
+        ctx.decoy_string = strategy.decoy_string;
+        ctx.decoy_is_prefix = strategy.is_prefix;
+        ctx.have_decoys = strategy.have_decoys;
         startProgress(0, 1, "Building fragment index...");
-        ctx.fragment_index.setParameters(getParameters());
+        ctx.fragment_index.setParameters(fragmentIndexParameters_());
         ctx.fragment_index.build(ctx.db);
         endProgress();
       }

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -822,7 +822,10 @@ namespace OpenMS
     // literal fall-back to the configured decoy_prefix so custom markers
     // outside the vocabulary are still recognised.
     FASTAContainer<TFI_Vector> container(db);
-    const DecoyHelper::Result det = DecoyHelper::findDecoyString(container);
+    // quiet=true: a target-only database is a normal case here (auto/generate
+    // then synthesise decoys), so suppress DecoyHelper's "unable to determine
+    // decoy string" ERROR/WARN noise — we handle the negative result ourselves.
+    const DecoyHelper::Result det = DecoyHelper::findDecoyString(container, /*quiet=*/true);
 
     bool existing = det.success;
     std::string ext_string = det.success ? det.name : decoy_prefix_;

--- a/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
@@ -53,8 +53,9 @@ public:
   using ProSEAlgorithm::last_mod_match_tolerance_used_;
   using ProSEAlgorithm::CalibrationResult_;
   using ProSEAlgorithm::preprocessSpectra_;
-  using ProSEAlgorithm::isDecoyAccession_;
-  using ProSEAlgorithm::detectDecoyStringPosition_;
+  using ProSEAlgorithm::resolveDecoyStrategy_;
+  using ProSEAlgorithm::DecoyStrategy_;
+  using ProSEAlgorithm::buildDecoyAugmentedDB_;
 };
 
 // --- Shared calibration fixture -------------------------------------------------
@@ -167,7 +168,7 @@ static void configure_calibration_params_(ProSEAlgorithm& algo,
   // crop at ProSEAlgorithm.cpp:1571 is skipped and every collected error reaches the
   // estimator. For our small fixture that's what we want.
   p.setValue("calibration:min_psms", static_cast<Int>(min_psms));
-  p.setValue("decoys", "false");
+  p.setValue("decoys", "ignore");
   p.setValue("peptide:min_size", 7);
   p.setValue("peptide:max_size", 40);
   p.setValue("peptide:missed_cleavages", 1);
@@ -207,33 +208,106 @@ START_SECTION(([EXTRA] default mass tolerances))
 }
 END_SECTION
 
-START_SECTION(([EXTRA] decoy detection: prefix and suffix))
+START_SECTION(([EXTRA] resolveDecoyStrategy_ / buildDecoyAugmentedDB_: auto/generate/ignore))
 {
-  ProSEAlgorithm_test algo;
-  Param p = algo.getParameters();
-  p.setValue("decoy_prefix", "DECOY_");
-  algo.setParameters(p);
+  // Target+decoy database (50% decoys, conventional DECOY_ prefix).
+  const std::vector<FASTAFile::FASTAEntry> td_db = {
+    FASTAFile::FASTAEntry("sp|P1|A", "", "PEPTIDEKAAR"),
+    FASTAFile::FASTAEntry("sp|P2|B", "", "SAMPLERPEPTIDEK"),
+    FASTAFile::FASTAEntry("DECOY_sp|P1|A", "", "RAAKEDITPEP"),
+    FASTAFile::FASTAEntry("DECOY_sp|P2|B", "", "KEDITPEPRELPMAS") };
+  // Target-only database.
+  const std::vector<FASTAFile::FASTAEntry> t_db = {
+    FASTAFile::FASTAEntry("sp|P1|A", "", "PEPTIDEKAAR"),
+    FASTAFile::FASTAEntry("sp|P2|B", "", "SAMPLERPEPTIDEK") };
 
-  // Both orientations of the marker count as decoy; no extra parameter needed.
-  TEST_EQUAL(algo.isDecoyAccession_("DECOY_sp|P12345|PROT"), true)   // prefix
-  TEST_EQUAL(algo.isDecoyAccession_("sp|P12345|PROT_DECOY_"), true)  // suffix
-  TEST_EQUAL(algo.isDecoyAccession_("sp|P12345|PROT"), false)        // target
+  auto count_prefix = [](const std::vector<FASTAFile::FASTAEntry>& db, const std::string& pre)
+  {
+    Size n = 0;
+    for (const auto& e : db) if (e.identifier.rfind(pre, 0) == 0) ++n;
+    return n;
+  };
 
-  // Position auto-detected from the database for PeptideIndexing.
-  std::vector<FASTAFile::FASTAEntry> db_prefix = {
-    FASTAFile::FASTAEntry("sp|P1|A", "", "PEPTIDEK"),
-    FASTAFile::FASTAEntry("DECOY_sp|P1|A", "", "KEDITPEP") };
-  TEST_STRING_EQUAL(algo.detectDecoyStringPosition_(db_prefix), "prefix")
+  // --- auto: reuse existing decoys (detected), do not generate -------------
+  {
+    ProSEAlgorithm_test algo;
+    Param p = algo.getParameters();
+    p.setValue("decoys", "auto");
+    algo.setParameters(p);
+    ProSEAlgorithm_test::DecoyStrategy_ s = algo.resolveDecoyStrategy_(td_db);
+    TEST_EQUAL(s.generate, false)
+    TEST_EQUAL(s.strip_existing, false)
+    TEST_EQUAL(s.have_decoys, true)
+    TEST_STRING_EQUAL(s.decoy_string, "DECOY_")
+    TEST_EQUAL(s.is_prefix, true)
+    // DB is searched unchanged.
+    std::vector<FASTAFile::FASTAEntry> built = algo.buildDecoyAugmentedDB_(td_db, s);
+    TEST_EQUAL(built.size(), 4)
+    TEST_EQUAL(count_prefix(built, "DECOY_"), 2)
+  }
 
-  std::vector<FASTAFile::FASTAEntry> db_suffix = {
-    FASTAFile::FASTAEntry("sp|P1|A", "", "PEPTIDEK"),
-    FASTAFile::FASTAEntry("sp|P1|A_DECOY_", "", "KEDITPEP") };
-  TEST_STRING_EQUAL(algo.detectDecoyStringPosition_(db_suffix), "suffix")
+  // --- auto: no decoys present -> generate them ---------------------------
+  {
+    ProSEAlgorithm_test algo;
+    Param p = algo.getParameters();
+    p.setValue("decoys", "auto");
+    algo.setParameters(p);
+    ProSEAlgorithm_test::DecoyStrategy_ s = algo.resolveDecoyStrategy_(t_db);
+    TEST_EQUAL(s.generate, true)
+    TEST_EQUAL(s.strip_existing, false)
+    TEST_EQUAL(s.have_decoys, true)
+    TEST_STRING_EQUAL(s.decoy_string, "DECOY_")
+    std::vector<FASTAFile::FASTAEntry> built = algo.buildDecoyAugmentedDB_(t_db, s);
+    TEST_EQUAL(built.size(), 4)             // 2 targets + 2 generated decoys
+    TEST_EQUAL(count_prefix(built, "DECOY_"), 2)
+  }
 
-  // No decoys / only targets -> conventional "prefix" default.
-  std::vector<FASTAFile::FASTAEntry> db_targets = {
-    FASTAFile::FASTAEntry("sp|P1|A", "", "PEPTIDEK") };
-  TEST_STRING_EQUAL(algo.detectDecoyStringPosition_(db_targets), "prefix")
+  // --- ignore: strip existing decoys, search targets only -----------------
+  {
+    ProSEAlgorithm_test algo;
+    Param p = algo.getParameters();
+    p.setValue("decoys", "ignore");
+    algo.setParameters(p);
+    ProSEAlgorithm_test::DecoyStrategy_ s = algo.resolveDecoyStrategy_(td_db);
+    TEST_EQUAL(s.generate, false)
+    TEST_EQUAL(s.strip_existing, true)
+    TEST_EQUAL(s.have_decoys, false)
+    std::vector<FASTAFile::FASTAEntry> built = algo.buildDecoyAugmentedDB_(td_db, s);
+    TEST_EQUAL(built.size(), 2)             // decoys removed
+    TEST_EQUAL(count_prefix(built, "DECOY_"), 0)
+  }
+
+  // --- generate: strip pre-existing decoys, then regenerate from targets ---
+  {
+    ProSEAlgorithm_test algo;
+    Param p = algo.getParameters();
+    p.setValue("decoys", "generate");
+    algo.setParameters(p);
+    ProSEAlgorithm_test::DecoyStrategy_ s = algo.resolveDecoyStrategy_(td_db);
+    TEST_EQUAL(s.generate, true)
+    TEST_EQUAL(s.strip_existing, true)
+    TEST_EQUAL(s.have_decoys, true)
+    std::vector<FASTAFile::FASTAEntry> built = algo.buildDecoyAugmentedDB_(td_db, s);
+    TEST_EQUAL(built.size(), 4)             // 2 targets + 2 freshly generated
+    TEST_EQUAL(count_prefix(built, "DECOY_"), 2)
+  }
+
+  // --- custom marker outside the common vocabulary: literal fall-back -----
+  {
+    ProSEAlgorithm_test algo;
+    Param p = algo.getParameters();
+    p.setValue("decoys", "auto");
+    p.setValue("decoy_prefix", "BOGUS_");
+    algo.setParameters(p);
+    const std::vector<FASTAFile::FASTAEntry> custom_db = {
+      FASTAFile::FASTAEntry("sp|P1|A", "", "PEPTIDEKAAR"),
+      FASTAFile::FASTAEntry("BOGUS_sp|P1|A", "", "RAAKEDITPEP") };
+    ProSEAlgorithm_test::DecoyStrategy_ s = algo.resolveDecoyStrategy_(custom_db);
+    TEST_EQUAL(s.generate, false)           // existing decoys recognised via fall-back
+    TEST_EQUAL(s.have_decoys, true)
+    TEST_STRING_EQUAL(s.decoy_string, "BOGUS_")
+    TEST_EQUAL(s.is_prefix, true)
+  }
 }
 END_SECTION
 
@@ -431,7 +505,7 @@ START_SECTION(([EXTRA] Synthetic modification discovery - open search))
   p.setValue("fragment:mass_tolerance_unit", "ppm");
   p.setValue("modifications:fixed", vector<string>{"Carbamidomethyl (C)"});
   p.setValue("modifications:variable", vector<string>{});
-  p.setValue("decoys", "false");
+  p.setValue("decoys", "ignore");
   p.setValue("peptide:min_size", 7);
   p.setValue("peptide:max_size", 40);
   p.setValue("peptide:missed_cleavages", 1);
@@ -727,7 +801,7 @@ START_SECTION(([EXTRA] FDR-filtered modification discovery))
   p.setValue("fragment:mass_tolerance_unit", "ppm");
   p.setValue("modifications:fixed", vector<string>{"Carbamidomethyl (C)"});
   p.setValue("modifications:variable", vector<string>{});
-  p.setValue("decoys", "true");  // Enable decoys for FDR
+  p.setValue("decoys", "auto");  // Enable decoys for FDR
   p.setValue("peptide:min_size", 7);
   p.setValue("peptide:max_size", 40);
   p.setValue("peptide:missed_cleavages", 1);
@@ -867,7 +941,7 @@ START_SECTION(([EXTRA] Closed search baseline))
   p.setValue("fragment:mass_tolerance_unit", "ppm");
   p.setValue("modifications:fixed", vector<string>{"Carbamidomethyl (C)"});
   p.setValue("modifications:variable", vector<string>{"Oxidation (M)"});
-  p.setValue("decoys", "false");
+  p.setValue("decoys", "ignore");
   p.setValue("peptide:min_size", 7);
   p.setValue("peptide:max_size", 40);
   p.setValue("peptide:missed_cleavages", 1);
@@ -939,7 +1013,7 @@ START_SECTION(([EXTRA] Closed search with c/z ions toggled - ETD-style fragmenta
     p.setValue("fragment:mass_tolerance_unit", "ppm");
     p.setValue("modifications:fixed", vector<string>{});
     p.setValue("modifications:variable", vector<string>{});
-    p.setValue("decoys", "false");
+    p.setValue("decoys", "ignore");
     p.setValue("peptide:min_size", 7);
     p.setValue("peptide:max_size", 40);
     p.setValue("peptide:missed_cleavages", 1);
@@ -1028,7 +1102,7 @@ START_SECTION(([EXTRA] Ion mobility annotation))
   p.setValue("fragment:mass_tolerance_unit", "ppm");
   p.setValue("modifications:fixed", vector<string>{});
   p.setValue("modifications:variable", vector<string>{});
-  p.setValue("decoys", "false");
+  p.setValue("decoys", "ignore");
   p.setValue("peptide:min_size", 7);
   p.setValue("peptide:max_size", 40);
   p.setValue("peptide:missed_cleavages", 1);
@@ -1070,7 +1144,7 @@ START_SECTION(([EXTRA] Edge cases - empty inputs))
 
     ProSEAlgorithm algo;
     Param p = algo.getParameters();
-    p.setValue("decoys", "false");
+    p.setValue("decoys", "ignore");
     algo.setParameters(p);
 
     vector<ProteinIdentification> prot_ids;
@@ -1170,7 +1244,7 @@ START_SECTION(([EXTRA] prepareContext + context-based search produces same IDs a
   p.setValue("fragment:mass_tolerance_unit", "ppm");
   p.setValue("modifications:fixed", vector<string>{"Carbamidomethyl (C)"});
   p.setValue("modifications:variable", vector<string>{});
-  p.setValue("decoys", "false");
+  p.setValue("decoys", "ignore");
   algo.setParameters(p);
 
   // Path A: single-shot search (builds + tears down the index internally).
@@ -1221,7 +1295,7 @@ START_SECTION((MultiFileSearchResult searchWithModificationAnalysis(const std::v
   // Verify the multi-file in-memory FASTA overload validates input list lengths.
   ProSEAlgorithm algo;
   Param p = algo.getParameters();
-  p.setValue("decoys", "false");
+  p.setValue("decoys", "ignore");
   algo.setParameters(p);
 
   vector<FASTAFile::FASTAEntry> fasta_db = {{"P01", "Test", "MSDEREKVLGFHQRMPNASTICYWDLK"}};

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -3218,7 +3218,7 @@ if (WITH_OPENTIMS AND OPENTIMS_DDA_TEST_DATA)
     -Search:enzyme Trypsin/P
     -Search:peptide:missed_cleavages 2
     "-Search:modifications:variable" "Oxidation (M)" "Acetyl (Protein N-term)"
-    -Search:decoys
+    -Search:decoys auto
     -threads 4)
 
   add_test("TOPP_FalseDiscoveryRate_SimpleSearchEngineDDA" ${TOPP_BIN_PATH}/FalseDiscoveryRate -test
@@ -3251,7 +3251,7 @@ if (WITH_OPENTIMS AND OPENTIMS_DDA_TEST_DATA)
     -Search:enzyme Trypsin/P
     -Search:peptide:missed_cleavages 2
     "-Search:modifications:variable" "Oxidation (M)" "Acetyl (Protein N-term)"
-    -Search:decoys)
+    -Search:decoys auto)
 
   add_test("TOPP_FalseDiscoveryRate_ProSEDDA" ${TOPP_BIN_PATH}/FalseDiscoveryRate -test
     -in ${TESTS_TEMP_DIR}/ProSE_DDA_out.tmp.idXML
@@ -3280,7 +3280,7 @@ if (WITH_OPENTIMS AND OPENTIMS_DDA_TEST_DATA)
     -Search:enzyme Trypsin/P
     -Search:peptide:missed_cleavages 2
     "-Search:modifications:variable" "Oxidation (M)" "Acetyl (Protein N-term)"
-    -Search:decoys
+    -Search:decoys auto
     -Search:calibration:enabled)
 
   add_test("TOPP_FalseDiscoveryRate_ProSEDDA_calibrated" ${TOPP_BIN_PATH}/FalseDiscoveryRate -test
@@ -3318,7 +3318,7 @@ if (WITH_OPENTIMS AND OPENTIMS_DDA_TEST_DATA)
     -Search:enzyme Trypsin/P
     -Search:peptide:missed_cleavages 2
     "-Search:modifications:variable" "Oxidation (M)" "Acetyl (Protein N-term)"
-    -Search:decoys
+    -Search:decoys auto
     -Search:calibration:enabled
     -Search:database:chunk_size 5000)
 

--- a/src/tests/topp/ProSE_1.ini
+++ b/src/tests/topp/ProSE_1.ini
@@ -14,7 +14,7 @@
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
       <NODE name="Search" description="">
         <ITEM name="enzyme" value="Trypsin" type="string" description="The enzyme used for peptide digestion." required="false" advanced="false" />
-        <ITEM name="decoys" value="false" type="string" description="Should decoys be generated?" required="false" advanced="false" restrictions="true,false" />
+        <ITEM name="decoys" value="ignore" type="string" description="Decoy handling for target-decoy FDR (auto/generate/ignore)." required="false" advanced="false" restrictions="auto,generate,ignore" />
         <NODE name="precursor" description="Precursor (Parent Ion) Options">
           <ITEM name="mass_tolerance_lower" value="5" type="double" description="Lower-side precursor-mass tolerance (positive magnitude; effective window is [-lower, +upper])." required="false" advanced="false" />
           <ITEM name="mass_tolerance_upper" value="5" type="double" description="Upper-side precursor-mass tolerance (positive magnitude)." required="false" advanced="false" />

--- a/src/tests/topp/ProSE_2.ini
+++ b/src/tests/topp/ProSE_2.ini
@@ -15,7 +15,7 @@
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />
       <NODE name="Search" description="">
         <ITEM name="enzyme" value="Trypsin" type="string" description="The enzyme used for peptide digestion." required="false" advanced="false" />
-        <ITEM name="decoys" value="false" type="bool" description="Should decoys be generated?" required="false" advanced="false" />
+        <ITEM name="decoys" value="ignore" type="string" description="Decoy handling for target-decoy FDR (auto/generate/ignore)." required="false" advanced="false" restrictions="auto,generate,ignore" />
         <NODE name="precursor" description="Precursor (Parent Ion) Options">
           <ITEM name="mass_tolerance_lower" value="10.0" type="double" description="Lower-side precursor-mass tolerance (positive magnitude; effective window is [-lower, +upper])." required="false" advanced="false" />
           <ITEM name="mass_tolerance_upper" value="10.0" type="double" description="Upper-side precursor-mass tolerance (positive magnitude)." required="false" advanced="false" />

--- a/src/tests/topp/ProSE_4.ini
+++ b/src/tests/topp/ProSE_4.ini
@@ -14,7 +14,7 @@
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
       <NODE name="Search" description="">
         <ITEM name="enzyme" value="Trypsin" type="string" description="The enzyme used for peptide digestion." required="false" advanced="false" />
-        <ITEM name="decoys" value="false" type="string" description="Should decoys be generated?" required="false" advanced="false" restrictions="true,false" />
+        <ITEM name="decoys" value="ignore" type="string" description="Decoy handling for target-decoy FDR (auto/generate/ignore)." required="false" advanced="false" restrictions="auto,generate,ignore" />
         <NODE name="precursor" description="Precursor (Parent Ion) Options">
           <ITEM name="mass_tolerance_lower" value="15" type="double" description="Lower-side precursor-mass tolerance (positive magnitude; effective window is [-lower, +upper])." required="false" advanced="false" />
           <ITEM name="mass_tolerance_upper" value="10" type="double" description="Upper-side precursor-mass tolerance (positive magnitude)." required="false" advanced="false" />

--- a/src/topp/ProSE.cpp
+++ b/src/topp/ProSE.cpp
@@ -62,7 +62,7 @@ It lacks behind in speed and/or quality of results when compared to state-of-the
 
 @note Currently mzIdentML (mzid) is not directly supported as an input/output format of this tool. Convert mzid files to/from idXML using @ref TOPP_IDFileConverter if necessary.
 @note Open-search mode is automatically determined by the precursor mass tolerance: enabled when tolerance exceeds 1 Da or 1000 ppm. No explicit open-search parameter is needed. This is logged at runtime and recorded in the output search parameters as UserParam 'open_search'.
-@note Decoy handling: either enable '-Search:decoys' to generate decoys internally, or provide a FASTA database that already contains decoy proteins (e.g., from DecoyDatabase). In both cases, the decoy accession prefix must match '-Search:decoy_prefix' (default: "DECOY_").
+@note Decoy handling is controlled by '-Search:decoys'. The default 'auto' ensures decoys are available for target-decoy FDR: it reuses decoys already present in the FASTA (the marker is auto-detected, prefix or suffix, e.g. from DecoyDatabase) or generates them internally (prefixing accessions with '-Search:decoy_prefix', default "DECOY_") if none are found. Use 'generate' to always (re)build decoys from the targets, or 'ignore' to search the targets only.
 
 <B>The command line parameters of this tool are:</B>
 @verbinclude TOPP_ProSE.cli
@@ -660,7 +660,11 @@ class ProSE :
       {
         try
         {
-          const std::string decoy_prefix = search_params.getValue("decoy_prefix").toString();
+          // Use the effective decoy marker/position the search resolved (which
+          // may be an auto-detected external marker, prefix or suffix), not the
+          // raw decoy_prefix parameter.
+          const std::string decoy_string = mfres.decoy_string;
+          const bool decoy_is_prefix = mfres.decoy_is_prefix;
 
           // Merge per-file results via IDMergerAlgorithm (accession dedup + identifier remap)
           IDMergerAlgorithm merger;
@@ -681,10 +685,10 @@ class ProSE :
           bpia.run(merged_peptides, merged_protein_ids);
 
           // Optional picked-protein FDR
-          if (user_protein_fdr > 0.0)
+          if (user_protein_fdr > 0.0 && mfres.have_decoys)
           {
             FalseDiscoveryRate fdr;
-            fdr.applyPickedProteinFDR(merged_protein_ids[0], decoy_prefix, true);
+            fdr.applyPickedProteinFDR(merged_protein_ids[0], decoy_string, decoy_is_prefix);
             IDFilter::filterHitsByScore(merged_protein_ids, user_protein_fdr);
 
             OPENMS_LOG_INFO << "[ProSE] Merged protein inference + FDR: "


### PR DESCRIPTION
## Summary

Makes ProSE's decoy handling **decide-less**: replaces the boolean `Search:decoys` (true/false) with a three-way mode.

| mode | target+decoy DB | target-only DB |
|------|-----------------|----------------|
| **`auto`** (default) | reuse existing decoys (marker auto-detected) | generate decoys |
| **`generate`** | strip existing, regenerate from targets | generate decoys |
| **`ignore`** | strip decoys → target-only | target-only |

`auto` **always ensures decoys are present** for target-decoy FDR — the user typically just sets an FDR threshold and nothing else. `ignore` is the explicit opt-out for a pure target-only search.

## How it works

A single `resolveDecoyStrategy_(db)` resolves decoy handling **once per input database** into a `DecoyStrategy_` (generate / strip-existing / effective marker+position / have_decoys). Existing decoys are detected with the codebase's `DecoyHelper::findDecoyString` (common-marker vocabulary, **prefix or suffix**), falling back to a literal `decoy_prefix` scan for custom markers.

The strategy is threaded through **every** search path (in-memory, chunked, single-context, file-based, multi-file) via `SearchContext` and a new `searchChunked_` parameter, so `PeptideIndexing` and picked-protein FDR use **the same decoys that were searched**. This fixes prior latent bugs where the decoy marker/position was hardcoded (`decoy_prefix` + `prefix`) for the protein-FDR and PeptideIndexing steps — wrong for external suffix/non-`DECOY_` decoys.

The effective marker is also surfaced on `MultiFileSearchResult` so the ProSE tool's `-out_merged` cross-file protein-FDR recognises the right decoys.

### FragmentIndex param collision
`FragmentIndex` declares its own (unused) boolean `decoys` flag `{true,false}`. ProSE forwards `getParameters()` to it, so the new enum value would trip FI's validation. ProSE now hands FI sanitised params via `fragmentIndexParameters_()` (overrides `decoys` to `false`; ProSE manages decoys at the DB level).

## Relationship to #9632
Stacked on `feat/prose-default-tolerances-suffix-decoys` (#9632). This **supersedes** that PR's `isDecoyAccession_`/`detectDecoyStringPosition_` helpers with the more capable `DecoyHelper`-based detection. Base retargets to `develop` once #9632 merges.

## Behavior change
- Default flips from `false` (no decoys, FDR silently skipped on target-only DBs) to `auto` (decoys ensured). Strict improvement; concatenated target+decoy DBs are unchanged (existing decoys reused, never double-generated).
- `decoys` valid-strings change bool→enum (no bool compat) — the three TOPP reference inis and the DDA test commands (old valueless `-Search:decoys` flag) are updated.

## Tests
- `ProSEAlgorithm_test`: new section covering auto-reuse / auto-generate / ignore-strip / generate-strip-regenerate / custom-marker fallback.
- All 19 `TOPP_ProSE*` tests pass, including the DDA FDR PSM-count floors (≥4350 / 4650 / 4400) on real Bruker data — confirming auto-mode generates decoys with equivalent FDR yields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
