### PR TITLE
[FIX] FIAMSScheduler_test: fix OMP race by using distinct time windows per CSV row

### DIFF
--- a/src/tests/class_tests/openms/data/FIAMS_input/params_test.csv
+++ b/src/tests/class_tests/openms/data/FIAMS_input/params_test.csv
@@ -1,3 +1,2 @@
 filename,dir_input,dir_output,resolution,charge,time,db_mapping,db_struct,positive_adducts,negative_adducts,store_progress
 SerumTest,FIAMS_input,FIAMS_output,120000,negative,10,reducedHMDBMapping.tsv,reducedHMDB2StructMapping.tsv,FIAMS_positive_adducts.tsv,FIAMS_negative_adducts.tsv,True
-SerumTest,FIAMS_input,FIAMS_output,120000,negative,10,reducedHMDBMapping.tsv,reducedHMDB2StructMapping.tsv,FIAMS_positive_adducts.tsv,FIAMS_negative_adducts.tsv,True

--- a/src/tests/class_tests/openms/data/FIAMS_input/params_test.csv
+++ b/src/tests/class_tests/openms/data/FIAMS_input/params_test.csv
@@ -1,2 +1,3 @@
 filename,dir_input,dir_output,resolution,charge,time,db_mapping,db_struct,positive_adducts,negative_adducts,store_progress
 SerumTest,FIAMS_input,FIAMS_output,120000,negative,10,reducedHMDBMapping.tsv,reducedHMDB2StructMapping.tsv,FIAMS_positive_adducts.tsv,FIAMS_negative_adducts.tsv,True
+SerumTest,FIAMS_input,FIAMS_output,120000,negative,20,reducedHMDBMapping.tsv,reducedHMDB2StructMapping.tsv,FIAMS_positive_adducts.tsv,FIAMS_negative_adducts.tsv,True

--- a/src/tests/class_tests/openms/source/FIAMSScheduler_test.cpp
+++ b/src/tests/class_tests/openms/source/FIAMSScheduler_test.cpp
@@ -53,11 +53,15 @@ START_SECTION(FIAMSScheduler)
       tmp_dir
   );
   const vector<map<std::string, std::string>> samples = fia_scheduler.getSamples();
+  TEST_EQUAL(samples.size(), 2);
   TEST_EQUAL(samples[0].at("time"), "10");
+  TEST_EQUAL(samples[1].at("time"), "20");
   fia_scheduler.run();
   std::string outfile =StringUtils::toStr(OPENMS_GET_TEST_DATA_PATH("FIAMS_output/SerumTest_10.mzTab"));
   std::string outfile2 = tmp_dir + "FIAMS_output/SerumTest_10.mzTab";
   TEST_FILE_EQUAL(outfile2.c_str(), outfile.c_str());
+  // verify the second OMP-parallel row also produced output
+  TEST_EQUAL(File::exists(tmp_dir + "FIAMS_output/SerumTest_20.mzTab"), true);
 }
 END_SECTION
 


### PR DESCRIPTION
## Summary

The nightly CI failed on macOS ARM64 (macos-15, xcode 16.4) with `FIAMSScheduler_test (Subprocess aborted)`.

**Root cause (confirmed via git history):** The `#pragma omp parallel for` and the two duplicate CSV rows were added in the same commit (Feb 2020, sgalkina). The intent was to test OMP-parallel processing of multiple samples — but both rows had the same `filename` **and** the same `time=10`, so they wrote to identical output paths concurrently.

Race sequence:
```
Thread A (row 0, load_cached_=true): File::exists(SerumTest_picked_10.mzML) → false
                                      → enters "calculate" path → creates/opens file
Thread B (row 1, load_cached_=true): File::exists(SerumTest_picked_10.mzML) → TRUE (empty/partial)
                                      → enters "load cached" path → XML parse on empty file
                                      → uncaught exception in OMP thread → SIGABRT
```

This race was latent since 2020 but only now surfaces on macOS ARM64 where OMP scheduling is fast enough to expose the sub-millisecond window.

## Fix

Give the second row `time=20` instead of `time=10`. The two OMP threads now write to `SerumTest_10.*` and `SerumTest_20.*` respectively — no path collision, OMP parallelism is preserved.

Also tighten test assertions to explicitly verify both rows ran:
- `TEST_EQUAL(samples.size(), 2)` — both rows parsed
- `TEST_EQUAL(samples[1].at("time"), "20")` — second row is distinct
- `TEST_EQUAL(File::exists(.../SerumTest_20.mzTab), true)` — second OMP thread produced output

## Test plan

- [ ] Confirm `FIAMSScheduler_test` passes on macOS ARM64 (macos-15, xcode 16.4) nightly
- [ ] Confirm the new `TEST_EQUAL(samples[1].at("time"), "20")` and existence check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6ajxzVLb7eqJbvV2XmsAy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for multi-sample processing, verifying correct handling of multiple samples and their corresponding output files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->