### PR TITLE
[FIX] ProSE: parallelize the calibration scoring pass (OpenMP)

### DIFF
--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -2419,7 +2419,18 @@ namespace OpenMS
     struct CalHit { double score; double prec_error; double frag_error; };
     vector<CalHit> cal_hits;
 
-    for (Size si = 0; si < subset_size; ++si)
+    // Parallelize over the calibration subset, mirroring the main scoring loop
+    // (scoreSpectraAgainstIndex_). Each iteration is independent: querySpectrum and
+    // the shared TheoreticalSpectrumGenerator expose const, thread-safe methods (the
+    // main loop already calls them concurrently), and every working variable below is
+    // loop-local. The only cross-thread write is the push into cal_hits, guarded by a
+    // critical section. Without this the calibration pass ran single-threaded: on a
+    // many-core machine the 10% subset took about as long as the entire parallel
+    // search, roughly doubling wall time for no extra useful work. Downstream is
+    // order-independent — cal_hits is sorted by score and the error vectors are sorted
+    // before quantiles — so parallel insertion order does not change the result.
+#pragma omp parallel for schedule(dynamic)
+    for (SignedSize si = 0; si < (SignedSize)subset_size; ++si)
     {
       const Size scan_idx = tic_index[si].second;
       const MSSpectrum& spec = spectra[scan_idx];
@@ -2478,6 +2489,7 @@ namespace OpenMS
                           ? Math::getPPM(corrected_exp_mz, theo_mz)
                           : (corrected_exp_mz - theo_mz);
 
+#pragma omp critical (prose_calibration_hits)
       cal_hits.push_back({best_score, prec_err, static_cast<double>(best_mean_error)});
     }
 


### PR DESCRIPTION
## Problem

The optional mass-recalibration pass (`Search:calibration:enabled`) scored its spectrum subset in a **fully serial loop**, while the main search scores in parallel (`#pragma omp parallel for`). On a many-core machine, the serial 10% subset takes about as long as the *entire* parallel search — so enabling calibration roughly **doubles** wall-clock time for no extra useful work.

## Measurements

172k MS2 spectra, 20 threads, **same binary** (only the calibration loop's pragmas differ):

| | wall | total CPU | CPU util |
|---|---:|---:|---:|
| base (no calibration) | 4:53 (293 s) | 4897 s | 1682% (~17 cores) |
| **serial calibration** (before) | **9:21 (561 s, +91%)** | 5389 s | **965%** (~9.6 cores) |
| **parallel calibration** (this PR) | **5:14 (314 s, +7%)** | 5424 s | 1734% (~17 cores) |

- Calibration went from **+91% wall** to **+7% wall** (the whole job is **1.79× faster** with calibration enabled).
- **Total CPU-seconds are unchanged** (5389 vs 5424) — the fix adds no work, it only spreads the same work across cores. The CPU-utilization collapse (965%) is the signature of a serial phase injected into a parallel job.

## Fix

Parallelize `runCalibrationPass_`'s scoring loop the same way as the main loop (`scoreSpectraAgainstIndex_`):
- `querySpectrum`, `reconstructModifiedSequence`, and the shared `TheoreticalSpectrumGenerator::getSpectrum` are `const`, thread-safe methods that the main scoring loop already calls concurrently; `HyperScore::computeWithDetail`/`Math::getPPM` are static and pure.
- Every working variable in the loop body is loop-local.
- The only cross-thread write (`cal_hits.push_back`) is guarded by a `critical` section.

## Correctness

Downstream is **order-independent** (`cal_hits` is sorted by score; the precursor/fragment error vectors are sorted before quantiles), so the calibrated tolerances do not depend on insertion order. On the benchmark, serial and parallel produce a **bit-identical** window `[-19.22, +19.80]`, and the `ProSEAlgorithm_test` calibration sections pass unchanged.

## Coverage

All three calibration call sites funnel through `runCalibrationPass_`, so this fixes the serial bottleneck for:
- non-chunked single-file
- chunked single-file
- chunk-major multi-file

The chunked paths additionally build a strided-sample calibration index via `FragmentIndex::build`, which is itself OpenMP-parallel and bounded (built once, reused per file) — so it is not a serial bottleneck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enhanced calibration processing efficiency through optimized parallel computation techniques.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->