### PR TITLE
feat(PSMFeatureExtractor): register andes search engine Percolator features

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -225,6 +225,13 @@ TOPP tools:
       - Added Thermo .raw input support; .raw files are accepted directly for all search modes; requires WITH_THERMO_RAW=ON (#9418)
       - Auto decoy mode: new Search:decoys parameter with three-way enum (auto/generate/ignore, default auto); auto reuses existing decoys detected via DecoyHelper::findDecoyString (supports both prefix and suffix markers) and generates decoys when none are found; generate always strips existing decoys and regenerates from targets; ignore performs a target-only search without FDR; replaces the previous boolean Search:decoys parameter; fixes latent bugs where PeptideIndexing and picked-protein FDR used a hardcoded decoy_prefix position regardless of the actual decoy marker position in the database (#9634)
       - Perf: calibration scoring pass (Search:calibration:enabled) is now parallelized with OpenMP, matching the main search loop; previously the serial subset pass took ~91% additional wall time on a 20-core machine, collapsing CPU utilisation from ~1682% to ~965%; after the fix wall-time overhead drops to ~7% and CPU utilisation is ~1734% — no extra work, the same scoring is simply spread across cores (#9639)
+    PSMFeatureExtractor:
+      - Added support for the andes search engine: PSMs whose search_engine is "andes" now have their
+        engine-specific Percolator features collected. andes annotates each PSM with its own numeric
+        features as MetaValues prefixed with "andes:" (e.g. "andes:RankScore", "andes:RawScore", ...);
+        all numeric "andes:"-prefixed MetaValues are registered as Percolator features (the andes side
+        remains the single source of truth for its feature set), instead of falling back to generic
+        features only. Mirrors the existing per-engine handling (Comet/MSGF+/MSFragger).
     PercolatorAdapter:
       - In-process rescoring backend: PercolatorAdapter now defaults to running Percolator in-process via the new OpenMS::Percolator class (vendored Percolator 3.08 + TRON solver) without requiring an external percolator binary; covers idXML/mzid input with PSM-level FDR; use -use_subprocess true to revert to the external binary path; OSW input, protein-level FDR, and peptide-level FDR still require the subprocess (#9218)
       - -percolator_executable is now optional (not required) when -use_subprocess false (the default); the parameter is still validated when -use_subprocess true (#9218)

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PercolatorFeatureSetHelper.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PercolatorFeatureSetHelper.h
@@ -97,6 +97,20 @@ namespace OpenMS
         static void addCOMETFeatures(PeptideIdentificationList& peptide_ids, StringList& feature_set);
 
         /**
+          @brief addANDESFeatures
+          @param[in] peptide_ids PeptideIdentification vector to create Percolator features in
+          @param[in] feature_set register of added features
+
+          Collects and registers the andes search engine specific Percolator features.
+          andes annotates every PSM with its own numeric features as MetaValues named
+          with the "andes:" prefix (e.g. "andes:RankScore", "andes:RawScore", ...). Rather
+          than hard-coding the (currently 47) feature names here, all numeric "andes:"-prefixed
+          MetaValues found on the hits are collected, keeping the andes side the single source
+          of truth for its feature set.
+         */
+        static void addANDESFeatures(PeptideIdentificationList& peptide_ids, StringList& feature_set);
+
+        /**
           @brief addMASCOTFeatures
           @param[in] peptide_ids PeptideIdentification vector to create Percolator features in
           @param[in] feature_set register of added features

--- a/src/openms/source/ANALYSIS/ID/PercolatorFeatureSetHelper.cpp
+++ b/src/openms/source/ANALYSIS/ID/PercolatorFeatureSetHelper.cpp
@@ -14,6 +14,8 @@
 
 #include <boost/lexical_cast.hpp>
 
+#include <set>
+
 using namespace std;
 
 namespace OpenMS
@@ -86,6 +88,35 @@ namespace OpenMS
       feature_set.push_back("hyperscore");
       feature_set.push_back("nextscore");
       feature_set.push_back(Constants::UserParam::ISOTOPE_ERROR);
+    }
+
+    void PercolatorFeatureSetHelper::addANDESFeatures(PeptideIdentificationList& peptide_ids, StringList& feature_set)
+    {
+      // andes annotates each PSM with its own numeric features as MetaValues prefixed with "andes:".
+      // We collect all numeric "andes:"-prefixed MetaValues present on the hits as Percolator features,
+      // so the andes search engine stays the single source of truth for its feature set (currently 47).
+      std::set<std::string> andes_features;
+      for (const auto& p : peptide_ids)
+      {
+        for (const auto& h : p.getHits())
+        {
+          StringList keys;
+          h.getKeys(keys);
+          for (const std::string& key : keys)
+          {
+            if (key.compare(0, 6, "andes:") != 0)
+            {
+              continue;
+            }
+            const DataValue::DataType vt = h.getMetaValue(key).valueType();
+            if (vt == DataValue::DOUBLE_VALUE || vt == DataValue::INT_VALUE)
+            {
+              andes_features.insert(key);
+            }
+          }
+        }
+      }
+      feature_set.insert(feature_set.end(), andes_features.begin(), andes_features.end());
     }
 
     void PercolatorFeatureSetHelper::addCOMETFeatures(PeptideIdentificationList& peptide_ids, StringList& feature_set)

--- a/src/tests/class_tests/openms/source/PercolatorFeatureSetHelper_test.cpp
+++ b/src/tests/class_tests/openms/source/PercolatorFeatureSetHelper_test.cpp
@@ -211,6 +211,36 @@ START_SECTION((static void addMASCOTFeatures(std::vector< PeptideIdentification 
 }
 END_SECTION
 
+START_SECTION((static void addANDESFeatures(std::vector< PeptideIdentification > &peptide_ids, StringList &feature_set)))
+{
+    // andes annotates hits with numeric "andes:"-prefixed MetaValues; these (and only these,
+    // when numeric) should be collected as Percolator features. Built in-memory to avoid a
+    // dependency on an andes-produced test-data file.
+    PeptideHit hit;
+    hit.setMetaValue("andes:RankScore", 12.5);          // double -> collected
+    hit.setMetaValue("andes:NumMatchedMainIons", 7);    // int -> collected
+    hit.setMetaValue("andes:DeltaRankScore", 3.25);     // double -> collected
+    hit.setMetaValue("andes:flag", "yes");              // string -> NOT collected
+    hit.setMetaValue("target_decoy", "target");         // non-andes -> NOT collected
+
+    PeptideIdentification pid;
+    pid.insertHit(hit);
+    PeptideIdentificationList andes_pids;
+    andes_pids.push_back(pid);
+
+    StringList fs;
+    PercolatorFeatureSetHelper::addANDESFeatures(andes_pids, fs);
+
+    // only the three numeric andes-prefixed features are registered (sorted/unique via std::set)
+    TEST_EQUAL(fs.size(), 3)
+    TEST_EQUAL(ListUtils::contains(fs, std::string("andes:RankScore")), true)
+    TEST_EQUAL(ListUtils::contains(fs, std::string("andes:NumMatchedMainIons")), true)
+    TEST_EQUAL(ListUtils::contains(fs, std::string("andes:DeltaRankScore")), true)
+    TEST_EQUAL(ListUtils::contains(fs, std::string("andes:flag")), false)
+    TEST_EQUAL(ListUtils::contains(fs, std::string("target_decoy")), false)
+}
+END_SECTION
+
 START_SECTION((static void addMULTISEFeatures(std::vector< PeptideIdentification > &peptide_ids, StringList &search_engines_used, StringList &feature_set, bool complete_only=true, bool limits_imputation=false)))
 {
   NOT_TESTABLE  // actually tested in combination with mergeMULTISEPeptideIds

--- a/src/topp/PSMFeatureExtractor.cpp
+++ b/src/topp/PSMFeatureExtractor.cpp
@@ -53,7 +53,7 @@ PSMFeatureExtractor is search engine sensitive, i.e. it's extra features
 vary, depending on the search engine. Thus, please make sure the input is
 compliant with TOPP SearchengineAdapter output. Also, PeptideIndexer compliant
 target/decoy annotation is mandatory.
-Currently supported search engines are Comet, X!Tandem, MSGF+.
+Currently supported search engines are Comet, X!Tandem, MSGF+, MSFragger, andes.
 Mascot support is available but in beta development.
 </p>
 
@@ -239,9 +239,13 @@ protected:
     {
       PercolatorFeatureSetHelper::addCOMETFeatures(all_peptide_ids, feature_set);
     }
-    else if (search_engine == "MSFragger") 
+    else if (search_engine == "MSFragger")
     {
       PercolatorFeatureSetHelper::addMSFRAGGERFeatures(feature_set);
+    }
+    else if (search_engine == "andes")
+    {
+      PercolatorFeatureSetHelper::addANDESFeatures(all_peptide_ids, feature_set);
     }
     else
     {


### PR DESCRIPTION
## Description

`PSMFeatureExtractor` only collects engine-specific Percolator features for engines it internally registers (Comet, MS-GF+, X!Tandem, Mascot, MSFragger). PSMs whose `search_engine` is `andes` fell through to the abort path / generic-only features, which can't separate target from decoy on realistic databases.

[andes](https://github.com/bigbio/andes) is a Rust DDA search engine that writes OpenMS-compatible `.idparquet`. It annotates each PSM with its own numeric features as MetaValues prefixed with `andes:` (e.g. `andes:RankScore`, `andes:RawScore`, `andes:DeltaRankScore`, `andes:TailorScore`, `andes:NumMatchedMainIons`, `andes:RichIonLLR`, …).

This PR adds `PercolatorFeatureSetHelper::addANDESFeatures()`, mirroring the existing per-engine handlers. It collects all numeric (`double`/`int`) MetaValues whose name starts with `andes:` and registers them as Percolator features — keeping the andes side the single source of truth for its feature set rather than hard-coding the (currently ~47) names in OpenMS. It is wired into the `PSMFeatureExtractor` engine dispatch on `search_engine == "andes"` (the exact lowercase string andes emits).

andes emits the same feature set on every PSM, so the union collected here is present on all hits (satisfies `PercolatorInfile`'s per-hit feature-completeness requirement).

## Changes
- `PercolatorFeatureSetHelper::addANDESFeatures()` (+ header declaration/doc).
- `PSMFeatureExtractor` engine dispatch + tool docu line.
- Self-contained unit test in `PercolatorFeatureSetHelper_test.cpp` (in-memory, no new test-data file).
- CHANGELOG entry.

No behavior change for any existing engine.

## Checklist
- [x] Mirrors the existing per-engine `add*Features` pattern.
- [x] Unit test added.
- [x] CHANGELOG updated.
- [ ] clang-format / CI checks (validated by CI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ANDES search engine is now fully supported with automatic extraction and registration of engine-specific Percolator features
  * MSFragger search engine is now supported

<!-- end of auto-generated comment: release notes by coderabbit.ai -->