### PR TITLE
docs(CHANGELOG): add missing entries for ProSE protein FDR fix (#9633) and pyOpenMS docstring fix (#9629)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -141,6 +141,7 @@ PyOpenMS:
   - Fix: ~50 mutable reference output parameter bugs fixed across all bindings (#8699)
   - Fix: ~100 missing default arguments restored (#8699)
   - Fix: AASequence.__str__() now returns the peptide sequence string instead of repr format; copy constructor dispatch fixed for AASequence and 11 other classes (ProteinHit, Software, CVTerm, PeptideEvidence, USI, and others) to prevent implicit string conversion (#9098)
+  - Fix: 6 docutils ERROR-level warnings in nanobind binding docstrings resolved; the warnings were non-fatal (pyOpenMS Sphinx/readthedocs build still succeeded) but polluted CI logs and broke cross-references in the rendered API docs (#9629)
   - Test: Docstring format validation tests added (#8674)
   - ProForma v2 support: Full Python bindings for ProFormaParser (#8648)
     - Parse ProForma strings: Peptidoform.fromString(), PeptidoformIon.fromString()
@@ -226,6 +227,7 @@ TOPP tools:
       - Auto decoy mode: new Search:decoys parameter with three-way enum (auto/generate/ignore, default auto); auto reuses existing decoys detected via DecoyHelper::findDecoyString (supports both prefix and suffix markers) and generates decoys when none are found; generate always strips existing decoys and regenerates from targets; ignore performs a target-only search without FDR; replaces the previous boolean Search:decoys parameter; fixes latent bugs where PeptideIndexing and picked-protein FDR used a hardcoded decoy_prefix position regardless of the actual decoy marker position in the database (#9634)
       - Changed default mass tolerances to typical high-resolution Orbitrap settings: precursor 20 -> 10 ppm (lower/upper) and fragment 10 -> 20 ppm. The tighter precursor window speeds the search and reduces spurious matches; data with calibration drift beyond 10 ppm may need a wider Search:precursor:mass_tolerance or Search:calibration:enabled (#9634)
       - Perf: calibration scoring pass (Search:calibration:enabled) is now parallelized with OpenMP, matching the main search loop; previously the serial subset pass took ~91% additional wall time on a 20-core machine, collapsing CPU utilisation from ~1682% to ~965%; after the fix wall-time overhead drops to ~7% and CPU utilisation is ~1734% — no extra work, the same scoring is simply spread across cores (#9639)
+      - Fix: protein-level FDR (FDR:protein) is now correctly applied for single-file runs; previously the FDR:protein pass was silently skipped unless a -out_merged path was requested in a multi-file run. Protein FDR is never applied per-file in multi-file mode — picked-protein FDR (Savitski 2015) is only statistically valid on a complete protein set and does not compose across separate runs (#9633, #9644)
     PSMFeatureExtractor:
       - Added support for the andes search engine: PSMs whose search_engine is "andes" now have their
         engine-specific Percolator features collected. andes annotates each PSM with its own numeric


### PR DESCRIPTION
## Summary

Reviewed all PRs merged into `develop` since the last CHANGELOG audit (PR #9641, 2026-06-21). Found two user-facing PRs with no CHANGELOG entry:

- **#9633** (ProSE: apply protein FDR for single-file runs) — a correctness fix where `FDR:protein` was silently skipped for single-file inputs; only the `-out_merged` multi-file path was covered. Added to the ProSE TOPP-tools section, also referencing the reconciliation PR #9644.
- **#9629** (pyOpenMS: fix docutils errors in nanobind docstrings) — 6 `ERROR`-level docutils warnings in the Sphinx build resolved. Added to the pyOpenMS section.

All other substantive PRs merged in the window (#9643 andes Percolator features, #9634/#9644 auto decoy mode, #9639 calibration parallelization, #9610 DistanceMatrix fix, #9623 ThermoRawFile metadata, #9521 imaging multi-region, #9602 FileInfo helper) were already documented by PRs #9627, #9637, and #9641. Test-only and CI-infrastructure PRs (#9638, #9592, #9542, #9553, #9549, #9548, #9560, #9557, #9587, #9591, #9589, #9558, #9585, #9577, #9545, #9582) are not changelog-worthy.

## Test plan

- [ ] Verify entries appear in the correct sections (pyOpenMS fixes, ProSE TOPP tools)
- [ ] Verify PR numbers link to the correct issues
- [ ] Verify no existing entries were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUrYEuLbeCJznCzV51iJjk

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUrYEuLbeCJznCzV51iJjk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed documentation warnings in API bindings that were affecting reference documentation
  * Corrected protein-level FDR filtering to properly apply in single-file analysis workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->