### PR TITLE
Improve error messages for missing OpenMS data files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@ General:
   - Parquet support enabled across all platforms; Arrow/Parquet is now a required dependency and the WITH_PARQUET CMake option has been removed (#8370, #8422, #8991)
   - Modernized TransformationDescription to use std::unique_ptr for memory safety
   - Fix undefined behavior in ProteinIdentification get*DataArrayByName by throwing ElementNotFound when the name is missing
+  - When a shared-data file (e.g. CHEMISTRY/custom_mods.xml) cannot be found, File::find now reports the resolved OpenMS data directory and where it was resolved from (OPENMS_DATA_PATH vs. compiled/executable-relative), so a stale OPENMS_DATA_PATH or a leftover old installation is easy to spot and fix (#9636)
   - Removed leftover traces of removed doc_internal target (#2256)
   - BREAKING: QDateTime/QDate/QSysInfo/QLocale replaced with std::chrono and platform APIs in DateTime, Date, BuildInfo, DimMapper, and TOPPBase; QDate constructor removed from Date class (#8937)
   - BREAKING: QDir/QFile/QFileInfo replaced with std::filesystem in the core library; copyDirRecursively/removeDir signatures changed from QString& to String&; ToolHandler returns StringList instead of QStringList; new PathUtils.h added with UTF-8-safe to_path() helper (#8938)

--- a/src/openms/include/OpenMS/CONCEPT/Exception.h
+++ b/src/openms/include/OpenMS/CONCEPT/Exception.h
@@ -474,7 +474,9 @@ namespace OpenMS
     class OPENMS_DLLAPI FileNotFound : public BaseException
     {
     public:
-      /// @param additional_message optional context appended to the message (e.g. which directories were searched)
+      // additional_message: optional context appended to the message (e.g. which directories were searched).
+      // NOTE: deliberately not a Doxygen '@param' to match the other exception ctors here (documenting one
+      // parameter would force Doxygen to demand docs for file/line/function/filename and fail Doxygen_Warning_test).
       FileNotFound(const char* file, int line, const char* function, const std::string& filename, const std::string& additional_message = "") noexcept;
     };
 

--- a/src/openms/include/OpenMS/CONCEPT/Exception.h
+++ b/src/openms/include/OpenMS/CONCEPT/Exception.h
@@ -474,7 +474,8 @@ namespace OpenMS
     class OPENMS_DLLAPI FileNotFound : public BaseException
     {
     public:
-      FileNotFound(const char* file, int line, const char* function, const std::string& filename) noexcept;
+      /// @param additional_message optional context appended to the message (e.g. which directories were searched)
+      FileNotFound(const char* file, int line, const char* function, const std::string& filename, const std::string& additional_message = "") noexcept;
     };
 
     /**

--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -360,6 +360,19 @@ private:
     /// Check if the given path is a valid OPENMS_DATA_PATH
     static bool isOpenMSDataPath_(const std::string& path);
 
+    /// Bundles the resolved OpenMS data path with a human-readable description of where it was found (for diagnostics).
+    struct OpenMSDataPath_
+    {
+      std::string path;    ///< the resolved shared-data directory
+      std::string source;  ///< human-readable origin, e.g. "the OPENMS_DATA_PATH environment variable"
+    };
+
+    /// Resolve (once, thread-safe) and return the OpenMS data path together with where it was found.
+    static const OpenMSDataPath_& resolveOpenMSDataPath_();
+
+    /// Human-readable description of where getOpenMSDataPath() was resolved from (for diagnostics in error messages).
+    static const std::string& getOpenMSDataPathSource_();
+
 #ifdef OPENMS_WINDOWSPLATFORM
     /**
       @brief Get list of file suffices to try during search on PATH (usually .exe, .bat etc)

--- a/src/openms/source/CONCEPT/Exception.cpp
+++ b/src/openms/source/CONCEPT/Exception.cpp
@@ -163,8 +163,8 @@ namespace OpenMS
       GlobalExceptionHandler::getInstance().setMessage(what());
     }
 
-    FileNotFound::FileNotFound(const char* file, int line, const char* function, const std::string& filename) noexcept :
-      BaseException(file, line, function, "FileNotFound", "the file '" + filename + "' could not be found")
+    FileNotFound::FileNotFound(const char* file, int line, const char* function, const std::string& filename, const std::string& additional_message) noexcept :
+      BaseException(file, line, function, "FileNotFound", "the file '" + filename + "' could not be found" + (additional_message.empty() ? "" : ". " + additional_message))
     {
       GlobalExceptionHandler::getInstance().setMessage(what());
     }

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -497,8 +497,13 @@ namespace OpenMS
       }
     }
 
-    //if the file was not found, throw an exception
-    throw Exception::FileNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
+    //if the file was not found, throw an exception that also points at the resolved data path
+    //(this is the usual culprit for missing standard share/OpenMS files, e.g. a stale OPENMS_DATA_PATH)
+    const std::string hint = "OpenMS searched its shared-data directory '" + getOpenMSDataPath()
+      + "' (resolved from " + getOpenMSDataPathSource_() + "). "
+      + "If this is a wrong or outdated OpenMS installation, set the OPENMS_DATA_PATH environment variable "
+      + "to the matching '.../share/OpenMS' directory, or unset it if it points to a stale location";
+    throw Exception::FileNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename, hint);
   }
 
   bool File::fileList(const std::string& dir, const std::string& file_pattern, StringList& output, bool full_path)
@@ -581,10 +586,10 @@ namespace OpenMS
     return d + "_" + t + "_" + hostname_str + pid + "_" + (++number);
   }
 
-  std::string File::getOpenMSDataPath()
+  const File::OpenMSDataPath_& File::resolveOpenMSDataPath_()
   {
-    // Use immediately evaluated lambda to protect static variable from concurrent access.
-    static const std::string path = [&]() -> std::string {
+    // Use immediately evaluated lambda to protect the static from concurrent access (thread-safe static init).
+    static const OpenMSDataPath_ info = []() -> OpenMSDataPath_ {
       std::string path;
       bool path_checked = false;
 
@@ -597,7 +602,7 @@ namespace OpenMS
         path_checked = isOpenMSDataPath_(path);
         if (path_checked)
         {
-          found_path_from = "OPENMS_DATA_PATH (environment)";
+          found_path_from = "the OPENMS_DATA_PATH environment variable";
         }
       }
 
@@ -608,7 +613,7 @@ namespace OpenMS
         path_checked = isOpenMSDataPath_(path);
         if (path_checked)
         {
-          found_path_from = "OPENMS_INSTALL_DATA_PATH (compiled)";
+          found_path_from = "the compiled-in installation path (OPENMS_INSTALL_DATA_PATH)";
         }
       }
 
@@ -617,7 +622,7 @@ namespace OpenMS
       {
         path = OPENMS_DATA_PATH;
         path_checked = isOpenMSDataPath_(path);
-        if (path_checked) found_path_from = "OPENMS_DATA_PATH (compiled)";
+        if (path_checked) found_path_from = "the compiled-in build path (OPENMS_DATA_PATH)";
       }
 
   #if defined(__APPLE__)
@@ -626,7 +631,7 @@ namespace OpenMS
       {
         path = getExecutablePath() + "../../../share/OpenMS";
         path_checked = isOpenMSDataPath_(path);
-        if (path_checked) found_path_from = "bundle path (run time)";
+        if (path_checked) found_path_from = "the application bundle (relative to the executable)";
       }
   #endif
 
@@ -637,7 +642,7 @@ namespace OpenMS
         path_checked = isOpenMSDataPath_(path);
         if (path_checked)
         {
-          found_path_from = "tool path (run time)";
+          found_path_from = "the executable location (../share/OpenMS)";
         }
       }
 
@@ -661,10 +666,20 @@ namespace OpenMS
         std::cerr << "Exiting now.\n";
         exit(1);
       }
-      return path;
+      return OpenMSDataPath_{path, found_path_from};
     }();
 
-    return path;
+    return info;
+  }
+
+  std::string File::getOpenMSDataPath()
+  {
+    return resolveOpenMSDataPath_().path;
+  }
+
+  const std::string& File::getOpenMSDataPathSource_()
+  {
+    return resolveOpenMSDataPath_().source;
   }
 
   bool File::isOpenMSDataPath_(const std::string& path)

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -89,8 +89,23 @@ START_SECTION((static std::string find(const std::string &filename, StringList d
   std::string s_obo = File::find("CV/psi-ms.obo");
   TEST_EQUAL(s_obo.empty(), false);
   TEST_EQUAL(File::find(s_obo), s_obo); // iterative finding should return the identical file
-  
+
   TEST_EXCEPTION(Exception::FileNotFound, File::find(""))
+
+  // a missing standard data file should point the user at the resolved data path and OPENMS_DATA_PATH (issue #9636)
+  {
+    std::string msg;
+    try
+    {
+      File::find("CHEMISTRY/this_file_does_not_exist_9636.xml");
+    }
+    catch (Exception::FileNotFound& e)
+    {
+      msg = e.getMessage();
+    }
+    TEST_EQUAL(msg.find("OPENMS_DATA_PATH") != std::string::npos, true)
+    TEST_EQUAL(msg.find(File::getOpenMSDataPath()) != std::string::npos, true)
+  }
 END_SECTION
 
 #ifdef ENABLE_DOCS


### PR DESCRIPTION
## Description

Enhances error reporting when OpenMS shared-data files cannot be found by including diagnostic information about the resolved data path and its source. This addresses issue #9636 where users with stale or misconfigured `OPENMS_DATA_PATH` environment variables receive unclear error messages.

### Changes

1. **Enhanced FileNotFound exception**: Added optional `additional_message` parameter to `Exception::FileNotFound` to allow context-specific error details.

2. **Refactored data path resolution**: 
   - Introduced `OpenMSDataPath_` struct to bundle the resolved path with a human-readable source description
   - Created `resolveOpenMSDataPath_()` to centralize thread-safe resolution logic
   - Added `getOpenMSDataPathSource_()` to expose where the data path was resolved from

3. **Improved File::find() error messages**: When a file is not found, the exception now includes:
   - The resolved OpenMS data directory path
   - Where it was resolved from (environment variable, compiled-in path, executable-relative, or bundle path)
   - Guidance on setting/unsetting `OPENMS_DATA_PATH`

4. **Better source descriptions**: Updated all data path source labels to be more user-friendly and descriptive (e.g., "the OPENMS_DATA_PATH environment variable" instead of "OPENMS_DATA_PATH (environment)").

5. **Added test coverage**: New test case verifies that missing file errors include both the resolved data path and mention of `OPENMS_DATA_PATH`.

### Motivation

Users encountering missing standard data files (e.g., `CHEMISTRY/custom_mods.xml`) now receive actionable diagnostic information instead of a generic "file not found" error, making it easier to troubleshoot installation or configuration issues.

## Checklist
- [x] Changes documented in CHANGELOG
- [x] Unit tests added and pass locally
- [x] No python bindings changes needed (internal utility functions)

https://claude.ai/code/session_01FsXevqRdFSsxxvMtvWPftZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error diagnostics for missing shared-data files. When files cannot be found, error messages now include the resolved OpenMS data directory path and a description of where it was sourced from, helping diagnose stale configuration or leftover installations.
  * Updated `File::find` to provide more targeted hints when standard shared-data files are missing.
* **Tests**
  * Added coverage to verify the improved exception message includes `OPENMS_DATA_PATH` details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->