### PR TITLE
clang: Add missing <thread> header

### DIFF
--- a/src/openms/source/SYSTEM/ExternalProcess.cpp
+++ b/src/openms/source/SYSTEM/ExternalProcess.cpp
@@ -34,6 +34,7 @@
 
 #include <array>
 #include <chrono>
+#include <thread>
 #include <utility>
 
 #ifndef _WIN32


### PR DESCRIPTION
LLVM/clang version 21+ seems to be a bit more strict than the default 17 found on the GitHub runner.  Without the `<thread>` header it reports the following error:

```
ExternalProcess.cpp:257:29: error: no member named 'sleep_for' in namespace 'std::this_thread'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a missing dependency that improves internal process stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->