### PR TITLE
LLVM 21+: Resolve build error

### DIFF
--- a/src/openms/source/CONCEPT/GlobalExceptionHandler.cpp
+++ b/src/openms/source/CONCEPT/GlobalExceptionHandler.cpp
@@ -15,6 +15,7 @@
 //#include <sys/types.h>
 #include <csignal> // for SIGSEGV and kill
 #include <iostream>
+#include <new>
 
 #ifndef OPENMS_WINDOWSPLATFORM
   #ifdef OPENMS_HAS_UNISTD_H


### PR DESCRIPTION
This is another LLVM/clang error:

I think it was commit e6fcc898f73705d090afa8ead817016ca8898522 removing `#include <OpenMS/CONCEPT/Exception.h>` from the `GlobalExceptionHandler.h` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application stability by updating exception handling support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->