### PR TITLE
docs(CHANGELOG): add missing entry for LLVM 21+ build fix (#9653)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -559,6 +559,7 @@ Build System:
   - CI: Windows build migrated from Visual Studio 2022 to Visual Studio 2026 (windows-2025 runner, MSVC v145 toolset, CMake generator "Visual Studio 18 2026") (#9514)
   - Build speedup: Boost.Spirit qi/karma replaced with std::from_chars/to_chars (C++17 charconv) for numeric string conversions in String, DataValue, and related utilities; reduces compile time by 30-40% and improves runtime string-to-number throughput (#9648)
   - Fix: added missing <thread> include in ExternalProcess.cpp for compatibility with LLVM/clang 21+ which no longer provides std::this_thread::sleep_for via transitive includes (#9651)
+  - Fix: added missing <new> include in GlobalExceptionHandler.cpp for compatibility with LLVM/clang 21+ which no longer provides placement-new/delete operators via transitive includes (#9653)
 
 
 ------------------------------------------------------------------------------------------


### PR DESCRIPTION
Reviewed all PRs merged into `develop` since the last CHANGELOG audit (PR #9652, 2026-06-24).

Found one PR merged after the last audit with no CHANGELOG entry:

- **#9653** (LLVM 21+: Resolve build error) — adds `#include <new>` to `GlobalExceptionHandler.cpp` for LLVM/clang 21+ compatibility; LLVM 21+ no longer provides placement-new/delete operators via transitive includes.

All other recently merged PRs were already covered:
- #9649 (UniPEFF TOPP tool) — covered in "New tools" section
- #9648 (30-40% faster build) — covered in Build system section
- #9651 (clang missing `<thread>`) — covered in Build system section
- #9642–#9644 (ProSE improvements) — covered in TOPP tools section
- #9643 (PSMFeatureExtractor Andes) — covered in TOPP tools section
- #9633, #9634, #9639 (ProSE fixes) — covered in TOPP tools section
- #9629 (pyOpenMS docutils) — covered in PyOpenMS section
- #9650 (error messages for missing data files) — covered in General section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFqM8n8Rpo796cs4vetXXV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFqM8n8Rpo796cs4vetXXV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue with newer LLVM/clang versions by ensuring required placement new/delete operators are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->