### PR TITLE
Fix empty USI column in TextExporter (resolve MS run from spectra_data)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -310,6 +310,7 @@ TOPP tools:
     TextExporter:
       - Added support for XIC Parquet files (#8737, #8738)
       - Added .idparquet, .featureparquet, and .consensusparquet read support on -in (load-only; output is always tsv/csv/txt) (#9405)
+      - Fix: -id:add_usi now populates the USI column for idXML/consensusXML by resolving the MS run from the run's spectra_data (via the merge index) instead of the never-populated per-ID base_name (#9657, fixes #8470)
     FeatureFinderMultiplex, MultiplexResolver:
       - BREAKING: Parameter `missed_cleavages` renamed to `max_nr_labelled_aas` (#8911)
       - Now errors out with INCOMPATIBLE_INPUT_DATA when given IM_PEAK format (per-peak ion mobility) data (#9018)

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -2390,6 +2390,11 @@ add_test("TOPP_TextExporter_9" ${TOPP_BIN_PATH}/TextExporter -test -in ${DATA_DI
 add_test("TOPP_TextExporter_9_out1" ${DIFF} -in1 ${TESTS_TEMP_DIR}/TextExporter_9_output.tmp.txt -in2 ${DATA_DIR_TOPP}/TextExporter_9_output.txt )
 set_tests_properties("TOPP_TextExporter_9_out1" PROPERTIES DEPENDS "TOPP_TextExporter_9")
 
+# USI column: ms_run resolved from the protein run's spectra_data (not the per-peptide base_name)
+add_test("TOPP_TextExporter_10" ${TOPP_BIN_PATH}/TextExporter -test -in ${DATA_DIR_TOPP}/TextExporter_10_input.idXML -no_progress -out ${TESTS_TEMP_DIR}/TextExporter_10_output.tmp.txt -id:add_usi -id:usi_dataset_id PXD000001)
+add_test("TOPP_TextExporter_10_out1" ${DIFF} -in1 ${TESTS_TEMP_DIR}/TextExporter_10_output.tmp.txt -in2 ${DATA_DIR_TOPP}/TextExporter_10_output.txt )
+set_tests_properties("TOPP_TextExporter_10_out1" PROPERTIES DEPENDS "TOPP_TextExporter_10")
+
 #------------------------------------------------------------------------------
 # FeatureLinker tests
 # "labeled" algorithm:

--- a/src/tests/topp/TextExporter_10_input.idXML
+++ b/src/tests/topp/TextExporter_10_input.idXML
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="http://open-ms.sourceforge.net/XSL/IdXML.xsl" ?>
+<IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<SearchParameters id="SP_0" db="test.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:3" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.02" peak_mass_tolerance_ppm="false" >
+	</SearchParameters>
+	<IdentificationRun date="2024-01-01T00:00:00" search_engine="TestEngine" search_engine_version="1.0" search_parameters_ref="SP_0" >
+		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
+			<ProteinHit id="PH_0" accession="PROT1" score="0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</ProteinHit>
+			<UserParam type="stringList" name="spectra_data" value="[/data/spectra/test_run.mzML]"/>
+		</ProteinIdentification>
+		<PeptideIdentification score_type="score" higher_score_better="true" significance_threshold="0" MZ="460.7400" RT="100.5" spectrum_reference="scan=42" >
+			<PeptideHit score="1.5" sequence="PEPTIDEK" charge="2" aa_before="K" aa_after="L" start="10" end="17" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="score" higher_score_better="true" significance_threshold="0" MZ="416.5300" RT="200.7" spectrum_reference="controllerType=0 controllerNumber=1 scan=99" >
+			<PeptideHit score="2.5" sequence="HM(Oxidation)WPK" charge="3" aa_before="R" aa_after="A" start="3" end="7" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+	</IdentificationRun>
+</IdXML>

--- a/src/tests/topp/TextExporter_10_output.txt
+++ b/src/tests/topp/TextExporter_10_output.txt
@@ -1,0 +1,7 @@
+#RUN	run_id	score_type	score_direction	date_time	search_engine_version	parameters
+#PROTEIN	score	rank	accession	protein_description	coverage	sequence
+#PEPTIDE	rt	mz	score	rank	sequence	charge	aa_before	aa_after	score_type	search_identifier	accessions	start	end	predicted_rt	predicted_pt	peak_annotations	USI
+RUN	TestEngine_2024-01-01T00:00:00_5233264595117471314		higher-score-better	2024-01-01T00:00:00	1.0	db=test.fasta, db_version=, taxonomy=, charges=2:3, mass_type=monoisotopic, fixed_modifications=, variable_modifications=, enzyme=Trypsin, missed_cleavages=1, peak_mass_tolerance=0.02, precursor_mass_tolerance=10.0
+PROTEIN	0.0	0	PROT1		-1.0	
+PEPTIDE	100.5	460.740000000000009	1.5	0	PEPTIDEK	2	K	L	score	TestEngine_2024-01-01T00:00:00_5233264595117471314	PROT1	10	17	-1	-1	-1	mzspec:PXD000001:test_run.mzML:scan:42:PEPTIDEK/2
+PEPTIDE	200.699999999999989	416.529999999999973	2.5	0	HM(Oxidation)WPK	3	R	A	score	TestEngine_2024-01-01T00:00:00_5233264595117471314	PROT1	3	7	-1	-1	-1	mzspec:PXD000001:test_run.mzML:scan:99:HM[UNIMOD:35]WPK/3

--- a/src/topp/TextExporter.cpp
+++ b/src/topp/TextExporter.cpp
@@ -21,6 +21,7 @@
 #include <OpenMS/FORMAT/SVOutStream.h>
 #include <OpenMS/METADATA/MetaInfoInterfaceUtils.h>
 #include <OpenMS/METADATA/USI.h>
+#include <OpenMS/METADATA/IdentifierMSRunMapper.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/SYSTEM/File.h>
 
@@ -408,6 +409,20 @@ namespace OpenMS
     StringList peptide_hit_meta_keys;
   };
 
+  // Resolve the MS run file name (basename) for a peptide's USI from the protein
+  // run's 'spectra_data' (selected per identification via the merge index in @p mapper).
+  // Falls back to a per-ID base_name when no run path is available (some pepXML-derived
+  // inputs set base_name but not spectra_data); idXML/consensusXML set neither otherwise.
+  std::string resolveUSIMSRun(const IdentifierMSRunMapper& mapper, const PeptideIdentification& pid)
+  {
+    std::string ms_run_path = mapper.getPrimaryMSRunPath(pid);
+    if (ms_run_path.empty())
+    {
+      ms_run_path = pid.getBaseName();
+    }
+    return USI::extractBasename(ms_run_path);
+  }
+
   // write the header for peptide data
   void writePeptideHeader(SVOutStream& out, const PeptideWriteOptions& opts = {})
   {
@@ -607,6 +622,27 @@ public:
     }
 
 protected:
+
+    // Build a mapping from each identification run to its MS run path(s) (from
+    // 'spectra_data') so USIs can reference the correct source file per identification.
+    // Returns an empty mapper when USIs are off or the runs cannot be mapped (e.g.
+    // duplicate spectra_data); ms-run names then fall back to per-ID base names.
+    IdentifierMSRunMapper buildUSIMapper_(const std::vector<ProteinIdentification>& prot_ids, bool add_usi) const
+    {
+      IdentifierMSRunMapper mapper;
+      if (add_usi)
+      {
+        try
+        {
+          mapper.create(prot_ids);
+        }
+        catch (const Exception::BaseException& e)
+        {
+          writeLogWarn_("Could not build MS-run mapping for USI generation: " + std::string(e.getMessage()) + ". Falling back to per-ID base names.");
+        }
+      }
+      return mapper;
+    }
 
     void registerOptionsAndFlags_() override
     {
@@ -824,6 +860,8 @@ protected:
         peptide_opts.peptide_id_meta_keys = peptide_id_meta_keys;
         peptide_opts.peptide_hit_meta_keys = peptide_hit_meta_keys;
 
+        IdentifierMSRunMapper usi_mapper = buildUSIMapper_(prot_ids, add_usi);
+
         // write header:
         output.modifyStrings(false);
         bool comment = true;
@@ -868,7 +906,7 @@ protected:
           }
           for (const PeptideIdentification& pep : feature_map.getUnassignedPeptideIdentifications())
           {
-            unassigned_opts.usi_ms_run = add_usi ? USI::extractBasename(pep.getBaseName()) : "";
+            unassigned_opts.usi_ms_run = add_usi ? resolveUSIMSRun(usi_mapper, pep) : "";
             writePeptideId(output, pep, unassigned_opts);
           }
         }
@@ -905,7 +943,7 @@ protected:
           {
             for (const PeptideIdentification& pep : feat.getPeptideIdentifications())
             {
-              peptide_opts.usi_ms_run = add_usi ? USI::extractBasename(pep.getBaseName()) : "";
+              peptide_opts.usi_ms_run = add_usi ? resolveUSIMSRun(usi_mapper, pep) : "";
               writePeptideId(output, pep, peptide_opts);
             }
           }
@@ -1290,6 +1328,8 @@ protected:
           peptide_opts.peptide_id_meta_keys = peptide_id_meta_keys;
           peptide_opts.peptide_hit_meta_keys = peptide_hit_meta_keys;
 
+          IdentifierMSRunMapper usi_mapper = buildUSIMapper_(consensus_map.getProteinIdentifications(), add_usi);
+
           FeatureHandle feature_handle_NaN;
           feature_handle_NaN.setRT(std::numeric_limits<
                                      FeatureHandle::CoordinateType>::quiet_NaN());
@@ -1398,8 +1438,7 @@ protected:
             // unassigned peptides
             for (PeptideIdentificationList::const_iterator pit = consensus_map.getUnassignedPeptideIdentifications().begin(); pit != consensus_map.getUnassignedPeptideIdentifications().end(); ++pit)
             {
-              // For USI, extract basename from the PeptideIdentification's base name
-              unassigned_opts.usi_ms_run = add_usi ? USI::extractBasename(pit->getBaseName()) : "";
+              unassigned_opts.usi_ms_run = add_usi ? resolveUSIMSRun(usi_mapper, *pit) : "";
               writePeptideId(output, *pit, unassigned_opts);
               // first_dim_... stuff not supported for now
             }
@@ -1438,8 +1477,7 @@ protected:
                      cmit->getPeptideIdentifications().begin(); pit !=
                    cmit->getPeptideIdentifications().end(); ++pit)
               {
-                // For USI, extract basename from the PeptideIdentification's base name
-                peptide_opts.usi_ms_run = add_usi ? USI::extractBasename(pit->getBaseName()) : "";
+                peptide_opts.usi_ms_run = add_usi ? resolveUSIMSRun(usi_mapper, *pit) : "";
                 writePeptideId(output, *pit, peptide_opts);
               }
             }
@@ -1498,6 +1536,8 @@ protected:
 
         std::string what = peptides_only ? "" : "PEPTIDE";
 
+        IdentifierMSRunMapper usi_mapper = buildUSIMapper_(prot_ids, add_usi);
+
         // Setup peptide write options for IDXML
         PeptideWriteOptions peptide_opts;
         peptide_opts.what = what;
@@ -1554,7 +1594,7 @@ protected:
             {
               if (pit->getIdentifier() == actual_id)
               {
-                peptide_opts.usi_ms_run = add_usi ? USI::extractBasename(pit->getBaseName()) : "";
+                peptide_opts.usi_ms_run = add_usi ? resolveUSIMSRun(usi_mapper, *pit) : "";
                 writePeptideId(output, *pit, peptide_opts);
               }
             }


### PR DESCRIPTION
## Summary

Fixes #8470. The `-id:add_usi` option in `TextExporter` added a `USI` column header but emitted **empty** values for idXML and consensusXML — the exact formats that issue asked about.

### Root cause
The USI `ms_run` component was sourced from `PeptideIdentification::getBaseName()`, which is only ever populated by `PepXMLFile`. The idXML/consensusXML/featureXML readers never set it, so `ms_run` was empty, which makes the whole USI invalid and `USI::toString()` return `""`.

### Fix
Resolve `ms_run` from the protein run's `spectra_data`, selected per identification via the merge index, using the existing `IdentifierMSRunMapper` — i.e. the same "`spectra_data` + merge index" mechanism described in the issue. A small `resolveUSIMSRun()` helper keeps a `base_name` fallback for pepXML-derived inputs, and mapper construction is guarded so export never aborts on degenerate input. Applied to all three identification-bearing input branches (featureXML, consensusXML, idXML).

### Result
- idXML: `mzspec:PXD000561:run.mzML:scan:2491:DEDEGEAADM[UNIMOD:35]EEY/2`
- merged consensusXML: each identification resolves to its correct source run via the merge index.

### Testing
- New TOPP test `TOPP_TextExporter_10` (idXML input + expected output with populated USIs).
- Full `TOPP_TextExporter_*` suite: 23/23 pass; no regressions (behavior is unchanged when `-id:add_usi` is off, since the mapper is only built then).

Usage:
```
TextExporter -in results.idXML -out results.tsv -id:add_usi -id:usi_dataset_id PXD000561
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USI output in text exports so peptide rows now show the correct run information for `idXML` and `consensusXML` files, even when per-item metadata is incomplete.
  * Exported peptide identifiers are now more consistently linked to the originating mass spectrometry run.

* **Tests**
  * Added regression coverage for the updated USI export behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->