### PR TITLE
[DOC] pyOpenMS: point nightly install links to pypi.openms.de

### DIFF
--- a/doc/pyopenms/README.md
+++ b/doc/pyopenms/README.md
@@ -18,7 +18,7 @@ Installation is best done through [PyPI](https://pypi.python.org/pypi/pyopenms)
 (the Python package index) where binary packages are provided for the release
 versions of OpenMS, covering Linux/Mac/Windows. Alternatively, it is available on (bio)conda.
 
-For the brave nightly build can be found at [our local PyPI server](https://pypi.cs.uni-tuebingen.de/).
+For the brave nightly build can be found at [our local PyPI server](https://pypi.openms.de/).
 
 Documentation
 =============

--- a/doc/pyopenms/docs/install_pyopenms.py
+++ b/doc/pyopenms/docs/install_pyopenms.py
@@ -73,7 +73,7 @@ def install_pyopenms(version):
         "pip",
         "install",
         "--extra-index-url",
-        "https://pypi.cs.uni-tuebingen.de/simple/",
+        "https://pypi.openms.de/simple/",
     ]
 
     if version == "latest":

--- a/doc/pyopenms/docs/source/user_guide/installation.rst
+++ b/doc/pyopenms/docs/source/user_guide/installation.rst
@@ -31,7 +31,7 @@ If you want the newest features you can also install nightly builds of pyOpenMS 
 
 .. code-block:: bash
 
-  pip install --index-url https://pypi.cs.uni-tuebingen.de/simple/ pyopenms
+  pip install --index-url https://pypi.openms.de/simple/ pyopenms
 
 Source (advanced users)
 -----------------------


### PR DESCRIPTION
## Description

The nightly pyOpenMS package index moved from `pypi.cs.uni-tuebingen.de` to `pypi.openms.de` (same `/simple/` layout, HTTPS, already serving the current nightly).

#9662 migrated the CI **upload** endpoint and credentials. This PR updates the remaining **download/install** references that #9662 did not touch:

- `doc/pyopenms/docs/source/user_guide/installation.rst` — `pip install --index-url …`
- `doc/pyopenms/docs/install_pyopenms.py` — `--extra-index-url …`
- `doc/pyopenms/README.md` — "local PyPI server" link

After this PR, `grep -rn pypi.cs.uni-tuebingen.de` returns nothing repo-wide. Documentation/CI-helper only — no code or test changes.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file (N/A — docs-only link update)
- [x] I have commented my code, particularly in hard-to-understand areas (N/A)
- [x] New and existing unit tests pass locally with my changes (N/A — no code change)
- [x] Updated or added python bindings for changed or new classes (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the installation guides for `pyopenms` to use a new package index URL for nightly and CI builds.
  * Replaced the older PyPI mirror address with the current OpenMS-hosted server in all relevant setup instructions.
  * No functional behavior changed; only the documented installation source was updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->