### PR TITLE
[Math] Make quantile1st/quantile3rd total for n<3; fix SummaryStatistics on small inputs (#9659)

### DIFF
--- a/src/openms/include/OpenMS/MATH/StatisticFunctions.h
+++ b/src/openms/include/OpenMS/MATH/StatisticFunctions.h
@@ -220,14 +220,16 @@ namespace OpenMS
 
     /**
        @brief Calculates the first quantile of a range of values
-       
+
        The range is divided into half and the median for the first half is returned.
+       For a range of size 1 or 2 the lower half is empty, so the minimum is returned
+       (consistent with the size-3 and size-4 results of this method).
 
        @param[in] begin Start of range
        @param[in] end End of range (past-the-end iterator)
        @param[in] sorted Is the range already sorted? If not, it will be sorted.
 
-       @exception Exception::InvalidRange is thrown if the range is NULL
+       @exception Exception::InvalidRange is thrown if the range is empty
 
        @ingroup MathFunctionsStatistics
     */
@@ -243,6 +245,10 @@ namespace OpenMS
       }
 
       Size size = std::distance(begin, end);
+      if (size < 3) // lower half is empty for size 1 or 2: the first quantile is the minimum
+      {
+        return static_cast<double>(*begin);
+      }
       if (size % 2 == 0)
       {
         return median(begin, begin + (size/2)-1, true); //-1 to exclude median values
@@ -254,12 +260,14 @@ namespace OpenMS
        @brief Calculates the third quantile of a range of values
 
        The range is divided into half and the median for the second half is returned.
+       For a range of size 1 or 2 the upper half is empty, so the maximum is returned
+       (consistent with the size-3 and size-4 results of this method).
 
        @param[in] begin Start of range
        @param[in] end End of range (past-the-end iterator)
        @param[in] sorted Is the range already sorted? If not, it will be sorted.
 
-       @exception Exception::InvalidRange is thrown if the range is NULL
+       @exception Exception::InvalidRange is thrown if the range is empty
 
        @ingroup MathFunctionsStatistics
     */
@@ -274,6 +282,10 @@ namespace OpenMS
       }
 
       Size size = std::distance(begin, end);
+      if (size < 3) // upper half is empty for size 1 or 2: the third quantile is the maximum
+      {
+        return static_cast<double>(*(begin + (size - 1)));
+      }
       return median(begin + (size/2)+1, end, true); //+1 to exclude median values
     }
 
@@ -935,7 +947,8 @@ namespace OpenMS
         {
           sort(data.begin(), data.end());
           mean = Math::mean(data.begin(), data.end());
-          variance = Math::variance(data.begin(), data.end(), mean);
+          // variance divides by (n-1) and is undefined for a single value; report 0.0 as in the empty case
+          variance = (count > 1) ? Math::variance(data.begin(), data.end(), mean) : 0.0;
           min = data.front();
           lowerq = Math::quantile1st(data.begin(), data.end(), true);
           median = Math::median(data.begin(), data.end(), true);

--- a/src/tests/class_tests/openms/source/StatisticFunctions_test.cpp
+++ b/src/tests/class_tests/openms/source/StatisticFunctions_test.cpp
@@ -417,7 +417,7 @@ START_SECTION([EXTRA](template< typename IteratorType1, typename IteratorType2 >
 }
 END_SECTION
 
-START_SECTION([EXTRA](template <typename IteratorType> static double quantile(IteratorType begin, IteratorType end, UInt quantile, bool sorted = false) ))
+START_SECTION([EXTRA](static double quantile1st/quantile3rd(IteratorType begin, IteratorType end, bool sorted)))
 {
   std::vector<int> x = {3,6,7,8,8,10,13,15,16,20};
   std::vector<int> y = {3,6,7,8,8,10,13,15,16};
@@ -428,6 +428,76 @@ START_SECTION([EXTRA](template <typename IteratorType> static double quantile(It
   TEST_REAL_SIMILAR(Math::quantile1st(y.begin(), y.end(), true),6.5);
   TEST_REAL_SIMILAR(Math::median(y.begin(), y.end(), true), 8.0);
   TEST_REAL_SIMILAR(Math::quantile3rd(y.begin(), y.end(), true), 14.0);
+
+  // --- small ranges (issue #9659): quantile1st/quantile3rd must be total for n >= 1 ---
+  // n == 1: first and third quantile both collapse to the single value
+  std::vector<double> n1{5.0};
+  TEST_REAL_SIMILAR(Math::quantile1st(n1.begin(), n1.end(), true), 5.0);
+  TEST_REAL_SIMILAR(Math::quantile3rd(n1.begin(), n1.end(), true), 5.0);
+  // n == 2: Q1 == min, Q3 == max (the median-of-halves convention)
+  std::vector<double> n2{1.0, 3.0};
+  TEST_REAL_SIMILAR(Math::quantile1st(n2.begin(), n2.end(), true), 1.0);
+  TEST_REAL_SIMILAR(Math::quantile3rd(n2.begin(), n2.end(), true), 3.0);
+  // unsorted input is sorted internally before the min/max is taken
+  std::vector<double> n2u{3.0, 1.0};
+  TEST_REAL_SIMILAR(Math::quantile1st(n2u.begin(), n2u.end()), 1.0);
+  TEST_REAL_SIMILAR(Math::quantile3rd(n2u.begin(), n2u.end()), 3.0);
+  // n == 3 and n == 4 already returned min/max before the fix; pin that continuity
+  std::vector<double> n3{1.0, 2.0, 3.0};
+  TEST_REAL_SIMILAR(Math::quantile1st(n3.begin(), n3.end(), true), 1.0);
+  TEST_REAL_SIMILAR(Math::quantile3rd(n3.begin(), n3.end(), true), 3.0);
+  std::vector<double> n4{1.0, 2.0, 3.0, 4.0};
+  TEST_REAL_SIMILAR(Math::quantile1st(n4.begin(), n4.end(), true), 1.0);
+  TEST_REAL_SIMILAR(Math::quantile3rd(n4.begin(), n4.end(), true), 4.0);
+  // empty range still throws
+  std::vector<double> none;
+  TEST_EXCEPTION(Exception::InvalidRange, Math::quantile1st(none.begin(), none.end(), true));
+  TEST_EXCEPTION(Exception::InvalidRange, Math::quantile3rd(none.begin(), none.end(), true));
+}
+END_SECTION
+
+START_SECTION([EXTRA](template <typename T> struct SummaryStatistics))
+{
+  // issue #9659: SummaryStatistics must not throw for n == 1 or n == 2
+  // n == 1: every quantile collapses to the single value; variance reported as 0 (as in the empty case)
+  std::vector<double> one{5.0};
+  Math::SummaryStatistics<std::vector<double>> s1(one);
+  TEST_EQUAL(s1.count, 1)
+  TEST_REAL_SIMILAR(s1.mean, 5.0)
+  TEST_REAL_SIMILAR(s1.variance, 0.0)
+  TEST_REAL_SIMILAR(s1.min, 5.0)
+  TEST_REAL_SIMILAR(s1.lowerq, 5.0)
+  TEST_REAL_SIMILAR(s1.median, 5.0)
+  TEST_REAL_SIMILAR(s1.upperq, 5.0)
+  TEST_REAL_SIMILAR(s1.max, 5.0)
+
+  // n == 2: lowerq == min, upperq == max, median == mean of the two
+  std::vector<double> two{1.0, 3.0};
+  Math::SummaryStatistics<std::vector<double>> s2(two);
+  TEST_EQUAL(s2.count, 2)
+  TEST_REAL_SIMILAR(s2.mean, 2.0)
+  TEST_REAL_SIMILAR(s2.variance, 2.0) // sample variance: ((1-2)^2 + (3-2)^2) / (2-1) == 2
+  TEST_REAL_SIMILAR(s2.min, 1.0)
+  TEST_REAL_SIMILAR(s2.lowerq, 1.0)
+  TEST_REAL_SIMILAR(s2.median, 2.0)
+  TEST_REAL_SIMILAR(s2.upperq, 3.0)
+  TEST_REAL_SIMILAR(s2.max, 3.0)
+
+  // n == 3: sanity check that the 3+ path is unaffected
+  std::vector<double> three{1.0, 2.0, 3.0};
+  Math::SummaryStatistics<std::vector<double>> s3(three);
+  TEST_EQUAL(s3.count, 3)
+  TEST_REAL_SIMILAR(s3.lowerq, 1.0)
+  TEST_REAL_SIMILAR(s3.median, 2.0)
+  TEST_REAL_SIMILAR(s3.upperq, 3.0)
+
+  // empty: all fields zero, no throw
+  std::vector<double> none;
+  Math::SummaryStatistics<std::vector<double>> s0(none);
+  TEST_EQUAL(s0.count, 0)
+  TEST_REAL_SIMILAR(s0.variance, 0.0)
+  TEST_REAL_SIMILAR(s0.lowerq, 0.0)
+  TEST_REAL_SIMILAR(s0.upperq, 0.0)
 }
 END_SECTION
 


### PR DESCRIPTION
## Summary

Fixes #9659. `Math::quantile1st`, `Math::quantile3rd`, and therefore `Math::SummaryStatistics` threw `Exception::InvalidRange` for input ranges of size **1 or 2** (they take the median of a *half* of the range, which is empty for n ≤ 2). For n ≥ 3 they already worked. This is a general-purpose statistics utility, so any caller handed a 1–2 element range was a latent crash — it surfaced as a ProteomicsLFQ acceptor run with exactly 2 donor features aborting via PIP-ECHO (#9647).

## Changes (`src/openms/include/OpenMS/MATH/StatisticFunctions.h`)

- **`quantile1st`**: for `size < 3` return the minimum (the lower half is empty).
- **`quantile3rd`**: for `size < 3` return the maximum (the upper half is empty).
- **`SummaryStatistics`**: `variance` divides by `(n-1)` and is undefined for a single value. Now that the quantile helpers no longer throw for n==1, guard it to report `0.0` (as in the empty case) instead of a silent `NaN`.
- Doc comments updated (and the stale `@exception ... NULL` corrected to `empty`).

## Why min / max (not Type-7 interpolation)

The fix preserves the existing algorithm's behavior. I cross-checked the convention against NumPy (all 9 Hyndman–Fan types), Python's `statistics.quantiles`, and the median-of-halves variants:

- **n = 1**: every method that is defined returns the single value.
- **n = 2**: every median-of-halves method (Moore-McCabe, Tukey hinges) and 7 of the 9 Hyndman–Fan types return **Q1 = min, Q3 = max**; only pure type-7 linear interpolation differs, and these helpers are not type-7.

Crucially, OpenMS's own algorithm **already returns min/max at n = 3 and n = 4**, so extending n ≤ 2 to min/max is continuous with existing behavior rather than a new convention. Routing through the newer interpolation-based `quantile(begin, end, q)` helper was rejected because it produces different values for n ≥ 3 (e.g. n=10 → 7.25/14.5 vs. the pinned 6.5/15.5) and would change the existing test and downstream reference outputs.

The **n ≥ 3 code path is byte-identical**, so pinned quantile values and reference outputs are unaffected.

## Tests (`StatisticFunctions_test.cpp`)

- `quantile1st` / `quantile3rd` at n = 1, 2 (sorted and unsorted), 3, 4, and empty-still-throws.
- New `SummaryStatistics` section at n = 1, 2, 3, and empty (this class had **no** prior test coverage).

Verified: `StatisticFunctions_test`, `FileInfo_test`, `PosteriorErrorProbabilityModel_test` (direct helper callers), and `TargetedExperiment_test` (`SummaryStatistics` consumer) all pass against a freshly rebuilt library.

## Note (out of scope)

The even-n `-1`/`+1` offsets make these helpers a slightly non-standard median-of-halves variant (n=4 → min/max where Moore-McCabe/Tukey give 1.5/3.5). That quirk is load-bearing for the existing pinned test values, so it is intentionally left unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quantile calculations for small datasets so first and third quartiles now return sensible results for 1–2 values.
  * Prevented invalid variance results for single-value summaries by returning `0.0` when there is not enough data.
  * Empty inputs continue to be handled safely with the expected error behavior.

* **Tests**
  * Expanded coverage for quartile and summary statistics behavior across empty, small, and unsorted inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->