### PR TITLE
fix(METADATA): leniently stringify non-string search settings (ProteomicsLFQ mzTab crash)

### DIFF
--- a/src/openms/source/METADATA/ProteinIdentification.cpp
+++ b/src/openms/source/METADATA/ProteinIdentification.cpp
@@ -611,7 +611,10 @@ namespace OpenMS
       {
         if (StringUtils::hasPrefix(mvkey, se))
         {
-          result.emplace_back(StringUtils::substr(mvkey, se.size()+1), params.getMetaValue(mvkey));
+          // Lenient stringification: settings meta values may be non-string (e.g. an
+          // Int like missed_cleavages). DataValue's implicit operator std::string() is
+          // strict (throws on non-string), so convert explicitly like the cases above.
+          result.emplace_back(StringUtils::substr(mvkey, se.size()+1), StringUtils::toStr(params.getMetaValue(mvkey)));
         }
       }
     }

--- a/src/tests/class_tests/openms/source/ProteinIdentification_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteinIdentification_test.cpp
@@ -351,6 +351,35 @@ START_SECTION((void setSearchParameters(const SearchParameters& search_parameter
 END_SECTION
 
 
+START_SECTION((std::vector<std::pair<std::string, std::string> > getSearchEngineSettingsAsPairs(const std::string& se = "") const))
+{
+	// Regression (ProteomicsLFQ mzTab export crash): non-string search settings such
+	// as an Int missed_cleavages must be stringified, not throw. DataValue's implicit
+	// operator std::string() is strict (throws on non-string) since the String class
+	// was removed, so this method must convert leniently (StringUtils::toStr).
+	ProteinIdentification prot;
+	prot.setSearchEngine("ConsensusID"); // merged run: per-engine settings live as meta values
+	ProteinIdentification::SearchParameters sp;
+	sp.setMetaValue("Comet:missed_cleavages", 2);    // Int    -- used to crash here
+	sp.setMetaValue("Comet:fragment_bin_tol", 0.02); // Double
+	sp.setMetaValue("Comet:enzyme", "Trypsin");      // String
+	prot.setSearchParameters(sp);
+
+	std::string missed, enzyme;
+	bool have_tol = false;
+	for (const std::pair<std::string, std::string>& kv : prot.getSearchEngineSettingsAsPairs("Comet"))
+	{
+		if (kv.first == "missed_cleavages") { missed = kv.second; }
+		else if (kv.first == "enzyme") { enzyme = kv.second; }
+		else if (kv.first == "fragment_bin_tol") { have_tol = true; }
+	}
+	TEST_EQUAL(missed == "2", true)
+	TEST_EQUAL(enzyme == "Trypsin", true)
+	TEST_EQUAL(have_tol, true)
+}
+END_SECTION
+
+
 START_SECTION((void sort()))
 {
 	ProteinIdentification id;


### PR DESCRIPTION
## Problem

`ProteomicsLFQ` aborts during mzTab export when the search settings include a non-string value (e.g. an integer `missed_cleavages`):

```
Error: Unexpected internal error (Could not convert non-string DataValue of type 'Int' and value '2' to string)
```

The abort happens **after** the consensusXML has already been written, so `-out_cxml` succeeds but `-out` (mzTab) and `-out_msstats` are left empty/missing.

## Root cause

`ProteinIdentification::getSearchEngineSettingsAsPairs()` built the `std::string` member of a `(key, value)` pair directly from a `DataValue`:

```cpp
result.emplace_back(StringUtils::substr(mvkey, se.size()+1), params.getMetaValue(mvkey));
```

Since the `String` class was removed, `DataValue::operator std::string()` is strict and throws `ConversionError` on any non-`STRING_VALUE` type (the lenient `String(const DataValue&)` stringification is gone). The first `Int` setting (e.g. `Comet:missed_cleavages = 2`) therefore throws.

Call path:
```
MzTabFile::store(…, ConsensusMap) -> CMMzTabStream ctor
  -> mapBetweenRunAndSearchEngines_ -> getSearchEngineSettingsAsPairs -> DataValue::operator std::string()  [throws]
```

The other settings in the same function already use `StringUtils::toStr`; this one branch was missed during the `String` removal.

## Fix

Use the lenient `StringUtils::toStr()` (the documented replacement for `String(const DataValue&)`), matching the rest of the function.

## Test

Adds a `ProteinIdentification_test` section for `getSearchEngineSettingsAsPairs` covering Int / Double / String settings (the method had no prior coverage).

## Verification

`ProteomicsLFQ` on a real dataset now exits 0 and writes a fully populated mzTab (PRT/PSM/PEP) + MSstats where it previously crashed. Surfaced while benchmarking match-between-runs for #9647 (PIP-ECHO), but the bug is independent of that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rawZsiVUCJjzyXTqkkrWK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of search engine metadata so settings are consistently returned as string pairs, even when some stored values are not already strings.
  * Prevented errors when converting non-string metadata values, making search engine settings export more reliable.

* **Tests**
  * Added coverage for search engine settings conversion, including non-string metadata values and expected output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->