### PR TITLE
fix(SimpleSVM): correct constant-predictor handling in predict() and setup() (#9661)

### DIFF
--- a/src/openms/source/ML/SVM/SimpleSVM.cpp
+++ b/src/openms/source/ML/SVM/SimpleSVM.cpp
@@ -424,6 +424,17 @@ void SimpleSVM::setup(PredictorMap& predictors, const map<Size, double>& outcome
 
   // count elements for first feature dimension to determine number of observations
   Size n_obs = predictors.begin()->second.size();
+  // All predictors must describe the same observations; an inconsistent length
+  // would desync this n_obs (and the outcome-index guard below) from the node
+  // arrays that convertData_() sizes from the first informative predictor.
+  for (const auto& predictor : predictors)
+  {
+    if (predictor.second.size() != n_obs)
+    {
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "All predictors must have the same number of observations.", predictor.first);
+    }
+  }
   pimpl_->n_parts_ = param_.getValue("xval");
 
   // clear old models
@@ -601,19 +612,39 @@ void SimpleSVM::predict(PredictorMap& predictors, vector<Prediction>& prediction
   const std::vector<std::string>& names = pimpl_->predictor_names_;
   const Size feature_dim = names.size();
 
-  // The observation count must come from a TRAINED predictor: the prediction map
-  // may carry extra predictors not in the model (e.g. ones that were constant
-  // during training and dropped), so predictors.begin() need not be a model
-  // feature, and an inconsistent length there would mis-size the loop.
-  PredictorMap::const_iterator first_trained =
-    feature_dim > 0 ? predictors.find(names[0]) : predictors.end();
-  if (first_trained == predictors.end())
+  // Resolve each trained predictor once, in the model's feature order (looking
+  // them up inside the per-observation loop would do feature_dim * n_obs map
+  // searches). The prediction map may carry extra predictors not in the model
+  // (e.g. constant-in-training ones that were dropped) -- those are ignored; a
+  // trained predictor missing here is an error. The observation count comes from
+  // a trained predictor (predictors.begin() need not be one), and all columns
+  // are checked to share it so the node loop cannot read past a shorter column.
+  if (feature_dim == 0)
   {
     throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-      "SimpleSVM::predict: the trained feature set is empty, or its first "
-      "predictor is missing from the prediction data.");
+                                  "SimpleSVM model has no features.");
   }
-  const Size n_obs = first_trained->second.size();
+  std::vector<const std::vector<double>*> columns(feature_dim);
+  for (Size k = 0; k < feature_dim; ++k)
+  {
+    PredictorMap::const_iterator pred_it = predictors.find(names[k]);
+    if (pred_it == predictors.end())
+    {
+      throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "SimpleSVM::predict: predictor '" + names[k] + "' used during training "
+        "is missing from the prediction data.");
+    }
+    columns[k] = &pred_it->second;
+  }
+  const Size n_obs = columns[0]->size();
+  for (Size k = 1; k < feature_dim; ++k)
+  {
+    if (columns[k]->size() != n_obs)
+    {
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "SimpleSVM::predict: predictors have inconsistent observation counts.", names[k]);
+    }
+  }
 
   Size n_classes = svm_get_nr_class(pimpl_->model_);
   vector<int> outcomes(n_classes);
@@ -627,16 +658,8 @@ void SimpleSVM::predict(PredictorMap& predictors, vector<Prediction>& prediction
   {
     for (Size k = 0; k < feature_dim; ++k)
     {
-      PredictorMap::const_iterator pred_it = predictors.find(names[k]);
-      if (pred_it == predictors.end())
-      {
-        delete[] x;
-        throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-          "SimpleSVM::predict: predictor '" + names[k] + "' used during training "
-          "is missing from the prediction data.");
-      }
       x[k].index = static_cast<int>(k + 1); // LIBSVM feature indices are 1-based
-      x[k].value = pred_it->second[i];       // feature value for observation i
+      x[k].value = (*columns[k])[i];         // feature value for observation i
     }
     x[feature_dim].index = -1;
     x[feature_dim].value = 0;

--- a/src/openms/source/ML/SVM/SimpleSVM.cpp
+++ b/src/openms/source/ML/SVM/SimpleSVM.cpp
@@ -590,8 +590,6 @@ void SimpleSVM::predict(PredictorMap& predictors, vector<Prediction>& prediction
                                   "'setup' method)");
   }
 
-  Size n_obs = predictors.begin()->second.size(); // length of the first feature ...
-
   scaleDataUsingTrainingRanges(predictors, pimpl_->scaling_);
 
   // Build the LIBSVM nodes over the TRAINED feature set, indexed in the exact
@@ -602,6 +600,20 @@ void SimpleSVM::predict(PredictorMap& predictors, vector<Prediction>& prediction
   // (issue #9661).
   const std::vector<std::string>& names = pimpl_->predictor_names_;
   const Size feature_dim = names.size();
+
+  // The observation count must come from a TRAINED predictor: the prediction map
+  // may carry extra predictors not in the model (e.g. ones that were constant
+  // during training and dropped), so predictors.begin() need not be a model
+  // feature, and an inconsistent length there would mis-size the loop.
+  PredictorMap::const_iterator first_trained =
+    feature_dim > 0 ? predictors.find(names[0]) : predictors.end();
+  if (first_trained == predictors.end())
+  {
+    throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+      "SimpleSVM::predict: the trained feature set is empty, or its first "
+      "predictor is missing from the prediction data.");
+  }
+  const Size n_obs = first_trained->second.size();
 
   Size n_classes = svm_get_nr_class(pimpl_->model_);
   vector<int> outcomes(n_classes);

--- a/src/openms/source/ML/SVM/SimpleSVM.cpp
+++ b/src/openms/source/ML/SVM/SimpleSVM.cpp
@@ -132,7 +132,21 @@ void SimpleSVM::Impl::scaleData_(PredictorMap& predictors)
 
 void SimpleSVM::Impl::convertData_(const SimpleSVM::PredictorMap& predictors)
 {
-  Size n_obs = predictors.begin()->second.size();
+  // The observation count must come from an INFORMATIVE predictor: scaleData_
+  // (called before this in setup()) empties the value vector of every constant
+  // predictor, so predictors.begin() may be empty. Taking n_obs from it would
+  // yield 0 whenever the alphabetically-first predictor is constant, sizing the
+  // node arrays to 0 and crashing setup() (related to #9661).
+  Size n_obs = 0;
+  for (const auto& predictor : predictors)
+  {
+    if (!predictor.second.empty()) { n_obs = predictor.second.size(); break; }
+  }
+  if (n_obs == 0)
+  {
+    throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+      "All predictors are constant (uninformative); the SVM cannot be trained.");
+  }
   nodes_.clear();
   nodes_.resize(n_obs);
   predictor_names_.clear();

--- a/src/openms/source/ML/SVM/SimpleSVM.cpp
+++ b/src/openms/source/ML/SVM/SimpleSVM.cpp
@@ -577,11 +577,17 @@ void SimpleSVM::predict(PredictorMap& predictors, vector<Prediction>& prediction
   }
 
   Size n_obs = predictors.begin()->second.size(); // length of the first feature ...
-  Size feature_dim = predictors.size();
 
   scaleDataUsingTrainingRanges(predictors, pimpl_->scaling_);
 
-  //std::cout << "Predicting on novel data with obs./feature dimensionality: " << n_obs << "/" << feature_dim << std::endl;
+  // Build the LIBSVM nodes over the TRAINED feature set, indexed in the exact
+  // order convertData_() used during setup() (recorded in predictor_names_).
+  // Iterating the prediction map by position instead would misalign feature
+  // indices whenever a predictor was constant during training -- and therefore
+  // dropped from the model -- but present here, silently corrupting predictions
+  // (issue #9661).
+  const std::vector<std::string>& names = pimpl_->predictor_names_;
+  const Size feature_dim = names.size();
 
   Size n_classes = svm_get_nr_class(pimpl_->model_);
   vector<int> outcomes(n_classes);
@@ -593,12 +599,18 @@ void SimpleSVM::predict(PredictorMap& predictors, vector<Prediction>& prediction
   svm_node *x = new svm_node[feature_dim + 1];
   for (Size i = 0; i != n_obs; ++i)
   {
-    size_t feature_index{0};
-    for (auto p : predictors) 
+    for (Size k = 0; k < feature_dim; ++k)
     {
-      x[feature_index].index = feature_index + 1;
-      x[feature_index].value = p.second[i]; // feature value for observation i
-      ++feature_index;
+      PredictorMap::const_iterator pred_it = predictors.find(names[k]);
+      if (pred_it == predictors.end())
+      {
+        delete[] x;
+        throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+          "SimpleSVM::predict: predictor '" + names[k] + "' used during training "
+          "is missing from the prediction data.");
+      }
+      x[k].index = static_cast<int>(k + 1); // LIBSVM feature indices are 1-based
+      x[k].value = pred_it->second[i];       // feature value for observation i
     }
     x[feature_dim].index = -1;
     x[feature_dim].value = 0;
@@ -611,7 +623,7 @@ void SimpleSVM::predict(PredictorMap& predictors, vector<Prediction>& prediction
     }
     predictions.push_back(pred);
   }
-  delete[] x;  
+  delete[] x;
 }
 
 // only works in classification mode

--- a/src/tests/class_tests/openms/source/SimpleSVM_test.cpp
+++ b/src/tests/class_tests/openms/source/SimpleSVM_test.cpp
@@ -350,6 +350,86 @@ START_SECTION(regression_train_and_predict_on_separate)
 }
 END_SECTION
 
+START_SECTION([EXTRA] predict() stays index-aligned when a predictor is constant during training but present at prediction (issue #9661))
+{
+  // A predictor that is constant during training is dropped by setup() (it gets
+  // no LIBSVM feature index). If predict() indexed features by prediction-map
+  // position, such a predictor -- still present at prediction -- would shift
+  // every later feature's index and silently corrupt the result. Here 'a'
+  // (which sorts before 'b','c') is constant during training, so the trained
+  // model must behave exactly as if it had only ever seen 'b','c'.
+
+  // Separable two-class problem in informative features a,c. The constant
+  // predictor 'b' sorts BETWEEN them, so it is dropped during training yet
+  // shifts 'c' if predict() indexed by position. (It must NOT sort first: the
+  // alphabetically-first predictor seeds convertData_'s observation count, and
+  // a constant one there would be a different, setup-side issue.)
+  auto make_train = [](bool with_b) {
+    SimpleSVM::PredictorMap m;
+    std::vector<double> a, c;
+    for (int k = 0; k < 10; ++k) { a.push_back(0.02 * k);        c.push_back(0.02 * k); }        // class 0: 0.00..0.18
+    for (int k = 0; k < 10; ++k) { a.push_back(0.82 + 0.02 * k); c.push_back(0.82 + 0.02 * k); } // class 1: 0.82..1.00
+    m["a"] = a; m["c"] = c;
+    if (with_b) { m["b"] = std::vector<double>(20, 7.0); } // constant -> dropped by setup()
+    return m;
+  };
+
+  std::map<Size, double> y;
+  for (Size i = 0; i < 10; ++i) { y[i] = 0.0; }
+  for (Size i = 10; i < 20; ++i) { y[i] = 1.0; }
+
+  Param param;
+  param.setValue("kernel", "linear");
+  param.setValue("log2_C", ListUtils::create<double>("0,3,6"));
+
+  SimpleSVM svm_with_b, svm_without_b;
+  svm_with_b.setParameters(param);
+  svm_without_b.setParameters(param);
+  SimpleSVM::PredictorMap train_with_b = make_train(true);
+  SimpleSVM::PredictorMap train_without_b = make_train(false);
+  svm_with_b.setup(train_with_b, y);       // 'b' constant -> dropped; trains on a,c
+  svm_without_b.setup(train_without_b, y); // trains on a,c
+
+  // The constant predictor really was dropped from the trained model.
+  TEST_EQUAL(svm_with_b.getScaling().find("b") == svm_with_b.getScaling().end(), true)
+
+  // Prediction data: identical a,c; for the 'b' model, 'b' is PRESENT and varies
+  // (the exact trigger for the index misalignment).
+  auto make_test = [](bool with_b) {
+    SimpleSVM::PredictorMap t;
+    t["a"] = std::vector<double>{0.05, 0.15, 0.85, 0.95};
+    t["c"] = std::vector<double>{0.05, 0.15, 0.85, 0.95};
+    if (with_b) { t["b"] = std::vector<double>{1.0, 9.0, 2.0, 8.0}; }
+    return t;
+  };
+  SimpleSVM::PredictorMap test_with_b = make_test(true);
+  SimpleSVM::PredictorMap test_without_b = make_test(false);
+
+  std::vector<SimpleSVM::Prediction> pred_with_b, pred_without_b;
+  svm_with_b.predict(test_with_b, pred_with_b);
+  svm_without_b.predict(test_without_b, pred_without_b);
+
+  TEST_EQUAL(pred_with_b.size(), 4)
+  TEST_EQUAL(pred_without_b.size(), 4)
+
+  // Invariant (#9661): a constant-in-training predictor present at prediction
+  // must not change anything -> identical to the model that never saw 'b'.
+  for (Size i = 0; i < pred_with_b.size(); ++i)
+  {
+    TEST_EQUAL(pred_with_b[i].outcome, pred_without_b[i].outcome)
+    TEST_REAL_SIMILAR(pred_with_b[i].probabilities[0.0], pred_without_b[i].probabilities[0.0])
+    TEST_REAL_SIMILAR(pred_with_b[i].probabilities[1.0], pred_without_b[i].probabilities[1.0])
+  }
+
+  // Sanity: the problem is separable, so the classes are recovered as expected
+  // (this is exactly what silently breaks without the fix).
+  TEST_EQUAL(pred_with_b[0].outcome, 0.0)
+  TEST_EQUAL(pred_with_b[1].outcome, 0.0)
+  TEST_EQUAL(pred_with_b[2].outcome, 1.0)
+  TEST_EQUAL(pred_with_b[3].outcome, 1.0)
+}
+END_SECTION
+
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/SimpleSVM_test.cpp
+++ b/src/tests/class_tests/openms/source/SimpleSVM_test.cpp
@@ -391,7 +391,7 @@ START_SECTION([EXTRA] predict() stays index-aligned when a predictor is constant
   svm_without_b.setup(train_without_b, y); // trains on a,c
 
   // The constant predictor really was dropped from the trained model.
-  TEST_EQUAL(svm_with_b.getScaling().find("b") == svm_with_b.getScaling().end(), true)
+  TEST_TRUE(svm_with_b.getScaling().find("b") == svm_with_b.getScaling().end())
 
   // Prediction data: identical a,c; for the 'b' model, 'b' is PRESENT and varies
   // (the exact trigger for the index misalignment).
@@ -464,7 +464,7 @@ START_SECTION([EXTRA] setup() handles a predictor that is constant during traini
   svm_a.setup(train_a, lab);        // must NOT crash (previously n_obs == 0)
   svm_plain.setup(train_plain, lab);
 
-  TEST_EQUAL(svm_a.getScaling().find("a") == svm_a.getScaling().end(), true)
+  TEST_TRUE(svm_a.getScaling().find("a") == svm_a.getScaling().end())
 
   auto make_test = [](bool with_a) {
     SimpleSVM::PredictorMap t;

--- a/src/tests/class_tests/openms/source/SimpleSVM_test.cpp
+++ b/src/tests/class_tests/openms/source/SimpleSVM_test.cpp
@@ -430,6 +430,72 @@ START_SECTION([EXTRA] predict() stays index-aligned when a predictor is constant
 }
 END_SECTION
 
+START_SECTION([EXTRA] setup() handles a predictor that is constant during training and sorts first)
+{
+  // scaleData_ empties the value vector of every constant predictor, so
+  // convertData_ must not take the observation count from a (now-empty) first
+  // predictor. A constant predictor 'a' that sorts BEFORE the informative
+  // features 'x','y' previously yielded n_obs == 0, sized the node arrays to
+  // zero, and crashed setup(). It must now train and predict identically to a
+  // model that never saw it.
+  auto make_train = [](bool with_a) {
+    SimpleSVM::PredictorMap m;
+    std::vector<double> x, y;
+    for (int k = 0; k < 10; ++k) { x.push_back(0.02 * k);        y.push_back(0.02 * k); }
+    for (int k = 0; k < 10; ++k) { x.push_back(0.82 + 0.02 * k); y.push_back(0.82 + 0.02 * k); }
+    m["x"] = x; m["y"] = y;
+    if (with_a) { m["a"] = std::vector<double>(20, 3.0); } // constant, sorts first
+    return m;
+  };
+
+  std::map<Size, double> lab;
+  for (Size i = 0; i < 10; ++i) { lab[i] = 0.0; }
+  for (Size i = 10; i < 20; ++i) { lab[i] = 1.0; }
+
+  Param param;
+  param.setValue("kernel", "linear");
+  param.setValue("log2_C", ListUtils::create<double>("0,3,6"));
+
+  SimpleSVM svm_a, svm_plain;
+  svm_a.setParameters(param);
+  svm_plain.setParameters(param);
+  SimpleSVM::PredictorMap train_a = make_train(true);
+  SimpleSVM::PredictorMap train_plain = make_train(false);
+  svm_a.setup(train_a, lab);        // must NOT crash (previously n_obs == 0)
+  svm_plain.setup(train_plain, lab);
+
+  TEST_EQUAL(svm_a.getScaling().find("a") == svm_a.getScaling().end(), true)
+
+  auto make_test = [](bool with_a) {
+    SimpleSVM::PredictorMap t;
+    t["x"] = std::vector<double>{0.05, 0.95};
+    t["y"] = std::vector<double>{0.05, 0.95};
+    if (with_a) { t["a"] = std::vector<double>{3.0, 3.0}; }
+    return t;
+  };
+  SimpleSVM::PredictorMap test_a = make_test(true);
+  SimpleSVM::PredictorMap test_plain = make_test(false);
+
+  std::vector<SimpleSVM::Prediction> pred_a, pred_plain;
+  svm_a.predict(test_a, pred_a);
+  svm_plain.predict(test_plain, pred_plain);
+
+  TEST_EQUAL(pred_a.size(), 2)
+  TEST_EQUAL(pred_a[0].outcome, pred_plain[0].outcome)
+  TEST_EQUAL(pred_a[1].outcome, pred_plain[1].outcome)
+  TEST_EQUAL(pred_a[0].outcome, 0.0)
+  TEST_EQUAL(pred_a[1].outcome, 1.0)
+
+  // All predictors constant -> a clean error, not a crash or empty model.
+  SimpleSVM svm_bad;
+  svm_bad.setParameters(param);
+  SimpleSVM::PredictorMap all_const;
+  all_const["a"] = std::vector<double>(20, 1.0);
+  all_const["b"] = std::vector<double>(20, 2.0);
+  TEST_EXCEPTION(Exception::MissingInformation, svm_bad.setup(all_const, lab))
+}
+END_SECTION
+
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/SimpleSVM_test.cpp
+++ b/src/tests/class_tests/openms/source/SimpleSVM_test.cpp
@@ -496,6 +496,48 @@ START_SECTION([EXTRA] setup() handles a predictor that is constant during traini
 }
 END_SECTION
 
+START_SECTION([EXTRA] setup() and predict() reject predictors with inconsistent observation counts)
+{
+  // All predictor vectors describe the same observations; a mismatched length
+  // must be rejected rather than silently desyncing the node arrays / loop.
+  std::map<Size, double> y;
+  for (Size i = 0; i < 10; ++i) { y[i] = 0.0; }
+  for (Size i = 10; i < 20; ++i) { y[i] = 1.0; }
+
+  // setup(): mismatched lengths throw (before any training).
+  {
+    SimpleSVM s;
+    SimpleSVM::PredictorMap bad;
+    bad["a"] = std::vector<double>{0, 1, 2, 3, 4, 5}; // 6
+    bad["b"] = std::vector<double>{0, 1, 2};          // 3 -> mismatch
+    std::map<Size, double> lab;
+    lab[0] = 0.0; lab[1] = 1.0;
+    TEST_EXCEPTION(Exception::InvalidValue, s.setup(bad, lab))
+  }
+
+  // predict(): a trained predictor present with the wrong length throws.
+  {
+    std::vector<double> a, b;
+    for (int k = 0; k < 10; ++k) { a.push_back(0.02 * k);        b.push_back(0.02 * k); }
+    for (int k = 0; k < 10; ++k) { a.push_back(0.82 + 0.02 * k); b.push_back(0.82 + 0.02 * k); }
+    SimpleSVM::PredictorMap train;
+    train["a"] = a; train["b"] = b;
+    Param param;
+    param.setValue("kernel", "linear");
+    param.setValue("log2_C", ListUtils::create<double>("0,3"));
+    SimpleSVM s;
+    s.setParameters(param);
+    s.setup(train, y);
+
+    SimpleSVM::PredictorMap bad_pred;
+    bad_pred["a"] = std::vector<double>{0.1, 0.9};
+    bad_pred["b"] = std::vector<double>{0.1}; // mismatch
+    std::vector<SimpleSVM::Prediction> out;
+    TEST_EXCEPTION(Exception::InvalidValue, s.predict(bad_pred, out))
+  }
+}
+END_SECTION
+
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #9661, plus a closely-related setup-side crash found (and independently confirmed) while fixing it. Both are about `SimpleSVM` mishandling a predictor that is **constant during training**.

## Bug 1 — `predict()` misaligns feature indices (#9661)

`predict(PredictorMap&)` built the LIBSVM nodes by iterating the prediction map **by position** (`index = position + 1`). But training drops constant predictors: `scaleData_` skips a predictor with `vmin == vmax`, and `convertData_` assigns LIBSVM indices only to the remaining *informative* predictors (recorded in order in `predictor_names_`). So a predictor that was constant during training (absent from the model) but present at prediction shifted every later feature's index — silently wrong predictions, and crashes once the shift ran past the model's feature count.

**Fix:** build the prediction nodes over `predictor_names_` (the trained feature set, in `convertData_`'s order), looking each up by name. Present-but-untrained predictors are ignored; a trained predictor missing at prediction now throws instead of misaligning.

## Bug 2 — `setup()` crashes when a constant predictor sorts first

`scaleData_` (called before `convertData_` in `setup()`) **empties** the value vector of every constant predictor. `convertData_` then took the observation count from `predictors.begin()->second.size()` — so if the **alphabetically-first** predictor was constant (hence emptied), `n_obs` became 0, the node arrays were sized to 0, and `setup()` crashed dereferencing `nodes_[training_index][0]`.

**Fix:** derive `n_obs` from the first **non-empty** predictor; throw `MissingInformation` when *every* predictor is constant rather than building a degenerate/empty model.

Both affect any `SimpleSVM` caller whose features can be constant within a training fold — e.g. PIP-ECHO's cross-validated transfer-FDR SVM (surfaced during the #9647 review).

## Tests (`SimpleSVM_test`, both verified to fail/crash without the fix)

- **predict() alignment:** train two models — one with an extra constant predictor `b` (mid-sort), one without — then predict identical data with `b` present-and-varying; the fix makes them agree and recover the known classes. Verified it fails without the fix (`outcome got '1', expected '0'`).
- **setup() robustness:** a constant predictor sorting **first** must train and predict like a model that never saw it; an **all-constant** input must throw `MissingInformation`. Verified it crashes `setup()` without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rawZsiVUCJjzyXTqkkrWK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model setup by deriving usable observation counts from informative predictors and failing when none remain.
  * Strengthened prediction input handling to use exactly the trained feature set and ordering with consistent scaling.
  * Added clear error handling when required trained predictors are missing during prediction.
* **Tests**
  * Added regression coverage for dropping constant predictors, including cases where such predictors sort first.
  * Added a negative test verifying failure when all predictors are constant, plus a check that prediction results remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->