### PR TITLE
[FIX] PeptideAndProteinQuant: O(1) sample-ID lookup (fixes IsobaricWorkflow "Quantifying peptides" hang)

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.h
@@ -16,6 +16,9 @@
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/ExperimentalDesign.h>
 
+#include <map>
+#include <string>
+#include <utility>
 
 namespace OpenMS
 {
@@ -206,6 +209,11 @@ private:
     /// Experimental design for filename/channel to sample mapping
     ExperimentalDesign experimental_design_;
 
+    /// Precomputed lookup (basename without extension, channel/label) -> sample ID,
+    /// built once from @p experimental_design_ to avoid linear scans of the MS file
+    /// section for every peptide/channel during aggregation.
+    std::map<std::pair<std::string, UInt>, size_t> sample_id_lookup_;
+
 
     /**
          @brief Get the "canonical" annotation (a single peptide hit) of a feature/consensus feature from the associated list of peptide identifications.
@@ -374,16 +382,24 @@ private:
     void countPeptides_(PeptideIdentificationList& peptides);
 
     /**
-         @brief Map (filename, channel) to sample using ExperimentalDesign.
-         
+         @brief (Re)build @p sample_id_lookup_ from @p experimental_design_.
+
+         Maps each (basename without extension, channel/label) of the MS file section to its
+         sample ID. The first occurrence of a (basename, label) pair wins, matching the
+         previous linear-scan semantics. Called whenever the experimental design is (re)set.
+    */
+    void buildSampleIDLookup_();
+
+    /**
+         @brief Map (filename, channel) to sample using the precomputed @p sample_id_lookup_.
+
          @param[in] filename The base filename (without path/extension)
          @param[in] channel_or_label The channel/label identifier
-         @param[in] ed The experimental design containing the mapping information
          @return The sample ID corresponding to the filename and channel
+         @throw Exception::MissingInformation if the (filename, channel) pair is not in the experimental design
     */
     size_t getSampleIDFromFilenameAndChannel_(const std::string& filename,
-                                           UInt channel_or_label,
-                                           const ExperimentalDesign& ed) const;
+                                           UInt channel_or_label) const;
 
     /// Clear all data when parameters are set
     void updateMembers_() override;

--- a/src/openms/source/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.cpp
@@ -174,26 +174,34 @@ namespace OpenMS
     return best_n_quant > 0; // Return true if at least one abundance was found
   }
 
-  size_t PeptideAndProteinQuant::getSampleIDFromFilenameAndChannel_(const std::string& filename,
-                                                                 UInt channel_or_label,
-                                                                 const ExperimentalDesign& ed) const
+  void PeptideAndProteinQuant::buildSampleIDLookup_()
   {
-    // Map filename and label to sample using experimental design
-    const auto& ms_section = ed.getMSFileSection();
-    for (const auto& entry : ms_section)
+    // Build a (basename, channel/label) -> sample lookup once, so that the
+    // per-peptide/per-channel aggregation below does not have to linearly scan
+    // the MS file section (and recompute File::stemName) for every single lookup.
+    sample_id_lookup_.clear();
+    for (const auto& entry : experimental_design_.getMSFileSection())
     {
-      std::string ed_filename = File::stemName(entry.path);
-      if (ed_filename == filename && entry.label == channel_or_label)
-      {
-        return entry.sample;
-      }
+      // emplace keeps the first occurrence of a (basename, label) pair, matching
+      // the previous linear-scan behaviour which returned the first match.
+      sample_id_lookup_.emplace(std::make_pair(File::stemName(entry.path), entry.label), entry.sample);
     }
-    
+  }
+
+  size_t PeptideAndProteinQuant::getSampleIDFromFilenameAndChannel_(const std::string& filename,
+                                                                 UInt channel_or_label) const
+  {
+    // Map filename and label to sample using the precomputed lookup.
+    if (auto it = sample_id_lookup_.find({filename, channel_or_label}); it != sample_id_lookup_.end())
+    {
+      return it->second;
+    }
+
     // If not found, throw an exception with detailed information
     throw Exception::MissingInformation(
-      __FILE__, 
-      __LINE__, 
-      OPENMS_PRETTY_FUNCTION, 
+      __FILE__,
+      __LINE__,
+      OPENMS_PRETTY_FUNCTION,
       "Could not find sample mapping for filename '" + filename + "' and channel '" + StringUtils::toStr(channel_or_label) + "' in experimental design.");
   }
 
@@ -259,6 +267,9 @@ namespace OpenMS
 
     //////////////////////////////////////////////////////
     // second, perform the actual peptide quantification:
+    // number of labels/channels is constant across the design; compute once
+    // (getNumberOfLabels() scans the whole MS file section on every call).
+    const Size n_labels = experimental_design_.getNumberOfLabels();
     for (auto & pep_q : pep_quant_)
     {
       if (param_.getValue("best_charge_and_fraction") == "true")
@@ -281,7 +292,7 @@ namespace OpenMS
         UInt best_channel = std::get<3>(best_combination);
         
         double abundance = pep_q.second.abundances[best_fraction][best_filename][best_charge][best_channel];
-        size_t sample_id = getSampleIDFromFilenameAndChannel_(best_filename, best_channel, experimental_design_);
+        size_t sample_id = getSampleIDFromFilenameAndChannel_(best_filename, best_channel);
         pep_q.second.total_abundances[sample_id] = abundance;
       }
       else
@@ -299,7 +310,7 @@ namespace OpenMS
                 const double & abundance = cha.second;
                 
                 // Map (filename, channel) to sample using ExperimentalDesign
-                size_t sample_id = getSampleIDFromFilenameAndChannel_(filename, channel, experimental_design_);
+                size_t sample_id = getSampleIDFromFilenameAndChannel_(filename, channel);
                 pep_q.second.total_abundances[sample_id] += abundance;
               }
             }
@@ -318,9 +329,9 @@ namespace OpenMS
             const double & psm_counts = ca.second;
             
             // In multiplexed design, e.g. TMT, a signle PSM is associated with all samples measured in the different channels/labels 
-            for (Size channel = 1; channel <= experimental_design_.getNumberOfLabels(); ++channel)
+            for (Size channel = 1; channel <= n_labels; ++channel)
             {
-              size_t sample_id = getSampleIDFromFilenameAndChannel_(filename, channel, experimental_design_);              
+              size_t sample_id = getSampleIDFromFilenameAndChannel_(filename, channel);              
               pep_q.second.total_psm_counts[sample_id] += psm_counts; // accumulate PSM counts for spectral counting
             }
           }
@@ -400,7 +411,7 @@ namespace OpenMS
             {
               const std::string & filename = fna.first;
               const UInt & channel = cha.first;
-              size_t sample_id = getSampleIDFromFilenameAndChannel_(filename, channel, experimental_design_);
+              size_t sample_id = getSampleIDFromFilenameAndChannel_(filename, channel);
               cha.second *= scale_factors[sample_id];
             }
           }
@@ -554,6 +565,7 @@ namespace OpenMS
   {
     updateMembers_(); // clear data
     experimental_design_ = ed; // store experimental design for aggregation
+    buildSampleIDLookup_(); // precompute (basename, channel) -> sample lookup
 
     stats_.n_samples = ed.getNumberOfSamples();
     stats_.n_fractions = 1;
@@ -602,6 +614,7 @@ namespace OpenMS
     // TODO check that the file section of the experimental design is compatible with what can be parsed from the consensus map.
     updateMembers_(); // clear data
     experimental_design_ = ed; // store experimental design for aggregation
+    buildSampleIDLookup_(); // precompute (basename, channel) -> sample lookup
 
     if (consensus.empty())
     {
@@ -695,6 +708,7 @@ namespace OpenMS
   {
     updateMembers_(); // clear data
     experimental_design_ = ed; // store experimental design for aggregation
+    buildSampleIDLookup_(); // precompute (basename, channel) -> sample lookup
 
     stats_.n_samples = ed.getNumberOfSamples();
     stats_.n_fractions = ed.getNumberOfFractions();
@@ -782,6 +796,7 @@ namespace OpenMS
     stats_ = Statistics();
     pep_quant_.clear();
     prot_quant_.clear();
+    sample_id_lookup_.clear();
   }
 
 
@@ -812,7 +827,11 @@ namespace OpenMS
   {
     // read experimental design as it is needed to annotate quantities in the correct order
     ExperimentalDesign::MSFileSection msfile_section = experimental_design_.getMSFileSection();
-    
+
+    // number of labels/channels is constant across the design; compute once
+    // (getNumberOfLabels() scans the whole MS file section on every call).
+    const Size n_labels = experimental_design_.getNumberOfLabels();
+
     // Extract the Spectra Filepath column from the design
     map<UInt64, map<UInt64, std::string>> design_group_fraction_filename;
     UInt64 n_files = 0;
@@ -913,7 +932,7 @@ namespace OpenMS
             #endif
 
             // for each file in the design, fill the channels quantity
-            for (Size c = 1; c <= experimental_design_.getNumberOfLabels(); ++c) // label/channel numbers are 1-based
+            for (Size c = 1; c <= n_labels; ++c) // label/channel numbers are 1-based
             {
               double channel_abundance{};
 


### PR DESCRIPTION
## Problem

`IsobaricWorkflow` (and `ProteinQuantifier`/`ProteomicsLFQ`) can hang for **hours** at the `Quantifying peptides...` step, with CPU usage sitting around ~5% — which looks like a deadlock but is actually **one core pegged at 100% on a many-core machine** (the code path is single-threaded).

### Root cause

`PeptideAndProteinQuant::getSampleIDFromFilenameAndChannel_()` performed a **linear scan** over the experimental-design MS file section and recomputed `File::stemName(entry.path)` (a heap-allocating string operation) for **every scanned row**:

```cpp
for (const auto& entry : ed.getMSFileSection())          // O(#files × #channels)
{
  std::string ed_filename = File::stemName(entry.path);  // string alloc, every row
  if (ed_filename == filename && entry.label == channel_or_label) return entry.sample;
}
```

It is called from the bottom of the 5-deep peptide aggregation loops (`peptide × fraction × file × charge × channel`) **and** a separate per-`(file,charge)` × label PSM-count loop. For a large isobaric experiment — e.g. **600 files × 18 channels → 10,800 MS-file-section rows** — the step degenerates to roughly `O(#observations × #channels × #ms_section_rows)` with two heap allocations per inner step. That is on the order of **10¹¹ allocating string comparisons**, i.e. **hours** of single-threaded wall time.

Additionally, the loop condition re-evaluated `experimental_design_.getNumberOfLabels()` every iteration, and that helper itself does an `O(ms_section)` `std::max_element`.

## Fix

1. **Precompute** a `std::map<std::pair<std::string, UInt>, size_t>` mapping `(stemName(path), label) → sample`, built **once** per `readQuantData()`. `getSampleIDFromFilenameAndChannel_()` now does a single `map::find`. `emplace` keeps the **first** occurrence of a `(stem, label)` pair, preserving the old "return first match" semantics. The cache is cleared in `updateMembers_()`.
2. **Hoist** `getNumberOfLabels()` into a `const` before the loops in `quantifyPeptides()` and `annotateQuantificationsToProteins()`.

This takes the lookups from `O(ms_section)`-with-allocations down to `O(log ms_section)`, turning the "Quantifying peptides" step from **hours → seconds** on large isobaric data. The number of lookups is unchanged, so results are bit-for-bit identical.

## Correctness / behavior

No behavioral change. The mapping is built from the same `getMSFileSection()` in the same order, with identical first-match semantics and the identical `Exception::MissingInformation` on a miss. The consensus path already validated `(basename, label)` uniqueness upstream.

## Testing

- `PeptideAndProteinQuant_test` ✅
- `TOPP_ProteinQuantifier`, `TOPP_IsobaricWorkflow`, `TOPP_ProteomicsLFQ` — **101/101 pass** with identical reference output ✅
- Adversarial static review (codex): no correctness regressions found; lifecycle (cache always built in `readQuantData` before any consumer) verified across all three TOPP drivers and the unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
