### PR TITLE
fix(PIPECHO): revive dead mass-error feature and drop raw/inverted RT from mbr_score

### DIFF
--- a/src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/RunStatistics.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/RunStatistics.cpp
@@ -157,13 +157,19 @@ Score RunStatistics::score(const Feature& donor, const Feature& acceptor,
              .im_diff_score = -1.0, // sentinel: ion mobility not applicable
              .mbr_score = MIN_SCORE};
 
-  // The MBR bootstrap score is the geometric mean of the individual feature
-  // scores. Ion mobility is an optional 4th feature, included only when the
-  // data carries it (e.g. timsTOF/.d) -- then the geometric mean becomes a
-  // 4th root instead of a cube root. `measures` tracks how many scores are
-  // multiplied below; keep it in sync with the product.
-  double product = s.intensity * s.rt_diff_error * s.mass_error;
-  double measures = 3.0;
+  // The MBR bootstrap score is the geometric mean of the agreement scores.
+  // Retention time is intentionally EXCLUDED: the current rt_diff_error is a raw,
+  // un-normalised |Δrt| with inverted monotonicity (a larger RT error would
+  // *increase* the score), and on pre-aligned runs the in-window decoys share the
+  // targets' RT range -- so multiplying it in only distorts the geometric mean and
+  // the best-acceptor/bootstrap ranking that mbr_score drives. A faithful RT
+  // agreement score (FlashLFQ uses an anchor-peptide RT prediction-error
+  // distribution) is a follow-up; RT is still given to the SVM as a feature.
+  // Ion mobility is an optional extra factor, included only when the data carries
+  // it (e.g. timsTOF/.d). `measures` tracks how many scores are multiplied below;
+  // keep it in sync with the product.
+  double product = s.intensity * s.mass_error;
+  double measures = 2.0;
 
   if (auto im = calc_im_score(donor, acceptor); im.has_value())
   {

--- a/src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/Util.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/Util.cpp
@@ -10,6 +10,12 @@
 
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/MATH/MathFunctions.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
+#include <OpenMS/DATASTRUCTURES/DataValue.h>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
 
 namespace OpenMS::PipEcho::Util
 {
@@ -42,11 +48,52 @@ bool feature_is_decoy(const Feature& feature)
 /**************************************************************************/
 std::optional<double> feature_mass_error(const Feature& feature)
 {
-  auto hit = Util::feature_hit(feature);
-  if (! hit.has_value()) return {};
-  double experimental = feature.getMZ();
-  double theoretical = hit->getSequence().getMZ(hit->getCharge());
-  return Math::getPPM(experimental, theoretical);
+  // Prefer FeatureFinderIdentification's observed mass-trace deviation:
+  // "masserror_ppm" is a per-isotope getPPM(observed, theoretical) from the DIA
+  // mass-difference score (-1 = "no signal" sentinel). It is the identified
+  // feature's REAL MS1 mass accuracy -- the quantity FlashLFQ calibrates its ppm
+  // distribution from. feature.getMZ() is FFID's THEORETICAL assay m/z (FFID seeds
+  // the position m/z), so getPPM(feature.getMZ(), theoretical) is identically 0
+  // and the calibration distribution collapses, leaving the mass feature dead.
+  // (Requires masserror_ppm to survive ProteomicsLFQ's feature-meta strip, where
+  // it is whitelisted in keep_meta.)
+  // A real mass error can be more negative than -1 ppm, so the "no signal"
+  // sentinel must be matched EXACTLY (-1), not as "<= -1". (DIAScoring pushes a
+  // literal -1.0 for an isotope with no observed signal.)
+  auto valid = [](double e) { return std::isfinite(e) && e != -1.0; };
+  if (feature.metaValueExists("masserror_ppm"))
+  {
+    const DataValue dv = feature.getMetaValue("masserror_ppm");
+    if (dv.valueType() == DataValue::DOUBLE_LIST)
+    {
+      std::vector<double> errs = dv.toDoubleList();
+      if (! errs.empty() && valid(errs.front())) { return errs.front(); } // monoisotopic
+      // monoisotopic missing -> robust median of the remaining valid isotopes
+      std::vector<double> rest;
+      for (double e : errs) { if (valid(e)) { rest.push_back(e); } }
+      if (! rest.empty())
+      {
+        std::sort(rest.begin(), rest.end());
+        return rest[rest.size() / 2];
+      }
+    }
+    else if (dv.valueType() == DataValue::DOUBLE_VALUE)
+    {
+      const double e = dv;
+      if (valid(e)) { return e; }
+    }
+  }
+
+  // Fallbacks when masserror_ppm is unavailable (e.g. a non-FFID feature path):
+  // the identification's OBSERVED precursor m/z vs theoretical, else feature.getMZ()
+  // (which is theoretical for FFID, giving a 0 error -- the dead-feature case).
+  const PeptideIdentificationList& peps = feature.getPeptideIdentifications();
+  if (peps.empty() || peps[0].getHits().empty()) { return {}; }
+  const PeptideHit& hit = peps[0].getHits()[0];
+  const double theoretical = hit.getSequence().getMZ(hit.getCharge());
+  double observed = peps[0].hasMZ() ? peps[0].getMZ() : feature.getMZ();
+  if (! std::isfinite(observed) || observed <= 0.0) { observed = feature.getMZ(); }
+  return Math::getPPM(observed, theoretical);
 }
 
 /**************************************************************************/

--- a/src/topp/ProteomicsLFQ.cpp
+++ b/src/topp/ProteomicsLFQ.cpp
@@ -1309,7 +1309,17 @@ protected:
       // "IM_median"; "n_scans" feeds the planned scan-count feature, see #9655).
       // FFID output features carry neither key, so this is a no-op for the
       // current FFID-based path.
+      // "IM"/"n_scans" carry no payload on the FFID path, so keeping them is a no-op.
       unordered_set<std::string> keep_meta = {"OffsetPeptide", "IM_median", "IM_min", "IM_max", "IM", "n_scans"};
+      // "masserror_ppm" is FFID's observed mass-trace deviation from the peptide's
+      // theoretical m/z (DIA mass-difference score) -- the only real per-feature
+      // mass-accuracy signal (FFID seeds the feature's *position* m/z to the
+      // theoretical value, so PIP-ECHO cannot recover the error from getMZ()). It is
+      // ONLY needed by PIP-ECHO's donor mass-error calibration, and keeping it on the
+      // default linker path would leak it into the consensusXML/mzTab output (the
+      // QT-linker path propagates feature metas), changing TOPP_ProteomicsLFQ
+      // references. So keep it only when pip_echo is enabled.
+      if (getStringOption_("pip_echo") == "true") { keep_meta.insert("masserror_ppm"); }
       for (auto & f : fm)
       {
         std::vector<std::string> keys;


### PR DESCRIPTION
# fix(PIPECHO): revive the dead mass-error feature and drop raw/inverted RT from `mbr_score`

## Summary

On real `ProteomicsLFQ` data, PIP-ECHO (`-pip_echo true`) produced **zero**
match-between-runs transfers at every FDR cutoff. Two of its three scoring
features were broken; the recently-merged #9661 `SimpleSVM` fix exposed it (the
old behaviour rode on a feature-index-misalignment bug that manufactured spurious
separation). This PR fixes the two feature bugs.

## How it was found

Replicating the PXD016921 single-cell blank-leakage benchmark (the quantms
[#287](https://github.com/bigbio/quantms/issues/287) dataset) on landed `develop`:
PIP-ECHO transferred **0** features at `fdr` = 0.01 / 0.05 / 0.10. Bisection
pinned the change to #9661; instrumenting the per-feature target/decoy AUC on real
data showed **no feature separated** (mass 0.50, intensity 0.52, RT 0.49). That
led to the two root causes below.

## Root causes

### 1. `mass_error` was a dead (constant) feature

`RunStatistics::init_mass_error` calibrates a donor mass-error distribution via
`Util::feature_mass_error`, which computed `getPPM(feature.getMZ(), theoretical)`.
But `FeatureFinderIdentification` **seeds the feature's position m/z to the
peptide's theoretical m/z**, so this is **identically 0 for every donor**. The
distribution is degenerate → `calc_score_using` returns a constant `MIN_SCORE`
for every acceptor → `SimpleSVM` logs `Predictor 'mass_error' is uninformative`
and drops it.

The real observed mass accuracy is already computed and stored on the feature as
the **`masserror_ppm`** meta (the OpenSWATH DIA mass-difference score,
`getPPM(observed, theoretical)` per isotope) — but `ProteomicsLFQ` strips it
before grouping.

**Fix:** whitelist `masserror_ppm` in `keep_meta`, and read it in
`feature_mass_error` (monoisotopic-first; the `-1` "no signal" sentinel matched
*exactly* so genuinely-negative errors are kept; precursor-m/z then feature-m/z
fallbacks). This mirrors FlashLFQ, which calibrates its ppm distribution from the
observed mass errors of identified peaks.

### 2. `rt_diff_error` was raw and inverted in `mbr_score`

The geometric-mean `mbr_score` multiplied in the **raw absolute RT difference**
(0–1200+ s, so it dominates the product by magnitude) with **inverted
monotonicity** — a larger RT error *increased* the score. Because `mbr_score`
drives best-acceptor selection and the round-1 bootstrap seed, this corrupted
both. On pre-aligned runs the in-window decoys share the targets' RT range, so RT
is also a weak discriminator here.

**Fix:** drop RT from the `mbr_score` geomean (it is still handed to the SVM as a
feature). A correctly *calibrated* RT-agreement score is deferred to #9655 (see
below).

## Results (PXD016921, Blank = empty run, direct-ID floor 93 peptides)

| config | transfers (fdr=0.05) | realized FDR | Blank Δpep | 100-cell Δpep |
|---|---:|---:|---:|---:|
| `develop` | **0** | — | 0 | 0 |
| this PR | **1280** | ~5.2% | **+2** | **+392** |

PIP-ECHO now performs genuine FDR-controlled MBR: transfers concentrate in the
data-rich runs (100-cell +888, 20-cell +317 features) while the empty Blank stays
clean (+4 transfers → +2 peptides). The FDR knob behaves monotonically
(Blank 65→98, sensitivity rising) — driven by real mass signal, not an SVM
artifact. The donor calibration is now `Normal(+1.91 ppm, 1.20)`, matching the
acceptor target population (+1.49 ppm).

## Validation

- `PipEchoAlgorithm_test` and `PipEchoAlgorithm_realistic_test` (slow): **pass**.
- The `keep_meta` change is **output-neutral**: `masserror_ppm` is dropped at the
  consensus level (`FeatureHandle` is not a `MetaInfoInterface`), so it never
  reaches the `consensusXML`. The default `pip_echo=false` path is unchanged.
  (Worth confirming `TOPP_ProteomicsLFQ_*` in CI.)

## Scope / honesty

This recovers the **mass** signal; it is **not** FlashLFQ-level MBR. The OpenMS
port still scores only **3 of FlashLFQ's 5 features** — the strongest
discriminators (isotopic-distribution similarity and MS1 scan count) are absent,
and RT is dropped rather than properly calibrated. An RT attribution run shows the
raw-RT variant is *more* sensitive (2048 vs 1280 at fdr=0.05) but leaks 2× into
the Blank (8 vs 4) via that arbitrary magnitude-dominating term — so RT does carry
signal and should be added back **calibrated**, not kept raw. All of this is
tracked in #9655.

## Files

- `src/topp/ProteomicsLFQ.cpp` — `keep_meta += "masserror_ppm"`
- `src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/Util.cpp` — `feature_mass_error` reads `masserror_ppm`
- `src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/RunStatistics.cpp` — drop raw RT from the `mbr_score` geomean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mass error handling to prefer the most reliable source, including per-isotope values when available, with safer parsing and fallback behavior when metadata is missing or invalid.
  * Adjusted bootstrap scoring so retention-time agreement is excluded from that calculation, aligning the score with the intended input signals.
  * Ensured mass error metadata is preserved during feature processing when pip_echo is enabled, preventing it from being dropped before downstream steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->