### PR TITLE
feat(PIPECHO): isotope-distribution MBR feature (envelope correlation)

### DIFF
--- a/src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/RunStatistics.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/RunStatistics.cpp
@@ -8,9 +8,14 @@
 
 #include <OpenMS/MATH/MathFunctions.h>
 #include <OpenMS/MATH/StatisticFunctions.h>
+#include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.h>
+#include <OpenMS/CHEMISTRY/AASequence.h>
 #include "Run.h"
 #include "RunStatistics.h"
 #include "Util.h"
+
+#include <algorithm>
+#include <cmath>
 
 // Standard deviation is computed from the interquartile range by
 // dividing by 27/20 ≅ 1.349.
@@ -155,6 +160,7 @@ Score RunStatistics::score(const Feature& donor, const Feature& acceptor,
              .rt_diff_error = std::fabs(acceptor.getRT() - donor_rt),
              .mass_error = calc_mass_error_score(donor, acceptor),
              .im_diff_score = -1.0, // sentinel: ion mobility not applicable
+             .isotope_score = calc_isotope_score(donor, acceptor),
              .mbr_score = MIN_SCORE};
 
   // The MBR bootstrap score is the geometric mean of the agreement scores.
@@ -224,6 +230,35 @@ RunStatistics::calc_im_score(const Feature& donor, const Feature& acceptor) cons
   // (same ion) scores near 1, a large one decays towards MIN_SCORE. Reuses the
   // two-tailed CDF helper (mean 0 => 2 * cdf(N(0, sigma), -|delta|)).
   return calc_score_using(im_tolerance, *acceptor_im - *donor_im);
+}
+
+/******************************************************************************/
+double RunStatistics::calc_isotope_score(const Feature& donor, const Feature& acceptor) const
+{
+  // Neutral "uncorrelated" value when the envelope is unavailable/too short.
+  constexpr double NA = 0.5;
+
+  auto obs = Util::feature_obs_envelope(acceptor);
+  auto donor_hit = Util::feature_hit(donor);
+  if (! obs.has_value() || ! donor_hit.has_value()) { return NA; }
+
+  // Donor peptide's theoretical isotope envelope (neutral formula -- the relative
+  // isotope intensities are charge-independent), to the observed envelope length.
+  IsotopeDistribution iso = donor_hit->getSequence().getFormula().getIsotopeDistribution(
+    CoarseIsotopePatternGenerator(obs->size()));
+
+  std::vector<double> theo;
+  theo.reserve(iso.size());
+  for (const auto& peak : iso) { theo.push_back(peak.getIntensity()); }
+
+  const std::size_t n = std::min(obs->size(), theo.size());
+  if (n < 3) { return NA; } // Pearson is degenerate for < 3 points
+
+  const double r = Math::pearsonCorrelationCoefficient(
+    obs->begin(), obs->begin() + n, theo.begin(), theo.begin() + n);
+  if (! std::isfinite(r)) { return NA; } // a constant envelope yields NaN
+
+  return (r + 1.0) / 2.0; // map [-1, 1] -> [0, 1] (1 = identical envelope shape)
 }
 
 /******************************************************************************/

--- a/src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/RunStatistics.h
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/RunStatistics.h
@@ -63,6 +63,14 @@ private:
   /// RT), mirroring the mass-error feature.
   std::optional<double> calc_im_score(const Feature& donor, const Feature& acceptor) const;
 
+  /// Isotope-distribution agreement score for a donor/acceptor pair: the Pearson
+  /// correlation between the acceptor's observed isotope envelope and the donor
+  /// peptide's theoretical envelope, mapped to [0, 1]. Returns 0.5
+  /// ("uncorrelated") when the envelope is unavailable or too short. Identity-
+  /// coupled (compares the acceptor signal to the DONOR's theoretical pattern),
+  /// so a coincidental m/z match scores low.
+  double calc_isotope_score(const Feature& donor, const Feature& acceptor) const;
+
 private:
   // Log intensity distribution.
   normal_t log_intensity;

--- a/src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/Score.h
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/Score.h
@@ -33,6 +33,13 @@ struct Score
   /// both the geometric-mean MBR score and the SVM feature set.
   double im_diff_score;
 
+  /// Isotope-distribution agreement score in [0, 1]: the Pearson correlation
+  /// between the acceptor's observed isotope envelope and the donor peptide's
+  /// theoretical envelope, mapped from [-1, 1] to [0, 1] (1 = identical shape).
+  /// 0.5 ("uncorrelated") is used when the envelope is unavailable. Currently an
+  /// SVM-only feature (not part of the geometric-mean MBR score).
+  double isotope_score;
+
   /// Single score used for bootstrapping.
   double mbr_score;
 };

--- a/src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/TransferFDRModel.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/TransferFDRModel.cpp
@@ -635,6 +635,9 @@ void predictors_t::encode(const TransferFDRModel::acceptor_t& acceptor,
   predictors["intensity"].push_back(acceptor.score.intensity);
   predictors["rt_diff_error"].push_back(acceptor.score.rt_diff_error);
   predictors["mass_error"].push_back(acceptor.score.mass_error);
+  // Isotope-distribution agreement is always [0, 1] (0.5 sentinel when absent),
+  // so the column is rectangular and can be pushed unconditionally.
+  predictors["isotope_score"].push_back(acceptor.score.isotope_score);
   // Ion mobility is added as a predictor only when used experiment-wide, so the
   // predictor columns stay equal-length (required by SimpleSVM).
   if (use_im)

--- a/src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/Util.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/Util.cpp
@@ -97,6 +97,17 @@ std::optional<double> feature_mass_error(const Feature& feature)
 }
 
 /**************************************************************************/
+std::optional<std::vector<double>> feature_obs_envelope(const Feature& feature)
+{
+  if (! feature.metaValueExists("pipecho_obs_envelope")) { return {}; }
+  const DataValue dv = feature.getMetaValue("pipecho_obs_envelope");
+  if (dv.valueType() != DataValue::DOUBLE_LIST) { return {}; }
+  std::vector<double> env = dv.toDoubleList();
+  if (env.empty()) { return {}; }
+  return env;
+}
+
+/**************************************************************************/
 std::optional<double> feature_ion_mobility(const Feature& feature)
 {
   if (feature.metaValueExists("IM_median"))

--- a/src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/Util.h
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/Util.h
@@ -12,6 +12,7 @@
 #include <OpenMS/METADATA/PeptideHit.h>
 
 #include <optional>
+#include <vector>
 
 namespace OpenMS::PipEcho::Util
 {
@@ -37,6 +38,15 @@ bool feature_is_decoy(const Feature&);
  * Compute the mass error in PPM for the given feature.
  */
 std::optional<double> feature_mass_error(const Feature&);
+
+/******************************************************************************/
+/**
+ * Return the feature's observed isotope envelope (per-isotope intensities), or
+ * nullopt if absent. Reads the "pipecho_obs_envelope" meta value snapshotted by
+ * ProteomicsLFQ from the FeatureFinderIdentification subordinate intensities
+ * before they are stripped.
+ */
+std::optional<std::vector<double>> feature_obs_envelope(const Feature&);
 
 /******************************************************************************/
 /**

--- a/src/topp/ProteomicsLFQ.cpp
+++ b/src/topp/ProteomicsLFQ.cpp
@@ -1190,6 +1190,18 @@ protected:
         ffi_param.setValue("detect:peak_width", 5.0 * median_fwhm);
         ffi_param.setValue("debug", debug_level_); // pass down debug level
 
+        // PIP-ECHO's isotope-distribution MBR feature correlates the acceptor's
+        // observed isotope envelope against the donor peptide's theoretical
+        // envelope; the default 2 isotopes give a degenerate Pearson. Extract 3
+        // (enough for a meaningful correlation) only on the pip_echo path. More
+        // (e.g. 5) measurably perturbs FFID's extraction/candidate set and costs
+        // direct quantifications, so 3 is the sweet spot. The default linker path
+        // (and its TOPP reference outputs) is untouched.
+        if (getStringOption_("pip_echo") == "true")
+        {
+          ffi_param.setValue("extract:n_isotopes", 3);
+        }
+
         // Note: no IM_window override needed — BrukerTimsFile loads with built-in IM centroiding
         // (ms1_centroid_mz_ppm=5, ms1_centroid_im_pct=3), so data is IM_CENTROIDED and the
         // default IM_window=0.06 is appropriate for matching centroided IM positions.
@@ -1313,13 +1325,15 @@ protected:
       unordered_set<std::string> keep_meta = {"OffsetPeptide", "IM_median", "IM_min", "IM_max", "IM", "n_scans"};
       // "masserror_ppm" is FFID's observed mass-trace deviation from the peptide's
       // theoretical m/z (DIA mass-difference score) -- the only real per-feature
-      // mass-accuracy signal (FFID seeds the feature's *position* m/z to the
-      // theoretical value, so PIP-ECHO cannot recover the error from getMZ()). It is
-      // ONLY needed by PIP-ECHO's donor mass-error calibration, and keeping it on the
-      // default linker path would leak it into the consensusXML/mzTab output (the
-      // QT-linker path propagates feature metas), changing TOPP_ProteomicsLFQ
-      // references. So keep it only when pip_echo is enabled.
-      if (getStringOption_("pip_echo") == "true") { keep_meta.insert("masserror_ppm"); }
+      // mass-accuracy signal (FFID seeds the feature's *position* m/z to theoretical,
+      // so PIP-ECHO cannot recover the error from getMZ()). "pipecho_obs_envelope" is
+      // the observed isotope envelope (subordinate intensities), snapshotted below
+      // before subordinates are cleared, for the isotope-distribution feature. BOTH
+      // are needed ONLY by PIP-ECHO; keeping/writing them on the default QT-linker path
+      // leaks them into the consensusXML/mzTab output (shifting TOPP_ProteomicsLFQ
+      // references), so gate on pip_echo.
+      const bool pip_echo_enabled = getStringOption_("pip_echo") == "true";
+      if (pip_echo_enabled) { keep_meta.insert("masserror_ppm"); keep_meta.insert("pipecho_obs_envelope"); }
       for (auto & f : fm)
       {
         std::vector<std::string> keys;
@@ -1327,6 +1341,16 @@ protected:
         for (const auto& k : keys)
         {
           if (auto it = keep_meta.find(k); it == keep_meta.end()) f.removeMetaValue(k);
+        }
+        // Snapshot the observed isotope envelope before subordinates are dropped
+        // (pip_echo only -- otherwise it would leak into the default-path output,
+        // since this writes AFTER the meta-strip above).
+        if (pip_echo_enabled && ! f.getSubordinates().empty())
+        {
+          DoubleList envelope;
+          envelope.reserve(f.getSubordinates().size());
+          for (const Feature& sub : f.getSubordinates()) { envelope.push_back(sub.getIntensity()); }
+          f.setMetaValue("pipecho_obs_envelope", envelope);
         }
         f.setSubordinates({});
         f.setConvexHulls({});


### PR DESCRIPTION
## What

Adds the **isotope-distribution similarity** MBR feature to PIP-ECHO — one of the two
features the OpenMS port dropped from FlashLFQ's 5-feature classifier (issue #9655).

For each candidate (donor, acceptor) transfer it computes the Pearson correlation between
the acceptor's **observed** isotope envelope and the donor peptide's **theoretical** envelope
(`CoarseIsotopePatternGenerator`), mapped to `[0,1]`, and feeds it to the transfer-FDR SVM.
It is **identity-coupled** (acceptor signal vs the *donor's* theoretical pattern), so a
coincidental same-m/z match scores lower.

Mechanics:
- ProteomicsLFQ extracts **3** isotopes on the `pip_echo` path (the default 2 give a
  degenerate Pearson) and snapshots the observed envelope into a `pipecho_obs_envelope` meta
  **before** the feature-meta strip (whitelisted, like the mass fix's `masserror_ppm`).
- `RunStatistics::calc_isotope_score` does the correlation; added as an SVM-only predictor
  (not the `mbr_score` geomean).

> **Stacked on #9674** (the mass-error/RT fix) — base branch is `fix/pipecho-mass-rt-features`;
> the diff here is just the isotope commit. Retarget to `develop` once #9674 merges.

## Results (PXD016921 single-cell, `PipEcho:fdr=0.05`, on top of #9674)

The right metric is **cross-run completeness** (consensus size = how many of the 7 runs a
peptide is quantified in), not distinct-peptide count — transfers fill out existing groups
(total consensus ~19,400 constant), reducing missing values. All rows at ~5% realized FDR
with a clean Blank.

| build | transfers | peptides in **all 7 runs** (sz7) | singletons (sz1) |
|---|---:|---:|---:|
| develop (mass dead) | 0 | 37 | 11533 |
| #9674 (n_iso=2, mass) | 1280 | 114 | 10969 |
| n_iso=3 mass-only (control) | 1343 | 124 | 10910 |
| **n_iso=3 + isotope (this PR)** | **1826** | **167 (+46% vs #9674)** | **10730** |

**Attribution (measured via the n_iso=3 mass-only control):** the isotope feature itself
contributes **+483 transfers (+36%) and +43 of the +53 sz7 gain (~81%)**. `n_isotopes=3`
alone is only a minor positive (sz7 114→124) and — unlike `n_isotopes=5`, which *hurts*
mass-only (1280→1103) — carries no extraction penalty. So the completeness win is genuinely
the feature, and `n_isotopes=3` is the sweet spot.

## Honest scope / caveats

- The feature's **univariate** target/decoy AUC is only **0.54** (it helps *multivariately*
  in the SVM). OpenMS PIP-ECHO has **no raw-MS1 access** (`group()` takes pre-extracted
  `FeatureMap`s), so it cannot re-extract the envelope at the candidate identity/RT the way
  FlashLFQ does to make isotope/scan strong; two peptides within 10 ppm have similar
  pre-extracted envelopes. The win is real but bounded by that architecture.
- **Scan count** (the other dropped feature) is **not** ported: the acceptor's self
  `points_across_baseline`/FWHM is identity-independent (redundant with intensity) and would
  need the same raw re-extraction.
- **RT** stays out of `mbr_score` (its raw/inverted form was fixed in #9674); calibrating it
  is a monotonic transform that cannot change its ~0.49 AUC.

Tests: `PipEchoAlgorithm_test` and `PipEchoAlgorithm_realistic_test` pass; the
`extract:n_isotopes` change is confined to the `pip_echo` path, so the default linker path
and its `TOPP_ProteomicsLFQ_*` references are untouched.

Closes part of #9655 (isotope feature); the remaining items (scan count via raw
re-extraction, faithful RT) are scoped in that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added isotope-envelope scoring to improve feature matching quality.
  * Preserved observed isotope envelope and mass error information for downstream scoring in relevant workflows.

* **Bug Fixes**
  * Improved handling of missing or incomplete isotope data by using a neutral fallback score.
  * Ensured scoring inputs are consistently available so matching behaves more reliably across samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->