### PR TITLE
Add unit tests for OpenSwathParquetExporter

### DIFF
--- a/src/tests/class_tests/openms/CMakeLists.txt
+++ b/src/tests/class_tests/openms/CMakeLists.txt
@@ -199,6 +199,12 @@ if (TARGET ArrowSchemaRegistry_test)
     ${OPENMS_PARQUET_TARGET}
   )
 endif()
+if (TARGET OpenSwathParquetExporter_test)
+  target_link_libraries(OpenSwathParquetExporter_test
+    ${OPENMS_ARROW_TARGET}
+    ${OPENMS_PARQUET_TARGET}
+  )
+endif()
 if (TARGET ArrowIOHelpers_test)
   target_link_libraries(ArrowIOHelpers_test
     ${OPENMS_ARROW_TARGET}

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -756,6 +756,7 @@ if(NOT DISABLE_OPENSWATH)
   list(APPEND swath_executables_list OpenSwathOSWParquetReader_test)
   list(APPEND swath_executables_list OpenSwathOSWParquetWriter_test)
   list(APPEND format_executables_list OpenSwathOSWParquetRoundTrip_test)
+  list(APPEND swath_executables_list OpenSwathParquetExporter_test)
 endif()
 
 set(Boost_dependent_tests

--- a/src/tests/class_tests/openms/source/OpenSwathParquetExporter_test.cpp
+++ b/src/tests/class_tests/openms/source/OpenSwathParquetExporter_test.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Justin Sing $
+// $Authors: Justin Sing $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+#include <OpenMS/ANALYSIS/OPENSWATH/OpenSwathParquetExporter.h>
+///////////////////////////
+
+#include <OpenMS/ANALYSIS/OPENSWATH/OpenSwathExportData.h>
+#include <OpenMS/FORMAT/ParquetFile.h>
+
+using namespace OpenMS;
+using namespace std;
+
+START_TEST(OpenSwathParquetExporter, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+START_SECTION((static void writeFeatureScores(const std::string& filename, const OpenSwathFeatureScoreTable& table)))
+{
+  OpenSwathFeatureScoreRow r;
+  r.protein_id = 1; r.peptide_id = 2; r.precursor_id = 3;
+  r.protein_accession = "PROT1";
+  r.unmodified_sequence = "PEPTIDEK";
+  r.modified_sequence = "PEPTIDEK(UniMod:1)";
+  r.precursor_mz = 450.7; r.precursor_charge = 2; r.run_id = 99; r.feature_id = 7777;
+  r.exp_rt = 120.5; r.norm_rt = 118.0; r.delta_rt = 2.5; r.left_width = 118.0; r.right_width = 123.0;
+
+  OpenSwathFeatureScoreRow r2 = r;
+  r2.feature_id = 8888;
+  r2.modified_sequence = "ACDEFGHIK";
+
+  OpenSwathFeatureScoreTable table; // no dynamic FEATURE_MS1/MS2 score columns
+  table.rows = {r, r2};
+
+  std::string fn;
+  NEW_TMP_FILE(fn)
+  fn += ".parquet";
+  OpenSwathParquetExporter::writeFeatureScores(fn, table);
+
+  // read the parquet back and check the round-tripped key columns
+  auto tbl = ParquetFile::readTable(fn);
+  TEST_NOT_EQUAL(tbl, nullptr)
+  TEST_EQUAL(tbl->num_rows(), 2)
+
+  auto fid = ParquetFile::getColumn(tbl, "FEATURE_ID");
+  TEST_EQUAL(ParquetFile::getInt64(fid, 0, -1, false), 7777)
+  TEST_EQUAL(ParquetFile::getInt64(fid, 1, -1, false), 8888)
+  TEST_EQUAL(ParquetFile::getString(ParquetFile::getColumn(tbl, "PROTEIN_ACCESSION"), 0), "PROT1")
+  TEST_EQUAL(ParquetFile::getString(ParquetFile::getColumn(tbl, "MODIFIED_SEQUENCE"), 0), "PEPTIDEK(UniMod:1)")
+  TEST_EQUAL(ParquetFile::getString(ParquetFile::getColumn(tbl, "MODIFIED_SEQUENCE"), 1), "ACDEFGHIK")
+  TEST_REAL_SIMILAR(ParquetFile::getDouble(ParquetFile::getColumn(tbl, "PRECURSOR_MZ"), 0, -1, false), 450.7)
+  TEST_REAL_SIMILAR(ParquetFile::getDouble(ParquetFile::getColumn(tbl, "EXP_RT"), 0, -1, false), 120.5)
+}
+END_SECTION
+
+START_SECTION((static void writeTransitionScores(const std::string& filename, const OpenSwathTransitionScoreTable& table)))
+{
+  OpenSwathTransitionScoreRow r;
+  r.precursor_id = 5; r.transition_id = 42; r.transition_traml_id = "tr42";
+  r.product_mz = 500.25; r.transition_charge = 1; r.transition_type = "y";
+  r.transition_ordinal = 3; r.annotation = "y3";
+  r.transition_detecting = true; r.transition_decoy = false;
+
+  OpenSwathTransitionScoreRow r2 = r;
+  r2.transition_id = 43; r2.annotation = "y4"; r2.transition_decoy = true;
+
+  OpenSwathTransitionScoreTable table;
+  table.rows = {r, r2};
+
+  std::string fn;
+  NEW_TMP_FILE(fn)
+  fn += ".parquet";
+  OpenSwathParquetExporter::writeTransitionScores(fn, table);
+
+  auto tbl = ParquetFile::readTable(fn);
+  TEST_NOT_EQUAL(tbl, nullptr)
+  TEST_EQUAL(tbl->num_rows(), 2)
+
+  auto tid = ParquetFile::getColumn(tbl, "TRANSITION_ID");
+  TEST_EQUAL(ParquetFile::getInt64(tid, 0, -1, false), 42)
+  TEST_EQUAL(ParquetFile::getInt64(tid, 1, -1, false), 43)
+  TEST_REAL_SIMILAR(ParquetFile::getDouble(ParquetFile::getColumn(tbl, "PRODUCT_MZ"), 0, -1, false), 500.25)
+  TEST_EQUAL(ParquetFile::getString(ParquetFile::getColumn(tbl, "ANNOTATION"), 1), "y4")
+  // decoy flag round-trips per row
+  auto dec = ParquetFile::getColumn(tbl, "TRANSITION_DECOY");
+  TEST_EQUAL(ParquetFile::getBool(dec, 0, true, false), false)
+  TEST_EQUAL(ParquetFile::getBool(dec, 1, false, false), true)
+
+  // an empty table is allowed (schema-only output) and writes a 0-row file
+  OpenSwathTransitionScoreTable empty;
+  std::string fn2;
+  NEW_TMP_FILE(fn2)
+  fn2 += ".parquet";
+  OpenSwathParquetExporter::writeTransitionScores(fn2, empty);
+  TEST_EQUAL(ParquetFile::rowCount(fn2), 0)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST

--- a/src/tests/class_tests/openms/source/OpenSwathParquetExporter_test.cpp
+++ b/src/tests/class_tests/openms/source/OpenSwathParquetExporter_test.cpp
@@ -42,13 +42,13 @@ START_SECTION((static void writeFeatureScores(const std::string& filename, const
   table.rows = {r, r2};
 
   std::string fn;
-  NEW_TMP_FILE(fn)
-  fn += ".parquet";
+  NEW_TMP_FILE_EXT(fn, ".parquet")
   OpenSwathParquetExporter::writeFeatureScores(fn, table);
 
   // read the parquet back and check the round-tripped key columns
   auto tbl = ParquetFile::readTable(fn);
   TEST_NOT_EQUAL(tbl, nullptr)
+  ABORT_IF(tbl == nullptr)
   TEST_EQUAL(tbl->num_rows(), 2)
 
   auto fid = ParquetFile::getColumn(tbl, "FEATURE_ID");
@@ -59,6 +59,13 @@ START_SECTION((static void writeFeatureScores(const std::string& filename, const
   TEST_EQUAL(ParquetFile::getString(ParquetFile::getColumn(tbl, "MODIFIED_SEQUENCE"), 1), "ACDEFGHIK")
   TEST_REAL_SIMILAR(ParquetFile::getDouble(ParquetFile::getColumn(tbl, "PRECURSOR_MZ"), 0, -1, false), 450.7)
   TEST_REAL_SIMILAR(ParquetFile::getDouble(ParquetFile::getColumn(tbl, "EXP_RT"), 0, -1, false), 120.5)
+
+  // an empty table is allowed (schema-only output) and writes a 0-row file
+  OpenSwathFeatureScoreTable empty;
+  std::string fn2;
+  NEW_TMP_FILE_EXT(fn2, ".parquet")
+  OpenSwathParquetExporter::writeFeatureScores(fn2, empty);
+  TEST_EQUAL(ParquetFile::rowCount(fn2), 0)
 }
 END_SECTION
 
@@ -77,12 +84,12 @@ START_SECTION((static void writeTransitionScores(const std::string& filename, co
   table.rows = {r, r2};
 
   std::string fn;
-  NEW_TMP_FILE(fn)
-  fn += ".parquet";
+  NEW_TMP_FILE_EXT(fn, ".parquet")
   OpenSwathParquetExporter::writeTransitionScores(fn, table);
 
   auto tbl = ParquetFile::readTable(fn);
   TEST_NOT_EQUAL(tbl, nullptr)
+  ABORT_IF(tbl == nullptr)
   TEST_EQUAL(tbl->num_rows(), 2)
 
   auto tid = ParquetFile::getColumn(tbl, "TRANSITION_ID");
@@ -98,8 +105,7 @@ START_SECTION((static void writeTransitionScores(const std::string& filename, co
   // an empty table is allowed (schema-only output) and writes a 0-row file
   OpenSwathTransitionScoreTable empty;
   std::string fn2;
-  NEW_TMP_FILE(fn2)
-  fn2 += ".parquet";
+  NEW_TMP_FILE_EXT(fn2, ".parquet")
   OpenSwathParquetExporter::writeTransitionScores(fn2, empty);
   TEST_EQUAL(ParquetFile::rowCount(fn2), 0)
 }


### PR DESCRIPTION
## Description

This PR adds comprehensive unit tests for the `OpenSwathParquetExporter` class, which handles exporting OpenSWATH feature and transition score data to Parquet format.

The test suite covers:
- **Feature scores export**: Tests writing and round-tripping of `OpenSwathFeatureScoreTable` data to Parquet, verifying that key columns (FEATURE_ID, PROTEIN_ACCESSION, MODIFIED_SEQUENCE, PRECURSOR_MZ, EXP_RT, etc.) are correctly serialized and deserialized.
- **Transition scores export**: Tests writing and round-tripping of `OpenSwathTransitionScoreTable` data to Parquet, including validation of transition identifiers, product m/z values, annotations, and boolean flags (TRANSITION_DECOY).
- **Edge cases**: Tests handling of empty tables (schema-only output with 0 rows).

The tests use the existing `ParquetFile` utility API to verify data integrity after round-tripping through the Parquet format.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

https://claude.ai/code/session_01L9EmQ8VLeYSbFGoeEDAevH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new OpenSWATH Parquet exporter tests that perform round-trip verification for exported feature and transition score tables.
  * Validated key column values (including per-row decoy fields) after re-reading the generated Parquet files.
  * Added assertions for empty-table exports to ensure they produce schema-only Parquet output with zero rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->