### PR TITLE
fix(EmgFitter1D): make EMG fit robust to degenerate/edge input

### DIFF
--- a/src/openms/source/FEATUREFINDER/EmgFitter1D.cpp
+++ b/src/openms/source/FEATUREFINDER/EmgFitter1D.cpp
@@ -12,8 +12,12 @@
 
 #include <OpenMS/MATH/StatisticFunctions.h>
 #include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/CONCEPT/Exception.h>
 
 #include <Eigen/Core>
+
+#include <algorithm>
+#include <cmath>
 
 namespace OpenMS
 {
@@ -141,33 +145,94 @@ namespace OpenMS
 
   EmgFitter1D::QualityType EmgFitter1D::fit1d(const RawDataArrayType& set, std::unique_ptr<InterpolationModel>& model)
   {
-    // Calculate bounding box
-    CoordinateType min_bb = set[0].getPos(), max_bb = set[0].getPos();
-    for (Size pos = 1; pos < set.size(); ++pos)
+    // Robustness (issue #6239): this method must never throw, never read out of bounds,
+    // and never emit non-finite model parameters. A degenerate or failed fit yields a
+    // stable, in-range fallback model and the quality sentinel -1.0. Well-formed fits are
+    // handled exactly as before (no change to scores feeding OpenSWATH/FeatureFinderId.).
+
+    // Builds an EmgModel from a parameter set; shared by the regular and fallback paths so
+    // they can never diverge on parameter keys / interpolation step.
+    auto build_model = [this](double height, double width, double symmetry, double retention,
+                              double bb_min, double bb_max) -> std::unique_ptr<InterpolationModel>
     {
-      CoordinateType tmp = set[pos].getPos();
-      if (min_bb > tmp)
+      std::unique_ptr<InterpolationModel> m(new EmgModel());
+      m->setInterpolationStep((std::isfinite(interpolation_step_) && interpolation_step_ > 0.0) ? interpolation_step_ : 0.2);
+      Param p;
+      p.setValue("bounding_box:min", bb_min);
+      p.setValue("bounding_box:max", bb_max);
+      p.setValue("statistics:variance", statistics_.variance());
+      p.setValue("statistics:mean", statistics_.mean());
+      p.setValue("emg:height", height);
+      p.setValue("emg:width", width);
+      p.setValue("emg:symmetry", symmetry);
+      p.setValue("emg:retention", retention);
+      m->setParameters(p);
+      return m;
+    };
+
+    const Size n = set.size();
+
+    // Degenerate: fewer points than the 4 EMG parameters (LM requires N >= params).
+    if (n < 4)
+    {
+      double lo = 0.0, hi = 1.0, apex = 0.0, height = 1.0;
+      if (n > 0)
       {
-        min_bb = tmp;
+        lo = hi = apex = set[0].getPos();
+        height = set[0].getIntensity();
+        for (Size i = 1; i < n; ++i)
+        {
+          const double pos = set[i].getPos();
+          if (std::isfinite(pos)) { lo = std::min(lo, pos); hi = std::max(hi, pos); }
+          if (set[i].getIntensity() > height) { height = set[i].getIntensity(); apex = pos; }
+        }
       }
-      if (max_bb < tmp)
-      {
-        max_bb = tmp;
-      }
+      if (!std::isfinite(lo) || !std::isfinite(hi) || hi <= lo) { lo = 0.0; hi = 1.0; }
+      if (!std::isfinite(apex) || apex < lo || apex > hi) { apex = lo; }
+      const double w = std::max((hi - lo) / 6.0, 1e-3);
+      model = build_model(std::isfinite(height) ? height : 1.0, w, w, apex, lo, hi);
+      return -1.0;
     }
 
-    // Enlarge the bounding box by a few multiples of the standard deviation
-    const CoordinateType stdev = sqrt(statistics_.variance()) * tolerance_stdev_box_;
-    min_bb -= stdev;
-    max_bb += stdev;
+    // Single pass: data range, apex (max-intensity position), intensity sum, finiteness.
+    double min_pos = set[0].getPos(), max_pos = set[0].getPos();
+    double apex_pos = set[0].getPos(), max_int = set[0].getIntensity();
+    double weight_sum = 0.0;
+    bool finite_input = std::isfinite(set[0].getPos()) && std::isfinite(set[0].getIntensity());
+    for (Size i = 0; i < n; ++i)
+    {
+      const double pos = set[i].getPos();
+      const double in = set[i].getIntensity();
+      if (!std::isfinite(pos) || !std::isfinite(in)) { finite_input = false; }
+      if (pos < min_pos) { min_pos = pos; }
+      if (pos > max_pos) { max_pos = pos; }
+      if (in > max_int) { max_int = in; apex_pos = pos; }
+      weight_sum += in;
+    }
+    const double span = max_pos - min_pos;
+    const double fb_w = std::max(span / 6.0, 1e-3);
+    if (!std::isfinite(apex_pos) || apex_pos < min_pos || apex_pos > max_pos) { apex_pos = min_pos; }
+    if (!std::isfinite(max_int)) { max_int = 1.0; }
 
+    // Unusable input or fitter settings -> stable fallback + sentinel.
+    if (!finite_input || !(span > 0.0) || !std::isfinite(weight_sum) || !(weight_sum > 0.0)
+        || !std::isfinite(interpolation_step_) || !(interpolation_step_ > 0.0))
+    {
+      model = build_model(max_int, fb_w, fb_w, apex_pos, min_pos, max_pos);
+      return -1.0;
+    }
+
+    // Bounding box enlarged by a few multiples of the standard deviation (unchanged).
+    const CoordinateType stdev = sqrt(statistics_.variance()) * tolerance_stdev_box_;
+    const CoordinateType min_bb = min_pos - stdev;
+    const CoordinateType max_bb = max_pos + stdev;
 
     // Set advanced parameters for residual_  und jacobian_ method
     EmgFitter1D::Data d;
     d.n = set.size();
     d.set = set;
 
-    // Compute start parameters
+    // Compute start parameters (method-of-moments path is OOB-safe, see setInitialParametersMOM_)
     setInitialParameters_(set);
 
     // Optimize parameter with Levenberg-Marquardt algorithm
@@ -177,10 +242,18 @@ namespace OpenMS
     x_init[2] = symmetry_;
     x_init[3] = retention_;
 
+    bool fit_ok = true;
     if (!symmetric_)
     {
+      try
+      {
         EgmFitterFunctor functor(4, &d);
         optimize_(x_init, functor);
+      }
+      catch (const Exception::UnableToFit&)
+      {
+        fit_ok = false;
+      }
     }
 
     // Set optimized parameters
@@ -189,20 +262,16 @@ namespace OpenMS
     symmetry_ = x_init[2];
     retention_ = x_init[3];
 
-    // build model
-    model = std::unique_ptr<InterpolationModel>(new EmgModel());
-    model->setInterpolationStep(interpolation_step_);
+    // Reject non-finite optimizer output: emit a stable fallback model instead of garbage.
+    if (!fit_ok || !std::isfinite(height_) || !std::isfinite(width_)
+        || !std::isfinite(symmetry_) || !std::isfinite(retention_))
+    {
+      model = build_model(max_int, fb_w, fb_w, apex_pos, min_pos, max_pos);
+      return -1.0;
+    }
 
-    Param tmp;
-    tmp.setValue("bounding_box:min", min_bb);
-    tmp.setValue("bounding_box:max", max_bb);
-    tmp.setValue("statistics:variance", statistics_.variance());
-    tmp.setValue("statistics:mean", statistics_.mean());
-    tmp.setValue("emg:height", height_);
-    tmp.setValue("emg:width", width_);
-    tmp.setValue("emg:symmetry", symmetry_);
-    tmp.setValue("emg:retention", retention_);
-    model->setParameters(tmp);
+    // build model
+    model = build_model(height_, width_, symmetry_, retention_, min_bb, max_bb);
 
     // calculate pearson correlation
     std::vector<float> real_data;
@@ -217,9 +286,12 @@ namespace OpenMS
     }
 
     QualityType correlation = Math::pearsonCorrelationCoefficient(real_data.begin(), real_data.end(), model_data.begin(), model_data.end());
-    if (std::isnan(correlation))
+
+    // Non-finite correlation -> unusable fit: stable fallback model + sentinel.
+    if (!std::isfinite(correlation))
     {
-      correlation = -1.0;
+      model = build_model(max_int, fb_w, fb_w, apex_pos, min_pos, max_pos);
+      return -1.0;
     }
     return correlation;
   }
@@ -240,7 +312,9 @@ namespace OpenMS
     int weighted_median_idx = 0;
     double sum = weight_sum - set[0].getIntensity(); // sum is the total weight of all `x[i] > x[k]`
 
-    while (sum > weight_sum/2.)
+    // Bound the index (issue #6239): with non-positive/degenerate weights `sum` may not
+    // decrease, so guard against advancing past the last element (out-of-bounds read).
+    while (sum > weight_sum/2. && weighted_median_idx + 1 < static_cast<int>(set.size()))
     {
       ++weighted_median_idx;
       sum -= set[weighted_median_idx].getIntensity();

--- a/src/openms/source/FEATUREFINDER/EmgFitter1D.cpp
+++ b/src/openms/source/FEATUREFINDER/EmgFitter1D.cpp
@@ -33,7 +33,7 @@ namespace OpenMS
     Eigen::Map<Eigen::VectorXd> fvec_map(fvec, m_values);
 
     Size n = m_data->n;
-    EmgFitter1D::RawDataArrayType set = m_data->set;
+    const EmgFitter1D::RawDataArrayType& set = m_data->set;
 
     EmgFitter1D::CoordinateType h = x_map(0);
     EmgFitter1D::CoordinateType w = x_map(1);
@@ -67,7 +67,7 @@ namespace OpenMS
     Eigen::Map<Eigen::MatrixXd> J_map(J, m_values, m_inputs);
 
     Size n =  m_data->n;
-    EmgFitter1D::RawDataArrayType set = m_data->set;
+    const EmgFitter1D::RawDataArrayType& set = m_data->set;
 
     EmgFitter1D::CoordinateType h = x_map(0);
     EmgFitter1D::CoordinateType w = x_map(1);
@@ -209,10 +209,21 @@ namespace OpenMS
       if (in > max_int) { max_int = in; apex_pos = pos; }
       weight_sum += in;
     }
+    // Sanitize the fallback range so a fallback model is ALWAYS finite and in-range, even
+    // when the input itself is non-finite (e.g. a NaN/Inf leading position leaves min_pos/
+    // max_pos non-finite, since NaN comparisons never update them). For well-formed data
+    // (finite positions, positive span) every condition below is false, so the regular path
+    // is unchanged. (issue #6239 contract: never emit non-finite model parameters.)
+    if (!std::isfinite(min_pos) || !std::isfinite(max_pos) || !(max_pos > min_pos))
+    {
+      const double center = std::isfinite(apex_pos) ? apex_pos : 0.0;
+      min_pos = center - 0.5;
+      max_pos = center + 0.5;
+    }
     const double span = max_pos - min_pos;
     const double fb_w = std::max(span / 6.0, 1e-3);
     if (!std::isfinite(apex_pos) || apex_pos < min_pos || apex_pos > max_pos) { apex_pos = min_pos; }
-    if (!std::isfinite(max_int)) { max_int = 1.0; }
+    if (!std::isfinite(max_int) || !(max_int > 0.0)) { max_int = 1.0; }
 
     // Unusable input or fitter settings -> stable fallback + sentinel.
     if (!finite_input || !(span > 0.0) || !std::isfinite(weight_sum) || !(weight_sum > 0.0)

--- a/src/tests/class_tests/openms/source/EmgFitter1D_test.cpp
+++ b/src/tests/class_tests/openms/source/EmgFitter1D_test.cpp
@@ -16,6 +16,8 @@
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <algorithm>
+#include <cmath>
+#include <memory>
 
 ///////////////////////////
 
@@ -136,6 +138,70 @@ START_SECTION((QualityType fit1d(const  RawDataArrayType &range, InterpolationMo
   TEST_REAL_SIMILAR((double)em_fitted1->getParameters().getValue("emg:symmetry"), 5.0);
   TEST_REAL_SIMILAR((double)em_fitted1->getParameters().getValue("emg:retention"), 725.0);
 
+END_SECTION
+
+START_SECTION([EXTRA] fit1d robustness for degenerate and truncated input issue 6239)
+{
+  // (a) Fewer points than parameters: must not throw; sentinel quality (<= 0); finite, non-null model.
+  {
+    EmgFitter1D ef;
+    EmgFitter1D::RawDataArrayType few;
+    Peak1D p;
+    p.setPosition(10.0); p.setIntensity(5.0f); few.push_back(p);
+    p.setPosition(11.0); p.setIntensity(7.0f); few.push_back(p);
+    p.setPosition(12.0); p.setIntensity(4.0f); few.push_back(p);
+    std::unique_ptr<InterpolationModel> m;
+    EmgFitter1D::QualityType q = ef.fit1d(few, m);
+    TEST_EQUAL(q <= 0.0, true)
+    TEST_EQUAL(m.get() != nullptr, true)
+    TEST_EQUAL(std::isfinite((double)m->getParameters().getValue("emg:retention")), true)
+  }
+
+  // (b) All-equal positions (zero span): must not throw; sentinel quality; finite, non-null model.
+  {
+    EmgFitter1D ef;
+    EmgFitter1D::RawDataArrayType flat;
+    for (int i = 0; i < 8; ++i)
+    {
+      Peak1D p; p.setPosition(50.0); p.setIntensity(3.0f); flat.push_back(p);
+    }
+    std::unique_ptr<InterpolationModel> m;
+    EmgFitter1D::QualityType q = ef.fit1d(flat, m);
+    TEST_EQUAL(q <= 0.0, true)
+    TEST_EQUAL(m.get() != nullptr, true)
+  }
+
+  // (c) Right-truncated edge peak (the #6239 scenario): a clean EMG sampled only up to ~1
+  //     step past its apex, no data beyond. Track A guarantees no throw and finite output.
+  //     In-range apex is a Track-B concern and intentionally NOT asserted here.
+  {
+    EmgModel em; em.setInterpolationStep(0.2);
+    Param tp;
+    tp.setValue("bounding_box:min", 0.0);
+    tp.setValue("bounding_box:max", 200.0);
+    tp.setValue("statistics:mean", 180.0);
+    tp.setValue("statistics:variance", 2.0);
+    tp.setValue("emg:height", 100000.0);
+    tp.setValue("emg:width", 5.0);
+    tp.setValue("emg:symmetry", 5.0);
+    tp.setValue("emg:retention", 180.0);
+    em.setParameters(tp);
+    EmgModel::SamplesType full; em.getSamples(full);
+    EmgFitter1D::RawDataArrayType trunc;
+    for (Size i = 0; i < full.size(); ++i)
+    {
+      if (full[i].getPosition()[0] <= 199.0) { trunc.push_back(full[i]); }
+    }
+    TEST_EQUAL(trunc.size() >= 4, true)
+    EmgFitter1D ef;
+    std::unique_ptr<InterpolationModel> m;
+    EmgFitter1D::QualityType q = ef.fit1d(trunc, m);
+    TEST_EQUAL(m.get() != nullptr, true)
+    TEST_EQUAL(std::isfinite((double)q), true)
+    TEST_EQUAL(std::isfinite((double)m->getParameters().getValue("emg:retention")), true)
+    TEST_EQUAL(std::isfinite((double)m->getParameters().getValue("emg:width")), true)
+  }
+}
 END_SECTION
 
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/EmgFitter1D_test.cpp
+++ b/src/tests/class_tests/openms/source/EmgFitter1D_test.cpp
@@ -17,6 +17,7 @@
 #include <boost/random/mersenne_twister.hpp>
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <memory>
 
 ///////////////////////////
@@ -200,6 +201,29 @@ START_SECTION([EXTRA] fit1d robustness for degenerate and truncated input issue 
     TEST_EQUAL(std::isfinite((double)q), true)
     TEST_EQUAL(std::isfinite((double)m->getParameters().getValue("emg:retention")), true)
     TEST_EQUAL(std::isfinite((double)m->getParameters().getValue("emg:width")), true)
+  }
+
+  // (d) Non-finite leading position (>= 4 points): even with a NaN/Inf at index 0 the
+  //     fallback range cannot recover from comparisons (NaN never updates min/max), so the
+  //     sanitizer must still yield a finite, non-null model and the -1.0 sentinel.
+  {
+    EmgFitter1D ef;
+    EmgFitter1D::RawDataArrayType bad;
+    Peak1D p;
+    p.setPosition(std::numeric_limits<double>::quiet_NaN()); p.setIntensity(5.0f); bad.push_back(p);
+    p.setPosition(11.0); p.setIntensity(7.0f); bad.push_back(p);
+    p.setPosition(12.0); p.setIntensity(4.0f); bad.push_back(p);
+    p.setPosition(13.0); p.setIntensity(3.0f); bad.push_back(p);
+    std::unique_ptr<InterpolationModel> m;
+    EmgFitter1D::QualityType q = ef.fit1d(bad, m);
+    TEST_REAL_SIMILAR(q, -1.0)
+    TEST_EQUAL(m.get() != nullptr, true)
+    TEST_EQUAL(std::isfinite((double)m->getParameters().getValue("emg:height")), true)
+    TEST_EQUAL(std::isfinite((double)m->getParameters().getValue("emg:width")), true)
+    TEST_EQUAL(std::isfinite((double)m->getParameters().getValue("emg:symmetry")), true)
+    TEST_EQUAL(std::isfinite((double)m->getParameters().getValue("emg:retention")), true)
+    TEST_EQUAL(std::isfinite((double)m->getParameters().getValue("bounding_box:min")), true)
+    TEST_EQUAL(std::isfinite((double)m->getParameters().getValue("bounding_box:max")), true)
   }
 }
 END_SECTION


### PR DESCRIPTION
## What

Hardens `EmgFitter1D::fit1d()` (the exponentially-modified-Gaussian fitter) against degenerate and edge-case input so it can never throw, read out of bounds, or emit non-finite/garbage model parameters.

## Why

`fit1d()` ran an unconstrained Levenberg–Marquardt fit with no guards:

- it dereferenced `set[0]` before any size check,
- it let `optimize_()` throw `UnableToFit` straight into callers,
- it could return `NaN`/garbage model parameters, and
- the method-of-moments initializer could read past the end of the input on degenerate weights.

This is the root cause behind **#6239** (out-of-range RT reported by the now-removed `FeatureFinderMRM`). The reporting tool is gone, but the same EMG fit is still live as the **elution-model-fit score** in OpenSWATH (`MRMFeatureFinderScoring`) and in `FeatureFinderIdentification` / `FeatureFinderAlgorithmMetaboIdent` (where `init_mom=true` is the default), so the robustness holes still matter there.

## What this PR does (minimal, score-neutral "safety net")

- **Guards degenerate input** — `size < 4`, non-finite positions/intensities, zero span, non-positive intensity sum, non-positive interpolation step → returns a **stable, in-range fallback model** plus the existing `-1.0` quality sentinel.
- **Catches `UnableToFit`** around `optimize_()` instead of letting it propagate into scoring.
- **Rejects non-finite optimizer output / correlation** and returns the fallback model rather than a `NaN`-laden one (previously it returned `-1` but kept the broken model).
- **Bounds the method-of-moments median loop** against an out-of-bounds read.
- Extracts a small shared `build_model` lambda so the normal and fallback paths cannot drift apart on parameter keys.

**Well-formed fits go through the unchanged path**, so the values feeding the OpenSWATH LDA and the `FeatureFinderIdentification` SVM (`var_elution_model_fit_score`) are unchanged. There is deliberately **no apex bound and no width cap** — the original #6239 width was still far below the data span, so width-bounding wouldn't catch it and would only risk shifting scores.

## Testing

New regression cases in `EmgFitter1D_test` (too-few-points, zero-span, right-truncated edge peak) assert no-throw + finite output. Verified green locally:

- `EmgFitter1D_test` (pinned clean-data recovery unchanged + new robustness cases)
- `EmgScoring_test`
- `MRMFeatureFinderScoring_test` (pins `elution_model_fit_score`)
- `FeatureFinderIdentificationAlgorithm_test` (exercises the `init_mom=true` MoM path)

## Scope / follow-up

This is the robustness half. Making truncated edge-peak fits produce an *in-range, meaningful* score (instead of `-1`) is a deliberate follow-up, gated on a paired score-stability benchmark on real OpenSWATH/FFId data, since any change to the fit shifts a distribution that pre-trained classifiers depend on.

Related to #6239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EMG fitting robustness for degenerate and truncated inputs (including too few points, zero span, and non-finite inputs), ensuring the fit completes safely without throwing.
  * Added stronger validation to prevent non-finite fitted parameters; correlation post-processing now treats any non-finite result as unusable.
  * Ensured stable fallback model output with a clear failure sentinel when fitting cannot be trusted.
* **Tests**
  * Expanded coverage for issue 6239 with edge cases such as NaN positions and right-truncated datasets, verifying non-throwing behavior and finite, well-formed outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->