### PR TITLE
perf(ProteinQuantifier): fix O(N^2) stall in PeptideAndProteinQuant::quantifyProteins

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.h
@@ -19,6 +19,7 @@
 #include <map>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace OpenMS
 {
@@ -197,6 +198,13 @@ public:
 
 private:
 
+    /// Index: unmodified peptide sequence -> all @p pep_quant_ entries (modified
+    /// peptidoforms) sharing that unmodified sequence, in @p pep_quant_
+    /// (AASequence-sorted) iteration order. Built once per quantifyProteins() call so
+    /// that channel-level aggregation does not rescan @p pep_quant_ (calling
+    /// AASequence::toUnmodifiedString() on every entry) for every (protein, peptide) pair.
+    typedef std::map<std::string, std::vector<const PeptideQuant::value_type*>> UnmodifiedToEntriesIndex;
+
     /// Processing statistics for output in the end
     Statistics stats_;
 
@@ -344,13 +352,15 @@ private:
          @param[in] top_n Maximum number of peptides to use per sample
          @param[in] include_all Whether to include proteins with insufficient peptides
          @param[in] accession_to_leader Map for resolving protein group leaders
+         @param[in] unmod_to_entries Precomputed index from unmodified peptide sequence to the @p pep_quant_ entries sharing it (avoids rescanning @p pep_quant_)
     */
     void calculateFileAndChannelLevelProteinAbundances_(const std::string& protein_accession,
                                            const std::vector<std::string>& selected_peptides,
                                            const std::string& aggregate_method,
                                            Size top_n,
                                            bool include_all,
-                                           const std::map<std::string, std::string>& accession_to_leader);
+                                           const std::map<std::string, std::string>& accession_to_leader,
+                                           const UnmodifiedToEntriesIndex& unmod_to_entries);
 
     /**
          @brief Perform iBAQ normalization on protein abundances.

--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.h
@@ -18,6 +18,7 @@
 
 #include <map>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -198,12 +199,27 @@ public:
 
 private:
 
+    /// Hash functor for (basename without extension, channel/label) keys, so that the
+    /// pure-lookup maps keyed on such pairs can use std::unordered_map. Iteration order of
+    /// those maps is never observed, so hashing does not affect output.
+    struct FileLabelHash
+    {
+      std::size_t operator()(const std::pair<std::string, UInt>& p) const noexcept
+      {
+        const std::size_t h1 = std::hash<std::string>{}(p.first);
+        const std::size_t h2 = std::hash<UInt>{}(p.second);
+        // boost-style hash_combine
+        return h1 ^ (h2 + 0x9e3779b97f4a7c15ULL + (h1 << 6) + (h1 >> 2));
+      }
+    };
+
     /// Index: unmodified peptide sequence -> all @p pep_quant_ entries (modified
-    /// peptidoforms) sharing that unmodified sequence, in @p pep_quant_
-    /// (AASequence-sorted) iteration order. Built once per quantifyProteins() call so
-    /// that channel-level aggregation does not rescan @p pep_quant_ (calling
+    /// peptidoforms) sharing that unmodified sequence. Built once per quantifyProteins()
+    /// call so that channel-level aggregation does not rescan @p pep_quant_ (calling
     /// AASequence::toUnmodifiedString() on every entry) for every (protein, peptide) pair.
-    typedef std::map<std::string, std::vector<const PeptideQuant::value_type*>> UnmodifiedToEntriesIndex;
+    /// Only looked up by key (never range-iterated); the per-bucket vector preserves
+    /// @p pep_quant_ (AASequence-sorted) order, so an unordered map keeps output identical.
+    typedef std::unordered_map<std::string, std::vector<const PeptideQuant::value_type*>> UnmodifiedToEntriesIndex;
 
     /// Processing statistics for output in the end
     Statistics stats_;
@@ -219,8 +235,9 @@ private:
 
     /// Precomputed lookup (basename without extension, channel/label) -> sample ID,
     /// built once from @p experimental_design_ to avoid linear scans of the MS file
-    /// section for every peptide/channel during aggregation.
-    std::map<std::pair<std::string, UInt>, size_t> sample_id_lookup_;
+    /// section for every peptide/channel during aggregation. Pure lookup (never iterated),
+    /// so an unordered map is used for O(1) access without affecting output.
+    std::unordered_map<std::pair<std::string, UInt>, size_t, FileLabelHash> sample_id_lookup_;
 
 
     /**

--- a/src/openms/source/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.cpp
@@ -484,6 +484,24 @@ namespace OpenMS
     }
 
     // Phase 3: Process each protein
+
+    // The accession -> group-leader map depends only on @p proteins and is loop-invariant;
+    // build it once here instead of rebuilding it inside the per-protein loop (which made
+    // this phase O(P^2) in the number of proteins).
+    const std::map<std::string, std::string> accession_to_leader = mapAccessionToLeader(proteins);
+
+    // Reverse index: unmodified peptide -> all pep_quant_ entries (modified peptidoforms)
+    // sharing that unmodified sequence. Built once by a single forward pass over pep_quant_,
+    // so each bucket lists its entries in pep_quant_ (AASequence-sorted) iteration order.
+    // This replaces the previous full rescan of pep_quant_ (with a toUnmodifiedString() per
+    // entry) that calculateFileAndChannelLevelProteinAbundances_ performed for every
+    // (protein, selected peptide) pair - the dominant O(N_pep^2) cost on large inputs.
+    UnmodifiedToEntriesIndex unmod_to_entries;
+    for (const auto& pep_q : pep_quant_)
+    {
+      unmod_to_entries[pep_q.first.toUnmodifiedString()].push_back(&pep_q);
+    }
+
     for (auto& prot_q : prot_quant_)
     {
       const std::string& accession = prot_q.first;
@@ -520,12 +538,10 @@ namespace OpenMS
       // Calculate protein abundances
       calculateProteinAbundances_(accession, selected_peptides, aggregate, top_n, include_all);
 
-      // if information about (indistinguishable) protein groups is available, map
-      // each accession to the accession of the leader of its group of proteins:
-      auto accession_to_leader = mapAccessionToLeader(proteins);
-      
+      // accession_to_leader and unmod_to_entries are loop-invariant and computed once before
+      // the loop (see above).
       calculateFileAndChannelLevelProteinAbundances_(accession, selected_peptides, aggregate,
-                                          top_n, include_all, accession_to_leader);
+                                          top_n, include_all, accession_to_leader, unmod_to_entries);
 
       // Update statistics
       if (prot_q.second.total_abundances.empty())
@@ -848,6 +864,19 @@ namespace OpenMS
 
     auto & id_groups = proteins.getIndistinguishableProteins();
 
+    // Build an accession -> protein-group index once. Previously the group for each
+    // quantified protein was located with a linear std::find_if over all groups, making
+    // annotation O(#quantified_proteins * #groups). For each accession we keep the FIRST
+    // group (in id_groups order) that contains it, matching the previous find_if semantics.
+    std::map<std::string, ProteinIdentification::ProteinGroup*> accession_to_group;
+    for (auto & g : id_groups)
+    {
+      for (const auto & a : g.accessions)
+      {
+        accession_to_group.emplace(a, &g);
+      }
+    }
+
     for (const auto& q : protein_quants)
     {
       // accession of quantified protein(group)
@@ -860,17 +889,12 @@ namespace OpenMS
         continue;
       } // not quantified
  
-      // lambda to check if a ProteinGroup has accession "acc"
-      auto hasProteinInGroup = [&acc] (const ProteinIdentification::ProteinGroup& g)->bool 
-      { 
-        return find(g.accessions.begin(), g.accessions.end(), acc) != g.accessions.end(); 
-      }; 
+      // retrieve protein group with accession "acc" via the precomputed index
+      auto group_it = accession_to_group.find(acc);
 
-      // retrieve protein group with accession "acc"
-      auto id_group = std::find_if(id_groups.begin(), id_groups.end(), hasProteinInGroup);  
-
-      if (id_group != id_groups.end())
+      if (group_it != accession_to_group.end())
       {
+        ProteinIdentification::ProteinGroup* id_group = group_it->second;
         // copy abundances to float data array
         const SampleAbundances& total_abundances = q.second.total_abundances;
         const SampleAbundances& total_psm_counts = q.second.total_psm_counts;
@@ -1052,13 +1076,13 @@ namespace OpenMS
             for (auto const& channel : charge.second)
             {
               prot_quant_[leader_accession].channel_level_abundances[filename.first][channel.first] += channel.second;
-#ifdef DEBUG_PROTEINQUANTIFIER                
-              std::cout << "DEBUG: Adding abundance for protein " << accession
+#ifdef DEBUG_PROTEINQUANTIFIER
+              std::cout << "DEBUG: Adding abundance for protein " << leader_accession
                         << " fraction " << fraction.first
                         << " filename " << filename.first
                         << " charge " << charge.first
                         << " channel " << channel.first
-                        << ": " << channel.second << endl; 
+                        << ": " << channel.second << endl;
 #endif
             }
           }
@@ -1219,7 +1243,8 @@ namespace OpenMS
                                                                   const std::string& aggregate_method,
                                                                   Size top_n,
                                                                   bool include_all,
-                                                                  const std::map<std::string, std::string>& accession_to_leader)
+                                                                  const std::map<std::string, std::string>& accession_to_leader,
+                                                                  const UnmodifiedToEntriesIndex& unmod_to_entries)
   {
     auto prot_it = prot_quant_.find(protein_accession);
     if ( prot_it == prot_quant_.end())
@@ -1235,42 +1260,45 @@ namespace OpenMS
     // collect detailed abundances from selected peptides
     for (const auto& pep : selected_peptides)    // for all selected peptides
     {
-      // find the original peptide data to get detailed abundances
-      for (auto const& pep_q_check : pep_quant_)
-      {
-        if (pep_q_check.first.toUnmodifiedString() == pep)
-        {
-          std::string check_accession = getAccession_(pep_q_check.second.accessions, accession_to_leader);
-          if (check_accession == protein_accession) // this peptide belongs to current protein
-          {
-            // collect detailed abundances from this peptide
-            for (auto const& fraction : pep_q_check.second.abundances)
-            {
-              for (auto const& filename : fraction.second)
-              {
-                for (auto const& charge : filename.second)
-                {
-                  for (auto const& channel : charge.second)
-                  {
-                    auto peptide = make_tuple(fraction.first, filename.first, channel.first);
-                    channel_level_abundances_for_selected_peptides[peptide].push_back(channel.second);
+      // Look up the modified peptidoforms sharing this unmodified sequence via the
+      // precomputed index. The bucket lists entries in pep_quant_ iteration order, so the
+      // first match below is identical to the previous full-scan first-match behaviour.
+      auto idx_it = unmod_to_entries.find(pep);
+      if (idx_it == unmod_to_entries.end()) { continue; }
 
-                    #ifdef DEBUG_PEPTIDEANDPROTEINQUANT
-                    std::cout << "DEBUG: Adding abundance for leader " <<
-                              getAccession_(pep_q_check.second.accessions, const_cast<std::map<std::string, std::string>&>(accession_to_leader))
-                              << pep
-                              << " fraction " << fraction.first
-                              << " filename " << filename.first
-                              << " charge " << charge.first
-                              << " channel " << channel.first
-                              << ": " << channel.second << endl;
-                    #endif
-                  }
+      for (const auto* pep_q_ptr : idx_it->second)
+      {
+        const auto& pep_q_check = *pep_q_ptr;
+        std::string check_accession = getAccession_(pep_q_check.second.accessions, accession_to_leader);
+        if (check_accession == protein_accession) // this peptide belongs to current protein
+        {
+          // collect detailed abundances from this peptide
+          for (auto const& fraction : pep_q_check.second.abundances)
+          {
+            for (auto const& filename : fraction.second)
+            {
+              for (auto const& charge : filename.second)
+              {
+                for (auto const& channel : charge.second)
+                {
+                  auto peptide = make_tuple(fraction.first, filename.first, channel.first);
+                  channel_level_abundances_for_selected_peptides[peptide].push_back(channel.second);
+
+                  #ifdef DEBUG_PEPTIDEANDPROTEINQUANT
+                  std::cout << "DEBUG: Adding abundance for leader " <<
+                            getAccession_(pep_q_check.second.accessions, accession_to_leader)
+                            << pep
+                            << " fraction " << fraction.first
+                            << " filename " << filename.first
+                            << " charge " << charge.first
+                            << " channel " << channel.first
+                            << ": " << channel.second << endl;
+                  #endif
                 }
               }
             }
-            break; // found the peptide, no need to continue searching
           }
+          break; // found the peptide, no need to continue searching
         }
       }
     }
@@ -1306,8 +1334,10 @@ namespace OpenMS
       pd.channel_level_abundances[filename][channel] = abundance_result;
       #ifdef DEBUG_PEPTIDEANDPROTEINQUANT
       Int fraction = get<0>(selected_peptide);
+      auto leader_it = accession_to_leader.find(protein_accession);
+      const std::string& leader_accession = (leader_it != accession_to_leader.end()) ? leader_it->second : protein_accession;
       std::cout << "DEBUG: Protein " << protein_accession
-                << " leader " << getAccession_(protein_accession, const_cast<std::map<std::string, std::string>&>(accession_to_leader))
+                << " leader " << leader_accession
                 << " fraction " << fraction
                 << " filename " << filename
                 << " channel " << channel

--- a/src/openms/source/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.cpp
@@ -653,7 +653,9 @@ namespace OpenMS
     // map filename and label of experimental design to the full experimental design entry for faster lookup
     const auto& ms_section = ed.getMSFileSection();
     using FileAndLabel = std::pair<std::string, UInt>;
-    std::map<FileAndLabel, ExperimentalDesign::MSFileSectionEntry> file_and_label_to_msfile_entry;
+    // Pure lookup (only emplace + find below, never iterated), so an unordered map gives
+    // O(1) access per consensus feature without affecting output order.
+    std::unordered_map<FileAndLabel, ExperimentalDesign::MSFileSectionEntry, FileLabelHash> file_and_label_to_msfile_entry;
     for (const auto& e : ms_section)
     {
       const std::string ed_filename = File::stemName(e.path);


### PR DESCRIPTION
## Problem

On large isobaric (TMT/iTRAQ) inputs (~7M PSMs), the isobaric workflow / `ProteinQuantifier` appears to **hang "at Quantifying peptides..."**. That log line is the only one emitted by `PeptideAndProteinQuant::quantifyPeptides()`. The next call, `quantifyProteins()`, emits no log of its own, so its cost is attributed to the previous line. `quantifyPeptides()` is linear — the stall is **quadratic work in `quantifyProteins()`**.

## Root cause & fix

Three quadratic hotspots in `quantifyProteins()` / its helpers, all replaced with one-time indexes. **All output is byte-identical.**

| Location | Before | After |
|---|---|---|
| `calculateFileAndChannelLevelProteinAbundances_` — rescanned **all** of `pep_quant_` calling `AASequence::toUnmodifiedString()` on every entry, for each (protein, selected peptide) pair | **O(N_pep²)** *(the dominant stall)* | reverse index `unmodified seq → pep_quant_ entries`, built once → **~O(N_pep)** |
| `mapAccessionToLeader(proteins)` rebuilt inside the per-protein loop (loop-invariant) | O(P²) | hoisted, built once → O(P) |
| `annotateQuantificationsToProteins` — `std::find_if` over all indistinguishable groups per protein (the *next* stall after the above) | O(P²) | `accession → group` index, built once → O(P) |

Net for the protein phase: **O(N_pep² + P²) → ~O(N_pep + P)**.

### Why it stays byte-identical
The reverse index is built by a **single forward pass** over `pep_quant_`, so each bucket preserves `std::map` (AASequence-sorted) iteration order. The first-match `break` therefore selects the identical peptidoform, and floating-point accumulation order is unchanged. The `accession → group` index keeps the first group in `id_groups` order, matching the previous `find_if` semantics.

### Also
Fixes two **pre-existing** dead-`#ifdef` debug-only compile errors in the same file (a wrong `getAccession_` overload and an undefined `accession` variable).

## Testing

- `PeptideAndProteinQuant_test` ✅
- All **35** `TOPP_ProteinQuantifier_*` tests ✅, including the isobaric **`_16`** (sample-level) and **`_17`** (file+channel-level) references — byte-identical.

## Notes

`IsobaricWorkflow` itself has no functional TOPP test (the block at `src/tests/topp/CMakeLists.txt:986-990` is commented out); its quantification path is covered indirectly via the shared `ProteinQuantifier` references. Adding a dedicated `IsobaricWorkflow` functional test is a sensible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of protein quantification and protein-level annotations, especially for file- and channel-level results.
  * Enhanced reliability when mapping peptide quantifications to protein groups and leaders in large datasets.
* **Refactor**
  * Optimized internal lookup and indexing used during quantification to reduce repeated rescans of peptide/protein containers.
  * Streamlined protein-group and accession/label lookups to reuse precomputed mappings across calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->