### PR TITLE
Remove unneeded expensive copies (perf, parallel hot paths)

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLHelper.h
+++ b/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLHelper.h
@@ -102,7 +102,7 @@ namespace OpenMS
        * @param[in] max_variable_mods_per_peptide The maximal number of variable modifications per peptide
        * @return A vector of AASeqWithMass containing the peptides, their masses and information about terminal peptides
        */
-      static std::vector<OPXLDataStructs::AASeqWithMass> digestDatabase(std::vector<FASTAFile::FASTAEntry> fasta_db,
+      static std::vector<OPXLDataStructs::AASeqWithMass> digestDatabase(const std::vector<FASTAFile::FASTAEntry>& fasta_db,
         const EnzymaticDigestion& digestor, Size min_peptide_length, const StringList& cross_link_residue1, const StringList& cross_link_residue2,
         const ModifiedPeptideGenerator::MapToResidueType& fixed_modifications,
         const ModifiedPeptideGenerator::MapToResidueType& variable_modifications,

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/SwathFileConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/SwathFileConsumer.h
@@ -203,7 +203,7 @@ public:
             "Swath scan does not provide a precursor.");
         }
 
-        const std::vector<Precursor> prec = s.getPrecursors();
+        const std::vector<Precursor>& prec = s.getPrecursors();
         double center = prec[0].getMZ();
         double lower = prec[0].getMZ() - prec[0].getIsolationWindowLowerOffset();
         double upper = prec[0].getMZ() + prec[0].getIsolationWindowUpperOffset();

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -732,9 +732,9 @@ namespace OpenMS
           }
 
           // store PSM
-          phs.push_back(ph);
+          phs.push_back(std::move(ph));
         }
-        pi.setHits(phs);
+        pi.setHits(std::move(phs));
         // Ensure hits are sorted by score (best first), then assign ranks explicitly (0 = top hit)
         pi.sort();
         {

--- a/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
@@ -361,7 +361,7 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
           ModifiedPeptideGenerator::applyVariableModifications(variable_modifications, aas, max_variable_mods_per_peptide, all_modified_peptides);
 
           // reannotate much more memory heavy AASequence object
-          AASequence fixed_and_variable_modified_peptide = all_modified_peptides[ah.peptide_mod_index]; 
+          const AASequence& fixed_and_variable_modified_peptide = all_modified_peptides[ah.peptide_mod_index];
           ph.setScore(ah.score);
           ph.setSequence(fixed_and_variable_modified_peptide);
 
@@ -510,9 +510,9 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
           }
 
           // store PSM
-          phs.push_back(ph);
+          phs.push_back(std::move(ph));
         }
-        pi.setHits(phs);
+        pi.setHits(std::move(phs));
         pi.sort();
 
 #pragma omp critical (peptide_ids_access)

--- a/src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/TransferFDRModel.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/PIPECHO/TransferFDRModel.cpp
@@ -499,7 +499,7 @@ void TransferFDRModel::compute_qvalues(bool pep_values_are_valid)
   double decoy_mbr_count {}, decoy_peptide_count {}, decoy_double_count {},
     total_so_far {};
 
-  for (auto acceptor : acceptors_)
+  for (const auto& acceptor : acceptors_)
   {
     ++total_so_far;
 

--- a/src/openms/source/ANALYSIS/NUXL/NuXLAnnotateAndLocate.cpp
+++ b/src/openms/source/ANALYSIS/NUXL/NuXLAnnotateAndLocate.cpp
@@ -402,7 +402,7 @@ namespace OpenMS
         // we don't localize on non-cross-links (only annotate)
         if (precursor_na_adduct == "none") 
         { 
-          a.fragment_annotations = fas;
+          a.fragment_annotations = std::move(fas);
           continue; 
         }
 
@@ -512,7 +512,7 @@ namespace OpenMS
 
         if (alignment.empty())
         {
-          a.fragment_annotations = fas;
+          a.fragment_annotations = std::move(fas);
           continue;
         }
 
@@ -821,7 +821,7 @@ namespace OpenMS
         a.best_localization = best_localization;
         a.best_localization_score = best_localization_score;
         a.best_localization_position = best_localization_position;
-        a.fragment_annotations = fas;
+        a.fragment_annotations = std::move(fas);
 
         #ifdef DEBUG_OpenNuXL1
           OPENMS_LOG_DEBUG << "Ion centric annotation: " << endl;

--- a/src/openms/source/ANALYSIS/NUXL/NuXLFDR.cpp
+++ b/src/openms/source/ANALYSIS/NUXL/NuXLFDR.cpp
@@ -80,12 +80,11 @@ namespace OpenMS
       {
         // spectrum already identified
         size_t index = native_id_to_id_index.at(pi.getMetaValue("spectrum_reference"));
-        auto hits = peptide_ids[index].getHits();
-        for (auto h : pi.getHits())
+        auto& hits = peptide_ids[index].getHits();
+        for (const auto& h : pi.getHits())
         {
           hits.push_back(h);
         }
-        peptide_ids[index].setHits(hits);
         peptide_ids[index].sort();
       }
     }

--- a/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
@@ -217,7 +217,7 @@ namespace OpenMS
   }
 
   std::vector<OPXLDataStructs::AASeqWithMass> OPXLHelper::digestDatabase(
-    vector<FASTAFile::FASTAEntry> fasta_db,
+    const vector<FASTAFile::FASTAEntry>& fasta_db,
     const EnzymaticDigestion& digestor,
     Size min_peptide_length,
     const StringList& cross_link_residue1,
@@ -394,9 +394,8 @@ namespace OpenMS
         peptide_second = &(peptide_masses[candidate.beta_index].peptide_seq);
         peptide_pos_second = peptide_masses[candidate.beta_index].position;
       }
-      std::string seq_first = candidate.alpha_seq;
-      std::string seq_second;
-      if (peptide_second) { seq_second = candidate.beta_seq; }
+      const std::string& seq_first = candidate.alpha_seq;
+      const std::string& seq_second = candidate.beta_seq; // empty for mono-/loop-links
 
       // mono-links and loop-links with different masses can be generated for the same precursor mass, but only one of them can be valid each time.
       // Find out which is the case. But it should not happen often enough to slow down the tool significantly.

--- a/src/openms/source/FEATUREFINDER/MultiplexFilteringProfile.cpp
+++ b/src/openms/source/FEATUREFINDER/MultiplexFilteringProfile.cpp
@@ -165,7 +165,7 @@ namespace OpenMS
           //double rt_peak = peak.getRT();
           double mz_peak = peak.getMZ();
 
-          std::multimap<size_t, MultiplexSatelliteCentroided > satellites = peak.getSatellites();
+          const std::multimap<size_t, MultiplexSatelliteCentroided >& satellites = peak.getSatellites();
           
           // Arrangement of peaks looks promising. Now scan through the spline fitted profile data around the peak i.e. from peak boundary to peak boundary.
           for (double mz_profile = peak_min; mz_profile < peak_max; mz_profile = navigators[idx_rt].getNextPos(mz_profile))

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
@@ -1104,13 +1104,18 @@ namespace OpenMS::Internal
           {
             MSNumpressCoder().encodeNPRaw(data_to_encode, uncompressed_str, npconfig_mz);
             OpenMS::ZlibCompression::compressString(uncompressed_str, encoded_string);
-            encoded_strings_mz[k] = encoded_string;
+            encoded_strings_mz[k] = std::move(encoded_string);
           }
           else
           {
-            std::string str_data = std::string((const char*) (&data_to_encode[0]), data_to_encode.size() * sizeof(double));
+            std::string str_data;
+            if (!data_to_encode.empty())
+            {
+              str_data.assign(reinterpret_cast<const char*>(data_to_encode.data()),
+                              data_to_encode.size() * sizeof(double));
+            }
             OpenMS::ZlibCompression::compressString(str_data, encoded_string);
-            encoded_strings_mz[k] = encoded_string;
+            encoded_strings_mz[k] = std::move(encoded_string);
           }
         }
 
@@ -1129,13 +1134,18 @@ namespace OpenMS::Internal
           {
             MSNumpressCoder().encodeNPRaw(data_to_encode, uncompressed_str, npconfig_int);
             OpenMS::ZlibCompression::compressString(uncompressed_str, encoded_string);
-            encoded_strings_int[k] = encoded_string;
+            encoded_strings_int[k] = std::move(encoded_string);
           }
           else
           {
-            std::string str_data = std::string((const char*) (&data_to_encode[0]), data_to_encode.size() * sizeof(double));
+            std::string str_data;
+            if (!data_to_encode.empty())
+            {
+              str_data.assign(reinterpret_cast<const char*>(data_to_encode.data()),
+                              data_to_encode.size() * sizeof(double));
+            }
             OpenMS::ZlibCompression::compressString(str_data, encoded_string);
-            encoded_strings_int[k] = encoded_string;
+            encoded_strings_int[k] = std::move(encoded_string);
           }
         }
       }
@@ -1334,13 +1344,18 @@ namespace OpenMS::Internal
           {
             MSNumpressCoder().encodeNPRaw(data_to_encode, uncompressed_str, npconfig_mz);
             OpenMS::ZlibCompression::compressString(uncompressed_str, encoded_string);
-            encoded_strings_rt[k] = encoded_string;
+            encoded_strings_rt[k] = std::move(encoded_string);
           }
           else
           {
-            std::string str_data = std::string((const char*) (&data_to_encode[0]), data_to_encode.size() * sizeof(double));
+            std::string str_data;
+            if (!data_to_encode.empty())
+            {
+              str_data.assign(reinterpret_cast<const char*>(data_to_encode.data()),
+                              data_to_encode.size() * sizeof(double));
+            }
             OpenMS::ZlibCompression::compressString(str_data, encoded_string);
-            encoded_strings_rt[k] = encoded_string;
+            encoded_strings_rt[k] = std::move(encoded_string);
           }
         }
 
@@ -1359,13 +1374,18 @@ namespace OpenMS::Internal
           {
             MSNumpressCoder().encodeNPRaw(data_to_encode, uncompressed_str, npconfig_int);
             OpenMS::ZlibCompression::compressString(uncompressed_str, encoded_string);
-            encoded_strings_int[k] = encoded_string;
+            encoded_strings_int[k] = std::move(encoded_string);
           }
           else
           {
-            std::string str_data = std::string((const char*) (&data_to_encode[0]), data_to_encode.size() * sizeof(double));
+            std::string str_data;
+            if (!data_to_encode.empty())
+            {
+              str_data.assign(reinterpret_cast<const char*>(data_to_encode.data()),
+                              data_to_encode.size() * sizeof(double));
+            }
             OpenMS::ZlibCompression::compressString(str_data, encoded_string);
-            encoded_strings_int[k] = encoded_string;
+            encoded_strings_int[k] = std::move(encoded_string);
           }
         }
       }

--- a/src/openms/source/FORMAT/HANDLERS/MzXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzXMLHandler.cpp
@@ -1256,12 +1256,12 @@ namespace OpenMS::Internal
           consumer_->consumeSpectrum(spectrum_data_[i].spectrum);
           if (options_.getAlwaysAppendData())
           {
-            exp_->addSpectrum(spectrum_data_[i].spectrum);
+            exp_->addSpectrum(std::move(spectrum_data_[i].spectrum));
           }
         }
         else
         {
-          exp_->addSpectrum(spectrum_data_[i].spectrum);
+          exp_->addSpectrum(std::move(spectrum_data_[i].spectrum));
         }
       }
 

--- a/src/openms/source/KERNEL/ConsensusMap.cpp
+++ b/src/openms/source/KERNEL/ConsensusMap.cpp
@@ -202,7 +202,7 @@ namespace OpenMS
         Size old_index = (Size)pid.getMetaValue("map_index");
         pid.setMetaValue("map_index", lhs_map_size + old_index);
       }
-      unassigned_peptide_identifications_.push_back(pid);
+      unassigned_peptide_identifications_.push_back(std::move(pid));
     }
 
     // combine IDs (new format):
@@ -234,7 +234,7 @@ namespace OpenMS
       // update IDs (new format):
       cf.updateIDReferences(trans);
 
-      emplace_back(cf);
+      emplace_back(std::move(cf));
     }
 
     // consistency


### PR DESCRIPTION
## Summary

Removes avoidable heavy copies across `src/openms`, found by an audit focused on **OpenMP parallel regions and hot loops**. All changes are `const&` conversions or `std::move`s of dead values — no behavior change.

Each edit was specifically vetted to ensure it is **not a deliberate thread-local snapshot** for parallelization safety:
- `const&` conversions only target objects that are **already thread-local** (constructed per-iteration) or **shared read-only input** (never mutated in the region).
- `std::move` targets are **dead thread-local locals** written to distinct per-thread indices.

Intentional copies (e.g. `std::set` const-iterator copies, sort-sink params, copies that mutate while the source must stay intact) were identified and left untouched.

## Changes

| Area | Change |
|------|--------|
| `OPXLHelper` | `digestDatabase` takes FASTA DB by `const&` (was a whole-DB copy); alpha/beta sequences bound as `const&` inside the OpenMP candidate loop |
| `MultiplexFilteringProfile` | Reference the per-peak satellites multimap instead of copying it inside the OpenMP loop |
| `MzMLSqliteHandler` | `std::move` block-local compressed payload strings into output vectors (8 sites, two OpenMP encoding loops) |
| `SwathFileConsumer` | Reference `getPrecursors()` instead of copying the vector per MS2 spectrum |
| `SimpleSearchEngineAlgorithm` / `ProSEAlgorithm` | `const&` the reannotated `AASequence`; `std::move` `PeptideHit`/hit-vector into `setHits` |
| `NuXLAnnotateAndLocate` | `std::move` dead fragment-annotation vectors |
| `NuXLFDR` | Append to the mutable `getHits()` reference instead of copying the hit vector out and back |
| `MzXMLHandler` | `std::move` spectra into `addSpectrum` (batch cleared afterwards) |
| `ConsensusMap::appendColumns` | `std::move` mutated loop copies into the unassigned-ID and consensus-feature lists |
| `TransferFDRModel` | Iterate `acceptors_` by `const&` to avoid `shared_ptr` refcount churn |

## Testing

- Full `OpenMS` library + all targets build clean (0 errors).
- `ctest` full suite: all class/unit tests covering the modified classes pass — `OPXLHelper_test` (relinked against the new signature), `ConsensusMap_test`, `MzMLSqliteHandler_test`, `MultiplexFilteringProfile_test`, `OpenPepXLAlgorithm_test`, all `ProSE_*` / `OpenNuXL_*` / `SimpleSearchEngine_1/2` / `FalseDiscoveryRate_*`.
- The only suite failures are pre-existing / environmental and unrelated to this branch (missing Comet binary → `CometAdapter`/`DatabaseSuitability`; a develop-side `-Search:decoys auto` CLI drift from #9644; a GLPK solver assertion in `MRMFeatureSelector_test`). None touch files changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced unnecessary copies by switching multiple internal collections to read-only references and using move semantics when transferring ownership.
  * Streamlined peptide-hit, precursor, candidate, feature, and consensus-map handling during post-processing and merging.

* **Performance**
  * Lowered memory churn and improved throughput across identification post-processing and map merging.
  * Improved robustness during export of spectra/chromatograms by safely handling empty data when building encoded payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->