### PR TITLE
Speed up Parquet identification I/O (single-pass metavalue write, hoisted reads)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@ PR - Pull Request (on GitHub), i.e. integration of a new feature or bugfix
 ------------------------------------------------------------------------------------------
 
 General:
+  - Performance: Faster Parquet identification I/O. idparquet writing (and the PSM bundle embedded in featureparquet/consensusparquet) builds the additional_scores and psm_metavalues columns in a single pass over each PeptideHit instead of two (~20-25% faster on metavalue-heavy PSMs); reading drops a per-row value_slice() allocation and hoists loop-invariant Arrow child-array lookups out of the row loop. Output is round-trip identical (#9689).
   - Performance: SimpleSearchEngine no longer serializes peptide-candidate parsing/modification on a global critical section. The per-candidate fromString()+modification application only does lock-free ResidueDB lookups of immutable standard residues and reads pre-resolved modification maps (no ResidueDB/ModificationsDB mutation), so the OpenMP parallel-for over the protein database now scales across threads where it previously bottlenecked on one lock.
   - macOS Intel builds discontinued; macOS deployment target raised to macOS 14
   - Ubuntu CI runners updated to 24.04

--- a/src/openms/source/FORMAT/ArrowIOHelpers.cpp
+++ b/src/openms/source/FORMAT/ArrowIOHelpers.cpp
@@ -230,14 +230,18 @@ void readMetaValues(
 {
   if (!array || array->IsNull(row)) return;
   auto list_arr = std::static_pointer_cast<arrow::ListArray>(array);
-  auto struct_arr = std::static_pointer_cast<arrow::StructArray>(list_arr->value_slice(row));
-  if (!struct_arr || struct_arr->length() == 0) return;
+  const int64_t off = list_arr->value_offset(row);
+  const int64_t len = list_arr->value_length(row);
+  if (len == 0) return;
 
+  // Index the shared child struct via value_offset/length instead of value_slice(row),
+  // which allocates a sliced array on every call (once per metavalue list per row).
+  auto struct_arr = std::static_pointer_cast<arrow::StructArray>(list_arr->values());
   auto name_arr = std::static_pointer_cast<arrow::StringArray>(struct_arr->field(0));
   auto value_arr = std::static_pointer_cast<arrow::StringArray>(struct_arr->field(1));
   auto type_arr = std::static_pointer_cast<arrow::StringArray>(struct_arr->field(2));
 
-  for (int64_t i = 0; i < struct_arr->length(); ++i)
+  for (int64_t i = off; i < off + len; ++i)
   {
     std::string name = name_arr->GetString(i);
     if (excluded_keys.contains(name)) continue;

--- a/src/openms/source/FORMAT/QPXFile.cpp
+++ b/src/openms/source/FORMAT/QPXFile.cpp
@@ -411,33 +411,7 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
         }
       }
 
-      // === additional_scores from hit metavalues ===
-      (void)additional_scores_builder.Append();
-      {
-        std::vector<std::string> keys;
-        hit.getKeys(keys);
-        for (const auto& key : keys)
-        {
-          if (excluded_hit_mvs_psm.contains(key)) continue;
-          const DataValue& val = hit.getMetaValue(key);
-          if ((val.valueType() == DataValue::INT_VALUE || val.valueType() == DataValue::DOUBLE_VALUE)
-              && Scores::isKnownScoreType(key))
-          {
-            (void)as_struct_b->Append();
-            (void)as_name_b->Append(key);
-            (void)as_value_b->Append(static_cast<double>(val));
-            try
-            {
-              auto st = IDScoreSwitcherAlgorithm::toScoreTypeEnum(key);
-              (void)as_hb_b->Append(idsa.isScoreTypeHigherBetter(st));
-            }
-            catch (...)
-            {
-              (void)as_hb_b->AppendNull();
-            }
-          }
-        }
-      }
+      // additional_scores + psm_metavalues are built together below (single metavalue pass).
 
       // === protein_accessions (list<struct{accession, aa_before, aa_after, start, end}>) ===
       (void)protein_accessions_builder.Append();
@@ -561,7 +535,10 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
       // === run_identifier ===
       (void)run_identifier_builder.Append(pep_id.getIdentifier());
 
-      // === psm_metavalues ===
+      // === additional_scores + psm_metavalues ===
+      // Single pass over the hit's metavalues: known numeric score types go to
+      // additional_scores, the rest to psm_metavalues (was two passes -> double getKeys()).
+      (void)additional_scores_builder.Append();
       (void)psm_metavalues_builder.Append();
       {
         std::vector<std::string> keys;
@@ -570,17 +547,30 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
         {
           if (excluded_hit_mvs_psm.contains(key)) continue;
           const DataValue& val = hit.getMetaValue(key);
-          // Skip known scores (already in additional_scores)
-          if ((val.valueType() == DataValue::INT_VALUE || val.valueType() == DataValue::DOUBLE_VALUE)
+          const auto vt = val.valueType();
+          if ((vt == DataValue::INT_VALUE || vt == DataValue::DOUBLE_VALUE)
               && Scores::isKnownScoreType(key))
           {
+            // known score -> additional_scores
+            (void)as_struct_b->Append();
+            (void)as_name_b->Append(key);
+            (void)as_value_b->Append(static_cast<double>(val));
+            try
+            {
+              auto st = IDScoreSwitcherAlgorithm::toScoreTypeEnum(key);
+              (void)as_hb_b->Append(idsa.isScoreTypeHigherBetter(st));
+            }
+            catch (...)
+            {
+              (void)as_hb_b->AppendNull();
+            }
             continue;
           }
+          // everything else -> psm_metavalues
           (void)pmv_struct_b->Append();
           (void)pmv_name_b->Append(key);
           (void)pmv_value_b->Append(val.toString());
-
-          switch (val.valueType())
+          switch (vt)
           {
             case DataValue::INT_VALUE: (void)pmv_type_b->Append("int"); break;
             case DataValue::DOUBLE_VALUE: (void)pmv_type_b->Append("double"); break;
@@ -1494,6 +1484,32 @@ bool QPXFile::importFromArrow(
   // run path on round-trip.
   std::unordered_map<std::string, std::string> run_id_to_ref_file;
 
+  // Hoist loop-invariant child arrays out of the row loop (GetFieldByName() is a
+  // linear field search); rows index them via value_offset/length.
+  std::shared_ptr<arrow::ListArray> pa_list;
+  std::shared_ptr<arrow::StringArray> pa_acc, pa_before, pa_after;
+  std::shared_ptr<arrow::Int32Array> pa_start, pa_end;
+  if (col_protein_accs)
+  {
+    pa_list = std::static_pointer_cast<arrow::ListArray>(col_protein_accs);
+    auto sa = std::static_pointer_cast<arrow::StructArray>(pa_list->values());
+    pa_acc    = std::static_pointer_cast<arrow::StringArray>(sa->GetFieldByName("accession"));
+    pa_before = std::static_pointer_cast<arrow::StringArray>(sa->GetFieldByName("aa_before"));
+    pa_after  = std::static_pointer_cast<arrow::StringArray>(sa->GetFieldByName("aa_after"));
+    pa_start  = std::static_pointer_cast<arrow::Int32Array>(sa->GetFieldByName("start"));
+    pa_end    = std::static_pointer_cast<arrow::Int32Array>(sa->GetFieldByName("end"));
+  }
+  std::shared_ptr<arrow::ListArray> as_list;
+  std::shared_ptr<arrow::StringArray> as_names;
+  std::shared_ptr<arrow::DoubleArray> as_values;
+  if (col_additional_scores)
+  {
+    as_list = std::static_pointer_cast<arrow::ListArray>(col_additional_scores);
+    auto sa = std::static_pointer_cast<arrow::StructArray>(as_list->values());
+    as_names  = std::static_pointer_cast<arrow::StringArray>(sa->GetFieldByName("score_name"));
+    as_values = std::static_pointer_cast<arrow::DoubleArray>(sa->GetFieldByName("score_value"));
+  }
+
   for (int64_t row = 0; row < num_rows; ++row)
   {
     int32_t p_id = ArrowIOHelpers::getInt32Value(col_p_id, row, -1);
@@ -1571,40 +1587,29 @@ bool QPXFile::importFromArrow(
 
     if (col_protein_accs && !ArrowIOHelpers::isNull(col_protein_accs, row))
     {
-      auto list_arr = std::static_pointer_cast<arrow::ListArray>(col_protein_accs);
-      auto struct_arr = std::static_pointer_cast<arrow::StructArray>(list_arr->values());
-      auto acc_arr    = std::static_pointer_cast<arrow::StringArray>(struct_arr->GetFieldByName("accession"));
-      auto before_arr = std::static_pointer_cast<arrow::StringArray>(struct_arr->GetFieldByName("aa_before"));
-      auto after_arr  = std::static_pointer_cast<arrow::StringArray>(struct_arr->GetFieldByName("aa_after"));
-      auto start_arr  = std::static_pointer_cast<arrow::Int32Array>(struct_arr->GetFieldByName("start"));
-      auto end_arr    = std::static_pointer_cast<arrow::Int32Array>(struct_arr->GetFieldByName("end"));
-      int64_t lstart = list_arr->value_offset(row);
-      int64_t lend = lstart + list_arr->value_length(row);
+      int64_t lstart = pa_list->value_offset(row);
+      int64_t lend = lstart + pa_list->value_length(row);
       for (int64_t k = lstart; k < lend; ++k)
       {
         PeptideEvidence ev;
-        ev.setProteinAccession(acc_arr->GetString(k));
-        const std::string before_s = before_arr->IsNull(k) ? std::string{} : before_arr->GetString(k);
+        ev.setProteinAccession(pa_acc->GetString(k));
+        const std::string before_s = pa_before->IsNull(k) ? std::string{} : pa_before->GetString(k);
         ev.setAABefore(before_s.empty() ? PeptideEvidence::UNKNOWN_AA : before_s[0]);
-        const std::string after_s = after_arr->IsNull(k) ? std::string{} : after_arr->GetString(k);
+        const std::string after_s = pa_after->IsNull(k) ? std::string{} : pa_after->GetString(k);
         ev.setAAAfter(after_s.empty() ? PeptideEvidence::UNKNOWN_AA : after_s[0]);
-        ev.setStart(start_arr->IsNull(k) ? PeptideEvidence::UNKNOWN_POSITION : start_arr->Value(k));
-        ev.setEnd  (end_arr  ->IsNull(k) ? PeptideEvidence::UNKNOWN_POSITION : end_arr  ->Value(k));
+        ev.setStart(pa_start->IsNull(k) ? PeptideEvidence::UNKNOWN_POSITION : pa_start->Value(k));
+        ev.setEnd  (pa_end  ->IsNull(k) ? PeptideEvidence::UNKNOWN_POSITION : pa_end  ->Value(k));
         hit.addPeptideEvidence(ev);
       }
     }
 
     if (col_additional_scores && !ArrowIOHelpers::isNull(col_additional_scores, row))
     {
-      auto list_arr = std::static_pointer_cast<arrow::ListArray>(col_additional_scores);
-      auto struct_arr = std::static_pointer_cast<arrow::StructArray>(list_arr->values());
-      auto names_arr = std::static_pointer_cast<arrow::StringArray>(struct_arr->GetFieldByName("score_name"));
-      auto values_arr = std::static_pointer_cast<arrow::DoubleArray>(struct_arr->GetFieldByName("score_value"));
-      int64_t start = list_arr->value_offset(row);
-      int64_t end = start + list_arr->value_length(row);
+      int64_t start = as_list->value_offset(row);
+      int64_t end = start + as_list->value_length(row);
       for (int64_t k = start; k < end; ++k)
       {
-        hit.setMetaValue(names_arr->GetString(k), values_arr->Value(k));
+        hit.setMetaValue(as_names->GetString(k), as_values->Value(k));
       }
     }
 


### PR DESCRIPTION
## What

Reduces the CPU cost of OpenMS's Parquet identification I/O (`QPXFile` / `ArrowIOHelpers`), which back the `idparquet` format and the PSM bundle embedded in `featureparquet`/`consensusparquet`.

Motivation: `idparquet` files are ~10x smaller than `idXML`, yet writing them was *slower*. Profiling showed the write cost is Arrow table **construction**, not compression (ZSTD is only ~11% of write time), and the per-PSM metavalue handling did redundant work.

## Changes

- **Write (`QPXFile::exportToArrow`)**: build the `additional_scores` and `psm_metavalues` columns in a single pass over each `PeptideHit`'s metavalues instead of two (they are complementary partitions of the same key set), removing a duplicate `getKeys()` allocation and `isKnownScoreType()`/`getMetaValue()` sweep per PSM.
- **Read (`ArrowIOHelpers::readMetaValues`)**: index the shared child struct via `value_offset`/`value_length` instead of `value_slice(row)`, which allocated a sliced array per row.
- **Read (`QPXFile::importFromArrow`)**: hoist loop-invariant `GetFieldByName` child-array lookups (`protein_accessions`/`additional_scores`) out of the row loop.

## Benchmarks

`idparquet` write of a 143 MB / 18,294-PSM (metavalue-heavy) file, in-process, 9 reps:

| | baseline | this PR |
|---|--:|--:|
| min | 2.57 s | 2.03 s (-21%) |
| median | 2.83 s | 2.06 s (-27%) |

The write fix also feeds `featureparquet`/`consensusparquet` (they embed the PSM bundle): ~6% faster feature round-trip. The read changes are correctness-neutral on this data (Arrow's `value_slice` is near-zero-copy) but remove allocations on evidence/row-heavy inputs.

## Correctness

Output is round-trip identical (`idXML -> idparquet -> idXML` byte-identical; feature/PSM counts preserved). All Arrow-IO class tests pass: `QPXFile`, `PSMArrowIO`, `FeatureMapArrowIO`, `ConsensusMapArrowIO`, `ConsensusMapArrowExport`, `ProteinIdentificationArrowIO`, `ArrowIOHelpers`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Arrow-based import/export performance, especially for identification data with many metadata fields.
  * Exported results now build score-related and metadata-related columns in a single pass, reducing processing overhead.
  * Import processing now reuses shared array lookups and avoids extra slicing, making reads faster.
  * Output remains round-trip identical.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->