### PR TITLE
feat(QPXConverter): accept consensusXML input

### DIFF
--- a/src/topp/QPXConverter.cpp
+++ b/src/topp/QPXConverter.cpp
@@ -8,10 +8,12 @@
 
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
+#include <OpenMS/FORMAT/ConsensusXMLFile.h>
 #include <OpenMS/FORMAT/QPXFile.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/METADATA/PeptideIdentificationList.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/FORMAT/FileTypes.h>
@@ -42,9 +44,11 @@ using namespace std;
     </table>
 </CENTER>
 
-QPXConverter reads peptide and protein identifications from idXML files
-and converts them to parquet format following the QPX PSM (Peptide
-Spectrum Match) specification.
+QPXConverter reads peptide and protein identifications from idXML or
+consensusXML files and converts them to parquet format following the QPX
+PSM (Peptide Spectrum Match) specification. When a consensusXML is given,
+the peptide identifications assigned to consensus features as well as the
+unassigned peptide identifications are exported.
 
 The output parquet file contains PSM data with structured columns following
 the QPX PSM specification including ProForma peptidoform notation,
@@ -72,8 +76,8 @@ public:
 protected:
   void registerOptionsAndFlags_() override
   {
-    registerInputFile_("in", "<file>", "", "Input idXML file");
-    setValidFormats_("in", ListUtils::create<std::string>("idXML"));
+    registerInputFile_("in", "<file>", "", "Input idXML or consensusXML file");
+    setValidFormats_("in", ListUtils::create<std::string>("idXML,consensusXML"));
 
     registerOutputFile_("out", "<file>", "", "Output parquet file", true);
     setValidFormats_("out", ListUtils::create<std::string>("parquet"));
@@ -96,9 +100,32 @@ protected:
     vector<ProteinIdentification> protein_identifications;
     PeptideIdentificationList peptide_identifications;
 
-    OPENMS_LOG_INFO << "Loading idXML file..." << endl;
-    IdXMLFile idxml_file;
-    idxml_file.load(in, protein_identifications, peptide_identifications);
+    const FileTypes::Type in_type = FileHandler::getType(in);
+
+    if (in_type == FileTypes::CONSENSUSXML)
+    {
+      OPENMS_LOG_INFO << "Loading consensusXML file..." << endl;
+      ConsensusMap consensus_map;
+      ConsensusXMLFile().load(in, consensus_map);
+
+      protein_identifications = consensus_map.getProteinIdentifications();
+
+      // gather PSMs assigned to consensus features ...
+      for (const ConsensusFeature& cf : consensus_map)
+      {
+        const PeptideIdentificationList& assigned = cf.getPeptideIdentifications();
+        peptide_identifications.insert(peptide_identifications.end(), assigned.begin(), assigned.end());
+      }
+      // ... and the unassigned PSMs
+      const PeptideIdentificationList& unassigned = consensus_map.getUnassignedPeptideIdentifications();
+      peptide_identifications.insert(peptide_identifications.end(), unassigned.begin(), unassigned.end());
+    }
+    else
+    {
+      OPENMS_LOG_INFO << "Loading idXML file..." << endl;
+      IdXMLFile idxml_file;
+      idxml_file.load(in, protein_identifications, peptide_identifications);
+    }
 
     if (peptide_identifications.empty())
     {


### PR DESCRIPTION
## Summary

`QPXConverter` previously only read **idXML**. This PR allows **consensusXML** as input so PSMs from a quantitative workflow (e.g. the output of ID/conflict resolution) can be exported directly to the QPX PSM parquet format without a separate ID-extraction step.

When a consensusXML is given, the tool:
- takes the map's protein identifications,
- gathers the peptide identifications assigned to consensus features, **and**
- appends the unassigned peptide identifications,

then exports them via `QPXFile::exportToParquet`. idXML input is unchanged; the input type is detected with `FileHandler::getType`.

## Test plan

Ran against a 827 MB `*.consensusXML` (PXD007683-TMT, idconflictresolver stage): 139,891 PSMs exported to an 8.7 MB parquet in ~29 s (peak ~1 GB RAM). Output schema verified with pyarrow to match the 40-column QPX PSM schema (`peptidoform`, structured `modifications` with UniMod accessions, `additional_scores`, `protein_accessions`, spectrum arrays, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The converter now accepts both `idXML` and `consensusXML` input files.
  * `consensusXML` inputs are processed to include protein and peptide identifications in the output conversion.

* **Documentation**
  * Updated usage guidance to reflect the newly supported input formats.
  * Clarified how consensus-based inputs are handled during conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->