### PR TITLE
[INTERNAL,TEST] deduplicate XIC/XIM parquet reader helpers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@ General:
   - Ubuntu CI runners updated to 24.04
   - macOS code signing and notarization integrated directly into CI (#8486, #8494, #8527)
   - Parquet support enabled across all platforms; Arrow/Parquet is now a required dependency and the WITH_PARQUET CMake option has been removed (#8370, #8422, #8991)
+  - OpenSWATH parquet readers: deduplicated the shared Arrow/Parquet plumbing between XICParquetFile and XIMParquetFile into one internal helper; XIC now uses the same type-safe DOUBLE/FLOAT/LARGE_STRING extraction path as XIM (#9691)
   - Modernized TransformationDescription to use std::unique_ptr for memory safety
   - Fix undefined behavior in ProteinIdentification get*DataArrayByName by throwing ElementNotFound when the name is missing
   - When a shared-data file (e.g. CHEMISTRY/custom_mods.xml) cannot be found, File::find now reports the resolved OpenMS data directory and where it was resolved from (OPENMS_DATA_PATH vs. compiled/executable-relative), so a stale OPENMS_DATA_PATH or a leftover old installation is easy to spot and fix (#9636, #9650)

--- a/src/openms/source/FORMAT/DATAACCESS/ParquetReaderHelpers.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/ParquetReaderHelpers.cpp
@@ -97,6 +97,35 @@ namespace OpenMS
           return *combined;
         }
 
+        std::shared_ptr<arrow::Table> readTableFromReader_(parquet::arrow::FileReader& reader,
+                                                           const std::string& filename)
+        {
+          std::shared_ptr<arrow::Table> table;
+          const auto status = reader.ReadTable(&table);
+          if (!status.ok() || !table)
+          {
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          "Failed to read parquet table",
+                                          filename + ": " + status.ToString());
+          }
+          return table;
+        }
+
+        std::shared_ptr<arrow::Table> readTableFromReader_(parquet::arrow::FileReader& reader,
+                                                           const std::vector<int>& column_indices,
+                                                           const std::string& filename)
+        {
+          std::shared_ptr<arrow::Table> table;
+          const auto status = reader.ReadTable(column_indices, &table);
+          if (!status.ok() || !table)
+          {
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          "Failed to read parquet table",
+                                          filename + ": " + status.ToString());
+          }
+          return table;
+        }
+
         std::string upper_(const std::string& input)
         {
           std::string out = input;
@@ -244,12 +273,19 @@ namespace OpenMS
           return name_map;
         }
 
+        struct PrunedFilterColumns
+        {
+          std::vector<std::string> unsupported_columns;
+          std::vector<std::string> unknown_columns;
+        };
+
         void normalizeAndPruneColumns_(FilterExpression& expr,
                                        const std::shared_ptr<arrow::Schema>& schema,
                                        const std::unordered_set<std::string>& unsupported_columns,
-                                       std::vector<std::string>& dropped_columns)
+                                       PrunedFilterColumns& pruned_columns)
         {
-          dropped_columns.clear();
+          pruned_columns.unsupported_columns.clear();
+          pruned_columns.unknown_columns.clear();
           if (expr.conditions.empty())
           {
             return;
@@ -269,16 +305,16 @@ namespace OpenMS
             const std::string upper_column = upper_(cond.column);
 
             auto it = name_map.find(upper_column);
-            if (it != name_map.end())
+            if (it == name_map.end())
             {
-              cond.column = it->second;
+              pruned_columns.unknown_columns.push_back(original);
+              continue;
             }
+            cond.column = it->second;
 
-            const bool unsupported = unsupported_columns.contains(upper_(cond.column));
-            const bool exists_in_schema = name_map.contains(upper_(cond.column));
-            if (unsupported || !exists_in_schema)
+            if (unsupported_columns.contains(upper_column))
             {
-              dropped_columns.push_back(original);
+              pruned_columns.unsupported_columns.push_back(original);
               continue;
             }
 
@@ -320,12 +356,19 @@ namespace OpenMS
                                          const std::string& filter_context,
                                          const FilterPruningOptions& pruning_options)
         {
-          std::vector<std::string> dropped;
-          normalizeAndPruneColumns_(expr, schema, pruning_options.unsupported_columns, dropped);
+          PrunedFilterColumns pruned_columns;
+          normalizeAndPruneColumns_(expr, schema, pruning_options.unsupported_columns, pruned_columns);
 
-          if (!dropped.empty())
+          if (!pruned_columns.unknown_columns.empty())
           {
-            const std::string dropped_text = joinColumns_(dropped);
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          "Unknown filter columns",
+                                          joinColumns_(pruned_columns.unknown_columns));
+          }
+
+          if (!pruned_columns.unsupported_columns.empty())
+          {
+            const std::string dropped_text = joinColumns_(pruned_columns.unsupported_columns);
             if (pruning_options.reject_unsupported_after_pruning)
             {
               throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
@@ -487,8 +530,17 @@ namespace OpenMS
               value = static_cast<arrow::Int8Array*>(array.get())->Value(row);
               return true;
             case arrow::Type::UINT64:
-              value = static_cast<arrow::UInt64Array*>(array.get())->Value(row);
+            {
+              const uint64_t raw_value = static_cast<arrow::UInt64Array*>(array.get())->Value(row);
+              if (raw_value > static_cast<uint64_t>(std::numeric_limits<Int64>::max()))
+              {
+                throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                              "UINT64 value exceeds Int64 range",
+                                              StringUtils::toStr(raw_value));
+              }
+              value = static_cast<Int64>(raw_value);
               return true;
+            }
             case arrow::Type::UINT32:
               value = static_cast<arrow::UInt32Array*>(array.get())->Value(row);
               return true;
@@ -642,15 +694,8 @@ namespace OpenMS
       std::shared_ptr<arrow::Table> readParquetTable(const std::string& filename)
       {
         auto reader = openReader_(filename);
-
-        auto table_result = reader->ReadTable();
-        if (!table_result.ok())
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Failed to read parquet table: " + table_result.status().ToString(), filename);
-        }
-
-        return combineChunks_(*table_result, filename, "Failed to combine parquet chunks");
+        return combineChunks_(readTableFromReader_(*reader, filename), filename,
+                              "Failed to combine parquet chunks");
       }
 
       std::shared_ptr<arrow::Table> readParquetTable(const std::vector<std::string>& filenames)
@@ -730,14 +775,8 @@ namespace OpenMS
                                               "No requested columns found in parquet file '" + filename + "'");
         }
 
-        auto table_result = reader->ReadTable(column_indices);
-        if (!table_result.ok())
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Failed to read parquet table", filename);
-        }
-
-        return combineChunks_(*table_result, filename, "Failed to combine parquet chunks");
+        return combineChunks_(readTableFromReader_(*reader, column_indices, filename), filename,
+                              "Failed to combine parquet chunks");
       }
 
       std::shared_ptr<arrow::Table> readParquetTableColumns(const std::vector<std::string>& filenames,

--- a/src/openms/source/FORMAT/DATAACCESS/ParquetReaderHelpers.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/ParquetReaderHelpers.cpp
@@ -1,0 +1,1223 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Justin Sing $
+// $Authors: Justin Sing $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/DATASTRUCTURES/StringUtils.h>
+#include "ParquetReaderHelpers.h"
+
+#include <arrow/io/api.h>
+#ifdef WITH_ARROW_DATASET
+#include <arrow/dataset/api.h>
+#include <arrow/filesystem/api.h>
+#endif
+#include <parquet/arrow/reader.h>
+
+#include <cctype>
+#include <exception>
+#include <limits>
+#include <sstream>
+#include <utility>
+
+namespace OpenMS
+{
+  namespace Internal
+  {
+    namespace ParquetReaderHelpers
+    {
+      namespace
+      {
+        std::unique_ptr<parquet::arrow::FileReader> openReader_(const std::string& filename)
+        {
+          auto infile_result = arrow::io::ReadableFile::Open(std::string(filename));
+          if (!infile_result.ok())
+          {
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          "Failed to open parquet file", filename);
+          }
+          const std::shared_ptr<arrow::io::ReadableFile>& infile = *infile_result;
+
+          auto reader_result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
+          if (!reader_result.ok())
+          {
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          "Failed to create parquet reader", filename);
+          }
+
+          return std::move(*reader_result);
+        }
+
+        std::shared_ptr<arrow::Table> combineChunks_(const std::shared_ptr<arrow::Table>& table,
+                                                     const std::string& filename,
+                                                     const std::string& message)
+        {
+          auto combined = table->CombineChunks(arrow::default_memory_pool());
+          if (!combined.ok())
+          {
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          message, filename);
+          }
+
+          return *combined;
+        }
+
+        std::shared_ptr<arrow::Table> concatenateTables_(const std::vector<std::shared_ptr<arrow::Table>>& tables)
+        {
+          if (tables.empty())
+          {
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          "No parquet tables provided", "");
+          }
+          if (tables.size() == 1)
+          {
+            return tables.front();
+          }
+
+          auto concat_result = arrow::ConcatenateTables(tables);
+          if (!concat_result.ok())
+          {
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          "Failed to concatenate parquet tables",
+                                          concat_result.status().ToString());
+          }
+
+          auto combined = (*concat_result)->CombineChunks(arrow::default_memory_pool());
+          if (!combined.ok())
+          {
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          "Failed to combine parquet chunks",
+                                          combined.status().ToString());
+          }
+
+          return *combined;
+        }
+
+        std::string upper_(const std::string& input)
+        {
+          std::string out = input;
+          for (Size i = 0; i < out.size(); ++i)
+          {
+            out[i] = static_cast<char>(std::toupper(static_cast<unsigned char>(out[i])));
+          }
+          return out;
+        }
+
+        std::vector<std::string> tokenize_(const std::string& expr)
+        {
+          std::vector<std::string> tokens;
+          std::string current;
+          bool in_string = false;
+          char quote_char = '\0';
+
+          for (Size i = 0; i < expr.size(); ++i)
+          {
+            const char c = expr[i];
+            if (in_string)
+            {
+              if (c == quote_char)
+              {
+                tokens.push_back(current);
+                current.clear();
+                in_string = false;
+                quote_char = '\0';
+              }
+              else
+              {
+                current += c;
+              }
+              continue;
+            }
+
+            if (c == '"' || c == '\'')
+            {
+              if (!current.empty())
+              {
+                tokens.push_back(current);
+                current.clear();
+              }
+              in_string = true;
+              quote_char = c;
+              continue;
+            }
+
+            if (std::isspace(static_cast<unsigned char>(c)))
+            {
+              if (!current.empty())
+              {
+                tokens.push_back(current);
+                current.clear();
+              }
+              continue;
+            }
+
+            if (c == '[' || c == ']' || c == ',' || c == '(' || c == ')')
+            {
+              if (!current.empty())
+              {
+                tokens.push_back(current);
+                current.clear();
+              }
+              tokens.emplace_back(StringUtils::toStr(c));
+              continue;
+            }
+
+            if (c == '=' || c == '!' || c == '<' || c == '>')
+            {
+              if (!current.empty())
+              {
+                tokens.push_back(current);
+                current.clear();
+              }
+              std::string op;
+              op += c;
+              if (i + 1 < expr.size())
+              {
+                const char next = expr[i + 1];
+                if (next == '=')
+                {
+                  op += next;
+                  ++i;
+                }
+              }
+              tokens.push_back(op);
+              continue;
+            }
+
+            if (c == '&' || c == '|')
+            {
+              if (!current.empty())
+              {
+                tokens.push_back(current);
+                current.clear();
+              }
+              std::string op;
+              op += c;
+              if (i + 1 < expr.size())
+              {
+                const char next = expr[i + 1];
+                if (next == c)
+                {
+                  op += next;
+                  ++i;
+                }
+              }
+              tokens.push_back(op);
+              continue;
+            }
+
+            current += c;
+          }
+
+          if (!current.empty())
+          {
+            tokens.push_back(current);
+          }
+
+          if (in_string)
+          {
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          "Unclosed quote in filter expression", expr);
+          }
+
+          return tokens;
+        }
+
+        std::unordered_map<std::string, std::string> buildSchemaNameMap_(const std::shared_ptr<arrow::Schema>& schema)
+        {
+          std::unordered_map<std::string, std::string> name_map;
+          if (!schema)
+          {
+            return name_map;
+          }
+
+          name_map.reserve(schema->num_fields());
+          for (const auto& field : schema->fields())
+          {
+            name_map[upper_(std::string(field->name()))] = std::string(field->name());
+          }
+
+          return name_map;
+        }
+
+        void normalizeAndPruneColumns_(FilterExpression& expr,
+                                       const std::shared_ptr<arrow::Schema>& schema,
+                                       const std::unordered_set<std::string>& unsupported_columns,
+                                       std::vector<std::string>& dropped_columns)
+        {
+          dropped_columns.clear();
+          if (expr.conditions.empty())
+          {
+            return;
+          }
+
+          const auto name_map = buildSchemaNameMap_(schema);
+
+          std::vector<Condition> kept;
+          kept.reserve(expr.conditions.size());
+          std::vector<std::string> new_connectors;
+          new_connectors.reserve(expr.connectors.size());
+
+          for (Size i = 0; i < expr.conditions.size(); ++i)
+          {
+            Condition cond = expr.conditions[i];
+            const std::string original = cond.column;
+            const std::string upper_column = upper_(cond.column);
+
+            auto it = name_map.find(upper_column);
+            if (it != name_map.end())
+            {
+              cond.column = it->second;
+            }
+
+            const bool unsupported = unsupported_columns.contains(upper_(cond.column));
+            const bool exists_in_schema = name_map.contains(upper_(cond.column));
+            if (unsupported || !exists_in_schema)
+            {
+              dropped_columns.push_back(original);
+              continue;
+            }
+
+            if (!kept.empty())
+            {
+              const Size prev_index = i - 1;
+              if (prev_index < expr.connectors.size())
+              {
+                new_connectors.push_back(expr.connectors[prev_index]);
+              }
+              else
+              {
+                new_connectors.push_back("AND");
+              }
+            }
+            kept.push_back(std::move(cond));
+          }
+
+          expr.conditions.swap(kept);
+          expr.connectors.swap(new_connectors);
+        }
+
+        std::string joinColumns_(const std::vector<std::string>& columns)
+        {
+          std::ostringstream oss;
+          for (Size i = 0; i < columns.size(); ++i)
+          {
+            if (i > 0)
+            {
+              oss << ", ";
+            }
+            oss << columns[i];
+          }
+          return oss.str();
+        }
+
+        bool normalizeAndValidateFilter_(FilterExpression& expr,
+                                         const std::shared_ptr<arrow::Schema>& schema,
+                                         const std::string& filter_context,
+                                         const FilterPruningOptions& pruning_options)
+        {
+          std::vector<std::string> dropped;
+          normalizeAndPruneColumns_(expr, schema, pruning_options.unsupported_columns, dropped);
+
+          if (!dropped.empty())
+          {
+            const std::string dropped_text = joinColumns_(dropped);
+            if (pruning_options.reject_unsupported_after_pruning)
+            {
+              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "Unsupported filter columns after pruning", dropped_text);
+            }
+            OPENMS_LOG_WARN << "Dropping unsupported filter columns: "
+                            << dropped_text << '\n';
+          }
+
+          if (expr.conditions.empty())
+          {
+            if (pruning_options.reject_empty_after_pruning)
+            {
+              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "Filter expression became empty after pruning unsupported columns",
+                                            filter_context);
+            }
+            return false;
+          }
+
+          return true;
+        }
+
+        arrow::compute::Expression buildConditionExpression_(const Condition& cond)
+        {
+          auto field = arrow::compute::field_ref(std::string(cond.column));
+
+          if (cond.op == "IN")
+          {
+            if (cond.type == ColumnType::INT)
+            {
+              arrow::Int64Builder builder;
+              for (const auto& value : cond.values)
+              {
+                auto status = builder.Append(StringUtils::toInt64(value));
+                if (!status.ok())
+                {
+                  throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                                "Failed to build INT64 value set", status.ToString());
+                }
+              }
+
+              std::shared_ptr<arrow::Array> value_set;
+              auto status = builder.Finish(&value_set);
+              if (!status.ok())
+              {
+                throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                              "Failed to finalize INT64 value set", status.ToString());
+              }
+
+              auto options = std::make_shared<arrow::compute::SetLookupOptions>(arrow::Datum(value_set));
+              return arrow::compute::call("is_in", {field}, options);
+            }
+
+            arrow::StringBuilder builder;
+            for (const auto& value : cond.values)
+            {
+              auto status = builder.Append(std::string(value));
+              if (!status.ok())
+              {
+                throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                              "Failed to build STRING value set", status.ToString());
+              }
+            }
+
+            std::shared_ptr<arrow::Array> value_set;
+            auto status = builder.Finish(&value_set);
+            if (!status.ok())
+            {
+              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "Failed to finalize STRING value set", status.ToString());
+            }
+
+            auto options = std::make_shared<arrow::compute::SetLookupOptions>(arrow::Datum(value_set));
+            return arrow::compute::call("is_in", {field}, options);
+          }
+
+          if (cond.values.empty())
+          {
+            return arrow::compute::literal(false);
+          }
+
+          arrow::compute::Expression literal;
+          if (cond.type == ColumnType::INT)
+          {
+            literal = arrow::compute::literal(static_cast<int64_t>(StringUtils::toInt64(cond.values.front())));
+          }
+          else
+          {
+            literal = arrow::compute::literal(std::string(cond.values.front()));
+          }
+
+          if (cond.op == "=") return arrow::compute::equal(field, literal);
+          if (cond.op == "!=") return arrow::compute::not_equal(field, literal);
+          if (cond.op == "<") return arrow::compute::less(field, literal);
+          if (cond.op == "<=") return arrow::compute::less_equal(field, literal);
+          if (cond.op == ">") return arrow::compute::greater(field, literal);
+          if (cond.op == ">=") return arrow::compute::greater_equal(field, literal);
+
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "Unsupported filter operator", cond.op);
+        }
+
+        arrow::compute::Expression buildFilterExpression_(const FilterExpression& expr)
+        {
+          if (expr.conditions.empty())
+          {
+            return arrow::compute::literal(true);
+          }
+
+          std::vector<arrow::compute::Expression> condition_expressions;
+          condition_expressions.reserve(expr.conditions.size());
+          for (const auto& cond : expr.conditions)
+          {
+            condition_expressions.push_back(buildConditionExpression_(cond));
+          }
+
+          arrow::compute::Expression result = condition_expressions.front();
+          for (Size i = 1; i < condition_expressions.size(); ++i)
+          {
+            if (i - 1 < expr.connectors.size() && expr.connectors[i - 1] == "OR")
+            {
+              result = arrow::compute::or_(result, condition_expressions[i]);
+            }
+            else
+            {
+              result = arrow::compute::and_(result, condition_expressions[i]);
+            }
+          }
+          return result;
+        }
+
+        struct ManualCondition
+        {
+          Condition cond;
+          int index{-1};
+          std::vector<Int64> int_values;
+        };
+
+        bool getIntValueFromArray_(const std::shared_ptr<arrow::Array>& array, int64_t row, Int64& value)
+        {
+          if (!array || array->IsNull(row))
+          {
+            return false;
+          }
+
+          switch (array->type_id())
+          {
+            case arrow::Type::INT64:
+              value = static_cast<arrow::Int64Array*>(array.get())->Value(row);
+              return true;
+            case arrow::Type::INT32:
+              value = static_cast<arrow::Int32Array*>(array.get())->Value(row);
+              return true;
+            case arrow::Type::INT16:
+              value = static_cast<arrow::Int16Array*>(array.get())->Value(row);
+              return true;
+            case arrow::Type::INT8:
+              value = static_cast<arrow::Int8Array*>(array.get())->Value(row);
+              return true;
+            case arrow::Type::UINT64:
+              value = static_cast<arrow::UInt64Array*>(array.get())->Value(row);
+              return true;
+            case arrow::Type::UINT32:
+              value = static_cast<arrow::UInt32Array*>(array.get())->Value(row);
+              return true;
+            case arrow::Type::UINT16:
+              value = static_cast<arrow::UInt16Array*>(array.get())->Value(row);
+              return true;
+            case arrow::Type::UINT8:
+              value = static_cast<arrow::UInt8Array*>(array.get())->Value(row);
+              return true;
+            case arrow::Type::BOOL:
+              value = static_cast<arrow::BooleanArray*>(array.get())->Value(row) ? 1 : 0;
+              return true;
+            default:
+              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "Unsupported integer column type",
+                                            std::string(array->type()->ToString()));
+          }
+        }
+
+        bool getStringValueFromArray_(const std::shared_ptr<arrow::Array>& array, int64_t row, std::string& value)
+        {
+          if (!array || array->IsNull(row))
+          {
+            return false;
+          }
+
+          switch (array->type_id())
+          {
+            case arrow::Type::STRING:
+              value = static_cast<arrow::StringArray*>(array.get())->GetString(row);
+              return true;
+            case arrow::Type::LARGE_STRING:
+              value = static_cast<arrow::LargeStringArray*>(array.get())->GetString(row);
+              return true;
+            default:
+              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "Unsupported string column type",
+                                            std::string(array->type()->ToString()));
+          }
+        }
+
+        bool evaluateCondition_(const ManualCondition& cond,
+                                const std::shared_ptr<arrow::RecordBatch>& batch,
+                                int64_t row)
+        {
+          if (!batch || cond.index < 0 || cond.index >= batch->num_columns())
+          {
+            return false;
+          }
+
+          const auto& array = batch->column(cond.index);
+          if (cond.cond.type == ColumnType::INT)
+          {
+            Int64 lhs = 0;
+            if (!getIntValueFromArray_(array, row, lhs))
+            {
+              return false;
+            }
+
+            if (cond.cond.op == "IN")
+            {
+              for (const auto& rhs : cond.int_values)
+              {
+                if (lhs == rhs)
+                {
+                  return true;
+                }
+              }
+              return false;
+            }
+
+            if (cond.int_values.empty())
+            {
+              return false;
+            }
+
+            const Int64 rhs = cond.int_values.front();
+            if (cond.cond.op == "=") return lhs == rhs;
+            if (cond.cond.op == "!=") return lhs != rhs;
+            if (cond.cond.op == "<") return lhs < rhs;
+            if (cond.cond.op == "<=") return lhs <= rhs;
+            if (cond.cond.op == ">") return lhs > rhs;
+            if (cond.cond.op == ">=") return lhs >= rhs;
+          }
+          else
+          {
+            std::string lhs;
+            if (!getStringValueFromArray_(array, row, lhs))
+            {
+              return false;
+            }
+
+            if (cond.cond.op == "IN")
+            {
+              for (const auto& rhs : cond.cond.values)
+              {
+                if (lhs == rhs)
+                {
+                  return true;
+                }
+              }
+              return false;
+            }
+
+            if (cond.cond.values.empty())
+            {
+              return false;
+            }
+
+            const std::string& rhs = cond.cond.values.front();
+            if (cond.cond.op == "=") return lhs == rhs;
+            if (cond.cond.op == "!=") return lhs != rhs;
+            if (cond.cond.op == "<") return lhs < rhs;
+            if (cond.cond.op == "<=") return lhs <= rhs;
+            if (cond.cond.op == ">") return lhs > rhs;
+            if (cond.cond.op == ">=") return lhs >= rhs;
+          }
+
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "Unsupported filter operator", cond.cond.op);
+        }
+
+        bool evaluateFilterExpression_(const std::vector<ManualCondition>& conditions,
+                                       const std::vector<std::string>& connectors,
+                                       const std::shared_ptr<arrow::RecordBatch>& batch,
+                                       int64_t row)
+        {
+          if (conditions.empty())
+          {
+            return true;
+          }
+
+          bool result = evaluateCondition_(conditions.front(), batch, row);
+          for (Size i = 1; i < conditions.size(); ++i)
+          {
+            const std::string connector = (i - 1 < connectors.size()) ? connectors[i - 1] : "AND";
+            const bool next = evaluateCondition_(conditions[i], batch, row);
+            if (connector == "OR")
+            {
+              result = result || next;
+            }
+            else
+            {
+              result = result && next;
+            }
+          }
+          return result;
+        }
+      } // namespace
+
+      std::shared_ptr<arrow::Table> readParquetTable(const std::string& filename)
+      {
+        auto reader = openReader_(filename);
+
+        auto table_result = reader->ReadTable();
+        if (!table_result.ok())
+        {
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "Failed to read parquet table: " + table_result.status().ToString(), filename);
+        }
+
+        return combineChunks_(*table_result, filename, "Failed to combine parquet chunks");
+      }
+
+      std::shared_ptr<arrow::Table> readParquetTable(const std::vector<std::string>& filenames)
+      {
+        std::vector<std::shared_ptr<arrow::Table>> tables;
+        tables.reserve(filenames.size());
+        for (const auto& filename : filenames)
+        {
+          tables.push_back(readParquetTable(filename));
+        }
+        return concatenateTables_(tables);
+      }
+
+      std::shared_ptr<arrow::Schema> readParquetSchema(const std::string& filename)
+      {
+        auto reader = openReader_(filename);
+
+        std::shared_ptr<arrow::Schema> schema;
+        auto status = reader->GetSchema(&schema);
+        if (!status.ok() || !schema)
+        {
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "Failed to read parquet schema", filename);
+        }
+        return schema;
+      }
+
+      std::shared_ptr<arrow::Schema> readParquetSchemaAllFiles(const std::vector<std::string>& filenames)
+      {
+        if (filenames.empty())
+        {
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "No parquet files provided for schema validation", "");
+        }
+
+        auto base = readParquetSchema(filenames.front());
+        for (size_t i = 1; i < filenames.size(); ++i)
+        {
+          auto other = readParquetSchema(filenames[i]);
+          if (!other->Equals(*base))
+          {
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          "Parquet input files have incompatible schemas: '" +
+                                            filenames.front() + "' vs '" + filenames[i] + "'",
+                                          "");
+          }
+        }
+        return base;
+      }
+
+      std::shared_ptr<arrow::Table> readParquetTableColumns(const std::string& filename,
+                                                            const std::vector<std::string>& columns)
+      {
+        auto reader = openReader_(filename);
+
+        std::shared_ptr<arrow::Schema> schema;
+        auto schema_status = reader->GetSchema(&schema);
+        if (!schema_status.ok() || !schema)
+        {
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "Failed to read parquet schema", filename);
+        }
+
+        std::vector<int> column_indices;
+        column_indices.reserve(columns.size());
+        for (const auto& name : columns)
+        {
+          const int idx = schema->GetFieldIndex(std::string(name));
+          if (idx >= 0)
+          {
+            column_indices.push_back(idx);
+          }
+        }
+        if (column_indices.empty())
+        {
+          throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                              "No requested columns found in parquet file '" + filename + "'");
+        }
+
+        auto table_result = reader->ReadTable(column_indices);
+        if (!table_result.ok())
+        {
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "Failed to read parquet table", filename);
+        }
+
+        return combineChunks_(*table_result, filename, "Failed to combine parquet chunks");
+      }
+
+      std::shared_ptr<arrow::Table> readParquetTableColumns(const std::vector<std::string>& filenames,
+                                                            const std::vector<std::string>& columns)
+      {
+        std::vector<std::shared_ptr<arrow::Table>> tables;
+        tables.reserve(filenames.size());
+        for (const auto& filename : filenames)
+        {
+          tables.push_back(readParquetTableColumns(filename, columns));
+        }
+        return concatenateTables_(tables);
+      }
+
+      std::shared_ptr<arrow::Array> getColumn(const std::shared_ptr<arrow::Table>& table,
+                                              const std::string& name,
+                                              bool required)
+      {
+        auto column = table->GetColumnByName(name);
+        if (!column)
+        {
+          if (required)
+          {
+            throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                                "Missing required column '" + name + "'");
+          }
+          return nullptr;
+        }
+        if (column->num_chunks() == 0)
+        {
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "Column has no chunks", name);
+        }
+        if (column->num_chunks() == 1)
+        {
+          return column->chunk(0);
+        }
+
+        auto combined = arrow::Concatenate(column->chunks(), arrow::default_memory_pool());
+        if (!combined.ok())
+        {
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "Failed to combine column chunks", combined.status().ToString());
+        }
+        return *combined;
+      }
+
+      bool getOptionalInt(const std::shared_ptr<arrow::Array>& array, int64_t row, Int64& value)
+      {
+        return getIntValueFromArray_(array, row, value);
+      }
+
+      bool getOptionalDouble(const std::shared_ptr<arrow::Array>& array, int64_t row, double& value)
+      {
+        if (!array || array->IsNull(row))
+        {
+          return false;
+        }
+
+        switch (array->type_id())
+        {
+          case arrow::Type::DOUBLE:
+            value = static_cast<arrow::DoubleArray*>(array.get())->Value(row);
+            return true;
+          case arrow::Type::FLOAT:
+            value = static_cast<double>(static_cast<arrow::FloatArray*>(array.get())->Value(row));
+            return true;
+          default:
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          "Unsupported floating-point column type",
+                                          std::string(array->type()->ToString()));
+        }
+      }
+
+      bool getOptionalString(const std::shared_ptr<arrow::Array>& array, int64_t row, std::string& value)
+      {
+        return getStringValueFromArray_(array, row, value);
+      }
+
+      std::string getBinaryView(const std::shared_ptr<arrow::Array>& array, int64_t row)
+      {
+        if (!array || array->IsNull(row))
+        {
+          return std::string();
+        }
+
+        switch (array->type_id())
+        {
+          case arrow::Type::BINARY:
+          {
+            auto typed = static_cast<arrow::BinaryArray*>(array.get());
+            const auto view = typed->GetView(row);
+            const size_t view_size = view.size();
+            if (view_size > static_cast<size_t>(std::numeric_limits<Size>::max()))
+            {
+              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "Binary data too large", StringUtils::toStr(view_size));
+            }
+            return std::string(view.data(), view_size);
+          }
+          case arrow::Type::LARGE_BINARY:
+          {
+            auto typed = static_cast<arrow::LargeBinaryArray*>(array.get());
+            const auto view = typed->GetView(row);
+            const size_t view_size = view.size();
+            if (view_size > static_cast<size_t>(std::numeric_limits<Size>::max()))
+            {
+              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "Binary data too large", StringUtils::toStr(view_size));
+            }
+            return std::string(view.data(), view_size);
+          }
+          default:
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          "Unsupported binary column type",
+                                          std::string(array->type()->ToString()));
+        }
+      }
+
+      FilterExpression parseFilter(const std::string& filter,
+                                   const std::unordered_map<std::string, ColumnType>& column_types)
+      {
+        FilterExpression expr;
+        if (filter.empty())
+        {
+          return expr;
+        }
+
+        auto tokens = tokenize_(filter);
+        Size i = 0;
+        while (i < tokens.size())
+        {
+          std::string column = upper_(tokens[i++]);
+          if (i >= tokens.size())
+          {
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          "Missing filter operator for column", column);
+          }
+
+          std::string op = upper_(tokens[i++]);
+          if (op == "==")
+          {
+            op = "=";
+          }
+          if (op != "=" && op != "!=" && op != "<" && op != "<=" && op != ">" && op != ">=" && op != "IN")
+          {
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          "Unsupported filter operator", op);
+          }
+
+          Condition cond;
+          cond.column = column;
+          cond.op = op;
+          auto type_it = column_types.find(column);
+          cond.type = (type_it == column_types.end()) ? ColumnType::INT : type_it->second;
+
+          if (op == "IN")
+          {
+            std::string close_token;
+            if (i < tokens.size() && (tokens[i] == "[" || tokens[i] == "("))
+            {
+              close_token = (tokens[i] == "[") ? "]" : ")";
+              ++i;
+            }
+            else
+            {
+              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "IN operator expects a bracketed value list", filter);
+            }
+
+            while (i < tokens.size() && tokens[i] != close_token)
+            {
+              if (tokens[i] != ",")
+              {
+                cond.values.push_back(tokens[i]);
+              }
+              ++i;
+            }
+            if (cond.values.empty())
+            {
+              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "IN operator expects at least one value", filter);
+            }
+            if (i >= tokens.size() || tokens[i] != close_token)
+            {
+              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "Unclosed IN list", filter);
+            }
+            ++i;
+          }
+          else
+          {
+            if (i >= tokens.size())
+            {
+              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "Missing filter value for operator", op);
+            }
+            cond.values.push_back(tokens[i++]);
+          }
+
+          expr.conditions.push_back(std::move(cond));
+          if (i < tokens.size())
+          {
+            std::string connector = upper_(tokens[i]);
+            bool consumed_connector = false;
+            if (connector == "AND" || connector == "&&" || connector == "&")
+            {
+              expr.connectors.push_back("AND");
+              ++i;
+              consumed_connector = true;
+            }
+            else if (connector == "OR" || connector == "||" || connector == "|")
+            {
+              expr.connectors.push_back("OR");
+              ++i;
+              consumed_connector = true;
+            }
+            if (consumed_connector && i >= tokens.size())
+            {
+              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "Dangling connector in filter expression", filter);
+            }
+          }
+        }
+
+        return expr;
+      }
+
+#ifdef WITH_ARROW_DATASET
+      std::shared_ptr<arrow::Table> readParquetTableDataset(const std::vector<std::string>& filenames,
+                                                            const FilterExpression& parsed,
+                                                            const std::string& filter_context,
+                                                            const FilterPruningOptions& pruning_options)
+      {
+        auto filesystem = std::make_shared<arrow::fs::LocalFileSystem>();
+        auto format = std::make_shared<arrow::dataset::ParquetFileFormat>();
+        arrow::dataset::FileSystemFactoryOptions options;
+
+        std::vector<std::string> paths;
+        paths.reserve(filenames.size());
+        for (const auto& filename : filenames)
+        {
+          paths.emplace_back(filename);
+        }
+
+        auto factory_result = arrow::dataset::FileSystemDatasetFactory::Make(filesystem, paths, format, options);
+        if (!factory_result.ok())
+        {
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "Failed to create dataset factory", "dataset");
+        }
+
+        auto dataset_result = (*factory_result)->Finish();
+        if (!dataset_result.ok())
+        {
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "Failed to create dataset", "dataset");
+        }
+        std::shared_ptr<arrow::dataset::Dataset> dataset = *dataset_result;
+
+        auto builder = std::make_shared<arrow::dataset::ScannerBuilder>(dataset);
+        if (!parsed.conditions.empty())
+        {
+          FilterExpression pruned = parsed;
+          if (!normalizeAndValidateFilter_(pruned, dataset->schema(), filter_context, pruning_options))
+          {
+            return readParquetTable(filenames);
+          }
+
+          auto status = builder->Filter(buildFilterExpression_(pruned));
+          if (!status.ok())
+          {
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          "Failed to bind dataset filter expression", status.ToString());
+          }
+        }
+
+        auto scanner_result = builder->Finish();
+        if (!scanner_result.ok())
+        {
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "Failed to create dataset scanner", "dataset");
+        }
+        auto table_result = (*scanner_result)->ToTable();
+        if (!table_result.ok())
+        {
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "Failed to read parquet table via dataset scanner", "dataset");
+        }
+
+        auto combined = (*table_result)->CombineChunks(arrow::default_memory_pool());
+        if (!combined.ok())
+        {
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "Failed to combine parquet chunks", combined.status().ToString());
+        }
+        return *combined;
+      }
+#endif
+
+      std::shared_ptr<arrow::Table> applyManualFilter(const std::shared_ptr<arrow::Table>& table,
+                                                      const FilterExpression& parsed,
+                                                      const std::string& filter_context)
+      {
+        std::vector<ManualCondition> conditions;
+        conditions.reserve(parsed.conditions.size());
+
+        auto schema = table->schema();
+        for (const auto& cond : parsed.conditions)
+        {
+          ManualCondition manual;
+          manual.cond = cond;
+          manual.index = schema->GetFieldIndex(std::string(cond.column));
+          if (manual.index < 0)
+          {
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          "Column not found in parquet schema", cond.column);
+          }
+
+          if (cond.type == ColumnType::INT)
+          {
+            manual.int_values.reserve(cond.values.size());
+            for (const auto& value : cond.values)
+            {
+              try
+              {
+                manual.int_values.push_back(StringUtils::toInt64(value));
+              }
+              catch (const std::exception&)
+              {
+                throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                              "Invalid integer filter value", value);
+              }
+            }
+          }
+
+          conditions.push_back(std::move(manual));
+        }
+
+        arrow::TableBatchReader reader(*table);
+        std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+        std::shared_ptr<arrow::RecordBatch> batch;
+
+        while (true)
+        {
+          auto read_status = reader.ReadNext(&batch);
+          if (!read_status.ok())
+          {
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          "Failed to read record batch", filter_context);
+          }
+          if (!batch)
+          {
+            break;
+          }
+
+          const int64_t num_rows = batch->num_rows();
+          for (int64_t row = 0; row < num_rows; ++row)
+          {
+            if (evaluateFilterExpression_(conditions, parsed.connectors, batch, row))
+            {
+              batches.push_back(batch->Slice(row, 1));
+            }
+          }
+        }
+
+        if (batches.empty())
+        {
+          std::vector<std::shared_ptr<arrow::Array>> empty_columns;
+          empty_columns.reserve(schema->num_fields());
+          for (const auto& field : schema->fields())
+          {
+            auto array_result = arrow::MakeArrayOfNull(field->type(), 0);
+            if (!array_result.ok())
+            {
+              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "Failed to create empty column", array_result.status().ToString());
+            }
+            empty_columns.push_back(*array_result);
+          }
+          return arrow::Table::Make(schema, empty_columns);
+        }
+
+        auto table_result = arrow::Table::FromRecordBatches(schema, batches);
+        if (!table_result.ok())
+        {
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "Failed to build filtered table", filter_context);
+        }
+
+        auto combined = (*table_result)->CombineChunks(arrow::default_memory_pool());
+        if (!combined.ok())
+        {
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "Failed to combine filtered chunks", combined.status().ToString());
+        }
+        return *combined;
+      }
+
+      std::shared_ptr<arrow::Table> applyArrowFilter(const std::shared_ptr<arrow::Table>& table,
+                                                     const FilterExpression& parsed,
+                                                     const std::string& filter_context,
+                                                     const FilterPruningOptions& pruning_options)
+      {
+        if (parsed.conditions.empty())
+        {
+          return table;
+        }
+
+        FilterExpression pruned = parsed;
+        if (!normalizeAndValidateFilter_(pruned, table->schema(), filter_context, pruning_options))
+        {
+          return table;
+        }
+
+        auto bound_result = buildFilterExpression_(pruned).Bind(*table->schema());
+        if (!bound_result.ok())
+        {
+          OPENMS_LOG_WARN << "Arrow compute filter unavailable, falling back to manual filter: "
+                          << bound_result.status().ToString() << '\n';
+          return applyManualFilter(table, pruned, filter_context);
+        }
+        const arrow::compute::Expression& bound_expr = *bound_result;
+
+        arrow::TableBatchReader reader(*table);
+        std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+        std::shared_ptr<arrow::RecordBatch> batch;
+
+        while (true)
+        {
+          auto read_status = reader.ReadNext(&batch);
+          if (!read_status.ok())
+          {
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          "Failed to read record batch", filter_context);
+          }
+          if (!batch)
+          {
+            break;
+          }
+
+          auto mask_result = arrow::compute::ExecuteScalarExpression(
+            bound_expr, *batch->schema(), arrow::Datum(batch));
+          if (!mask_result.ok())
+          {
+            OPENMS_LOG_WARN << "Arrow compute filter failed, falling back to manual filter: "
+                            << mask_result.status().ToString() << '\n';
+            return applyManualFilter(table, pruned, filter_context);
+          }
+
+          auto filtered_result = arrow::compute::Filter(arrow::Datum(batch), *mask_result);
+          if (!filtered_result.ok())
+          {
+            OPENMS_LOG_WARN << "Arrow compute filter failed, falling back to manual filter: "
+                            << filtered_result.status().ToString() << '\n';
+            return applyManualFilter(table, pruned, filter_context);
+          }
+
+          const auto& filtered_batch = filtered_result->record_batch();
+          if (filtered_batch && filtered_batch->num_rows() > 0)
+          {
+            batches.push_back(filtered_batch);
+          }
+        }
+
+        auto table_result = arrow::Table::FromRecordBatches(table->schema(), batches);
+        if (!table_result.ok())
+        {
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "Failed to build filtered table", filter_context);
+        }
+
+        auto combined = (*table_result)->CombineChunks(arrow::default_memory_pool());
+        if (!combined.ok())
+        {
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "Failed to combine filtered chunks", combined.status().ToString());
+        }
+        return *combined;
+      }
+    } // namespace ParquetReaderHelpers
+  } // namespace Internal
+} // namespace OpenMS

--- a/src/openms/source/FORMAT/DATAACCESS/ParquetReaderHelpers.h
+++ b/src/openms/source/FORMAT/DATAACCESS/ParquetReaderHelpers.h
@@ -24,45 +24,190 @@ namespace OpenMS
 {
   namespace Internal
   {
+    /**
+      @brief Shared internal Arrow/Parquet helpers for OpenSWATH readers.
+
+      These helpers centralize schema access, value extraction, and filter
+      execution for the XIC/XIM parquet readers while keeping Arrow types out
+      of the public OpenMS headers.
+    */
     namespace ParquetReaderHelpers
     {
+      /**
+        @brief Controls how filter expressions are pruned against a schema.
+      */
       struct FilterPruningOptions
       {
+        /// Columns that are known to exist but cannot be evaluated by the helper.
         std::unordered_set<std::string> unsupported_columns;
+        /// Throw if unsupported columns remain after schema-aware pruning.
         bool reject_unsupported_after_pruning{false};
+        /// Throw if pruning removes all remaining filter conditions.
         bool reject_empty_after_pruning{false};
       };
 
+      /** @name Table and Schema Access
+      */
+      //@{
+      /**
+        @brief Read a parquet table from a single file.
+
+        @param[in] filename Path to the parquet file.
+
+        @return The chunk-combined table.
+      */
       std::shared_ptr<arrow::Table> readParquetTable(const std::string& filename);
+
+      /**
+        @brief Read and concatenate parquet tables from multiple files.
+
+        @param[in] filenames Paths to parquet files with compatible schemas.
+
+        @return The concatenated, chunk-combined table.
+      */
       std::shared_ptr<arrow::Table> readParquetTable(const std::vector<std::string>& filenames);
 
+      /**
+        @brief Read the schema from a single parquet file.
+
+        @param[in] filename Path to the parquet file.
+
+        @return The parquet schema.
+      */
       std::shared_ptr<arrow::Schema> readParquetSchema(const std::string& filename);
+
+      /**
+        @brief Read and validate schemas across multiple parquet files.
+
+        @param[in] filenames Paths to parquet files with expected identical schemas.
+
+        @return The shared schema.
+      */
       std::shared_ptr<arrow::Schema> readParquetSchemaAllFiles(const std::vector<std::string>& filenames);
 
+      /**
+        @brief Read a subset of columns from a single parquet file.
+
+        @param[in] filename Path to the parquet file.
+        @param[in] columns Requested column names.
+
+        @return The chunk-combined table containing the requested columns.
+      */
       std::shared_ptr<arrow::Table> readParquetTableColumns(const std::string& filename,
                                                             const std::vector<std::string>& columns);
+
+      /**
+        @brief Read and concatenate a subset of columns from multiple parquet files.
+
+        @param[in] filenames Paths to parquet files with compatible schemas.
+        @param[in] columns Requested column names.
+
+        @return The concatenated, chunk-combined table containing the requested columns.
+      */
       std::shared_ptr<arrow::Table> readParquetTableColumns(const std::vector<std::string>& filenames,
                                                             const std::vector<std::string>& columns);
+      //@}
 
+      /** @name Column Access and Value Extraction
+      */
+      //@{
+      /**
+        @brief Return a single logical Arrow array for a named table column.
+
+        If the table column is chunked, all chunks are concatenated first.
+
+        @param[in] table Source table.
+        @param[in] name Column name.
+        @param[in] required Throw if the column is missing.
+
+        @return The resolved Arrow array or `nullptr` for missing optional columns.
+      */
       std::shared_ptr<arrow::Array> getColumn(const std::shared_ptr<arrow::Table>& table,
                                               const std::string& name,
                                               bool required = true);
 
-      bool getOptionalInt(const std::shared_ptr<arrow::Array>& array, int64_t row, Int64& value);
-      bool getOptionalDouble(const std::shared_ptr<arrow::Array>& array, int64_t row, double& value);
-      bool getOptionalString(const std::shared_ptr<arrow::Array>& array, int64_t row, std::string& value);
-      std::string getBinaryView(const std::shared_ptr<arrow::Array>& array, int64_t row);
+      /**
+        @brief Read an optional integer-like value from an Arrow array.
 
+        @param[in] array Source Arrow array.
+        @param[in] row Zero-based row index.
+        @param[out] value Extracted integer value.
+
+        @return `true` if the value exists, `false` for null cells.
+      */
+      bool getOptionalInt(const std::shared_ptr<arrow::Array>& array, int64_t row, Int64& value);
+
+      /**
+        @brief Read an optional floating-point value from an Arrow array.
+
+        @param[in] array Source Arrow array.
+        @param[in] row Zero-based row index.
+        @param[out] value Extracted floating-point value.
+
+        @return `true` if the value exists, `false` for null cells.
+      */
+      bool getOptionalDouble(const std::shared_ptr<arrow::Array>& array, int64_t row, double& value);
+
+      /**
+        @brief Read an optional string value from an Arrow array.
+
+        @param[in] array Source Arrow array.
+        @param[in] row Zero-based row index.
+        @param[out] value Extracted string value.
+
+        @return `true` if the value exists, `false` for null cells.
+      */
+      bool getOptionalString(const std::shared_ptr<arrow::Array>& array, int64_t row, std::string& value);
+
+      /**
+        @brief Return a binary cell as a `std::string` view copy.
+
+        @param[in] array Source Arrow array.
+        @param[in] row Zero-based row index.
+
+        @return Binary payload for the requested cell, or an empty string for null cells.
+      */
+      std::string getBinaryView(const std::shared_ptr<arrow::Array>& array, int64_t row);
+      //@}
+
+      /**
+        @brief Parse a textual filter expression into a typed helper expression.
+
+        @param[in] filter User-provided filter expression.
+        @param[in] column_types Mapping from uppercase column names to expected scalar types.
+
+        @return Parsed filter expression.
+      */
       FilterExpression parseFilter(const std::string& filter,
                                    const std::unordered_map<std::string, ColumnType>& column_types);
 
 #ifdef WITH_ARROW_DATASET
+      /**
+        @brief Read parquet files through Arrow Dataset with filter pushdown.
+
+        @param[in] filenames Paths to parquet files.
+        @param[in] parsed Parsed filter expression.
+        @param[in] filter_context Original filter string for diagnostics.
+        @param[in] pruning_options Filter pruning policy.
+
+        @return The filtered, chunk-combined table.
+      */
       std::shared_ptr<arrow::Table> readParquetTableDataset(const std::vector<std::string>& filenames,
                                                             const FilterExpression& parsed,
                                                             const std::string& filter_context,
                                                             const FilterPruningOptions& pruning_options);
 #endif
 
+      /**
+        @brief Apply an Arrow compute filter to an in-memory table.
+
+        @param[in] table Source table.
+        @param[in] parsed Parsed filter expression.
+        @param[in] filter_context Original filter string for diagnostics.
+        @param[in] pruning_options Filter pruning policy.
+
+        @return The filtered, chunk-combined table.
+      */
       std::shared_ptr<arrow::Table> applyArrowFilter(const std::shared_ptr<arrow::Table>& table,
                                                      const FilterExpression& parsed,
                                                      const std::string& filter_context,

--- a/src/openms/source/FORMAT/DATAACCESS/ParquetReaderHelpers.h
+++ b/src/openms/source/FORMAT/DATAACCESS/ParquetReaderHelpers.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Justin Sing $
+// $Authors: Justin Sing $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/FORMAT/ParquetFilter.h>
+
+#include <arrow/api.h>
+#include <arrow/compute/api.h>
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace OpenMS
+{
+  namespace Internal
+  {
+    namespace ParquetReaderHelpers
+    {
+      struct FilterPruningOptions
+      {
+        std::unordered_set<std::string> unsupported_columns;
+        bool reject_unsupported_after_pruning{false};
+        bool reject_empty_after_pruning{false};
+      };
+
+      std::shared_ptr<arrow::Table> readParquetTable(const std::string& filename);
+      std::shared_ptr<arrow::Table> readParquetTable(const std::vector<std::string>& filenames);
+
+      std::shared_ptr<arrow::Schema> readParquetSchema(const std::string& filename);
+      std::shared_ptr<arrow::Schema> readParquetSchemaAllFiles(const std::vector<std::string>& filenames);
+
+      std::shared_ptr<arrow::Table> readParquetTableColumns(const std::string& filename,
+                                                            const std::vector<std::string>& columns);
+      std::shared_ptr<arrow::Table> readParquetTableColumns(const std::vector<std::string>& filenames,
+                                                            const std::vector<std::string>& columns);
+
+      std::shared_ptr<arrow::Array> getColumn(const std::shared_ptr<arrow::Table>& table,
+                                              const std::string& name,
+                                              bool required = true);
+
+      bool getOptionalInt(const std::shared_ptr<arrow::Array>& array, int64_t row, Int64& value);
+      bool getOptionalDouble(const std::shared_ptr<arrow::Array>& array, int64_t row, double& value);
+      bool getOptionalString(const std::shared_ptr<arrow::Array>& array, int64_t row, std::string& value);
+      std::string getBinaryView(const std::shared_ptr<arrow::Array>& array, int64_t row);
+
+      FilterExpression parseFilter(const std::string& filter,
+                                   const std::unordered_map<std::string, ColumnType>& column_types);
+
+#ifdef WITH_ARROW_DATASET
+      std::shared_ptr<arrow::Table> readParquetTableDataset(const std::vector<std::string>& filenames,
+                                                            const FilterExpression& parsed,
+                                                            const std::string& filter_context,
+                                                            const FilterPruningOptions& pruning_options);
+#endif
+
+      std::shared_ptr<arrow::Table> applyArrowFilter(const std::shared_ptr<arrow::Table>& table,
+                                                     const FilterExpression& parsed,
+                                                     const std::string& filter_context,
+                                                     const FilterPruningOptions& pruning_options);
+    } // namespace ParquetReaderHelpers
+  } // namespace Internal
+} // namespace OpenMS

--- a/src/openms/source/FORMAT/DATAACCESS/sources.cmake
+++ b/src/openms/source/FORMAT/DATAACCESS/sources.cmake
@@ -17,6 +17,7 @@ set(sources_list
 
 list(APPEND sources_list MSChromatogramParquetConsumer.cpp)
 list(APPEND sources_list MobilogramParquetConsumer.cpp)
+list(APPEND sources_list ParquetReaderHelpers.cpp)
 
 ### add path to the filenames
 set(sources)

--- a/src/openms/source/FORMAT/XICParquetFile.cpp
+++ b/src/openms/source/FORMAT/XICParquetFile.cpp
@@ -6,23 +6,14 @@
 // $Authors: Justin Sing $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/FORMAT/XICParquetFile.h>
-
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
-#include <OpenMS/FORMAT/ParquetFilter.h>
+#include "DATAACCESS/ParquetReaderHelpers.h"
 #include <OpenMS/FORMAT/MSNumpressCoder.h>
+#include <OpenMS/FORMAT/XICParquetFile.h>
 #include <OpenMS/FORMAT/ZlibCompression.h>
 #include <OpenMS/SYSTEM/File.h>
 
-#include <arrow/api.h>
-#include <arrow/compute/api.h>
-#include <arrow/io/api.h>
-#include <parquet/arrow/reader.h>
-#ifdef WITH_ARROW_DATASET
-#include <arrow/dataset/api.h>
-#include <arrow/filesystem/api.h>
-#endif
 
 #include <cstring>
 #include <cctype>
@@ -35,276 +26,16 @@ namespace OpenMS
 {
   namespace
   {
-    /// Read a single parquet file into an Arrow table.
-    std::shared_ptr<arrow::Table> readParquetTable_(const std::string& filename)
+    namespace PRH = Internal::ParquetReaderHelpers;
+
+    const PRH::FilterPruningOptions& filterPruningOptions_()
     {
-      auto infile_result = arrow::io::ReadableFile::Open(std::string(filename));
-      if (!infile_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to open parquet file", filename);
-      }
-      const std::shared_ptr<arrow::io::ReadableFile>& infile = *infile_result;
-
-      auto reader_result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
-      if (!reader_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to create parquet reader", filename);
-      }
-      std::unique_ptr<parquet::arrow::FileReader> reader = std::move(reader_result.ValueOrDie());
-
-      std::shared_ptr<arrow::Table> table;
-      auto read_status = reader->ReadTable(&table);
-      if (!read_status.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to read parquet table: " + read_status.ToString(), filename);
-      }
-
-      auto combined = table->CombineChunks(arrow::default_memory_pool());
-      if (!combined.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to combine parquet chunks", filename);
-      }
-
-      return *combined;
-    }
-
-    /// Read the parquet schema from a single file.
-    std::shared_ptr<arrow::Schema> readParquetSchema_(const std::string& filename)
-    {
-      auto infile_result = arrow::io::ReadableFile::Open(std::string(filename));
-      if (!infile_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to open parquet file", filename);
-      }
-      const std::shared_ptr<arrow::io::ReadableFile>& infile = *infile_result;
-
-      auto reader_result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
-      if (!reader_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to create parquet reader", filename);
-      }
-      std::unique_ptr<parquet::arrow::FileReader> reader = std::move(reader_result.ValueOrDie());
-
-      std::shared_ptr<arrow::Schema> schema;
-      auto status = reader->GetSchema(&schema);
-      if (!status.ok() || !schema)
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to read parquet schema", filename);
-      }
-      return schema;
-    }
-
-    /// Read parquet schema from all files and ensure they are compatible.
-    std::shared_ptr<arrow::Schema> readParquetSchemaAllFiles_(const std::vector<std::string>& filenames)
-    {
-      if (filenames.empty())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "No parquet files provided for schema validation", "");
-      }
-      auto base = readParquetSchema_(filenames.front());
-      for (size_t i = 1; i < filenames.size(); ++i)
-      {
-        auto other = readParquetSchema_(filenames[i]);
-        // Use Arrow Schema equality check to ensure fields and types match.
-        if (!other->Equals(*base))
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Parquet input files have incompatible schemas: '" + filenames.front() + "' vs '" + filenames[i] + "'", "");
-        }
-      }
-      return base;
-    }
-
-    /// Read selected columns from a parquet file into an Arrow table.
-    std::shared_ptr<arrow::Table> readParquetTableColumns_(const std::string& filename,
-                                                           const std::vector<std::string>& columns)
-    {
-      auto infile_result = arrow::io::ReadableFile::Open(std::string(filename));
-      if (!infile_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to open parquet file", filename);
-      }
-      const std::shared_ptr<arrow::io::ReadableFile>& infile = *infile_result;
-
-      auto reader_result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
-      if (!reader_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to create parquet reader", filename);
-      }
-      std::unique_ptr<parquet::arrow::FileReader> reader = std::move(reader_result.ValueOrDie());
-
-      std::shared_ptr<arrow::Schema> schema;
-      auto schema_status = reader->GetSchema(&schema);
-      if (!schema_status.ok() || !schema)
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to read parquet schema", filename);
-      }
-
-      std::vector<int> column_indices;
-      column_indices.reserve(columns.size());
-      for (const auto& name : columns)
-      {
-        const int idx = schema->GetFieldIndex(std::string(name));
-        if (idx >= 0)
-        {
-          column_indices.push_back(idx);
-        }
-      }
-      if (column_indices.empty())
-      {
-        throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                            "No requested columns found in parquet file '" +
-                                            filename + "'");
-      }
-
-      std::shared_ptr<arrow::Table> table;
-      auto read_status = reader->ReadTable(column_indices, &table);
-      if (!read_status.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to read parquet table", filename);
-      }
-
-      auto combined = table->CombineChunks(arrow::default_memory_pool());
-      if (!combined.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to combine parquet chunks", filename);
-      }
-
-      return *combined;
-    }
-
-    /// Concatenate multiple Arrow tables (multiple input files).
-    std::shared_ptr<arrow::Table> concatenateTables_(const std::vector<std::shared_ptr<arrow::Table>>& tables)
-    {
-      if (tables.empty())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "No parquet tables provided", "");
-      }
-      if (tables.size() == 1)
-      {
-        return tables.front();
-      }
-
-      // Concatenate multiple file tables into a single logical view.
-      auto concat_result = arrow::ConcatenateTables(tables);
-      if (!concat_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to concatenate parquet tables", concat_result.status().ToString());
-      }
-
-      auto combined = (*concat_result)->CombineChunks(arrow::default_memory_pool());
-      if (!combined.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to combine parquet chunks", combined.status().ToString());
-      }
-
-      return *combined;
-    }
-
-    /// Read and concatenate multiple parquet files.
-    std::shared_ptr<arrow::Table> readParquetTable_(const std::vector<std::string>& filenames)
-    {
-      std::vector<std::shared_ptr<arrow::Table>> tables;
-      tables.reserve(filenames.size());
-      for (const auto& filename : filenames)
-      {
-        tables.push_back(readParquetTable_(filename));
-      }
-      return concatenateTables_(tables);
-    }
-
-    /// Read and concatenate selected columns from multiple parquet files.
-    std::shared_ptr<arrow::Table> readParquetTableColumns_(const std::vector<std::string>& filenames,
-                                                           const std::vector<std::string>& columns)
-    {
-      std::vector<std::shared_ptr<arrow::Table>> tables;
-      tables.reserve(filenames.size());
-      for (const auto& filename : filenames)
-      {
-        tables.push_back(readParquetTableColumns_(filename, columns));
-      }
-      return concatenateTables_(tables);
-    }
-
-    /// Fetch a named column or throw if required and missing.
-    std::shared_ptr<arrow::Array> getColumn_(const std::shared_ptr<arrow::Table>& table,
-                                             const std::string& name,
-                                             bool required = true)
-    {
-      auto column = table->GetColumnByName(name);
-      if (!column)
-      {
-        if (required)
-        {
-          throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                              "Missing required column '" + name + "'");
-        }
-        return nullptr;
-      }
-      if (column->num_chunks() == 0)
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Column has no chunks", name);
-      }
-      if (column->num_chunks() == 1)
-      {
-        return column->chunk(0);
-      }
-      auto combined = arrow::Concatenate(column->chunks(), arrow::default_memory_pool());
-      if (!combined.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to combine column chunks", combined.status().ToString());
-      }
-      return *combined;
-    }
-
-    /// Read optional Int64 value at row; returns false if null or absent.
-    bool getOptionalInt_(const std::shared_ptr<arrow::Array>& array, int64_t row, Int64& value)
-    {
-      if (!array || array->IsNull(row))
-      {
-        return false;
-      }
-      auto typed = std::static_pointer_cast<arrow::Int64Array>(array);
-      value = typed->Value(row);
-      return true;
-    }
-
-    /// Read optional std::string value at row; returns false if null or absent.
-    bool getOptionalString_(const std::shared_ptr<arrow::Array>& array, int64_t row, std::string& value)
-    {
-      if (!array || array->IsNull(row))
-      {
-        return false;
-      }
-      auto typed = std::static_pointer_cast<arrow::StringArray>(array);
-      value = typed->GetString(row);
-      return true;
-    }
-
-    /// Read a binary cell as a std::string view.
-    std::string getBinaryView_(const std::shared_ptr<arrow::Array>& array, int64_t row)
-    {
-      auto typed = std::static_pointer_cast<arrow::BinaryArray>(array);
-      const auto view = typed->GetView(row);
-      return std::string(view.data(), view.size());
+      static const PRH::FilterPruningOptions options{
+        {"RT", "INTENSITY"},
+        false,
+        false
+      };
+      return options;
     }
 
     /// Decode RT/intensity arrays stored as compressed binary blobs.
@@ -330,7 +61,7 @@ namespace OpenMS
           if (data.size() % sizeof(double) != 0)
           {
             throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                          "Invalid RT/intensity data size (not divisible by 8)",StringUtils::toStr(data.size()));
+                                          "Invalid RT/intensity data size (not divisible by 8)", StringUtils::toStr(data.size()));
           }
           const size_t count = data.size() / sizeof(double);
           output.resize(count);
@@ -344,7 +75,7 @@ namespace OpenMS
           if (decoded.size() % sizeof(double) != 0)
           {
             throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                          "Invalid decompressed RT/intensity data size",StringUtils::toStr(decoded.size()));
+                                          "Invalid decompressed RT/intensity data size", StringUtils::toStr(decoded.size()));
           }
           const size_t count = decoded.size() / sizeof(double);
           output.resize(count);
@@ -389,233 +120,18 @@ namespace OpenMS
         }
         default:
           throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Unsupported compression type",StringUtils::toStr(compression));
+                                        "Unsupported compression type", StringUtils::toStr(compression));
       }
     }
 
-    /// Uppercase helper for column normalization.
     std::string upper_(const std::string& input)
     {
       std::string out = input;
       for (Size i = 0; i < out.size(); ++i)
       {
-        out[i] = static_cast<char>(std::toupper(out[i]));
+        out[i] = static_cast<char>(std::toupper(static_cast<unsigned char>(out[i])));
       }
       return out;
-    }
-
-    /// Tokenize a filter string into operators/identifiers/values.
-    std::vector<std::string> tokenize_(const std::string& expr)
-    {
-      std::vector<std::string> tokens;
-      std::string current;
-      bool in_string = false;
-      char quote_char = '\0';
-
-      for (Size i = 0; i < expr.size(); ++i)
-      {
-        const char c = expr[i];
-        if (in_string)
-        {
-          if (c == quote_char)
-          {
-            tokens.push_back(current);
-            current.clear();
-            in_string = false;
-            quote_char = '\0';
-          }
-          else
-          {
-            current += c;
-          }
-          continue;
-        }
-
-        if (c == '"' || c == '\'')
-        {
-          if (!current.empty())
-          {
-            tokens.push_back(current);
-            current.clear();
-          }
-          in_string = true;
-          quote_char = c;
-          continue;
-        }
-
-        if (std::isspace(static_cast<unsigned char>(c)))
-        {
-          if (!current.empty())
-          {
-            tokens.push_back(current);
-            current.clear();
-          }
-          continue;
-        }
-
-        if (c == '[' || c == ']' || c == ',' || c == '(' || c == ')')
-        {
-          if (!current.empty())
-          {
-            tokens.push_back(current);
-            current.clear();
-          }
-          tokens.emplace_back(StringUtils::toStr(c));
-          continue;
-        }
-
-        if (c == '=' || c == '!' || c == '<' || c == '>')
-        {
-          if (!current.empty())
-          {
-            tokens.push_back(current);
-            current.clear();
-          }
-          std::string op;
-          op += c;
-          if (i + 1 < expr.size())
-          {
-            const char next = expr[i + 1];
-            if (next == '=')
-            {
-              op += next;
-              ++i;
-            }
-          }
-          tokens.push_back(op);
-          continue;
-        }
-
-        if (c == '&' || c == '|')
-        {
-          if (!current.empty())
-          {
-            tokens.push_back(current);
-            current.clear();
-          }
-          std::string op;
-          op += c;
-          if (i + 1 < expr.size())
-          {
-            const char next = expr[i + 1];
-            if (next == c)
-            {
-              op += next;
-              ++i;
-            }
-          }
-          tokens.push_back(op);
-          continue;
-        }
-
-        current += c;
-      }
-
-      if (!current.empty())
-      {
-        tokens.push_back(current);
-      }
-
-      if (in_string)
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Unclosed quote in filter expression", expr);
-      }
-
-      return tokens;
-    }
-
-    /// Parse filter text into a structured expression.
-    FilterExpression parseFilter_(const std::string& filter,
-                                  const std::unordered_map<std::string, ColumnType>& column_types)
-    {
-      FilterExpression expr;
-      if (filter.empty())
-      {
-        return expr;
-      }
-
-      auto tokens = tokenize_(filter);
-      Size i = 0;
-      while (i < tokens.size())
-      {
-        std::string column = upper_(tokens[i++]);
-        if (i >= tokens.size())
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Missing filter operator for column", column);
-        }
-        std::string op = upper_(tokens[i++]);
-        if (op == "==")
-        {
-          op = "=";
-        }
-        if (op != "=" && op != "!=" && op != "<" && op != "<=" && op != ">" && op != ">=" && op != "IN")
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Unsupported filter operator", op);
-        }
-
-        Condition cond;
-        cond.column = column;
-        cond.op = op;
-        auto type_it = column_types.find(column);
-        cond.type = (type_it == column_types.end()) ? ColumnType::INT : type_it->second;
-
-        if (op == "IN")
-        {
-          if (i < tokens.size() && tokens[i] == "[") ++i;
-          while (i < tokens.size() && tokens[i] != "]")
-          {
-            if (tokens[i] != ",")
-            {
-              cond.values.push_back(tokens[i]);
-            }
-            ++i;
-          }
-          if (cond.values.empty())
-          {
-            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                          "IN operator expects at least one value", filter);
-          }
-          if (i < tokens.size() && tokens[i] == "]") ++i;
-        }
-        else
-        {
-          if (i >= tokens.size())
-          {
-            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                          "Missing filter value for operator", op);
-          }
-          cond.values.push_back(tokens[i++]);
-        }
-
-        expr.conditions.push_back(cond);
-        if (i < tokens.size())
-        {
-          std::string connector = upper_(tokens[i]);
-          bool consumed_connector = false;
-          if (connector == "AND" || connector == "&&" || connector == "&")
-          {
-            expr.connectors.push_back("AND");
-            ++i;
-            consumed_connector = true;
-          }
-          else if (connector == "OR" || connector == "||" || connector == "|")
-          {
-            expr.connectors.push_back("OR");
-            ++i;
-            consumed_connector = true;
-          }
-          if (consumed_connector && i >= tokens.size())
-          {
-            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                          "Dangling connector in filter expression", filter);
-          }
-        }
-      }
-
-      return expr;
     }
 
     FilterExpression buildFilterFromArgs_(Int64 precursor_id,
@@ -637,93 +153,6 @@ namespace OpenMS
       return builder.expression();
     }
 
-    /// Map upper-case column names to their schema names.
-    std::unordered_map<std::string, std::string> buildSchemaNameMap_(const std::shared_ptr<arrow::Schema>& schema)
-    {
-      std::unordered_map<std::string, std::string> name_map;
-      if (!schema)
-      {
-        return name_map;
-      }
-      name_map.reserve(schema->num_fields());
-      for (const auto& field : schema->fields())
-      {
-        name_map[upper_(std::string(field->name()))] =std::string(field->name());
-      }
-      return name_map;
-    }
-
-    /// Join columns for diagnostics/log output.
-    std::string joinColumns_(const std::vector<std::string>& columns)
-    {
-      std::ostringstream oss;
-      for (Size i = 0; i < columns.size(); ++i)
-      {
-        if (i > 0) oss << ", ";
-        oss << columns[i];
-      }
-      return oss.str();
-    }
-
-    /// Normalize column names to schema and drop unsupported columns.
-    void normalizeAndPruneColumns_(FilterExpression& expr,
-                                   const std::shared_ptr<arrow::Schema>& schema,
-                                   std::vector<std::string>& dropped_columns)
-    {
-      dropped_columns.clear();
-      if (expr.conditions.empty())
-      {
-        return;
-      }
-
-      auto name_map = buildSchemaNameMap_(schema);
-      // Unsupported columns that cannot be filtered on.
-      // RT and INTENSITY are stored as binary blobs in parquet, so we cannot filter on them here. Filtering on these can only be done after decoding.
-      const std::unordered_set<std::string> unsupported = {"RT", "INTENSITY"};
-
-      std::vector<Condition> kept;
-      kept.reserve(expr.conditions.size());
-      std::vector<std::string> new_connectors;
-      new_connectors.reserve(expr.connectors.size());
-
-      for (Size i = 0; i < expr.conditions.size(); ++i)
-      {
-        Condition cond = expr.conditions[i];
-        const std::string original = cond.column;
-        auto it = name_map.find(upper_(cond.column));
-        if (it != name_map.end())
-        {
-          cond.column = it->second;
-        }
-
-        const bool unsupported_col = unsupported.contains(upper_(cond.column));
-        const bool exists_in_schema = name_map.contains(upper_(cond.column));
-        if (unsupported_col || !exists_in_schema)
-        {
-          dropped_columns.push_back(original);
-          continue;
-        }
-
-        if (!kept.empty())
-        {
-          const Size prev_index = i - 1;
-          if (prev_index < expr.connectors.size())
-          {
-            new_connectors.push_back(expr.connectors[prev_index]);
-          }
-          else
-          {
-            new_connectors.push_back("AND");
-          }
-        }
-        kept.push_back(cond);
-      }
-
-      expr.conditions.swap(kept);
-      expr.connectors.swap(new_connectors);
-    }
-
-    /// Append an integer part to a composite key.
     void appendKeyPart_(std::ostringstream& oss, bool has_value, Int64 value)
     {
       if (has_value)
@@ -737,556 +166,9 @@ namespace OpenMS
       oss << '|';
     }
 
-    /// Append a string part to a composite key.
     void appendKeyPart_(std::ostringstream& oss, const std::string& value)
     {
       oss << value << '|';
-    }
-
-    /// Build a single Arrow condition expression from one clause.
-    arrow::compute::Expression buildConditionExpression_(const Condition& cond)
-    {
-      auto field = arrow::compute::field_ref(std::string(cond.column));
-
-      if (cond.op == "IN")
-      {
-        if (cond.type == ColumnType::INT)
-        {
-          arrow::Int64Builder builder;
-          for (const auto& value : cond.values)
-          {
-            auto status = builder.Append(StringUtils::toInt64(value));
-            if (!status.ok())
-            {
-              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                            "Failed to build INT64 value set", status.ToString());
-            }
-          }
-          std::shared_ptr<arrow::Array> value_set;
-          auto status = builder.Finish(&value_set);
-          if (!status.ok())
-          {
-            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                          "Failed to finalize INT64 value set", status.ToString());
-          }
-          auto options = std::make_shared<arrow::compute::SetLookupOptions>(arrow::Datum(value_set));
-          return arrow::compute::call("is_in", {field}, options);
-        }
-        else
-        {
-          arrow::StringBuilder builder;
-          for (const auto& value : cond.values)
-          {
-            auto status = builder.Append(std::string(value));
-            if (!status.ok())
-            {
-              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                            "Failed to build STRING value set", status.ToString());
-            }
-          }
-          std::shared_ptr<arrow::Array> value_set;
-          auto status = builder.Finish(&value_set);
-          if (!status.ok())
-          {
-            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                          "Failed to finalize STRING value set", status.ToString());
-          }
-          auto options = std::make_shared<arrow::compute::SetLookupOptions>(arrow::Datum(value_set));
-          return arrow::compute::call("is_in", {field}, options);
-        }
-      }
-
-      if (cond.values.empty())
-      {
-        return arrow::compute::literal(false);
-      }
-
-      arrow::compute::Expression literal;
-      if (cond.type == ColumnType::INT)
-      {
-        literal = arrow::compute::literal(static_cast<int64_t>(StringUtils::toInt64(cond.values.front())));
-      }
-      else
-      {
-        literal = arrow::compute::literal(std::string(cond.values.front()));
-      }
-
-      if (cond.op == "=") return arrow::compute::equal(field, literal);
-      if (cond.op == "!=") return arrow::compute::not_equal(field, literal);
-      if (cond.op == "<") return arrow::compute::less(field, literal);
-      if (cond.op == "<=") return arrow::compute::less_equal(field, literal);
-      if (cond.op == ">") return arrow::compute::greater(field, literal);
-      if (cond.op == ">=") return arrow::compute::greater_equal(field, literal);
-      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                    "Unsupported filter operator", cond.op);
-    }
-
-    /// Combine conditions into a single Arrow expression.
-    arrow::compute::Expression buildFilterExpression_(const FilterExpression& expr)
-    {
-      if (expr.conditions.empty())
-      {
-        return arrow::compute::literal(true);
-      }
-
-      std::vector<arrow::compute::Expression> cond_exprs;
-      cond_exprs.reserve(expr.conditions.size());
-      for (const auto& cond : expr.conditions)
-      {
-        cond_exprs.push_back(buildConditionExpression_(cond));
-      }
-
-      arrow::compute::Expression result = cond_exprs.front();
-      for (Size i = 1; i < cond_exprs.size(); ++i)
-      {
-        if (i - 1 < expr.connectors.size() && expr.connectors[i - 1] == "OR")
-        {
-          result = arrow::compute::or_(result, cond_exprs[i]);
-        }
-        else
-        {
-          result = arrow::compute::and_(result, cond_exprs[i]);
-        }
-      }
-      return result;
-    }
-
-    struct ManualCondition
-    {
-      Condition cond;
-      int index{-1};
-      std::vector<Int64> int_values;
-    };
-
-    bool getIntValueFromArray_(const std::shared_ptr<arrow::Array>& array, int64_t row, Int64& value)
-    {
-      if (!array || array->IsNull(row))
-      {
-        return false;
-      }
-
-      switch (array->type_id())
-      {
-        case arrow::Type::INT64:
-          value = static_cast<arrow::Int64Array*>(array.get())->Value(row);
-          return true;
-        case arrow::Type::INT32:
-          value = static_cast<arrow::Int32Array*>(array.get())->Value(row);
-          return true;
-        case arrow::Type::INT16:
-          value = static_cast<arrow::Int16Array*>(array.get())->Value(row);
-          return true;
-        case arrow::Type::INT8:
-          value = static_cast<arrow::Int8Array*>(array.get())->Value(row);
-          return true;
-        case arrow::Type::UINT64:
-          value = static_cast<arrow::UInt64Array*>(array.get())->Value(row);
-          return true;
-        case arrow::Type::UINT32:
-          value = static_cast<arrow::UInt32Array*>(array.get())->Value(row);
-          return true;
-        case arrow::Type::UINT16:
-          value = static_cast<arrow::UInt16Array*>(array.get())->Value(row);
-          return true;
-        case arrow::Type::UINT8:
-          value = static_cast<arrow::UInt8Array*>(array.get())->Value(row);
-          return true;
-        case arrow::Type::BOOL:
-          value = static_cast<arrow::BooleanArray*>(array.get())->Value(row) ? 1 : 0;
-          return true;
-        default:
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Unsupported integer column type",std::string(array->type()->ToString()));
-      }
-    }
-
-    bool getStringValueFromArray_(const std::shared_ptr<arrow::Array>& array, int64_t row, std::string& value)
-    {
-      if (!array || array->IsNull(row))
-      {
-        return false;
-      }
-
-      switch (array->type_id())
-      {
-        case arrow::Type::STRING:
-          value = static_cast<arrow::StringArray*>(array.get())->GetString(row);
-          return true;
-        case arrow::Type::LARGE_STRING:
-          value = static_cast<arrow::LargeStringArray*>(array.get())->GetString(row);
-          return true;
-        default:
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Unsupported string column type",std::string(array->type()->ToString()));
-      }
-    }
-
-    bool evaluateCondition_(const ManualCondition& cond,
-                            const std::shared_ptr<arrow::RecordBatch>& batch,
-                            int64_t row)
-    {
-      if (!batch || cond.index < 0 || cond.index >= batch->num_columns())
-      {
-        return false;
-      }
-
-      const auto& array = batch->column(cond.index);
-      if (cond.cond.type == ColumnType::INT)
-      {
-        Int64 lhs = 0;
-        if (!getIntValueFromArray_(array, row, lhs))
-        {
-          return false;
-        }
-
-        if (cond.cond.op == "IN")
-        {
-          for (const auto& rhs : cond.int_values)
-          {
-            if (lhs == rhs) return true;
-          }
-          return false;
-        }
-
-        if (cond.int_values.empty())
-        {
-          return false;
-        }
-        const Int64 rhs = cond.int_values.front();
-        if (cond.cond.op == "=") return lhs == rhs;
-        if (cond.cond.op == "!=") return lhs != rhs;
-        if (cond.cond.op == "<") return lhs < rhs;
-        if (cond.cond.op == "<=") return lhs <= rhs;
-        if (cond.cond.op == ">") return lhs > rhs;
-        if (cond.cond.op == ">=") return lhs >= rhs;
-      }
-      else
-      {
-        std::string lhs;
-        if (!getStringValueFromArray_(array, row, lhs))
-        {
-          return false;
-        }
-
-        if (cond.cond.op == "IN")
-        {
-          for (const auto& rhs : cond.cond.values)
-          {
-            if (lhs == rhs) return true;
-          }
-          return false;
-        }
-
-        if (cond.cond.values.empty())
-        {
-          return false;
-        }
-        const std::string& rhs = cond.cond.values.front();
-        if (cond.cond.op == "=") return lhs == rhs;
-        if (cond.cond.op == "!=") return lhs != rhs;
-        if (cond.cond.op == "<") return lhs < rhs;
-        if (cond.cond.op == "<=") return lhs <= rhs;
-        if (cond.cond.op == ">") return lhs > rhs;
-        if (cond.cond.op == ">=") return lhs >= rhs;
-      }
-
-      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                    "Unsupported filter operator", cond.cond.op);
-    }
-
-    bool evaluateFilterExpression_(const std::vector<ManualCondition>& conditions,
-                                   const std::vector<std::string>& connectors,
-                                   const std::shared_ptr<arrow::RecordBatch>& batch,
-                                   int64_t row)
-    {
-      if (conditions.empty())
-      {
-        return true;
-      }
-
-      bool result = evaluateCondition_(conditions.front(), batch, row);
-      for (Size i = 1; i < conditions.size(); ++i)
-      {
-        const std::string connector = (i - 1 < connectors.size()) ? connectors[i - 1] : "AND";
-        const bool next = evaluateCondition_(conditions[i], batch, row);
-        if (connector == "OR")
-        {
-          result = result || next;
-        }
-        else
-        {
-          result = result && next;
-        }
-      }
-      return result;
-    }
-
-    std::shared_ptr<arrow::Table> applyManualFilter_(const std::shared_ptr<arrow::Table>& table,
-                                                     const FilterExpression& parsed,
-                                                     const std::string& filter)
-    {
-      std::vector<ManualCondition> conditions;
-      conditions.reserve(parsed.conditions.size());
-
-      auto schema = table->schema();
-      for (const auto& cond : parsed.conditions)
-      {
-        ManualCondition manual;
-        manual.cond = cond;
-        manual.index = schema->GetFieldIndex(std::string(cond.column));
-        if (manual.index < 0)
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Column not found in parquet schema", cond.column);
-        }
-        if (cond.type == ColumnType::INT)
-        {
-          manual.int_values.reserve(cond.values.size());
-          for (const auto& value : cond.values)
-          {
-            try
-            {
-              manual.int_values.push_back(StringUtils::toInt64(value));
-            }
-            catch (const std::exception&)
-            {
-              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                            "Invalid integer filter value", value);
-            }
-          }
-        }
-        conditions.push_back(std::move(manual));
-      }
-
-      arrow::TableBatchReader reader(*table);
-      std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
-      std::shared_ptr<arrow::RecordBatch> batch;
-
-      while (true)
-      {
-        auto read_status = reader.ReadNext(&batch);
-        if (!read_status.ok())
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Failed to read record batch", filter);
-        }
-        if (!batch)
-        {
-          break;
-        }
-
-        const int64_t num_rows = batch->num_rows();
-        for (int64_t row = 0; row < num_rows; ++row)
-        {
-          if (evaluateFilterExpression_(conditions, parsed.connectors, batch, row))
-          {
-            batches.push_back(batch->Slice(row, 1));
-          }
-        }
-      }
-
-      if (batches.empty())
-      {
-        std::vector<std::shared_ptr<arrow::Array>> empty_columns;
-        empty_columns.reserve(schema->num_fields());
-        for (const auto& field : schema->fields())
-        {
-          auto array_result = arrow::MakeArrayOfNull(field->type(), 0);
-          if (!array_result.ok())
-          {
-            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                          "Failed to create empty column", array_result.status().ToString());
-          }
-          empty_columns.push_back(*array_result);
-        }
-        return arrow::Table::Make(schema, empty_columns);
-      }
-
-      auto table_result = arrow::Table::FromRecordBatches(schema, batches);
-      if (!table_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to build filtered table", filter);
-      }
-      auto combined = (*table_result)->CombineChunks(arrow::default_memory_pool());
-      if (!combined.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to combine filtered chunks", combined.status().ToString());
-      }
-      return *combined;
-    }
-
-#ifdef WITH_ARROW_DATASET
-    /// Read parquet files via Arrow Dataset with predicate pushdown.
-    std::shared_ptr<arrow::Table> readParquetTableDataset_(const std::vector<std::string>& filenames,
-                                                           const FilterExpression& parsed,
-                                                           const std::string& filter_context)
-    {
-      (void)filter_context;
-      // Arrow Dataset enables predicate pushdown across multiple parquet files.
-      auto filesystem = std::make_shared<arrow::fs::LocalFileSystem>();
-      auto format = std::make_shared<arrow::dataset::ParquetFileFormat>();
-      arrow::dataset::FileSystemFactoryOptions options;
-
-      std::vector<std::string> paths;
-      paths.reserve(filenames.size());
-      for (const auto& filename : filenames)
-      {
-        paths.emplace_back(filename);
-      }
-      auto factory_result = arrow::dataset::FileSystemDatasetFactory::Make(
-        filesystem, paths, format, options);
-      if (!factory_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to create dataset factory", "dataset");
-      }
-
-      auto dataset_result = (*factory_result)->Finish();
-      if (!dataset_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to create dataset", "dataset");
-      }
-      std::shared_ptr<arrow::dataset::Dataset> dataset = *dataset_result;
-
-      auto builder = std::make_shared<arrow::dataset::ScannerBuilder>(dataset);
-      if (!parsed.conditions.empty())
-      {
-        FilterExpression pruned = parsed;
-        std::vector<std::string> dropped;
-        normalizeAndPruneColumns_(pruned, dataset->schema(), dropped);
-        if (!dropped.empty())
-        {
-          OPENMS_LOG_WARN << "Dropping unsupported filter columns: "
-                          << joinColumns_(dropped) << '\n';
-        }
-        if (pruned.conditions.empty())
-        {
-          return readParquetTable_(filenames);
-        }
-        // Convert the parsed filter into an Arrow expression for pushdown.
-        arrow::compute::Expression expr = buildFilterExpression_(pruned);
-        auto status = builder->Filter(expr);
-        if (!status.ok())
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Failed to bind dataset filter expression", status.ToString());
-        }
-      }
-
-      auto scanner_result = builder->Finish();
-      if (!scanner_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to create dataset scanner", "dataset");
-      }
-      auto table_result = (*scanner_result)->ToTable();
-      if (!table_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to read parquet table via dataset scanner", "dataset");
-      }
-
-      auto combined = (*table_result)->CombineChunks(arrow::default_memory_pool());
-      if (!combined.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to combine parquet chunks", combined.status().ToString());
-      }
-      return *combined;
-    }
-#endif
-
-    /// Read parquet files via Arrow Dataset with predicate pushdown.
-    std::shared_ptr<arrow::Table> applyArrowFilter_(const std::shared_ptr<arrow::Table>& table,
-                                                    const FilterExpression& parsed,
-                                                    const std::string& filter_context)
-    {
-      if (parsed.conditions.empty())
-      {
-        return table;
-      }
-
-      FilterExpression pruned = parsed;
-      std::vector<std::string> dropped;
-      normalizeAndPruneColumns_(pruned, table->schema(), dropped);
-      if (!dropped.empty())
-      {
-        OPENMS_LOG_WARN << "Dropping unsupported filter columns: "
-                        << joinColumns_(dropped) << '\n';
-      }
-      if (pruned.conditions.empty())
-      {
-        return table;
-      }
-
-      // Execute the expression in memory when dataset pushdown is unavailable.
-      arrow::compute::Expression expr = buildFilterExpression_(pruned);
-      auto bound_result = expr.Bind(*table->schema());
-      if (!bound_result.ok())
-      {
-        OPENMS_LOG_WARN << "Arrow compute filter unavailable, falling back to manual filter: "
-                        << bound_result.status().ToString() << '\n';
-        return applyManualFilter_(table, pruned, filter_context);
-      }
-      const arrow::compute::Expression& bound_expr = *bound_result;
-
-      arrow::TableBatchReader reader(*table);
-      std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
-      std::shared_ptr<arrow::RecordBatch> batch;
-
-      while (true)
-      {
-        auto read_status = reader.ReadNext(&batch);
-        if (!read_status.ok())
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Failed to read record batch", filter_context);
-        }
-        if (!batch)
-        {
-          break;
-        }
-
-        auto mask_result = arrow::compute::ExecuteScalarExpression(
-          bound_expr, *batch->schema(), arrow::Datum(batch));
-        if (!mask_result.ok())
-        {
-          OPENMS_LOG_WARN << "Arrow compute filter failed, falling back to manual filter: "
-                          << mask_result.status().ToString() << '\n';
-          return applyManualFilter_(table, pruned, filter_context);
-        }
-
-        auto filtered_result = arrow::compute::Filter(arrow::Datum(batch), *mask_result);
-        if (!filtered_result.ok())
-        {
-          OPENMS_LOG_WARN << "Arrow compute filter failed, falling back to manual filter: "
-                          << filtered_result.status().ToString() << '\n';
-          return applyManualFilter_(table, pruned, filter_context);
-        }
-
-        const auto& filtered_batch = filtered_result->record_batch();
-        if (filtered_batch && filtered_batch->num_rows() > 0)
-        {
-          batches.push_back(filtered_batch);
-        }
-      }
-
-      auto table_result = arrow::Table::FromRecordBatches(table->schema(), batches);
-      if (!table_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to build filtered table", filter_context);
-      }
-      auto combined = (*table_result)->CombineChunks(arrow::default_memory_pool());
-      if (!combined.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to combine filtered chunks", combined.status().ToString());
-      }
-      return *combined;
     }
   } // namespace
 
@@ -1374,7 +256,7 @@ namespace OpenMS
                                                        product_charge,
                                                        ms_level,
                                                        run_id);
-    FilterExpression string_filter = parseFilter_(filter, column_types);
+    FilterExpression string_filter = PRH::parseFilter(filter, column_types);
     FilterExpression combined_filter = ParquetFilter::merge(args_filter, string_filter, "AND");
     combined_filter = ParquetFilter::merge(combined_filter, extra_filter, "AND");
 
@@ -1387,7 +269,7 @@ namespace OpenMS
       try
       {
         // Prefer dataset pushdown when available; fall back to compute filtering on failure.
-        table = readParquetTableDataset_(filenames_, combined_filter, filter_context);
+        table = PRH::readParquetTableDataset(filenames_, combined_filter, filter_context, filterPruningOptions_());
         used_dataset = true;
       }
       catch (const std::exception& e)
@@ -1407,31 +289,31 @@ namespace OpenMS
 #endif
     if (!table)
     {
-      table = readParquetTable_(filenames_);
+      table = PRH::readParquetTable(filenames_);
     }
     if (!used_dataset)
     {
-      table = applyArrowFilter_(table, combined_filter, filter_context);
+      table = PRH::applyArrowFilter(table, combined_filter, filter_context, filterPruningOptions_());
     }
 
-    auto run_id_col = getColumn_(table, "RUN_ID");
-    auto source_file_col = getColumn_(table, "SOURCE_FILE", false);
-    auto ms_level_col = getColumn_(table, "MS_LEVEL", false);
-    auto precursor_id_col = getColumn_(table, "PRECURSOR_ID");
-    auto transition_id_col = getColumn_(table, "TRANSITION_ID", false);
-    auto modified_sequence_col = getColumn_(table, "MODIFIED_SEQUENCE", false);
-    auto precursor_charge_col = getColumn_(table, "PRECURSOR_CHARGE", false);
-    auto product_charge_col = getColumn_(table, "PRODUCT_CHARGE", false);
-    auto detecting_transition_col = getColumn_(table, "DETECTING_TRANSITION", false);
-    auto precursor_decoy_col = getColumn_(table, "PRECURSOR_DECOY", false);
-    auto product_decoy_col = getColumn_(table, "PRODUCT_DECOY", false);
-    auto transition_ordinal_col = getColumn_(table, "TRANSITION_ORDINAL", false);
-    auto transition_type_col = getColumn_(table, "TRANSITION_TYPE", false);
-    auto annotation_col = getColumn_(table, "ANNOTATION", false);
-    auto rt_data_col = getColumn_(table, "RT_DATA");
-    auto intensity_data_col = getColumn_(table, "INTENSITY_DATA");
-    auto rt_compression_col = getColumn_(table, "RT_COMPRESSION");
-    auto intensity_compression_col = getColumn_(table, "INTENSITY_COMPRESSION");
+    auto run_id_col = PRH::getColumn(table, "RUN_ID");
+    auto source_file_col = PRH::getColumn(table, "SOURCE_FILE", false);
+    auto ms_level_col = PRH::getColumn(table, "MS_LEVEL", false);
+    auto precursor_id_col = PRH::getColumn(table, "PRECURSOR_ID");
+    auto transition_id_col = PRH::getColumn(table, "TRANSITION_ID", false);
+    auto modified_sequence_col = PRH::getColumn(table, "MODIFIED_SEQUENCE", false);
+    auto precursor_charge_col = PRH::getColumn(table, "PRECURSOR_CHARGE", false);
+    auto product_charge_col = PRH::getColumn(table, "PRODUCT_CHARGE", false);
+    auto detecting_transition_col = PRH::getColumn(table, "DETECTING_TRANSITION", false);
+    auto precursor_decoy_col = PRH::getColumn(table, "PRECURSOR_DECOY", false);
+    auto product_decoy_col = PRH::getColumn(table, "PRODUCT_DECOY", false);
+    auto transition_ordinal_col = PRH::getColumn(table, "TRANSITION_ORDINAL", false);
+    auto transition_type_col = PRH::getColumn(table, "TRANSITION_TYPE", false);
+    auto annotation_col = PRH::getColumn(table, "ANNOTATION", false);
+    auto rt_data_col = PRH::getColumn(table, "RT_DATA");
+    auto intensity_data_col = PRH::getColumn(table, "INTENSITY_DATA");
+    auto rt_compression_col = PRH::getColumn(table, "RT_COMPRESSION");
+    auto intensity_compression_col = PRH::getColumn(table, "INTENSITY_COMPRESSION");
 
     const int64_t rows = table->num_rows();
     output.reserve(rows);
@@ -1441,28 +323,28 @@ namespace OpenMS
       XICChromatogram chrom;
 
       // Defensive: RUN_ID is a required column but individual cells may be null in malformed files.
-      // Use getOptionalInt_ and throw a descriptive error if a required cell is null.
-      if (!getOptionalInt_(run_id_col, row, chrom.run_id))
+      // Use the shared typed extractor and throw a descriptive error if a required cell is null.
+      if (!PRH::getOptionalInt(run_id_col, row, chrom.run_id))
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                       "NULL value in required RUN_ID column",StringUtils::toStr(row));
       }
-      chrom.has_precursor_id = getOptionalInt_(precursor_id_col, row, chrom.precursor_id);
-      chrom.has_transition_id = getOptionalInt_(transition_id_col, row, chrom.transition_id);
-      chrom.has_precursor_charge = getOptionalInt_(precursor_charge_col, row, chrom.precursor_charge);
-      chrom.has_product_charge = getOptionalInt_(product_charge_col, row, chrom.product_charge);
-      chrom.has_detecting_transition = getOptionalInt_(detecting_transition_col, row, chrom.detecting_transition);
-      chrom.has_precursor_decoy = getOptionalInt_(precursor_decoy_col, row, chrom.precursor_decoy);
-      chrom.has_product_decoy = getOptionalInt_(product_decoy_col, row, chrom.product_decoy);
-      chrom.has_transition_ordinal = getOptionalInt_(transition_ordinal_col, row, chrom.transition_ordinal);
+      chrom.has_precursor_id = PRH::getOptionalInt(precursor_id_col, row, chrom.precursor_id);
+      chrom.has_transition_id = PRH::getOptionalInt(transition_id_col, row, chrom.transition_id);
+      chrom.has_precursor_charge = PRH::getOptionalInt(precursor_charge_col, row, chrom.precursor_charge);
+      chrom.has_product_charge = PRH::getOptionalInt(product_charge_col, row, chrom.product_charge);
+      chrom.has_detecting_transition = PRH::getOptionalInt(detecting_transition_col, row, chrom.detecting_transition);
+      chrom.has_precursor_decoy = PRH::getOptionalInt(precursor_decoy_col, row, chrom.precursor_decoy);
+      chrom.has_product_decoy = PRH::getOptionalInt(product_decoy_col, row, chrom.product_decoy);
+      chrom.has_transition_ordinal = PRH::getOptionalInt(transition_ordinal_col, row, chrom.transition_ordinal);
 
-      getOptionalString_(source_file_col, row, chrom.source_file);
-      getOptionalString_(modified_sequence_col, row, chrom.modified_sequence);
-      getOptionalString_(transition_type_col, row, chrom.transition_type);
-      getOptionalString_(annotation_col, row, chrom.annotation);
+      PRH::getOptionalString(source_file_col, row, chrom.source_file);
+      PRH::getOptionalString(modified_sequence_col, row, chrom.modified_sequence);
+      PRH::getOptionalString(transition_type_col, row, chrom.transition_type);
+      PRH::getOptionalString(annotation_col, row, chrom.annotation);
 
       Int64 ms_level_value = 0;
-      if (getOptionalInt_(ms_level_col, row, ms_level_value))
+      if (PRH::getOptionalInt(ms_level_col, row, ms_level_value))
       {
         chrom.ms_level = ms_level_value;
       }
@@ -1477,11 +359,11 @@ namespace OpenMS
 
       Int64 rt_compression = 0;
       Int64 intensity_compression = 0;
-      getOptionalInt_(rt_compression_col, row, rt_compression);
-      getOptionalInt_(intensity_compression_col, row, intensity_compression);
+      PRH::getOptionalInt(rt_compression_col, row, rt_compression);
+      PRH::getOptionalInt(intensity_compression_col, row, intensity_compression);
 
-      const std::string rt_data = getBinaryView_(rt_data_col, row);
-      const std::string intensity_data = getBinaryView_(intensity_data_col, row);
+      const std::string rt_data = PRH::getBinaryView(rt_data_col, row);
+      const std::string intensity_data = PRH::getBinaryView(intensity_data_col, row);
 
       decodeBinary_(rt_data, rt_compression, chrom.rt);
       decodeBinary_(intensity_data, intensity_compression, chrom.intensity);
@@ -1500,10 +382,10 @@ namespace OpenMS
     output.clear();
 
     const std::vector<std::string> columns = {"RUN_ID", "SOURCE_FILE"};
-    auto table = readParquetTableColumns_(filenames_, columns);
+    auto table = PRH::readParquetTableColumns(filenames_, columns);
 
-    auto run_id_col = getColumn_(table, "RUN_ID");
-    auto source_file_col = getColumn_(table, "SOURCE_FILE", false);
+    auto run_id_col = PRH::getColumn(table, "RUN_ID");
+    auto source_file_col = PRH::getColumn(table, "SOURCE_FILE", false);
 
     std::unordered_set<std::string> seen;
     const int64_t rows = table->num_rows();
@@ -1512,12 +394,12 @@ namespace OpenMS
     for (int64_t row = 0; row < rows; ++row)
     {
       XICRunInfo info;
-      if (!getOptionalInt_(run_id_col, row, info.run_id))
+      if (!PRH::getOptionalInt(run_id_col, row, info.run_id))
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                       "NULL value in required RUN_ID column",StringUtils::toStr(row));
       }
-      getOptionalString_(source_file_col, row, info.source_file);
+      PRH::getOptionalString(source_file_col, row, info.source_file);
 
       std::ostringstream oss;
       appendKeyPart_(oss, true, info.run_id);
@@ -1577,7 +459,7 @@ namespace OpenMS
     };
     const std::vector<std::string>& requested_columns = columns.empty() ? default_columns : columns;
 
-  std::shared_ptr<arrow::Schema> schema = readParquetSchemaAllFiles_(filenames_);
+    std::shared_ptr<arrow::Schema> schema = PRH::readParquetSchemaAllFiles(filenames_);
     std::unordered_set<std::string> schema_columns;
     schema_columns.reserve(schema->num_fields());
     for (const auto& field : schema->fields())
@@ -1629,19 +511,19 @@ namespace OpenMS
       return requested_set.contains(name);
     };
 
-    auto table = readParquetTableColumns_(filenames_, normalized_columns);
+    auto table = PRH::readParquetTableColumns(filenames_, normalized_columns);
 
-    auto precursor_id_col = getColumn_(table, "PRECURSOR_ID", want("PRECURSOR_ID"));
-    auto modified_sequence_col = getColumn_(table, "MODIFIED_SEQUENCE", want("MODIFIED_SEQUENCE"));
-    auto precursor_charge_col = getColumn_(table, "PRECURSOR_CHARGE", want("PRECURSOR_CHARGE"));
-    auto precursor_decoy_col = getColumn_(table, "PRECURSOR_DECOY", want("PRECURSOR_DECOY"));
-    auto transition_id_col = getColumn_(table, "TRANSITION_ID", want("TRANSITION_ID"));
-    auto product_charge_col = getColumn_(table, "PRODUCT_CHARGE", want("PRODUCT_CHARGE"));
-    auto transition_ordinal_col = getColumn_(table, "TRANSITION_ORDINAL", want("TRANSITION_ORDINAL"));
-    auto detecting_transition_col = getColumn_(table, "DETECTING_TRANSITION", want("DETECTING_TRANSITION"));
-    auto product_decoy_col = getColumn_(table, "PRODUCT_DECOY", want("PRODUCT_DECOY"));
-    auto transition_type_col = getColumn_(table, "TRANSITION_TYPE", want("TRANSITION_TYPE"));
-    auto annotation_col = getColumn_(table, "ANNOTATION", want("ANNOTATION"));
+    auto precursor_id_col = PRH::getColumn(table, "PRECURSOR_ID", want("PRECURSOR_ID"));
+    auto modified_sequence_col = PRH::getColumn(table, "MODIFIED_SEQUENCE", want("MODIFIED_SEQUENCE"));
+    auto precursor_charge_col = PRH::getColumn(table, "PRECURSOR_CHARGE", want("PRECURSOR_CHARGE"));
+    auto precursor_decoy_col = PRH::getColumn(table, "PRECURSOR_DECOY", want("PRECURSOR_DECOY"));
+    auto transition_id_col = PRH::getColumn(table, "TRANSITION_ID", want("TRANSITION_ID"));
+    auto product_charge_col = PRH::getColumn(table, "PRODUCT_CHARGE", want("PRODUCT_CHARGE"));
+    auto transition_ordinal_col = PRH::getColumn(table, "TRANSITION_ORDINAL", want("TRANSITION_ORDINAL"));
+    auto detecting_transition_col = PRH::getColumn(table, "DETECTING_TRANSITION", want("DETECTING_TRANSITION"));
+    auto product_decoy_col = PRH::getColumn(table, "PRODUCT_DECOY", want("PRODUCT_DECOY"));
+    auto transition_type_col = PRH::getColumn(table, "TRANSITION_TYPE", want("TRANSITION_TYPE"));
+    auto annotation_col = PRH::getColumn(table, "ANNOTATION", want("ANNOTATION"));
 
     const int64_t rows = table->num_rows();
     output.reserve(rows);
@@ -1655,48 +537,48 @@ namespace OpenMS
 
         if (want("PRECURSOR_ID"))
         {
-          analyte.has_precursor_id = getOptionalInt_(precursor_id_col, row, analyte.precursor_id);
+          analyte.has_precursor_id = PRH::getOptionalInt(precursor_id_col, row, analyte.precursor_id);
         }
         if (want("MODIFIED_SEQUENCE"))
         {
-          getOptionalString_(modified_sequence_col, row, analyte.modified_sequence);
+          PRH::getOptionalString(modified_sequence_col, row, analyte.modified_sequence);
         }
         if (want("PRECURSOR_CHARGE"))
         {
-          analyte.has_precursor_charge = getOptionalInt_(precursor_charge_col, row, analyte.precursor_charge);
+          analyte.has_precursor_charge = PRH::getOptionalInt(precursor_charge_col, row, analyte.precursor_charge);
         }
         if (want("PRECURSOR_DECOY"))
         {
-          analyte.has_precursor_decoy = getOptionalInt_(precursor_decoy_col, row, analyte.precursor_decoy);
+          analyte.has_precursor_decoy = PRH::getOptionalInt(precursor_decoy_col, row, analyte.precursor_decoy);
         }
 
         if (want("TRANSITION_ID"))
         {
-          analyte.has_transition_id = getOptionalInt_(transition_id_col, row, analyte.transition_id);
+          analyte.has_transition_id = PRH::getOptionalInt(transition_id_col, row, analyte.transition_id);
         }
         if (want("PRODUCT_CHARGE"))
         {
-          analyte.has_product_charge = getOptionalInt_(product_charge_col, row, analyte.product_charge);
+          analyte.has_product_charge = PRH::getOptionalInt(product_charge_col, row, analyte.product_charge);
         }
         if (want("TRANSITION_ORDINAL"))
         {
-          analyte.has_transition_ordinal = getOptionalInt_(transition_ordinal_col, row, analyte.transition_ordinal);
+          analyte.has_transition_ordinal = PRH::getOptionalInt(transition_ordinal_col, row, analyte.transition_ordinal);
         }
         if (want("DETECTING_TRANSITION"))
         {
-          analyte.has_detecting_transition = getOptionalInt_(detecting_transition_col, row, analyte.detecting_transition);
+          analyte.has_detecting_transition = PRH::getOptionalInt(detecting_transition_col, row, analyte.detecting_transition);
         }
         if (want("PRODUCT_DECOY"))
         {
-          analyte.has_product_decoy = getOptionalInt_(product_decoy_col, row, analyte.product_decoy);
+          analyte.has_product_decoy = PRH::getOptionalInt(product_decoy_col, row, analyte.product_decoy);
         }
         if (want("TRANSITION_TYPE"))
         {
-          getOptionalString_(transition_type_col, row, analyte.transition_type);
+          PRH::getOptionalString(transition_type_col, row, analyte.transition_type);
         }
         if (want("ANNOTATION"))
         {
-          getOptionalString_(annotation_col, row, analyte.annotation);
+          PRH::getOptionalString(annotation_col, row, analyte.annotation);
         }
 
         std::ostringstream oss;
@@ -1759,10 +641,10 @@ namespace OpenMS
     for (int64_t row = 0; row < rows; ++row)
     {
       XICAnalyte analyte;
-      analyte.has_precursor_id = getOptionalInt_(precursor_id_col, row, analyte.precursor_id);
-      getOptionalString_(modified_sequence_col, row, analyte.modified_sequence);
-      analyte.has_precursor_charge = getOptionalInt_(precursor_charge_col, row, analyte.precursor_charge);
-      analyte.has_precursor_decoy = getOptionalInt_(precursor_decoy_col, row, analyte.precursor_decoy);
+      analyte.has_precursor_id = PRH::getOptionalInt(precursor_id_col, row, analyte.precursor_id);
+      PRH::getOptionalString(modified_sequence_col, row, analyte.modified_sequence);
+      analyte.has_precursor_charge = PRH::getOptionalInt(precursor_charge_col, row, analyte.precursor_charge);
+      analyte.has_precursor_decoy = PRH::getOptionalInt(precursor_decoy_col, row, analyte.precursor_decoy);
 
       std::ostringstream precursor_key;
       if (want("PRECURSOR_ID"))
@@ -1811,31 +693,31 @@ namespace OpenMS
 
       if (want("TRANSITION_ID"))
       {
-        has_transition_id = getOptionalInt_(transition_id_col, row, transition_id);
+        has_transition_id = PRH::getOptionalInt(transition_id_col, row, transition_id);
       }
       if (want("PRODUCT_CHARGE"))
       {
-        has_product_charge = getOptionalInt_(product_charge_col, row, product_charge);
+        has_product_charge = PRH::getOptionalInt(product_charge_col, row, product_charge);
       }
       if (want("TRANSITION_ORDINAL"))
       {
-        has_transition_ordinal = getOptionalInt_(transition_ordinal_col, row, transition_ordinal);
+        has_transition_ordinal = PRH::getOptionalInt(transition_ordinal_col, row, transition_ordinal);
       }
       if (want("DETECTING_TRANSITION"))
       {
-        has_detecting_transition = getOptionalInt_(detecting_transition_col, row, detecting_transition);
+        has_detecting_transition = PRH::getOptionalInt(detecting_transition_col, row, detecting_transition);
       }
       if (want("PRODUCT_DECOY"))
       {
-        has_product_decoy = getOptionalInt_(product_decoy_col, row, product_decoy);
+        has_product_decoy = PRH::getOptionalInt(product_decoy_col, row, product_decoy);
       }
       if (want("TRANSITION_TYPE"))
       {
-        getOptionalString_(transition_type_col, row, transition_type);
+        PRH::getOptionalString(transition_type_col, row, transition_type);
       }
       if (want("ANNOTATION"))
       {
-        getOptionalString_(annotation_col, row, annotation);
+        PRH::getOptionalString(annotation_col, row, annotation);
       }
 
       std::ostringstream transition_key;
@@ -1906,7 +788,7 @@ namespace OpenMS
   void XICParquetFile::getColumns(std::vector<std::string>& output) const
   {
     output.clear();
-    std::shared_ptr<arrow::Schema> schema = readParquetSchemaAllFiles_(filenames_);
+    std::shared_ptr<arrow::Schema> schema = PRH::readParquetSchemaAllFiles(filenames_);
     output.reserve(schema->num_fields());
     for (const auto& field : schema->fields())
     {

--- a/src/openms/source/FORMAT/XIMParquetFile.cpp
+++ b/src/openms/source/FORMAT/XIMParquetFile.cpp
@@ -6,28 +6,18 @@
 // $Authors: Justin Sing $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/FORMAT/XIMParquetFile.h>
-
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
-#include <OpenMS/FORMAT/ParquetFilter.h>
+#include "DATAACCESS/ParquetReaderHelpers.h"
 #include <OpenMS/FORMAT/MSNumpressCoder.h>
+#include <OpenMS/FORMAT/XIMParquetFile.h>
 #include <OpenMS/FORMAT/ZlibCompression.h>
 #include <OpenMS/SYSTEM/File.h>
 
-#include <arrow/api.h>
-#include <arrow/compute/api.h>
-#include <arrow/io/api.h>
-#include <parquet/arrow/reader.h>
-#ifdef WITH_ARROW_DATASET
-#include <arrow/dataset/api.h>
-#include <arrow/filesystem/api.h>
-#endif
 
 #include <cstring>
 #include <cctype>
 #include <cmath>
-#include <limits>
 #include <exception>
 #include <sstream>
 #include <unordered_map>
@@ -37,340 +27,16 @@ namespace OpenMS
 {
   namespace
   {
-    /// Read a single parquet file into an Arrow table.
-    std::shared_ptr<arrow::Table> readParquetTable_(const std::string& filename)
+    namespace PRH = Internal::ParquetReaderHelpers;
+
+    const PRH::FilterPruningOptions& filterPruningOptions_()
     {
-      auto infile_result = arrow::io::ReadableFile::Open(std::string(filename));
-      if (!infile_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to open parquet file", filename);
-      }
-      const std::shared_ptr<arrow::io::ReadableFile>& infile = *infile_result;
-
-      auto reader_result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
-      if (!reader_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to create parquet reader", filename);
-      }
-      std::unique_ptr<parquet::arrow::FileReader> reader = std::move(*reader_result);
-
-      std::shared_ptr<arrow::Table> table;
-      auto read_status = reader->ReadTable(&table);
-      if (!read_status.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to read parquet table: " + read_status.ToString(), filename);
-      }
-
-      auto combined = table->CombineChunks(arrow::default_memory_pool());
-      if (!combined.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to combine parquet chunks", filename);
-      }
-
-      return *combined;
-    }
-
-    /// Read the parquet schema from a single file.
-    std::shared_ptr<arrow::Schema> readParquetSchema_(const std::string& filename)
-    {
-      auto infile_result = arrow::io::ReadableFile::Open(std::string(filename));
-      if (!infile_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to open parquet file", filename);
-      }
-      const std::shared_ptr<arrow::io::ReadableFile>& infile = *infile_result;
-
-      auto reader_result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
-      if (!reader_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to create parquet reader", filename);
-      }
-      std::unique_ptr<parquet::arrow::FileReader> reader = std::move(*reader_result);
-
-      std::shared_ptr<arrow::Schema> schema;
-      auto status = reader->GetSchema(&schema);
-      if (!status.ok() || !schema)
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to read parquet schema", filename);
-      }
-      return schema;
-    }
-
-    /// Read parquet schema from all files and ensure they are compatible.
-    std::shared_ptr<arrow::Schema> readParquetSchemaAllFiles_(const std::vector<std::string>& filenames)
-    {
-      if (filenames.empty())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "No parquet files provided for schema validation", "");
-      }
-      auto base = readParquetSchema_(filenames.front());
-      for (size_t i = 1; i < filenames.size(); ++i)
-      {
-        auto other = readParquetSchema_(filenames[i]);
-        // Use Arrow Schema equality check to ensure fields and types match.
-        if (!other->Equals(*base))
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Parquet input files have incompatible schemas: '" + filenames.front() + "' vs '" + filenames[i] + "'", "");
-        }
-      }
-      return base;
-    }
-
-    /// Read selected columns from a parquet file into an Arrow table.
-    std::shared_ptr<arrow::Table> readParquetTableColumns_(const std::string& filename,
-                                                           const std::vector<std::string>& columns)
-    {
-      auto infile_result = arrow::io::ReadableFile::Open(std::string(filename));
-      if (!infile_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to open parquet file", filename);
-      }
-      const std::shared_ptr<arrow::io::ReadableFile>& infile = *infile_result;
-
-      auto reader_result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
-      if (!reader_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to create parquet reader", filename);
-      }
-      std::unique_ptr<parquet::arrow::FileReader> reader = std::move(*reader_result);
-
-      std::shared_ptr<arrow::Schema> schema;
-      auto schema_status = reader->GetSchema(&schema);
-      if (!schema_status.ok() || !schema)
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to read parquet schema", filename);
-      }
-
-      std::vector<int> column_indices;
-      column_indices.reserve(columns.size());
-      for (const auto& name : columns)
-      {
-        const int idx = schema->GetFieldIndex(std::string(name));
-        if (idx >= 0)
-        {
-          column_indices.push_back(idx);
-        }
-      }
-      if (column_indices.empty())
-      {
-        throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                            "No requested columns found in parquet file '" +
-                                            filename + "'");
-      }
-
-      std::shared_ptr<arrow::Table> table;
-      auto read_status = reader->ReadTable(column_indices, &table);
-      if (!read_status.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to read parquet table", filename);
-      }
-
-      auto combined = table->CombineChunks(arrow::default_memory_pool());
-      if (!combined.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to combine parquet chunks", filename);
-      }
-
-      return *combined;
-    }
-
-    /// Concatenate multiple Arrow tables (multiple input files).
-    std::shared_ptr<arrow::Table> concatenateTables_(const std::vector<std::shared_ptr<arrow::Table>>& tables)
-    {
-      if (tables.empty())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "No parquet tables provided", "");
-      }
-      if (tables.size() == 1)
-      {
-        return tables.front();
-      }
-
-      // Concatenate multiple file tables into a single logical view.
-      auto concat_result = arrow::ConcatenateTables(tables);
-      if (!concat_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to concatenate parquet tables", concat_result.status().ToString());
-      }
-
-      auto combined = (*concat_result)->CombineChunks(arrow::default_memory_pool());
-      if (!combined.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to combine parquet chunks", combined.status().ToString());
-      }
-
-      return *combined;
-    }
-
-    /// Read and concatenate multiple parquet files.
-    std::shared_ptr<arrow::Table> readParquetTable_(const std::vector<std::string>& filenames)
-    {
-      std::vector<std::shared_ptr<arrow::Table>> tables;
-      tables.reserve(filenames.size());
-      for (const auto& filename : filenames)
-      {
-        tables.push_back(readParquetTable_(filename));
-      }
-      return concatenateTables_(tables);
-    }
-
-    /// Read and concatenate selected columns from multiple parquet files.
-    std::shared_ptr<arrow::Table> readParquetTableColumns_(const std::vector<std::string>& filenames,
-                                                           const std::vector<std::string>& columns)
-    {
-      std::vector<std::shared_ptr<arrow::Table>> tables;
-      tables.reserve(filenames.size());
-      for (const auto& filename : filenames)
-      {
-        tables.push_back(readParquetTableColumns_(filename, columns));
-      }
-      return concatenateTables_(tables);
-    }
-
-    /// Fetch a named column or throw if required and missing.
-    std::shared_ptr<arrow::Array> getColumn_(const std::shared_ptr<arrow::Table>& table,
-                                             const std::string& name,
-                                             bool required = true)
-    {
-      auto column = table->GetColumnByName(name);
-      if (!column)
-      {
-        if (required)
-        {
-          throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                              "Missing required column '" + name + "'");
-        }
-        return nullptr;
-      }
-      if (column->num_chunks() == 0)
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Column has no chunks", name);
-      }
-      if (column->num_chunks() == 1)
-      {
-        return column->chunk(0);
-      }
-      auto combined = arrow::Concatenate(column->chunks(), arrow::default_memory_pool());
-      if (!combined.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to combine column chunks", combined.status().ToString());
-      }
-      return *combined;
-    }
-
-    /// Read optional Int64 value at row; returns false if null or absent.
-    // Forward declarations for helpers defined later in this translation unit.
-    bool getIntValueFromArray_(const std::shared_ptr<arrow::Array>& array, int64_t row, Int64& value);
-    bool getStringValueFromArray_(const std::shared_ptr<arrow::Array>& array, int64_t row, std::string& value);
-    bool getOptionalInt_(const std::shared_ptr<arrow::Array>& array, int64_t row, Int64& value)
-    {
-      // Delegate to the type-checked helper which also validates integer column types.
-      try
-      {
-        return getIntValueFromArray_(array, row, value);
-      }
-      catch (const Exception::BaseException&)
-      {
-        // Re-throw to preserve original error behaviour for unsupported types.
-        throw;
-      }
-    }
-
-    /// Read optional Double value at row; returns false if null or absent.
-    bool getOptionalDouble_(const std::shared_ptr<arrow::Array>& array, int64_t row, double& value)
-    {
-      if (!array || array->IsNull(row))
-      {
-        return false;
-      }
-      switch (array->type_id())
-      {
-        case arrow::Type::DOUBLE:
-          value = static_cast<arrow::DoubleArray*>(array.get())->Value(row);
-          return true;
-        case arrow::Type::FLOAT:
-          value = static_cast<double>(static_cast<arrow::FloatArray*>(array.get())->Value(row));
-          return true;
-        default:
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                       "Unsupported floating-point column type",std::string(array->type()->ToString()));
-      }
-    }
-
-    /// Read optional std::string value at row; returns false if null or absent.
-    bool getOptionalString_(const std::shared_ptr<arrow::Array>& array, int64_t row, std::string& value)
-    {
-      // Reuse the validated helper that supports STRING and LARGE_STRING
-      try
-      {
-        return getStringValueFromArray_(array, row, value);
-      }
-      catch (const Exception::BaseException&)
-      {
-        throw;
-      }
-    }
-
-    /// Read a binary cell as a std::string view.
-    std::string getBinaryView_(const std::shared_ptr<arrow::Array>& array, int64_t row)
-    {
-      if (!array || array->IsNull(row))
-      {
-        return std::string();
-      }
-      switch (array->type_id())
-      {
-        case arrow::Type::BINARY:
-        {
-          auto typed = static_cast<arrow::BinaryArray*>(array.get());
-          const auto view = typed->GetView(row);
-          {
-            const size_t vsize = view.size();
-            if (vsize > static_cast<size_t>(std::numeric_limits<Size>::max()))
-            {
-              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                            "Binary data too large",StringUtils::toStr(vsize));
-            }
-            return std::string(view.data(), vsize);
-          }
-        }
-        case arrow::Type::LARGE_BINARY:
-        {
-          auto typed = static_cast<arrow::LargeBinaryArray*>(array.get());
-          const auto view = typed->GetView(row);
-          {
-            const size_t vsize = view.size();
-            if (vsize > static_cast<size_t>(std::numeric_limits<Size>::max()))
-            {
-              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                            "Binary data too large",StringUtils::toStr(vsize));
-            }
-            return std::string(view.data(), vsize);
-          }
-        }
-        default:
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Unsupported binary column type",std::string(array->type()->ToString()));
-      }
+      static const PRH::FilterPruningOptions options{
+        {"MOBILITY", "INTENSITY", "FEATURE_RT"},
+        true,
+        true
+      };
+      return options;
     }
 
     /// Decode mobility/intensity arrays stored as compressed binary blobs.
@@ -459,244 +125,14 @@ namespace OpenMS
       }
     }
 
-    /// Uppercase helper for column normalization.
     std::string upper_(const std::string& input)
     {
       std::string out = input;
       for (Size i = 0; i < out.size(); ++i)
       {
-        out[i] = static_cast<char>(std::toupper(out[i]));
+        out[i] = static_cast<char>(std::toupper(static_cast<unsigned char>(out[i])));
       }
       return out;
-    }
-
-    /// Tokenize a filter string into operators/identifiers/values.
-    std::vector<std::string> tokenize_(const std::string& expr)
-    {
-      std::vector<std::string> tokens;
-      std::string current;
-      bool in_string = false;
-      char quote_char = '\0';
-
-      for (Size i = 0; i < expr.size(); ++i)
-      {
-        const char c = expr[i];
-        if (in_string)
-        {
-          if (c == quote_char)
-          {
-            tokens.push_back(current);
-            current.clear();
-            in_string = false;
-            quote_char = '\0';
-          }
-          else
-          {
-            current += c;
-          }
-          continue;
-        }
-
-        if (c == '"' || c == '\'')
-        {
-          if (!current.empty())
-          {
-            tokens.push_back(current);
-            current.clear();
-          }
-          in_string = true;
-          quote_char = c;
-          continue;
-        }
-
-        if (std::isspace(static_cast<unsigned char>(c)))
-        {
-          if (!current.empty())
-          {
-            tokens.push_back(current);
-            current.clear();
-          }
-          continue;
-        }
-
-        if (c == '[' || c == ']' || c == ',' || c == '(' || c == ')')
-        {
-          if (!current.empty())
-          {
-            tokens.push_back(current);
-            current.clear();
-          }
-          tokens.emplace_back(StringUtils::toStr(c));
-          continue;
-        }
-
-        if (c == '=' || c == '!' || c == '<' || c == '>')
-        {
-          if (!current.empty())
-          {
-            tokens.push_back(current);
-            current.clear();
-          }
-          std::string op;
-          op += c;
-          if (i + 1 < expr.size())
-          {
-            const char next = expr[i + 1];
-            if (next == '=')
-            {
-              op += next;
-              ++i;
-            }
-          }
-          tokens.push_back(op);
-          continue;
-        }
-
-        if (c == '&' || c == '|')
-        {
-          if (!current.empty())
-          {
-            tokens.push_back(current);
-            current.clear();
-          }
-          std::string op;
-          op += c;
-          if (i + 1 < expr.size())
-          {
-            const char next = expr[i + 1];
-            if (next == c)
-            {
-              op += next;
-              ++i;
-            }
-          }
-          tokens.push_back(op);
-          continue;
-        }
-
-        current += c;
-      }
-
-      if (!current.empty())
-      {
-        tokens.push_back(current);
-      }
-
-      if (in_string)
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Unclosed quote in filter expression", expr);
-      }
-
-      return tokens;
-    }
-
-    /// Parse filter text into a structured expression.
-    FilterExpression parseFilter_(const std::string& filter,
-                                  const std::unordered_map<std::string, ColumnType>& column_types)
-    {
-      FilterExpression expr;
-      if (filter.empty())
-      {
-        return expr;
-      }
-
-      auto tokens = tokenize_(filter);
-      Size i = 0;
-      while (i < tokens.size())
-      {
-        std::string column = upper_(tokens[i++]);
-        if (i >= tokens.size())
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Missing filter operator for column", column);
-        }
-        std::string op = upper_(tokens[i++]);
-        if (op == "==")
-        {
-          op = "=";
-        }
-        if (op != "=" && op != "!=" && op != "<" && op != "<=" && op != ">" && op != ">=" && op != "IN")
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Unsupported filter operator", op);
-        }
-
-        Condition cond;
-        cond.column = column;
-        cond.op = op;
-        auto type_it = column_types.find(column);
-        cond.type = (type_it == column_types.end()) ? ColumnType::INT : type_it->second;
-
-        if (op == "IN")
-        {
-          std::string close_token;
-          if (i < tokens.size() && (tokens[i] == "[" || tokens[i] == "("))
-          {
-            close_token = (tokens[i] == "[") ? "]" : ")";
-            ++i;
-          }
-          else
-          {
-            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                          "IN operator expects a bracketed value list", filter);
-          }
-          while (i < tokens.size() && tokens[i] != close_token)
-          {
-            if (tokens[i] != ",")
-            {
-              cond.values.push_back(tokens[i]);
-            }
-            ++i;
-          }
-          if (cond.values.empty())
-          {
-            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                          "IN operator expects at least one value", filter);
-          }
-          if (i >= tokens.size() || tokens[i] != close_token)
-          {
-            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                          "Unclosed IN list", filter);
-          }
-          ++i;
-        }
-        else
-        {
-          if (i >= tokens.size())
-          {
-            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                          "Missing filter value for operator", op);
-          }
-          cond.values.push_back(tokens[i++]);
-        }
-
-        expr.conditions.push_back(cond);
-        if (i < tokens.size())
-        {
-          std::string connector = upper_(tokens[i]);
-          bool consumed_connector = false;
-          if (connector == "AND" || connector == "&&" || connector == "&")
-          {
-            expr.connectors.push_back("AND");
-            ++i;
-            consumed_connector = true;
-          }
-          else if (connector == "OR" || connector == "||" || connector == "|")
-          {
-            expr.connectors.push_back("OR");
-            ++i;
-            consumed_connector = true;
-          }
-          if (consumed_connector && i >= tokens.size())
-          {
-            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                          "Dangling connector in filter expression", filter);
-          }
-        }
-      }
-
-      return expr;
     }
 
     FilterExpression buildFilterFromArgs_(Int64 precursor_id,
@@ -724,94 +160,6 @@ namespace OpenMS
       return builder.expression();
     }
 
-    /// Map upper-case column names to their schema names.
-    std::unordered_map<std::string, std::string> buildSchemaNameMap_(const std::shared_ptr<arrow::Schema>& schema)
-    {
-      std::unordered_map<std::string, std::string> name_map;
-      if (!schema)
-      {
-        return name_map;
-      }
-      name_map.reserve(schema->num_fields());
-      for (const auto& field : schema->fields())
-      {
-        name_map[upper_(std::string(field->name()))] =std::string(field->name());
-      }
-      return name_map;
-    }
-
-    /// Join columns for diagnostics/log output.
-    std::string joinColumns_(const std::vector<std::string>& columns)
-    {
-      std::ostringstream oss;
-      for (Size i = 0; i < columns.size(); ++i)
-      {
-        if (i > 0) oss << ", ";
-        oss << columns[i];
-      }
-      return oss.str();
-    }
-
-    /// Normalize column names to schema and drop unsupported columns.
-    void normalizeAndPruneColumns_(FilterExpression& expr,
-                                   const std::shared_ptr<arrow::Schema>& schema,
-                                   std::vector<std::string>& dropped_columns)
-    {
-      dropped_columns.clear();
-      if (expr.conditions.empty())
-      {
-        return;
-      }
-
-      auto name_map = buildSchemaNameMap_(schema);
-      // Unsupported columns that cannot be filtered on.
-      // MOBILITY and INTENSITY are stored as binary blobs in parquet, so we cannot filter on them here.
-      // FEATURE_RT is a floating-point column and currently not supported by the integer/string filter DSL.
-      const std::unordered_set<std::string> unsupported = {"MOBILITY", "INTENSITY", "FEATURE_RT"};
-
-      std::vector<Condition> kept;
-      kept.reserve(expr.conditions.size());
-      std::vector<std::string> new_connectors;
-      new_connectors.reserve(expr.connectors.size());
-
-      for (Size i = 0; i < expr.conditions.size(); ++i)
-      {
-        Condition cond = expr.conditions[i];
-        const std::string original = cond.column;
-        auto it = name_map.find(upper_(cond.column));
-        if (it != name_map.end())
-        {
-          cond.column = it->second;
-        }
-
-        const bool unsupported_col = unsupported.contains(upper_(cond.column));
-        const bool exists_in_schema = name_map.contains(upper_(cond.column));
-        if (unsupported_col || !exists_in_schema)
-        {
-          dropped_columns.push_back(original);
-          continue;
-        }
-
-        if (!kept.empty())
-        {
-          const Size prev_index = i - 1;
-          if (prev_index < expr.connectors.size())
-          {
-            new_connectors.push_back(expr.connectors[prev_index]);
-          }
-          else
-          {
-            new_connectors.push_back("AND");
-          }
-        }
-        kept.push_back(cond);
-      }
-
-      expr.conditions.swap(kept);
-      expr.connectors.swap(new_connectors);
-    }
-
-    /// Append an integer part to a composite key.
     void appendKeyPart_(std::ostringstream& oss, bool has_value, Int64 value)
     {
       if (has_value)
@@ -829,554 +177,6 @@ namespace OpenMS
     void appendKeyPart_(std::ostringstream& oss, const std::string& value)
     {
       oss << value << '|';
-    }
-
-    /// Build a single Arrow condition expression from one clause.
-    arrow::compute::Expression buildConditionExpression_(const Condition& cond)
-    {
-      auto field = arrow::compute::field_ref(std::string(cond.column));
-
-      if (cond.op == "IN")
-      {
-        if (cond.type == ColumnType::INT)
-        {
-          arrow::Int64Builder builder;
-          for (const auto& value : cond.values)
-          {
-            auto status = builder.Append(StringUtils::toInt64(value));
-            if (!status.ok())
-            {
-              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                            "Failed to build INT64 value set", status.ToString());
-            }
-          }
-          std::shared_ptr<arrow::Array> value_set;
-          auto status = builder.Finish(&value_set);
-          if (!status.ok())
-          {
-            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                          "Failed to finalize INT64 value set", status.ToString());
-          }
-          auto options = std::make_shared<arrow::compute::SetLookupOptions>(arrow::Datum(value_set));
-          return arrow::compute::call("is_in", {field}, options);
-        }
-        else
-        {
-          arrow::StringBuilder builder;
-          for (const auto& value : cond.values)
-          {
-            auto status = builder.Append(std::string(value));
-            if (!status.ok())
-            {
-              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                            "Failed to build STRING value set", status.ToString());
-            }
-          }
-          std::shared_ptr<arrow::Array> value_set;
-          auto status = builder.Finish(&value_set);
-          if (!status.ok())
-          {
-            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                          "Failed to finalize STRING value set", status.ToString());
-          }
-          auto options = std::make_shared<arrow::compute::SetLookupOptions>(arrow::Datum(value_set));
-          return arrow::compute::call("is_in", {field}, options);
-        }
-      }
-
-      if (cond.values.empty())
-      {
-        return arrow::compute::literal(false);
-      }
-
-      arrow::compute::Expression literal;
-      if (cond.type == ColumnType::INT)
-      {
-        literal = arrow::compute::literal(static_cast<int64_t>(StringUtils::toInt64(cond.values.front())));
-      }
-      else
-      {
-        literal = arrow::compute::literal(std::string(cond.values.front()));
-      }
-
-      if (cond.op == "=") return arrow::compute::equal(field, literal);
-      if (cond.op == "!=") return arrow::compute::not_equal(field, literal);
-      if (cond.op == "<") return arrow::compute::less(field, literal);
-      if (cond.op == "<=") return arrow::compute::less_equal(field, literal);
-      if (cond.op == ">") return arrow::compute::greater(field, literal);
-      if (cond.op == ">=") return arrow::compute::greater_equal(field, literal);
-      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                    "Unsupported filter operator", cond.op);
-    }
-
-    /// Combine conditions into a single Arrow expression.
-    arrow::compute::Expression buildFilterExpression_(const FilterExpression& expr)
-    {
-      if (expr.conditions.empty())
-      {
-        return arrow::compute::literal(true);
-      }
-
-      std::vector<arrow::compute::Expression> cond_exprs;
-      cond_exprs.reserve(expr.conditions.size());
-      for (const auto& cond : expr.conditions)
-      {
-        cond_exprs.push_back(buildConditionExpression_(cond));
-      }
-
-      arrow::compute::Expression result = cond_exprs.front();
-      for (Size i = 1; i < cond_exprs.size(); ++i)
-      {
-        if (i - 1 < expr.connectors.size() && expr.connectors[i - 1] == "OR")
-        {
-          result = arrow::compute::or_(result, cond_exprs[i]);
-        }
-        else
-        {
-          result = arrow::compute::and_(result, cond_exprs[i]);
-        }
-      }
-      return result;
-    }
-
-    struct ManualCondition
-    {
-      Condition cond;
-      int index{-1};
-      std::vector<Int64> int_values;
-    };
-
-    bool getIntValueFromArray_(const std::shared_ptr<arrow::Array>& array, int64_t row, Int64& value)
-    {
-      if (!array || array->IsNull(row))
-      {
-        return false;
-      }
-
-      switch (array->type_id())
-      {
-        case arrow::Type::INT64:
-          value = static_cast<arrow::Int64Array*>(array.get())->Value(row);
-          return true;
-        case arrow::Type::INT32:
-          value = static_cast<arrow::Int32Array*>(array.get())->Value(row);
-          return true;
-        case arrow::Type::INT16:
-          value = static_cast<arrow::Int16Array*>(array.get())->Value(row);
-          return true;
-        case arrow::Type::INT8:
-          value = static_cast<arrow::Int8Array*>(array.get())->Value(row);
-          return true;
-        case arrow::Type::UINT64:
-          value = static_cast<arrow::UInt64Array*>(array.get())->Value(row);
-          return true;
-        case arrow::Type::UINT32:
-          value = static_cast<arrow::UInt32Array*>(array.get())->Value(row);
-          return true;
-        case arrow::Type::UINT16:
-          value = static_cast<arrow::UInt16Array*>(array.get())->Value(row);
-          return true;
-        case arrow::Type::UINT8:
-          value = static_cast<arrow::UInt8Array*>(array.get())->Value(row);
-          return true;
-        case arrow::Type::BOOL:
-          value = static_cast<arrow::BooleanArray*>(array.get())->Value(row) ? 1 : 0;
-          return true;
-        default:
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Unsupported integer column type",std::string(array->type()->ToString()));
-      }
-    }
-
-    bool getStringValueFromArray_(const std::shared_ptr<arrow::Array>& array, int64_t row, std::string& value)
-    {
-      if (!array || array->IsNull(row))
-      {
-        return false;
-      }
-
-      switch (array->type_id())
-      {
-        case arrow::Type::STRING:
-          value = static_cast<arrow::StringArray*>(array.get())->GetString(row);
-          return true;
-        case arrow::Type::LARGE_STRING:
-          value = static_cast<arrow::LargeStringArray*>(array.get())->GetString(row);
-          return true;
-        default:
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Unsupported string column type",std::string(array->type()->ToString()));
-      }
-    }
-
-    bool evaluateCondition_(const ManualCondition& cond,
-                            const std::shared_ptr<arrow::RecordBatch>& batch,
-                            int64_t row)
-    {
-      if (!batch || cond.index < 0 || cond.index >= batch->num_columns())
-      {
-        return false;
-      }
-
-      const auto& array = batch->column(cond.index);
-      if (cond.cond.type == ColumnType::INT)
-      {
-        Int64 lhs = 0;
-        if (!getIntValueFromArray_(array, row, lhs))
-        {
-          return false;
-        }
-
-        if (cond.cond.op == "IN")
-        {
-          for (const auto& rhs : cond.int_values)
-          {
-            if (lhs == rhs) return true;
-          }
-          return false;
-        }
-
-        if (cond.int_values.empty())
-        {
-          return false;
-        }
-        const Int64 rhs = cond.int_values.front();
-        if (cond.cond.op == "=") return lhs == rhs;
-        if (cond.cond.op == "!=") return lhs != rhs;
-        if (cond.cond.op == "<") return lhs < rhs;
-        if (cond.cond.op == "<=") return lhs <= rhs;
-        if (cond.cond.op == ">") return lhs > rhs;
-        if (cond.cond.op == ">=") return lhs >= rhs;
-      }
-      else
-      {
-        std::string lhs;
-        if (!getStringValueFromArray_(array, row, lhs))
-        {
-          return false;
-        }
-
-        if (cond.cond.op == "IN")
-        {
-          for (const auto& rhs : cond.cond.values)
-          {
-            if (lhs == rhs) return true;
-          }
-          return false;
-        }
-
-        if (cond.cond.values.empty())
-        {
-          return false;
-        }
-        const std::string& rhs = cond.cond.values.front();
-        if (cond.cond.op == "=") return lhs == rhs;
-        if (cond.cond.op == "!=") return lhs != rhs;
-        if (cond.cond.op == "<") return lhs < rhs;
-        if (cond.cond.op == "<=") return lhs <= rhs;
-        if (cond.cond.op == ">") return lhs > rhs;
-        if (cond.cond.op == ">=") return lhs >= rhs;
-      }
-
-      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                    "Unsupported filter operator", cond.cond.op);
-    }
-
-    bool evaluateFilterExpression_(const std::vector<ManualCondition>& conditions,
-                                   const std::vector<std::string>& connectors,
-                                   const std::shared_ptr<arrow::RecordBatch>& batch,
-                                   int64_t row)
-    {
-      if (conditions.empty())
-      {
-        return true;
-      }
-
-      bool result = evaluateCondition_(conditions.front(), batch, row);
-      for (Size i = 1; i < conditions.size(); ++i)
-      {
-        const std::string connector = (i - 1 < connectors.size()) ? connectors[i - 1] : "AND";
-        const bool next = evaluateCondition_(conditions[i], batch, row);
-        if (connector == "OR")
-        {
-          result = result || next;
-        }
-        else
-        {
-          result = result && next;
-        }
-      }
-      return result;
-    }
-
-    std::shared_ptr<arrow::Table> applyManualFilter_(const std::shared_ptr<arrow::Table>& table,
-                                                     const FilterExpression& parsed,
-                                                     const std::string& filter)
-    {
-      std::vector<ManualCondition> conditions;
-      conditions.reserve(parsed.conditions.size());
-
-      auto schema = table->schema();
-      for (const auto& cond : parsed.conditions)
-      {
-        ManualCondition manual;
-        manual.cond = cond;
-        manual.index = schema->GetFieldIndex(std::string(cond.column));
-        if (manual.index < 0)
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Column not found in parquet schema", cond.column);
-        }
-        if (cond.type == ColumnType::INT)
-        {
-          manual.int_values.reserve(cond.values.size());
-          for (const auto& value : cond.values)
-          {
-            try
-            {
-              manual.int_values.push_back(StringUtils::toInt64(value));
-            }
-            catch (const std::exception&)
-            {
-              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                            "Invalid integer filter value", value);
-            }
-          }
-        }
-        conditions.push_back(std::move(manual));
-      }
-
-      arrow::TableBatchReader reader(*table);
-      std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
-      std::shared_ptr<arrow::RecordBatch> batch;
-
-      while (true)
-      {
-        auto read_status = reader.ReadNext(&batch);
-        if (!read_status.ok())
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Failed to read record batch", filter);
-        }
-        if (!batch)
-        {
-          break;
-        }
-
-        const int64_t num_rows = batch->num_rows();
-        for (int64_t row = 0; row < num_rows; ++row)
-        {
-          if (evaluateFilterExpression_(conditions, parsed.connectors, batch, row))
-          {
-            batches.push_back(batch->Slice(row, 1));
-          }
-        }
-      }
-
-      if (batches.empty())
-      {
-        std::vector<std::shared_ptr<arrow::Array>> empty_columns;
-        empty_columns.reserve(schema->num_fields());
-        for (const auto& field : schema->fields())
-        {
-          auto array_result = arrow::MakeArrayOfNull(field->type(), 0);
-          if (!array_result.ok())
-          {
-            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                          "Failed to create empty column", array_result.status().ToString());
-          }
-          empty_columns.push_back(*array_result);
-        }
-        return arrow::Table::Make(schema, empty_columns);
-      }
-
-      auto table_result = arrow::Table::FromRecordBatches(schema, batches);
-      if (!table_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to build filtered table", filter);
-      }
-      auto combined = (*table_result)->CombineChunks(arrow::default_memory_pool());
-      if (!combined.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to combine filtered chunks", combined.status().ToString());
-      }
-      return *combined;
-    }
-
-#ifdef WITH_ARROW_DATASET
-    /// Read parquet files via Arrow Dataset with predicate pushdown.
-    std::shared_ptr<arrow::Table> readParquetTableDataset_(const std::vector<std::string>& filenames,
-                                                           const FilterExpression& parsed,
-                                                           const std::string& filter_context)
-    {
-      (void)filter_context;
-      // Arrow Dataset enables predicate pushdown across multiple parquet files.
-      auto filesystem = std::make_shared<arrow::fs::LocalFileSystem>();
-      auto format = std::make_shared<arrow::dataset::ParquetFileFormat>();
-      arrow::dataset::FileSystemFactoryOptions options;
-
-      std::vector<std::string> paths;
-      paths.reserve(filenames.size());
-      for (const auto& filename : filenames)
-      {
-        paths.emplace_back(filename);
-      }
-      auto factory_result = arrow::dataset::FileSystemDatasetFactory::Make(
-        filesystem, paths, format, options);
-      if (!factory_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to create dataset factory", "dataset");
-      }
-
-      auto dataset_result = (*factory_result)->Finish();
-      if (!dataset_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to create dataset", "dataset");
-      }
-      std::shared_ptr<arrow::dataset::Dataset> dataset = *dataset_result;
-
-      auto builder = std::make_shared<arrow::dataset::ScannerBuilder>(dataset);
-      if (!parsed.conditions.empty())
-      {
-        FilterExpression pruned = parsed;
-        std::vector<std::string> dropped;
-        normalizeAndPruneColumns_(pruned, dataset->schema(), dropped);
-        if (!dropped.empty())
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Unsupported filter columns after pruning", joinColumns_(dropped));
-        }
-        if (pruned.conditions.empty())
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Filter expression became empty after pruning unsupported columns", filter_context);
-        }
-        // Convert the parsed filter into an Arrow expression for pushdown.
-        arrow::compute::Expression expr = buildFilterExpression_(pruned);
-        auto status = builder->Filter(expr);
-        if (!status.ok())
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Failed to bind dataset filter expression", status.ToString());
-        }
-      }
-
-      auto scanner_result = builder->Finish();
-      if (!scanner_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to create dataset scanner", "dataset");
-      }
-      auto table_result = (*scanner_result)->ToTable();
-      if (!table_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to read parquet table via dataset scanner", "dataset");
-      }
-
-      auto combined = (*table_result)->CombineChunks(arrow::default_memory_pool());
-      if (!combined.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to combine parquet chunks", combined.status().ToString());
-      }
-      return *combined;
-    }
-#endif
-
-    /// Read parquet files via Arrow Dataset with predicate pushdown.
-    std::shared_ptr<arrow::Table> applyArrowFilter_(const std::shared_ptr<arrow::Table>& table,
-                                                    const FilterExpression& parsed,
-                                                    const std::string& filter_context)
-    {
-      if (parsed.conditions.empty())
-      {
-        return table;
-      }
-
-      FilterExpression pruned = parsed;
-      std::vector<std::string> dropped;
-      normalizeAndPruneColumns_(pruned, table->schema(), dropped);
-      if (!dropped.empty())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Unsupported filter columns after pruning", joinColumns_(dropped));
-      }
-      if (pruned.conditions.empty())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Filter expression became empty after pruning unsupported columns", filter_context);
-      }
-
-      // Execute the expression in memory when dataset pushdown is unavailable.
-      arrow::compute::Expression expr = buildFilterExpression_(pruned);
-      auto bound_result = expr.Bind(*table->schema());
-      if (!bound_result.ok())
-      {
-        OPENMS_LOG_WARN << "Arrow compute filter unavailable, falling back to manual filter: "
-                        << bound_result.status().ToString() << '\n';
-        return applyManualFilter_(table, pruned, filter_context);
-      }
-      const arrow::compute::Expression& bound_expr = *bound_result;
-
-      arrow::TableBatchReader reader(*table);
-      std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
-      std::shared_ptr<arrow::RecordBatch> batch;
-
-      while (true)
-      {
-        auto read_status = reader.ReadNext(&batch);
-        if (!read_status.ok())
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        "Failed to read record batch", filter_context);
-        }
-        if (!batch)
-        {
-          break;
-        }
-
-        auto mask_result = arrow::compute::ExecuteScalarExpression(
-          bound_expr, *batch->schema(), arrow::Datum(batch));
-        if (!mask_result.ok())
-        {
-          OPENMS_LOG_WARN << "Arrow compute filter failed, falling back to manual filter: "
-                          << mask_result.status().ToString() << '\n';
-          return applyManualFilter_(table, pruned, filter_context);
-        }
-
-        auto filtered_result = arrow::compute::Filter(arrow::Datum(batch), *mask_result);
-        if (!filtered_result.ok())
-        {
-          OPENMS_LOG_WARN << "Arrow compute filter failed, falling back to manual filter: "
-                          << filtered_result.status().ToString() << '\n';
-          return applyManualFilter_(table, pruned, filter_context);
-        }
-
-        const auto& filtered_batch = filtered_result->record_batch();
-        if (filtered_batch && filtered_batch->num_rows() > 0)
-        {
-          batches.push_back(filtered_batch);
-        }
-      }
-
-      auto table_result = arrow::Table::FromRecordBatches(table->schema(), batches);
-      if (!table_result.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to build filtered table", filter_context);
-      }
-      auto combined = (*table_result)->CombineChunks(arrow::default_memory_pool());
-      if (!combined.ok())
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                      "Failed to combine filtered chunks", combined.status().ToString());
-      }
-      return *combined;
     }
   } // namespace
 
@@ -1472,7 +272,7 @@ namespace OpenMS
                                                        mobilogram_type,
                                                        feature_id,
                                                        feature_rt);
-    FilterExpression string_filter = parseFilter_(filter, column_types);
+    FilterExpression string_filter = PRH::parseFilter(filter, column_types);
     FilterExpression combined_filter = ParquetFilter::merge(args_filter, string_filter, "AND");
     combined_filter = ParquetFilter::merge(combined_filter, extra_filter, "AND");
 
@@ -1485,7 +285,7 @@ namespace OpenMS
       try
       {
         // Prefer dataset pushdown when available; fall back to compute filtering on failure.
-        table = readParquetTableDataset_(filenames_, combined_filter, filter_context);
+        table = PRH::readParquetTableDataset(filenames_, combined_filter, filter_context, filterPruningOptions_());
         used_dataset = true;
       }
       catch (const std::exception& e)
@@ -1505,34 +305,34 @@ namespace OpenMS
 #endif
     if (!table)
     {
-      table = readParquetTable_(filenames_);
+      table = PRH::readParquetTable(filenames_);
     }
     if (!used_dataset)
     {
-      table = applyArrowFilter_(table, combined_filter, filter_context);
+      table = PRH::applyArrowFilter(table, combined_filter, filter_context, filterPruningOptions_());
     }
 
-    auto run_id_col = getColumn_(table, "RUN_ID");
-    auto source_file_col = getColumn_(table, "SOURCE_FILE", false);
-    auto ms_level_col = getColumn_(table, "MS_LEVEL", false);
-    auto mobilogram_type_col = getColumn_(table, "MOBILOGRAM_TYPE", false);
-    auto precursor_id_col = getColumn_(table, "PRECURSOR_ID");
-    auto transition_id_col = getColumn_(table, "TRANSITION_ID", false);
-    auto feature_id_col = getColumn_(table, "FEATURE_ID", false);
-    auto feature_rt_col = getColumn_(table, "FEATURE_RT", false);
-    auto modified_sequence_col = getColumn_(table, "MODIFIED_SEQUENCE", false);
-    auto precursor_charge_col = getColumn_(table, "PRECURSOR_CHARGE", false);
-    auto product_charge_col = getColumn_(table, "PRODUCT_CHARGE", false);
-    auto detecting_transition_col = getColumn_(table, "DETECTING_TRANSITION", false);
-    auto precursor_decoy_col = getColumn_(table, "PRECURSOR_DECOY", false);
-    auto product_decoy_col = getColumn_(table, "PRODUCT_DECOY", false);
-    auto transition_ordinal_col = getColumn_(table, "TRANSITION_ORDINAL", false);
-    auto transition_type_col = getColumn_(table, "TRANSITION_TYPE", false);
-    auto annotation_col = getColumn_(table, "ANNOTATION", false);
-    auto mobility_data_col = getColumn_(table, "MOBILITY_DATA");
-    auto intensity_data_col = getColumn_(table, "INTENSITY_DATA");
-    auto mobility_compression_col = getColumn_(table, "MOBILITY_COMPRESSION");
-    auto intensity_compression_col = getColumn_(table, "INTENSITY_COMPRESSION");
+    auto run_id_col = PRH::getColumn(table, "RUN_ID");
+    auto source_file_col = PRH::getColumn(table, "SOURCE_FILE", false);
+    auto ms_level_col = PRH::getColumn(table, "MS_LEVEL", false);
+    auto mobilogram_type_col = PRH::getColumn(table, "MOBILOGRAM_TYPE", false);
+    auto precursor_id_col = PRH::getColumn(table, "PRECURSOR_ID");
+    auto transition_id_col = PRH::getColumn(table, "TRANSITION_ID", false);
+    auto feature_id_col = PRH::getColumn(table, "FEATURE_ID", false);
+    auto feature_rt_col = PRH::getColumn(table, "FEATURE_RT", false);
+    auto modified_sequence_col = PRH::getColumn(table, "MODIFIED_SEQUENCE", false);
+    auto precursor_charge_col = PRH::getColumn(table, "PRECURSOR_CHARGE", false);
+    auto product_charge_col = PRH::getColumn(table, "PRODUCT_CHARGE", false);
+    auto detecting_transition_col = PRH::getColumn(table, "DETECTING_TRANSITION", false);
+    auto precursor_decoy_col = PRH::getColumn(table, "PRECURSOR_DECOY", false);
+    auto product_decoy_col = PRH::getColumn(table, "PRODUCT_DECOY", false);
+    auto transition_ordinal_col = PRH::getColumn(table, "TRANSITION_ORDINAL", false);
+    auto transition_type_col = PRH::getColumn(table, "TRANSITION_TYPE", false);
+    auto annotation_col = PRH::getColumn(table, "ANNOTATION", false);
+    auto mobility_data_col = PRH::getColumn(table, "MOBILITY_DATA");
+    auto intensity_data_col = PRH::getColumn(table, "INTENSITY_DATA");
+    auto mobility_compression_col = PRH::getColumn(table, "MOBILITY_COMPRESSION");
+    auto intensity_compression_col = PRH::getColumn(table, "INTENSITY_COMPRESSION");
 
     const int64_t rows = table->num_rows();
     output.reserve(rows);
@@ -1542,31 +342,31 @@ namespace OpenMS
       XIMMobilogram mobilogram;
 
       // Defensive: RUN_ID is a required column but individual cells may be null in malformed files.
-      // Use getOptionalInt_ and throw a descriptive error if a required cell is null.
-      if (!getOptionalInt_(run_id_col, row, mobilogram.run_id))
+      // Use the shared typed extractor and throw a descriptive error if a required cell is null.
+      if (!PRH::getOptionalInt(run_id_col, row, mobilogram.run_id))
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                       "NULL value in required RUN_ID column",StringUtils::toStr(row));
       }
-      mobilogram.has_precursor_id = getOptionalInt_(precursor_id_col, row, mobilogram.precursor_id);
-      mobilogram.has_transition_id = getOptionalInt_(transition_id_col, row, mobilogram.transition_id);
-      mobilogram.has_feature_id = getOptionalInt_(feature_id_col, row, mobilogram.feature_id);
-      mobilogram.has_feature_rt = getOptionalDouble_(feature_rt_col, row, mobilogram.feature_rt);
-      mobilogram.has_precursor_charge = getOptionalInt_(precursor_charge_col, row, mobilogram.precursor_charge);
-      mobilogram.has_product_charge = getOptionalInt_(product_charge_col, row, mobilogram.product_charge);
-      mobilogram.has_detecting_transition = getOptionalInt_(detecting_transition_col, row, mobilogram.detecting_transition);
-      mobilogram.has_precursor_decoy = getOptionalInt_(precursor_decoy_col, row, mobilogram.precursor_decoy);
-      mobilogram.has_product_decoy = getOptionalInt_(product_decoy_col, row, mobilogram.product_decoy);
-      mobilogram.has_transition_ordinal = getOptionalInt_(transition_ordinal_col, row, mobilogram.transition_ordinal);
+      mobilogram.has_precursor_id = PRH::getOptionalInt(precursor_id_col, row, mobilogram.precursor_id);
+      mobilogram.has_transition_id = PRH::getOptionalInt(transition_id_col, row, mobilogram.transition_id);
+      mobilogram.has_feature_id = PRH::getOptionalInt(feature_id_col, row, mobilogram.feature_id);
+      mobilogram.has_feature_rt = PRH::getOptionalDouble(feature_rt_col, row, mobilogram.feature_rt);
+      mobilogram.has_precursor_charge = PRH::getOptionalInt(precursor_charge_col, row, mobilogram.precursor_charge);
+      mobilogram.has_product_charge = PRH::getOptionalInt(product_charge_col, row, mobilogram.product_charge);
+      mobilogram.has_detecting_transition = PRH::getOptionalInt(detecting_transition_col, row, mobilogram.detecting_transition);
+      mobilogram.has_precursor_decoy = PRH::getOptionalInt(precursor_decoy_col, row, mobilogram.precursor_decoy);
+      mobilogram.has_product_decoy = PRH::getOptionalInt(product_decoy_col, row, mobilogram.product_decoy);
+      mobilogram.has_transition_ordinal = PRH::getOptionalInt(transition_ordinal_col, row, mobilogram.transition_ordinal);
 
-      getOptionalString_(source_file_col, row, mobilogram.source_file);
-      getOptionalString_(mobilogram_type_col, row, mobilogram.mobilogram_type);
-      getOptionalString_(modified_sequence_col, row, mobilogram.modified_sequence);
-      getOptionalString_(transition_type_col, row, mobilogram.transition_type);
-      getOptionalString_(annotation_col, row, mobilogram.annotation);
+      PRH::getOptionalString(source_file_col, row, mobilogram.source_file);
+      PRH::getOptionalString(mobilogram_type_col, row, mobilogram.mobilogram_type);
+      PRH::getOptionalString(modified_sequence_col, row, mobilogram.modified_sequence);
+      PRH::getOptionalString(transition_type_col, row, mobilogram.transition_type);
+      PRH::getOptionalString(annotation_col, row, mobilogram.annotation);
 
       Int64 ms_level_value = 0;
-      if (getOptionalInt_(ms_level_col, row, ms_level_value))
+      if (PRH::getOptionalInt(ms_level_col, row, ms_level_value))
       {
         mobilogram.ms_level = ms_level_value;
       }
@@ -1584,11 +384,11 @@ namespace OpenMS
 
       Int64 mobility_compression = 0;
       Int64 intensity_compression = 0;
-      getOptionalInt_(mobility_compression_col, row, mobility_compression);
-      getOptionalInt_(intensity_compression_col, row, intensity_compression);
+      PRH::getOptionalInt(mobility_compression_col, row, mobility_compression);
+      PRH::getOptionalInt(intensity_compression_col, row, intensity_compression);
 
-      const std::string mobility_data = getBinaryView_(mobility_data_col, row);
-      const std::string intensity_data = getBinaryView_(intensity_data_col, row);
+      const std::string mobility_data = PRH::getBinaryView(mobility_data_col, row);
+      const std::string intensity_data = PRH::getBinaryView(intensity_data_col, row);
 
       decodeBinary_(mobility_data, mobility_compression, mobilogram.mobility);
       decodeBinary_(intensity_data, intensity_compression, mobilogram.intensity);
@@ -1607,10 +407,10 @@ namespace OpenMS
     output.clear();
 
     const std::vector<std::string> columns = {"RUN_ID", "SOURCE_FILE"};
-    auto table = readParquetTableColumns_(filenames_, columns);
+    auto table = PRH::readParquetTableColumns(filenames_, columns);
 
-    auto run_id_col = getColumn_(table, "RUN_ID");
-    auto source_file_col = getColumn_(table, "SOURCE_FILE", false);
+    auto run_id_col = PRH::getColumn(table, "RUN_ID");
+    auto source_file_col = PRH::getColumn(table, "SOURCE_FILE", false);
 
     std::unordered_set<std::string> seen;
     const int64_t rows = table->num_rows();
@@ -1619,12 +419,12 @@ namespace OpenMS
     for (int64_t row = 0; row < rows; ++row)
     {
       XIMRunInfo info;
-      if (!getOptionalInt_(run_id_col, row, info.run_id))
+      if (!PRH::getOptionalInt(run_id_col, row, info.run_id))
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                       "NULL value in required RUN_ID column",StringUtils::toStr(row));
       }
-      getOptionalString_(source_file_col, row, info.source_file);
+      PRH::getOptionalString(source_file_col, row, info.source_file);
 
       std::ostringstream oss;
       appendKeyPart_(oss, true, info.run_id);
@@ -1688,7 +488,7 @@ namespace OpenMS
     };
     const std::vector<std::string>& requested_columns = columns.empty() ? default_columns : columns;
 
-  std::shared_ptr<arrow::Schema> schema = readParquetSchemaAllFiles_(filenames_);
+    std::shared_ptr<arrow::Schema> schema = PRH::readParquetSchemaAllFiles(filenames_);
     std::unordered_set<std::string> schema_columns;
     schema_columns.reserve(schema->num_fields());
     for (const auto& field : schema->fields())
@@ -1764,19 +564,19 @@ namespace OpenMS
       return requested_set.contains(name);
     };
 
-    auto table = readParquetTableColumns_(filenames_, normalized_columns);
+    auto table = PRH::readParquetTableColumns(filenames_, normalized_columns);
 
-    auto precursor_id_col = getColumn_(table, "PRECURSOR_ID", want("PRECURSOR_ID"));
-    auto modified_sequence_col = getColumn_(table, "MODIFIED_SEQUENCE", want("MODIFIED_SEQUENCE"));
-    auto precursor_charge_col = getColumn_(table, "PRECURSOR_CHARGE", want("PRECURSOR_CHARGE"));
-    auto precursor_decoy_col = getColumn_(table, "PRECURSOR_DECOY", want("PRECURSOR_DECOY"));
-    auto transition_id_col = getColumn_(table, "TRANSITION_ID", want("TRANSITION_ID"));
-    auto product_charge_col = getColumn_(table, "PRODUCT_CHARGE", want("PRODUCT_CHARGE"));
-    auto transition_ordinal_col = getColumn_(table, "TRANSITION_ORDINAL", want("TRANSITION_ORDINAL"));
-    auto detecting_transition_col = getColumn_(table, "DETECTING_TRANSITION", want("DETECTING_TRANSITION"));
-    auto product_decoy_col = getColumn_(table, "PRODUCT_DECOY", want("PRODUCT_DECOY"));
-    auto transition_type_col = getColumn_(table, "TRANSITION_TYPE", want("TRANSITION_TYPE"));
-    auto annotation_col = getColumn_(table, "ANNOTATION", want("ANNOTATION"));
+    auto precursor_id_col = PRH::getColumn(table, "PRECURSOR_ID", want("PRECURSOR_ID"));
+    auto modified_sequence_col = PRH::getColumn(table, "MODIFIED_SEQUENCE", want("MODIFIED_SEQUENCE"));
+    auto precursor_charge_col = PRH::getColumn(table, "PRECURSOR_CHARGE", want("PRECURSOR_CHARGE"));
+    auto precursor_decoy_col = PRH::getColumn(table, "PRECURSOR_DECOY", want("PRECURSOR_DECOY"));
+    auto transition_id_col = PRH::getColumn(table, "TRANSITION_ID", want("TRANSITION_ID"));
+    auto product_charge_col = PRH::getColumn(table, "PRODUCT_CHARGE", want("PRODUCT_CHARGE"));
+    auto transition_ordinal_col = PRH::getColumn(table, "TRANSITION_ORDINAL", want("TRANSITION_ORDINAL"));
+    auto detecting_transition_col = PRH::getColumn(table, "DETECTING_TRANSITION", want("DETECTING_TRANSITION"));
+    auto product_decoy_col = PRH::getColumn(table, "PRODUCT_DECOY", want("PRODUCT_DECOY"));
+    auto transition_type_col = PRH::getColumn(table, "TRANSITION_TYPE", want("TRANSITION_TYPE"));
+    auto annotation_col = PRH::getColumn(table, "ANNOTATION", want("ANNOTATION"));
 
     const int64_t rows = table->num_rows();
     output.reserve(rows);
@@ -1790,48 +590,48 @@ namespace OpenMS
 
         if (want("PRECURSOR_ID"))
         {
-          analyte.has_precursor_id = getOptionalInt_(precursor_id_col, row, analyte.precursor_id);
+          analyte.has_precursor_id = PRH::getOptionalInt(precursor_id_col, row, analyte.precursor_id);
         }
         if (want("MODIFIED_SEQUENCE"))
         {
-          getOptionalString_(modified_sequence_col, row, analyte.modified_sequence);
+          PRH::getOptionalString(modified_sequence_col, row, analyte.modified_sequence);
         }
         if (want("PRECURSOR_CHARGE"))
         {
-          analyte.has_precursor_charge = getOptionalInt_(precursor_charge_col, row, analyte.precursor_charge);
+          analyte.has_precursor_charge = PRH::getOptionalInt(precursor_charge_col, row, analyte.precursor_charge);
         }
         if (want("PRECURSOR_DECOY"))
         {
-          analyte.has_precursor_decoy = getOptionalInt_(precursor_decoy_col, row, analyte.precursor_decoy);
+          analyte.has_precursor_decoy = PRH::getOptionalInt(precursor_decoy_col, row, analyte.precursor_decoy);
         }
 
         if (want("TRANSITION_ID"))
         {
-          analyte.has_transition_id = getOptionalInt_(transition_id_col, row, analyte.transition_id);
+          analyte.has_transition_id = PRH::getOptionalInt(transition_id_col, row, analyte.transition_id);
         }
         if (want("PRODUCT_CHARGE"))
         {
-          analyte.has_product_charge = getOptionalInt_(product_charge_col, row, analyte.product_charge);
+          analyte.has_product_charge = PRH::getOptionalInt(product_charge_col, row, analyte.product_charge);
         }
         if (want("TRANSITION_ORDINAL"))
         {
-          analyte.has_transition_ordinal = getOptionalInt_(transition_ordinal_col, row, analyte.transition_ordinal);
+          analyte.has_transition_ordinal = PRH::getOptionalInt(transition_ordinal_col, row, analyte.transition_ordinal);
         }
         if (want("DETECTING_TRANSITION"))
         {
-          analyte.has_detecting_transition = getOptionalInt_(detecting_transition_col, row, analyte.detecting_transition);
+          analyte.has_detecting_transition = PRH::getOptionalInt(detecting_transition_col, row, analyte.detecting_transition);
         }
         if (want("PRODUCT_DECOY"))
         {
-          analyte.has_product_decoy = getOptionalInt_(product_decoy_col, row, analyte.product_decoy);
+          analyte.has_product_decoy = PRH::getOptionalInt(product_decoy_col, row, analyte.product_decoy);
         }
         if (want("TRANSITION_TYPE"))
         {
-          getOptionalString_(transition_type_col, row, analyte.transition_type);
+          PRH::getOptionalString(transition_type_col, row, analyte.transition_type);
         }
         if (want("ANNOTATION"))
         {
-          getOptionalString_(annotation_col, row, analyte.annotation);
+          PRH::getOptionalString(annotation_col, row, analyte.annotation);
         }
 
         std::ostringstream oss;
@@ -1894,10 +694,10 @@ namespace OpenMS
     for (int64_t row = 0; row < rows; ++row)
     {
       XIMAnalyte analyte;
-      analyte.has_precursor_id = getOptionalInt_(precursor_id_col, row, analyte.precursor_id);
-      getOptionalString_(modified_sequence_col, row, analyte.modified_sequence);
-      analyte.has_precursor_charge = getOptionalInt_(precursor_charge_col, row, analyte.precursor_charge);
-      analyte.has_precursor_decoy = getOptionalInt_(precursor_decoy_col, row, analyte.precursor_decoy);
+      analyte.has_precursor_id = PRH::getOptionalInt(precursor_id_col, row, analyte.precursor_id);
+      PRH::getOptionalString(modified_sequence_col, row, analyte.modified_sequence);
+      analyte.has_precursor_charge = PRH::getOptionalInt(precursor_charge_col, row, analyte.precursor_charge);
+      analyte.has_precursor_decoy = PRH::getOptionalInt(precursor_decoy_col, row, analyte.precursor_decoy);
 
       std::ostringstream precursor_key;
       if (want("PRECURSOR_ID"))
@@ -1946,31 +746,31 @@ namespace OpenMS
 
       if (want("TRANSITION_ID"))
       {
-        has_transition_id = getOptionalInt_(transition_id_col, row, transition_id);
+        has_transition_id = PRH::getOptionalInt(transition_id_col, row, transition_id);
       }
       if (want("PRODUCT_CHARGE"))
       {
-        has_product_charge = getOptionalInt_(product_charge_col, row, product_charge);
+        has_product_charge = PRH::getOptionalInt(product_charge_col, row, product_charge);
       }
       if (want("TRANSITION_ORDINAL"))
       {
-        has_transition_ordinal = getOptionalInt_(transition_ordinal_col, row, transition_ordinal);
+        has_transition_ordinal = PRH::getOptionalInt(transition_ordinal_col, row, transition_ordinal);
       }
       if (want("DETECTING_TRANSITION"))
       {
-        has_detecting_transition = getOptionalInt_(detecting_transition_col, row, detecting_transition);
+        has_detecting_transition = PRH::getOptionalInt(detecting_transition_col, row, detecting_transition);
       }
       if (want("PRODUCT_DECOY"))
       {
-        has_product_decoy = getOptionalInt_(product_decoy_col, row, product_decoy);
+        has_product_decoy = PRH::getOptionalInt(product_decoy_col, row, product_decoy);
       }
       if (want("TRANSITION_TYPE"))
       {
-        getOptionalString_(transition_type_col, row, transition_type);
+        PRH::getOptionalString(transition_type_col, row, transition_type);
       }
       if (want("ANNOTATION"))
       {
-        getOptionalString_(annotation_col, row, annotation);
+        PRH::getOptionalString(annotation_col, row, annotation);
       }
 
       std::ostringstream transition_key;
@@ -2041,7 +841,7 @@ namespace OpenMS
   void XIMParquetFile::getColumns(std::vector<std::string>& output) const
   {
     output.clear();
-    std::shared_ptr<arrow::Schema> schema = readParquetSchemaAllFiles_(filenames_);
+    std::shared_ptr<arrow::Schema> schema = PRH::readParquetSchemaAllFiles(filenames_);
     output.reserve(schema->num_fields());
     for (const auto& field : schema->fields())
     {

--- a/src/tests/class_tests/openms/CMakeLists.txt
+++ b/src/tests/class_tests/openms/CMakeLists.txt
@@ -154,6 +154,14 @@ target_link_libraries(ConsensusMapArrowIO_test
   ${OPENMS_ARROW_TARGET}
   ${OPENMS_PARQUET_TARGET}
 )
+target_link_libraries(XICParquetFile_test
+  ${OPENMS_ARROW_TARGET}
+  ${OPENMS_PARQUET_TARGET}
+)
+target_link_libraries(XIMParquetFile_test
+  ${OPENMS_ARROW_TARGET}
+  ${OPENMS_PARQUET_TARGET}
+)
 target_link_libraries(Libzip_test
   ${OPENMS_ARROW_TARGET}
   ${OPENMS_PARQUET_TARGET}

--- a/src/tests/class_tests/openms/source/XICParquetFile_test.cpp
+++ b/src/tests/class_tests/openms/source/XICParquetFile_test.cpp
@@ -18,6 +18,8 @@
 #include <arrow/io/api.h>
 #include <parquet/arrow/writer.h>
 
+#include <limits>
+
 using namespace OpenMS;
 using namespace std;
 
@@ -124,6 +126,10 @@ START_SECTION(void getChromatograms(std::vector<XICChromatogram>&, Int64, Int64,
   std::vector<XICChromatogram> chroms_invalid_in;
   TEST_EXCEPTION(Exception::InvalidValue,
                  xic.getChromatograms(chroms_invalid_in, -1, -1, "", -1, -1, -1, -1, "precursor_id IN []"))
+
+  std::vector<XICChromatogram> chroms_unknown_column;
+  TEST_EXCEPTION(Exception::InvalidValue,
+                 xic.getChromatograms(chroms_unknown_column, -1, -1, "", -1, -1, -1, -1, "precusor_id=2"))
 }
 END_SECTION
 
@@ -198,6 +204,57 @@ START_SECTION(void getChromatograms_large_string_columns)
   TEST_EQUAL(chroms[0].intensity.size(), 2)
   TEST_REAL_SIMILAR(chroms[0].rt[0], 100.0)
   TEST_REAL_SIMILAR(chroms[0].intensity[1], 1001.0)
+}
+END_SECTION
+
+START_SECTION(void load_uint64_overflow_throws)
+{
+  std::string filename;
+  NEW_TMP_FILE(filename);
+
+  arrow::UInt64Builder run_id_builder;
+  arrow::Int64Builder precursor_id_builder;
+  arrow::StringBuilder source_file_builder;
+  arrow::BinaryBuilder rt_data_builder;
+  arrow::BinaryBuilder intensity_data_builder;
+  arrow::Int64Builder rt_compression_builder;
+  arrow::Int64Builder intensity_compression_builder;
+
+  const uint64_t overflowing_run_id = static_cast<uint64_t>(std::numeric_limits<Int64>::max()) + 1ULL;
+
+  appendOk_(run_id_builder, overflowing_run_id);
+  appendOk_(precursor_id_builder, static_cast<int64_t>(42));
+  appendOk_(source_file_builder, std::string("overflow.raw"));
+  appendBinaryOk_(rt_data_builder, encodeDoubles_({100.0}));
+  appendBinaryOk_(intensity_data_builder, encodeDoubles_({1000.0}));
+  appendOk_(rt_compression_builder, static_cast<int64_t>(0));
+  appendOk_(intensity_compression_builder, static_cast<int64_t>(0));
+
+  auto table = arrow::Table::Make(
+    arrow::schema({
+      arrow::field(XICSchema::RUN_ID, arrow::uint64()),
+      arrow::field(XICSchema::PRECURSOR_ID, arrow::int64()),
+      arrow::field(XICSchema::SOURCE_FILE, arrow::utf8()),
+      arrow::field(XICSchema::RT_DATA, arrow::binary()),
+      arrow::field(XICSchema::INTENSITY_DATA, arrow::binary()),
+      arrow::field(XICSchema::RT_COMPRESSION, arrow::int64()),
+      arrow::field(XICSchema::INTENSITY_COMPRESSION, arrow::int64())
+    }),
+    {
+      finishArray_(run_id_builder),
+      finishArray_(precursor_id_builder),
+      finishArray_(source_file_builder),
+      finishArray_(rt_data_builder),
+      finishArray_(intensity_data_builder),
+      finishArray_(rt_compression_builder),
+      finishArray_(intensity_compression_builder)
+    });
+
+  TEST_EQUAL(writeParquetTable_(table, filename).ok(), true)
+
+  XICParquetFile xic(filename);
+  std::vector<XICParquetFile::XICChromatogram> chroms;
+  TEST_EXCEPTION(Exception::InvalidValue, xic.load(chroms))
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/XICParquetFile_test.cpp
+++ b/src/tests/class_tests/openms/source/XICParquetFile_test.cpp
@@ -10,11 +10,62 @@
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/test_config.h>
 
+#include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
 #include <OpenMS/FORMAT/XICParquetFile.h>
 #include <OpenMS/FORMAT/ParquetFilter.h>
 
+#include <arrow/api.h>
+#include <arrow/io/api.h>
+#include <parquet/arrow/writer.h>
+
 using namespace OpenMS;
 using namespace std;
+
+namespace
+{
+  template <typename BuilderT, typename ValueT>
+  void appendOk_(BuilderT& builder, const ValueT& value)
+  {
+    TEST_EQUAL(builder.Append(value).ok(), true)
+  }
+
+  template <typename BuilderT>
+  std::shared_ptr<arrow::Array> finishArray_(BuilderT& builder)
+  {
+    auto result = builder.Finish();
+    TEST_EQUAL(result.ok(), true)
+    if (result.ok())
+    {
+      return result.ValueOrDie();
+    }
+    return nullptr;
+  }
+
+  void appendBinaryOk_(arrow::BinaryBuilder& builder, const std::string& value)
+  {
+    auto status = builder.Append(reinterpret_cast<const uint8_t*>(value.data()),
+                                 static_cast<int32_t>(value.size()));
+    TEST_EQUAL(status.ok(), true)
+  }
+
+  std::string encodeDoubles_(std::initializer_list<double> values)
+  {
+    std::vector<double> buffer(values);
+    return std::string(reinterpret_cast<const char*>(buffer.data()),
+                       buffer.size() * sizeof(double));
+  }
+
+  ::arrow::Status writeParquetTable_(const std::shared_ptr<arrow::Table>& table, const std::string& filename)
+  {
+    auto outfile_result = arrow::io::FileOutputStream::Open(std::string(filename));
+    if (!outfile_result.ok())
+    {
+      return outfile_result.status();
+    }
+    auto outfile = outfile_result.ValueOrDie();
+    return parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), outfile, 1024);
+  }
+}
 
 START_TEST(XICParquetFile, "$Id$")
 
@@ -86,6 +137,67 @@ START_SECTION(void getChromatograms_multi_file)
   std::vector<XICChromatogram> chroms_multi;
   xic_multi.getChromatograms(chroms_multi);
   TEST_EQUAL(chroms_multi.size(), 36)
+}
+END_SECTION
+
+START_SECTION(void getChromatograms_large_string_columns)
+{
+  std::string filename;
+  NEW_TMP_FILE(filename);
+
+  arrow::Int64Builder run_id_builder;
+  arrow::Int64Builder precursor_id_builder;
+  arrow::LargeStringBuilder source_file_builder;
+  arrow::LargeStringBuilder modified_sequence_builder;
+  arrow::BinaryBuilder rt_data_builder;
+  arrow::BinaryBuilder intensity_data_builder;
+  arrow::Int64Builder rt_compression_builder;
+  arrow::Int64Builder intensity_compression_builder;
+
+  appendOk_(run_id_builder, static_cast<int64_t>(7));
+  appendOk_(precursor_id_builder, static_cast<int64_t>(42));
+  appendOk_(source_file_builder, std::string("large_source.raw"));
+  appendOk_(modified_sequence_builder, std::string("PEPTIDE"));
+  appendBinaryOk_(rt_data_builder, encodeDoubles_({100.0, 101.0}));
+  appendBinaryOk_(intensity_data_builder, encodeDoubles_({1000.0, 1001.0}));
+  appendOk_(rt_compression_builder, static_cast<int64_t>(0));
+  appendOk_(intensity_compression_builder, static_cast<int64_t>(0));
+
+  auto table = arrow::Table::Make(
+    arrow::schema({
+      arrow::field(XICSchema::RUN_ID, arrow::int64()),
+      arrow::field(XICSchema::PRECURSOR_ID, arrow::int64()),
+      arrow::field(XICSchema::SOURCE_FILE, arrow::large_utf8()),
+      arrow::field(XICSchema::MODIFIED_SEQUENCE, arrow::large_utf8()),
+      arrow::field(XICSchema::RT_DATA, arrow::binary()),
+      arrow::field(XICSchema::INTENSITY_DATA, arrow::binary()),
+      arrow::field(XICSchema::RT_COMPRESSION, arrow::int64()),
+      arrow::field(XICSchema::INTENSITY_COMPRESSION, arrow::int64())
+    }),
+    {
+      finishArray_(run_id_builder),
+      finishArray_(precursor_id_builder),
+      finishArray_(source_file_builder),
+      finishArray_(modified_sequence_builder),
+      finishArray_(rt_data_builder),
+      finishArray_(intensity_data_builder),
+      finishArray_(rt_compression_builder),
+      finishArray_(intensity_compression_builder)
+    });
+
+  TEST_EQUAL(writeParquetTable_(table, filename).ok(), true)
+
+  XICParquetFile xic(filename);
+  std::vector<XICChromatogram> chroms;
+  xic.getChromatograms(chroms, -1, -1, "", -1, -1, -1, -1, "MODIFIED_SEQUENCE=PEPTIDE");
+
+  TEST_EQUAL(chroms.size(), 1)
+  TEST_STRING_EQUAL(chroms[0].source_file, "large_source.raw")
+  TEST_STRING_EQUAL(chroms[0].modified_sequence, "PEPTIDE")
+  TEST_EQUAL(chroms[0].rt.size(), 2)
+  TEST_EQUAL(chroms[0].intensity.size(), 2)
+  TEST_REAL_SIMILAR(chroms[0].rt[0], 100.0)
+  TEST_REAL_SIMILAR(chroms[0].intensity[1], 1001.0)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/XIMParquetFile_test.cpp
+++ b/src/tests/class_tests/openms/source/XIMParquetFile_test.cpp
@@ -10,11 +10,62 @@
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/test_config.h>
 
+#include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
 #include <OpenMS/FORMAT/XIMParquetFile.h>
 #include <OpenMS/FORMAT/ParquetFilter.h>
 
+#include <arrow/api.h>
+#include <arrow/io/api.h>
+#include <parquet/arrow/writer.h>
+
 using namespace OpenMS;
 using namespace std;
+
+namespace
+{
+  template <typename BuilderT, typename ValueT>
+  void appendOk_(BuilderT& builder, const ValueT& value)
+  {
+    TEST_EQUAL(builder.Append(value).ok(), true)
+  }
+
+  template <typename BuilderT>
+  std::shared_ptr<arrow::Array> finishArray_(BuilderT& builder)
+  {
+    auto result = builder.Finish();
+    TEST_EQUAL(result.ok(), true)
+    if (result.ok())
+    {
+      return result.ValueOrDie();
+    }
+    return nullptr;
+  }
+
+  void appendBinaryOk_(arrow::BinaryBuilder& builder, const std::string& value)
+  {
+    auto status = builder.Append(reinterpret_cast<const uint8_t*>(value.data()),
+                                 static_cast<int32_t>(value.size()));
+    TEST_EQUAL(status.ok(), true)
+  }
+
+  std::string encodeDoubles_(std::initializer_list<double> values)
+  {
+    std::vector<double> buffer(values);
+    return std::string(reinterpret_cast<const char*>(buffer.data()),
+                       buffer.size() * sizeof(double));
+  }
+
+  ::arrow::Status writeParquetTable_(const std::shared_ptr<arrow::Table>& table, const std::string& filename)
+  {
+    auto outfile_result = arrow::io::FileOutputStream::Open(std::string(filename));
+    if (!outfile_result.ok())
+    {
+      return outfile_result.status();
+    }
+    auto outfile = outfile_result.ValueOrDie();
+    return parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), outfile, 1024);
+  }
+}
 
 START_TEST(XIMParquetFile, "$Id$")
 
@@ -88,6 +139,131 @@ START_SECTION(void getMobilograms_multi_file)
   std::vector<XIMMobilogram> mobilograms_multi;
   xim_multi.getMobilograms(mobilograms_multi);
   TEST_EQUAL(mobilograms_multi.size(), 2 * mobilograms_single.size())
+}
+END_SECTION
+
+START_SECTION(void getMobilograms_large_string_and_double_feature_rt)
+{
+  std::string filename;
+  NEW_TMP_FILE(filename);
+
+  arrow::Int64Builder run_id_builder;
+  arrow::Int64Builder precursor_id_builder;
+  arrow::Int64Builder feature_id_builder;
+  arrow::DoubleBuilder feature_rt_builder;
+  arrow::LargeStringBuilder source_file_builder;
+  arrow::LargeStringBuilder mobilogram_type_builder;
+  arrow::LargeStringBuilder modified_sequence_builder;
+  arrow::BinaryBuilder mobility_data_builder;
+  arrow::BinaryBuilder intensity_data_builder;
+  arrow::Int64Builder mobility_compression_builder;
+  arrow::Int64Builder intensity_compression_builder;
+
+  appendOk_(run_id_builder, static_cast<int64_t>(11));
+  appendOk_(precursor_id_builder, static_cast<int64_t>(101));
+  appendOk_(feature_id_builder, static_cast<int64_t>(202));
+  appendOk_(feature_rt_builder, 12.5);
+  appendOk_(source_file_builder, std::string("large_mobi.raw"));
+  appendOk_(mobilogram_type_builder, std::string("precursor"));
+  appendOk_(modified_sequence_builder, std::string("PEPTIDE"));
+  appendBinaryOk_(mobility_data_builder, encodeDoubles_({0.8, 0.9}));
+  appendBinaryOk_(intensity_data_builder, encodeDoubles_({10.0, 20.0}));
+  appendOk_(mobility_compression_builder, static_cast<int64_t>(0));
+  appendOk_(intensity_compression_builder, static_cast<int64_t>(0));
+
+  auto table = arrow::Table::Make(
+    arrow::schema({
+      arrow::field(XIMSchema::RUN_ID, arrow::int64()),
+      arrow::field(XIMSchema::PRECURSOR_ID, arrow::int64()),
+      arrow::field(XIMSchema::FEATURE_ID, arrow::int64()),
+      arrow::field(XIMSchema::FEATURE_RT, arrow::float64()),
+      arrow::field(XIMSchema::SOURCE_FILE, arrow::large_utf8()),
+      arrow::field(XIMSchema::MOBILOGRAM_TYPE, arrow::large_utf8()),
+      arrow::field(XIMSchema::MODIFIED_SEQUENCE, arrow::large_utf8()),
+      arrow::field(XIMSchema::MOBILITY_DATA, arrow::binary()),
+      arrow::field(XIMSchema::INTENSITY_DATA, arrow::binary()),
+      arrow::field(XIMSchema::MOBILITY_COMPRESSION, arrow::int64()),
+      arrow::field(XIMSchema::INTENSITY_COMPRESSION, arrow::int64())
+    }),
+    {
+      finishArray_(run_id_builder),
+      finishArray_(precursor_id_builder),
+      finishArray_(feature_id_builder),
+      finishArray_(feature_rt_builder),
+      finishArray_(source_file_builder),
+      finishArray_(mobilogram_type_builder),
+      finishArray_(modified_sequence_builder),
+      finishArray_(mobility_data_builder),
+      finishArray_(intensity_data_builder),
+      finishArray_(mobility_compression_builder),
+      finishArray_(intensity_compression_builder)
+    });
+
+  TEST_EQUAL(writeParquetTable_(table, filename).ok(), true)
+
+  XIMParquetFile xim(filename);
+  std::vector<XIMMobilogram> mobilograms;
+  xim.getMobilograms(mobilograms, -1, -1, "", -1, -1, -1, -1, "", -1, 12.5, "MOBILOGRAM_TYPE=precursor");
+
+  TEST_EQUAL(mobilograms.size(), 1)
+  TEST_STRING_EQUAL(mobilograms[0].source_file, "large_mobi.raw")
+  TEST_STRING_EQUAL(mobilograms[0].mobilogram_type, "precursor")
+  TEST_REAL_SIMILAR(mobilograms[0].feature_rt, 12.5)
+  TEST_EQUAL(mobilograms[0].mobility.size(), 2)
+  TEST_EQUAL(mobilograms[0].intensity.size(), 2)
+}
+END_SECTION
+
+START_SECTION(void getMobilograms_float_feature_rt)
+{
+  std::string filename;
+  NEW_TMP_FILE(filename);
+
+  arrow::Int64Builder run_id_builder;
+  arrow::Int64Builder precursor_id_builder;
+  arrow::FloatBuilder feature_rt_builder;
+  arrow::BinaryBuilder mobility_data_builder;
+  arrow::BinaryBuilder intensity_data_builder;
+  arrow::Int64Builder mobility_compression_builder;
+  arrow::Int64Builder intensity_compression_builder;
+
+  appendOk_(run_id_builder, static_cast<int64_t>(12));
+  appendOk_(precursor_id_builder, static_cast<int64_t>(303));
+  appendOk_(feature_rt_builder, 42.5f);
+  appendBinaryOk_(mobility_data_builder, encodeDoubles_({1.1, 1.2}));
+  appendBinaryOk_(intensity_data_builder, encodeDoubles_({30.0, 40.0}));
+  appendOk_(mobility_compression_builder, static_cast<int64_t>(0));
+  appendOk_(intensity_compression_builder, static_cast<int64_t>(0));
+
+  auto table = arrow::Table::Make(
+    arrow::schema({
+      arrow::field(XIMSchema::RUN_ID, arrow::int64()),
+      arrow::field(XIMSchema::PRECURSOR_ID, arrow::int64()),
+      arrow::field(XIMSchema::FEATURE_RT, arrow::float32()),
+      arrow::field(XIMSchema::MOBILITY_DATA, arrow::binary()),
+      arrow::field(XIMSchema::INTENSITY_DATA, arrow::binary()),
+      arrow::field(XIMSchema::MOBILITY_COMPRESSION, arrow::int64()),
+      arrow::field(XIMSchema::INTENSITY_COMPRESSION, arrow::int64())
+    }),
+    {
+      finishArray_(run_id_builder),
+      finishArray_(precursor_id_builder),
+      finishArray_(feature_rt_builder),
+      finishArray_(mobility_data_builder),
+      finishArray_(intensity_data_builder),
+      finishArray_(mobility_compression_builder),
+      finishArray_(intensity_compression_builder)
+    });
+
+  TEST_EQUAL(writeParquetTable_(table, filename).ok(), true)
+
+  XIMParquetFile xim(filename);
+  std::vector<XIMMobilogram> mobilograms;
+  xim.getMobilograms(mobilograms, -1, -1, "", -1, -1, -1, -1, "", -1, 42.5, "");
+
+  TEST_EQUAL(mobilograms.size(), 1)
+  TEST_EQUAL(mobilograms[0].has_feature_rt, true)
+  TEST_REAL_SIMILAR(mobilograms[0].feature_rt, 42.5)
 }
 END_SECTION
 


### PR DESCRIPTION
## Description

Address #9688, extract shared Arrow/Parquet reader plumbing into an internal helper used by XICParquetFile and XIMParquetFile.

Keep the public reader and row-struct APIs unchanged, and add regression coverage for LARGE_STRING plus FLOAT/DOUBLE parquet column handling.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Parquet-based loading with stronger filter support for chromatogram and mobilogram retrieval, including better handling of large string columns.
* **Bug Fixes**
  * More reliable schema/column selection across multiple Parquet files.
  * Clearer behavior for invalid/unknown filters and stricter checks for out-of-range run identifiers (e.g., `uint64` overflow).
  * More consistent type-safe decoding for numeric features (including `FEATURE_RT` as `float` vs `double`).
* **Tests**
  * Added write-then-read Arrow/Parquet coverage for large-string columns and `FEATURE_RT` float/double scenarios.
  * Added tests for invalid filters and `uint64` overflow handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->