### PR TITLE
Stream QPX feature Parquet export in batches to bound peak memory

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/ConsensusMapArrowExport.h
+++ b/src/openms/include/OpenMS/FORMAT/ConsensusMapArrowExport.h
@@ -64,6 +64,31 @@ public:
     const ConsensusMap& cmap,
     const std::string& filename,
     const ParquetWriteConfig& config = ParquetWriteConfig{});
+
+  /**
+    @brief Stream a ConsensusMap to a Parquet file in row batches (bounded peak memory)
+
+    Functionally equivalent to exportToParquet() but builds and flushes the feature
+    table one @p batch_size -sized range at a time through a persistent
+    @c parquet::arrow::FileWriter, instead of materializing the whole ~N-row Arrow
+    table in memory before a single write. For isobaric data (one consensus feature
+    per PSM) N can be in the millions, where the one-shot path's transient peak drives
+    the process into swap / OOM; here peak memory stays bounded by one batch.
+
+    The written rows and their order are identical to exportToParquet(); only the
+    Parquet row-group layout may differ.
+
+    @param[in] cmap The ConsensusMap to export
+    @param[in] filename Output file path
+    @param[in] batch_size Consensus features materialized per batch (0 is treated as the default)
+    @param[in] config Parquet writing options
+    @return true on success, false on error
+  */
+  static bool exportToParquetStreaming(
+    const ConsensusMap& cmap,
+    const std::string& filename,
+    size_t batch_size = 1000000,
+    const ParquetWriteConfig& config = ParquetWriteConfig{});
 };
 
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
@@ -22,6 +22,7 @@
 #include <parquet/arrow/writer.h>
 #include <parquet/properties.h>
 
+#include <algorithm>
 #include <limits>
 #include <map>
 #include <unordered_map>
@@ -49,7 +50,91 @@ namespace // anonymous
 } // anonymous namespace
 
 
-std::shared_ptr<arrow::Table> ConsensusMapArrowExport::exportToArrow(const ConsensusMap& cmap)
+namespace // anonymous (feature range builder + shared per-map lookups)
+{
+
+/// Per-map, read-only lookups derived once from the ConsensusMap's protein
+/// identifications. Shared by the whole-table and streaming feature export paths
+/// (built once, reused across all batches).
+struct FeatureIdLookups
+{
+  std::unordered_map<std::string, double> pg_qvalue;               ///< accession -> protein-group q-value
+  std::unordered_map<std::string, std::vector<std::string>> gg_accessions; ///< accession -> gene accessions
+  std::unordered_map<std::string, std::vector<std::string>> gg_names;      ///< accession -> gene names
+};
+
+/// Build the per-map protein-group q-value and gene-info lookups from the
+/// ConsensusMap's ProteinIdentifications.
+FeatureIdLookups buildFeatureIdLookups(const ConsensusMap& cmap)
+{
+  FeatureIdLookups lut;
+  for (const auto& prot_id : cmap.getProteinIdentifications())
+  {
+    // Gene info from ProteinHit metavalues
+    for (const auto& ph : prot_id.getHits())
+    {
+      const std::string& acc = ph.getAccession();
+      if (ph.metaValueExists("gene_accession"))
+      {
+        lut.gg_accessions[acc].push_back(ph.getMetaValue("gene_accession").toString());
+      }
+      if (ph.metaValueExists("gene_name"))
+      {
+        lut.gg_names[acc].push_back(ph.getMetaValue("gene_name").toString());
+      }
+    }
+
+    for (const auto& pg : prot_id.getProteinGroups())
+    {
+      for (const auto& acc : pg.accessions)
+      {
+        lut.pg_qvalue[acc] = pg.probability;
+      }
+    }
+    for (const auto& ig : prot_id.getIndistinguishableProteins())
+    {
+      for (const auto& acc : ig.accessions)
+      {
+        if (!lut.pg_qvalue.contains(acc))
+        {
+          lut.pg_qvalue[acc] = ig.probability;
+        }
+      }
+    }
+  }
+  return lut;
+}
+
+/// Build Parquet WriterProperties from the OpenMS config (shared by the one-shot
+/// and streaming feature export paths).
+std::shared_ptr<parquet::WriterProperties> makeFeatureWriterProperties(const ParquetWriteConfig& config)
+{
+  auto builder = parquet::WriterProperties::Builder();
+  switch (config.compression)
+  {
+    case ParquetWriteConfig::Compression::NONE:   builder.compression(arrow::Compression::UNCOMPRESSED); break;
+    case ParquetWriteConfig::Compression::SNAPPY: builder.compression(arrow::Compression::SNAPPY); break;
+    case ParquetWriteConfig::Compression::GZIP:   builder.compression(arrow::Compression::GZIP); builder.compression_level(config.compression_level); break;
+    case ParquetWriteConfig::Compression::LZ4:    builder.compression(arrow::Compression::LZ4); break;
+    case ParquetWriteConfig::Compression::ZSTD:   builder.compression(arrow::Compression::ZSTD); builder.compression_level(config.compression_level); break;
+  }
+  builder.data_pagesize(config.data_page_size);
+  if (config.write_statistics) { builder.enable_statistics(); }
+  else                         { builder.disable_statistics(); }
+  return builder.build();
+}
+
+/// Build a QPXFeatureSchema Arrow table for the half-open feature range
+/// [range_begin, range_end) of @p cmap. @p id_lut holds the prebuilt per-map
+/// protein-group/gene lookups. Each row is independent (no cross-row state), so
+/// any contiguous sub-range yields a self-contained, schema-valid table; this is
+/// what lets exportToParquetStreaming() flush one batch at a time. Shared by
+/// exportToArrow() (whole map) and exportToParquetStreaming() (one batch per call).
+std::shared_ptr<arrow::Table> buildFeatureTableRange(
+  const ConsensusMap& cmap,
+  const FeatureIdLookups& id_lut,
+  size_t range_begin,
+  size_t range_end)
 {
   // -- Simple column builders --
   arrow::StringBuilder sequence_builder, peptidoform_builder, anchor_protein_builder;
@@ -205,7 +290,7 @@ std::shared_ptr<arrow::Table> ConsensusMapArrowExport::exportToArrow(const Conse
   arrow::ListBuilder pg_positions_builder(arrow::default_memory_pool(), pgp_struct_b);
 
   arrow::Status status;
-  const Size num_features = cmap.size();
+  const Size num_features = range_end - range_begin;
 
   // Reserve capacity for simple column builders
   #define RESERVE_OR_FAIL(builder) \
@@ -239,45 +324,10 @@ std::shared_ptr<arrow::Table> ConsensusMapArrowExport::exportToArrow(const Conse
   // Build column header lookup
   const auto& column_headers = cmap.getColumnHeaders();
 
-  // Build protein group q-value lookup and gene info lookup
-  std::unordered_map<std::string, double> pg_qvalue_lookup;
-  std::unordered_map<std::string, std::vector<std::string>> gg_accessions_lookup;
-  std::unordered_map<std::string, std::vector<std::string>> gg_names_lookup;
-
-  for (const auto& prot_id : cmap.getProteinIdentifications())
-  {
-    // Gene info from ProteinHit metavalues
-    for (const auto& ph : prot_id.getHits())
-    {
-      const std::string& acc = ph.getAccession();
-      if (ph.metaValueExists("gene_accession"))
-      {
-        gg_accessions_lookup[acc].push_back(ph.getMetaValue("gene_accession").toString());
-      }
-      if (ph.metaValueExists("gene_name"))
-      {
-        gg_names_lookup[acc].push_back(ph.getMetaValue("gene_name").toString());
-      }
-    }
-
-    for (const auto& pg : prot_id.getProteinGroups())
-    {
-      for (const auto& acc : pg.accessions)
-      {
-        pg_qvalue_lookup[acc] = pg.probability;
-      }
-    }
-    for (const auto& ig : prot_id.getIndistinguishableProteins())
-    {
-      for (const auto& acc : ig.accessions)
-      {
-        if (!pg_qvalue_lookup.contains(acc))
-        {
-          pg_qvalue_lookup[acc] = ig.probability;
-        }
-      }
-    }
-  }
+  // Per-map protein-group q-value and gene-info lookups (prebuilt once, shared across batches)
+  const auto& pg_qvalue_lookup = id_lut.pg_qvalue;
+  const auto& gg_accessions_lookup = id_lut.gg_accessions;
+  const auto& gg_names_lookup = id_lut.gg_names;
 
   // Metavalue keys excluded from additional_scores on PeptideHit
   static const std::unordered_set<std::string> excluded_hit_mvs = {
@@ -286,8 +336,9 @@ std::shared_ptr<arrow::Table> ConsensusMapArrowExport::exportToArrow(const Conse
 
   IDScoreSwitcherAlgorithm idsa;
 
-  for (const auto& cf : cmap)
+  for (size_t feat_idx = range_begin; feat_idx < range_end; ++feat_idx)
   {
+    const auto& cf = cmap[feat_idx];
     const auto& pep_ids = cf.getPeptideIdentifications();
     bool has_id = !pep_ids.empty() && !pep_ids[0].getHits().empty();
     const PeptideHit* best_hit = has_id ? &pep_ids[0].getHits()[0] : nullptr;
@@ -866,6 +917,14 @@ std::shared_ptr<arrow::Table> ConsensusMapArrowExport::exportToArrow(const Conse
   return table;
 }
 
+} // anonymous namespace (feature range builder + shared per-map lookups)
+
+
+std::shared_ptr<arrow::Table> ConsensusMapArrowExport::exportToArrow(const ConsensusMap& cmap)
+{
+  return buildFeatureTableRange(cmap, buildFeatureIdLookups(cmap), 0, cmap.size());
+}
+
 
 bool ConsensusMapArrowExport::exportToParquet(
   const ConsensusMap& cmap,
@@ -888,43 +947,7 @@ bool ConsensusMapArrowExport::exportToParquet(
   }
   const auto& outfile = *result;
 
-  // Configure Parquet writer
-  auto builder = parquet::WriterProperties::Builder();
-
-  switch (config.compression)
-  {
-    case ParquetWriteConfig::Compression::NONE:
-      builder.compression(arrow::Compression::UNCOMPRESSED);
-      break;
-    case ParquetWriteConfig::Compression::SNAPPY:
-      builder.compression(arrow::Compression::SNAPPY);
-      break;
-    case ParquetWriteConfig::Compression::GZIP:
-      builder.compression(arrow::Compression::GZIP);
-      builder.compression_level(config.compression_level);
-      break;
-    case ParquetWriteConfig::Compression::LZ4:
-      builder.compression(arrow::Compression::LZ4);
-      break;
-    case ParquetWriteConfig::Compression::ZSTD:
-      builder.compression(arrow::Compression::ZSTD);
-      builder.compression_level(config.compression_level);
-      break;
-  }
-
-  builder.data_pagesize(config.data_page_size);
-
-  if (config.write_statistics)
-  {
-    builder.enable_statistics();
-  }
-  else
-  {
-    builder.disable_statistics();
-  }
-
-  auto writer_props = builder.build();
-
+  auto writer_props = makeFeatureWriterProperties(config);
   auto arrow_props = parquet::ArrowWriterProperties::Builder().store_schema()->build();
 
   // Write
@@ -940,6 +963,98 @@ bool ConsensusMapArrowExport::exportToParquet(
   }
 
   return true;
+}
+
+
+bool ConsensusMapArrowExport::exportToParquetStreaming(
+  const ConsensusMap& cmap,
+  const std::string& filename,
+  size_t batch_size,
+  const ParquetWriteConfig& config)
+{
+  if (batch_size == 0) { batch_size = 1000000; } // guard: a zero step would never advance
+
+  // Prebuild the per-map protein-group/gene lookups once; reused for every batch.
+  const auto id_lut = buildFeatureIdLookups(cmap);
+
+  // The writer's schema must match each batch table's schema exactly. buildFeatureTableRange()
+  // stamps QPXFeatureSchema::schema() on every batch, so open the writer with the same schema.
+  const auto schema = QPXFeatureSchema::schema();
+
+  auto file_result = arrow::io::FileOutputStream::Open(filename);
+  if (!file_result.ok())
+  {
+    OPENMS_LOG_ERROR << "ConsensusMapArrowExport: Failed to open " << filename << " for writing: "
+                     << file_result.status().ToString() << std::endl;
+    return false;
+  }
+  auto outfile = file_result.ValueOrDie();
+
+  auto writer_props = makeFeatureWriterProperties(config);
+  auto arrow_props = parquet::ArrowWriterProperties::Builder().store_schema()->build();
+
+  auto writer_result = parquet::arrow::FileWriter::Open(
+    *schema, arrow::default_memory_pool(), outfile, writer_props, arrow_props);
+  if (!writer_result.ok())
+  {
+    OPENMS_LOG_ERROR << "ConsensusMapArrowExport: Failed to open Parquet writer for " << filename << ": "
+                     << writer_result.status().ToString() << std::endl;
+    return false;
+  }
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  const int64_t rg = static_cast<int64_t>(config.row_group_size);
+
+  // Build one feature range [b, e) into a self-contained table and flush it. Peak memory stays
+  // bounded by one batch (one batch's rows) instead of the whole map's ~N-row table at once.
+  auto write_batch = [&](size_t b, size_t e) -> bool
+  {
+    auto batch = buildFeatureTableRange(cmap, id_lut, b, e);
+    if (!batch)
+    {
+      OPENMS_LOG_ERROR << "ConsensusMapArrowExport: Failed to build feature batch [" << b << ", " << e << ")" << std::endl;
+      return false;
+    }
+    auto st = writer->WriteTable(*batch, rg);
+    if (!st.ok())
+    {
+      OPENMS_LOG_ERROR << "ConsensusMapArrowExport: Failed to write feature batch to " << filename << ": "
+                       << st.ToString() << std::endl;
+      return false;
+    }
+    return true;
+  };
+
+  bool ok = true;
+  const size_t N = cmap.size();
+  if (N == 0)
+  {
+    ok = write_batch(0, 0); // valid 0-row file (schema only), matching the one-shot path
+  }
+  else
+  {
+    for (size_t b = 0; b < N && ok; b += batch_size)
+    {
+      ok = write_batch(b, std::min(b + batch_size, N));
+    }
+  }
+
+  // Close the writer (flushes the footer) then the sink, regardless of write outcome.
+  auto writer_close = writer->Close();
+  if (!writer_close.ok())
+  {
+    OPENMS_LOG_ERROR << "ConsensusMapArrowExport: Failed to close Parquet writer for " << filename << ": "
+                     << writer_close.ToString() << std::endl;
+    ok = false;
+  }
+  auto outfile_close = outfile->Close();
+  if (!outfile_close.ok())
+  {
+    OPENMS_LOG_ERROR << "ConsensusMapArrowExport: Failed to close output stream for " << filename << ": "
+                     << outfile_close.ToString() << std::endl;
+    ok = false;
+  }
+  return ok;
 }
 
 } // namespace OpenMS

--- a/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
@@ -436,14 +436,14 @@ START_SECTION((static bool exportToParquetStreaming(const ConsensusMap& cmap, co
 
   // --- Streaming write with a small batch (multiple row groups: 2500 / 1000) ---
   std::string stream_file; NEW_TMP_FILE(stream_file)
-  TEST_EQUAL(ConsensusMapArrowExport::exportToParquetStreaming(cmap, stream_file, 1000), true)
+  TEST_TRUE(ConsensusMapArrowExport::exportToParquetStreaming(cmap, stream_file, 1000))
   auto st_table = read_combined(stream_file);
   TEST_NOT_EQUAL(st_table, nullptr)
   TEST_EQUAL(st_table->num_rows(), (int64_t)N)
 
   // --- One-shot reference ---
   std::string ref_file; NEW_TMP_FILE(ref_file)
-  TEST_EQUAL(ConsensusMapArrowExport::exportToParquet(cmap, ref_file), true)
+  TEST_TRUE(ConsensusMapArrowExport::exportToParquet(cmap, ref_file))
   auto ref_table = read_combined(ref_file);
   TEST_NOT_EQUAL(ref_table, nullptr)
   TEST_EQUAL(ref_table->num_rows(), st_table->num_rows())
@@ -470,19 +470,19 @@ START_SECTION((static bool exportToParquetStreaming(const ConsensusMap& cmap, co
       if (rt_s->Value(r)      != rt_r->Value(r))      { all_eq = false; break; } // order-sensitive
       if (dec_s->Value(r)     != dec_r->Value(r))     { all_eq = false; break; }
     }
-    TEST_EQUAL(all_eq, true)
+    TEST_TRUE(all_eq)
   }
 
   // --- Full logical equivalence: also covers nested/list columns (modifications,
   // intensities, pg_accessions, gg_*) and lookup-derived columns (pg_global_qvalue).
   // Both tables were CombineChunks()ed and round-tripped through parquet the same way,
   // so schema (incl. nested types) and values must match; ignore schema metadata. ---
-  TEST_EQUAL(st_table->Equals(*ref_table), true)
+  TEST_TRUE(st_table->Equals(*ref_table))
 
   // --- batch_size >= N: single batch, still correct ---
   {
     std::string one_batch; NEW_TMP_FILE(one_batch)
-    TEST_EQUAL(ConsensusMapArrowExport::exportToParquetStreaming(cmap, one_batch, N + 1000), true)
+    TEST_TRUE(ConsensusMapArrowExport::exportToParquetStreaming(cmap, one_batch, N + 1000))
     auto t = read_combined(one_batch);
     TEST_NOT_EQUAL(t, nullptr)
     TEST_EQUAL(t->num_rows(), (int64_t)N)
@@ -491,7 +491,7 @@ START_SECTION((static bool exportToParquetStreaming(const ConsensusMap& cmap, co
   // --- batch_size == 0 guard: treated as default, valid file ---
   {
     std::string zero_batch; NEW_TMP_FILE(zero_batch)
-    TEST_EQUAL(ConsensusMapArrowExport::exportToParquetStreaming(cmap, zero_batch, 0), true)
+    TEST_TRUE(ConsensusMapArrowExport::exportToParquetStreaming(cmap, zero_batch, 0))
     auto t = read_combined(zero_batch);
     TEST_NOT_EQUAL(t, nullptr)
     TEST_EQUAL(t->num_rows(), (int64_t)N)
@@ -501,12 +501,12 @@ START_SECTION((static bool exportToParquetStreaming(const ConsensusMap& cmap, co
   {
     ConsensusMap empty;
     std::string empty_file; NEW_TMP_FILE(empty_file)
-    TEST_EQUAL(ConsensusMapArrowExport::exportToParquetStreaming(empty, empty_file, 1000), true)
-    TEST_EQUAL(File::exists(empty_file), true)
+    TEST_TRUE(ConsensusMapArrowExport::exportToParquetStreaming(empty, empty_file, 1000))
+    TEST_TRUE(File::exists(empty_file))
     auto t = read_combined(empty_file);
     TEST_NOT_EQUAL(t, nullptr)
     TEST_EQUAL(t->num_rows(), 0)
-    TEST_EQUAL(t->num_columns() > 0, true)
+    TEST_TRUE(t->num_columns() > 0)
   }
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
@@ -24,6 +24,8 @@
 
 #include <arrow/api.h>
 #include <arrow/type.h>
+#include <arrow/io/file.h>
+#include <parquet/arrow/reader.h>
 
 using namespace OpenMS;
 using namespace std;
@@ -366,6 +368,146 @@ START_SECTION(exportToParquet - no compression)
   TEST_EQUAL(success, true)
 
   TEST_EQUAL(File::exists(filename), true)
+}
+END_SECTION
+
+START_SECTION((static bool exportToParquetStreaming(const ConsensusMap& cmap, const std::string& filename, size_t batch_size, const ParquetWriteConfig& config)))
+{
+  arrow::MemoryPool* pool = arrow::default_memory_pool();
+
+  // Read a parquet file into a single-chunk (combined) Arrow table. Streaming writes
+  // one row group per batch, so columns come back multi-chunk; combine before row indexing.
+  auto read_combined = [pool](const std::string& path) -> std::shared_ptr<arrow::Table>
+  {
+    auto open_res = arrow::io::ReadableFile::Open(path.c_str());
+    if (!open_res.ok()) { return nullptr; }
+    auto reader_res = parquet::arrow::OpenFile(open_res.ValueOrDie(), pool);
+    if (!reader_res.ok()) { return nullptr; }
+    auto reader = std::move(reader_res).ValueOrDie();
+    std::shared_ptr<arrow::Table> t;
+    if (!reader->ReadTable(&t).ok()) { return nullptr; }
+    auto comb = t->CombineChunks(pool);
+    if (!comb.ok()) { return nullptr; }
+    return comb.ValueOrDie();
+  };
+
+  // Build a ConsensusMap with many features and a UNIQUE rt per feature so the rt
+  // check below is order-sensitive (catches any batch-boundary reordering). Mixes
+  // identified/unidentified, modified/unmodified, target/decoy.
+  ConsensusMap cmap;
+  ConsensusMap::ColumnHeaders headers;
+  ConsensusMap::ColumnHeader ch0; ch0.filename = "sample1.mzML"; headers[0] = ch0;
+  cmap.setColumnHeaders(headers);
+
+  ProteinIdentification prot_id;
+  prot_id.setIdentifier("PI_0");
+  ProteinHit ph; ph.setAccession("PROT_A"); ph.setScore(0.99);
+  prot_id.setHits({ph});
+  ProteinIdentification::ProteinGroup pg; pg.probability = 0.01; pg.accessions = {"PROT_A"};
+  prot_id.insertProteinGroup(pg);
+  cmap.setProteinIdentifications({prot_id});
+
+  const size_t N = 2500;
+  for (size_t i = 0; i < N; ++i)
+  {
+    ConsensusFeature cf;
+    cf.setMZ(400.0 + (i % 500));
+    cf.setRT(100.0 + i);          // unique per row -> order-sensitive
+    cf.setCharge(2 + (i % 3));
+    BaseFeature bf; bf.setIntensity(1000.0f + i); bf.setMZ(cf.getMZ()); bf.setRT(cf.getRT());
+    cf.insert(0, bf);
+    if (i % 4 != 0) // most identified, every 4th left unidentified
+    {
+      PeptideIdentification pid;
+      pid.setRT(cf.getRT()); pid.setMZ(cf.getMZ());
+      pid.setScoreType("Posterior Error Probability"); pid.setHigherScoreBetter(false);
+      PeptideHit hit;
+      hit.setSequence(AASequence::fromString((i % 3 == 0) ? "PEM(Oxidation)TIDER" : "PEPTIDEK"));
+      hit.setCharge(cf.getCharge());
+      hit.setScore(0.01 + (i % 100) * 0.001);
+      hit.setMetaValue("target_decoy", (i % 2 == 0) ? "target" : "decoy");
+      PeptideEvidence ev; ev.setProteinAccession("PROT_A");
+      hit.setPeptideEvidences({ev});
+      pid.setHits({hit});
+      cf.setPeptideIdentifications({pid});
+    }
+    cmap.push_back(cf);
+  }
+
+  // --- Streaming write with a small batch (multiple row groups: 2500 / 1000) ---
+  std::string stream_file; NEW_TMP_FILE(stream_file)
+  TEST_EQUAL(ConsensusMapArrowExport::exportToParquetStreaming(cmap, stream_file, 1000), true)
+  auto st_table = read_combined(stream_file);
+  TEST_NOT_EQUAL(st_table, nullptr)
+  TEST_EQUAL(st_table->num_rows(), (int64_t)N)
+
+  // --- One-shot reference ---
+  std::string ref_file; NEW_TMP_FILE(ref_file)
+  TEST_EQUAL(ConsensusMapArrowExport::exportToParquet(cmap, ref_file), true)
+  auto ref_table = read_combined(ref_file);
+  TEST_NOT_EQUAL(ref_table, nullptr)
+  TEST_EQUAL(ref_table->num_rows(), st_table->num_rows())
+  TEST_EQUAL(st_table->num_columns(), ref_table->num_columns())
+
+  // --- Column-wise, order-sensitive equivalence on representative columns ---
+  {
+    auto seq_s = std::static_pointer_cast<arrow::StringArray>(st_table->GetColumnByName("sequence")->chunk(0));
+    auto seq_r = std::static_pointer_cast<arrow::StringArray>(ref_table->GetColumnByName("sequence")->chunk(0));
+    auto pf_s  = std::static_pointer_cast<arrow::StringArray>(st_table->GetColumnByName("peptidoform")->chunk(0));
+    auto pf_r  = std::static_pointer_cast<arrow::StringArray>(ref_table->GetColumnByName("peptidoform")->chunk(0));
+    auto chg_s = std::static_pointer_cast<arrow::Int16Array>(st_table->GetColumnByName("charge")->chunk(0));
+    auto chg_r = std::static_pointer_cast<arrow::Int16Array>(ref_table->GetColumnByName("charge")->chunk(0));
+    auto rt_s  = std::static_pointer_cast<arrow::FloatArray>(st_table->GetColumnByName("rt")->chunk(0));
+    auto rt_r  = std::static_pointer_cast<arrow::FloatArray>(ref_table->GetColumnByName("rt")->chunk(0));
+    auto dec_s = std::static_pointer_cast<arrow::BooleanArray>(st_table->GetColumnByName("is_decoy")->chunk(0));
+    auto dec_r = std::static_pointer_cast<arrow::BooleanArray>(ref_table->GetColumnByName("is_decoy")->chunk(0));
+    bool all_eq = true;
+    for (int64_t r = 0; r < st_table->num_rows(); ++r)
+    {
+      if (seq_s->GetString(r) != seq_r->GetString(r)) { all_eq = false; break; }
+      if (pf_s->GetString(r)  != pf_r->GetString(r))  { all_eq = false; break; }
+      if (chg_s->Value(r)     != chg_r->Value(r))     { all_eq = false; break; }
+      if (rt_s->Value(r)      != rt_r->Value(r))      { all_eq = false; break; } // order-sensitive
+      if (dec_s->Value(r)     != dec_r->Value(r))     { all_eq = false; break; }
+    }
+    TEST_EQUAL(all_eq, true)
+  }
+
+  // --- Full logical equivalence: also covers nested/list columns (modifications,
+  // intensities, pg_accessions, gg_*) and lookup-derived columns (pg_global_qvalue).
+  // Both tables were CombineChunks()ed and round-tripped through parquet the same way,
+  // so schema (incl. nested types) and values must match; ignore schema metadata. ---
+  TEST_EQUAL(st_table->Equals(*ref_table), true)
+
+  // --- batch_size >= N: single batch, still correct ---
+  {
+    std::string one_batch; NEW_TMP_FILE(one_batch)
+    TEST_EQUAL(ConsensusMapArrowExport::exportToParquetStreaming(cmap, one_batch, N + 1000), true)
+    auto t = read_combined(one_batch);
+    TEST_NOT_EQUAL(t, nullptr)
+    TEST_EQUAL(t->num_rows(), (int64_t)N)
+  }
+
+  // --- batch_size == 0 guard: treated as default, valid file ---
+  {
+    std::string zero_batch; NEW_TMP_FILE(zero_batch)
+    TEST_EQUAL(ConsensusMapArrowExport::exportToParquetStreaming(cmap, zero_batch, 0), true)
+    auto t = read_combined(zero_batch);
+    TEST_NOT_EQUAL(t, nullptr)
+    TEST_EQUAL(t->num_rows(), (int64_t)N)
+  }
+
+  // --- Edge case: empty map -> valid 0-row file with full schema ---
+  {
+    ConsensusMap empty;
+    std::string empty_file; NEW_TMP_FILE(empty_file)
+    TEST_EQUAL(ConsensusMapArrowExport::exportToParquetStreaming(empty, empty_file, 1000), true)
+    TEST_EQUAL(File::exists(empty_file), true)
+    auto t = read_combined(empty_file);
+    TEST_NOT_EQUAL(t, nullptr)
+    TEST_EQUAL(t->num_rows(), 0)
+    TEST_EQUAL(t->num_columns() > 0, true)
+  }
 }
 END_SECTION
 

--- a/src/topp/IsobaricWorkflow.cpp
+++ b/src/topp/IsobaricWorkflow.cpp
@@ -907,8 +907,10 @@ protected:
       {
         OPENMS_LOG_INFO << "Exporting QPX Parquet files to: " << out_qpx << std::endl;
 
-        // Feature-level export
-        if (!ConsensusMapArrowExport::exportToParquet(cmap, out_qpx + "/quantms.feature.parquet"))
+        // Feature-level export: stream in batches so peak memory stays bounded. For isobaric
+        // data there is ~one consensus feature per PSM, so the feature table has millions of
+        // rows; the one-shot path builds it all in memory at once and drives large runs into swap.
+        if (!ConsensusMapArrowExport::exportToParquetStreaming(cmap, out_qpx + "/quantms.feature.parquet"))
         {
           OPENMS_LOG_ERROR << "Failed to write features Parquet file" << std::endl;
           return CANNOT_WRITE_OUTPUT_FILE;


### PR DESCRIPTION
## Motivation

`IsobaricWorkflow` writes three QPX Parquet files in order: `quantms.feature.parquet` (via `ConsensusMapArrowExport`), then `quantms.psm.parquet`, then `quantms.pg.parquet`.

For **isobaric labeling there is ~one consensus feature per PSM**, so the feature table can be **millions of rows**. The old `ConsensusMapArrowExport::exportToArrow` built the *entire* Arrow table in memory before a single write, so on large runs peak memory drove the process into swap/OOM — and because the feature file is written **first**, `quantms.feature.parquet` was never created at all (the run died before any file hit disk).

#9697 already fixed the equivalent problem for the **PSM** export (`QPXFile::exportToParquetStreaming`). This PR ports the **same pattern to the feature export**, serial only.

## What this does

- Refactor the per-row build into an anonymous-namespace range builder `buildFeatureTableRange(cmap, id_lut, [begin, end))`; hoist the per-map protein-group/gene lookups into `buildFeatureIdLookups` and the Parquet writer-property setup into `makeFeatureWriterProperties`. Each feature row is independent (no cross-row state), so any contiguous sub-range yields a self-contained, schema-valid table.
- `exportToArrow()` now delegates over the whole range `[0, size())` — **output unchanged**.
- Add `exportToParquetStreaming(cmap, filename, batch_size, config)`: build and flush one `batch_size`-sized range at a time through a persistent `parquet::arrow::FileWriter`, so **peak memory stays bounded by one batch** instead of the whole ~N-row table.
- `IsobaricWorkflow` uses the streaming path for the feature export.

The written rows and their order are identical to the one-shot path; only the Parquet row-group layout may differ.

## Scope

- **Feature export only.** The `pg` export builds one row per *indistinguishable protein group* (bounded by protein count, not per-PSM), so it is not a memory risk and is intentionally left unchanged.
- **Serial only.** The per-feature build touches `ProForma`/modifications/`MetaInfoRegistry`; an OpenMP parallel build (as in #9697's PSM path) is deliberately out of scope here and can be a follow-up.

## Tests

`ConsensusMapArrowExport_test` extended with a streaming↔one-shot equivalence section: full `Table::Equals` over combined chunks (covers nested/list + lookup-derived columns), made **order-sensitive** via a unique per-feature RT, across multiple batches, the single-batch and `batch_size == 0` cases, and the empty-map edge. All `ConsensusMapArrowExport` class tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HcY3LMYuUDF2psYat9uUYN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streaming Parquet export for consensus map data to support large outputs with bounded peak memory.
  * Updated the isobaric workflow QPX feature-level export to use the new streaming Parquet mode.

* **Bug Fixes**
  * Improved edge-case behavior for streaming exports, including empty maps and batch size handling (including zero and oversized batch sizes).
  * Ensured streaming and non-streaming Parquet exports remain row- and content-consistent on round-trip.

* **Tests**
  * Added Parquet round-trip coverage to validate streaming output across key column sets and scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->