### PR TITLE
Parallelize the streaming QPX feature Parquet export (OpenMP)

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/ConsensusMapArrowExport.h
+++ b/src/openms/include/OpenMS/FORMAT/ConsensusMapArrowExport.h
@@ -75,20 +75,25 @@ public:
     per PSM) N can be in the millions, where the one-shot path's transient peak drives
     the process into swap / OOM; here peak memory stays bounded by one batch.
 
-    The written rows and their order are identical to exportToParquet(); only the
+    Each batch is optionally partitioned and built in parallel with OpenMP and written
+    in index order (the Parquet writer stays serial), so the written rows and their order
+    are identical to exportToParquet() and deterministic for any thread count; only the
     Parquet row-group layout may differ.
 
     @param[in] cmap The ConsensusMap to export
     @param[in] filename Output file path
     @param[in] batch_size Consensus features materialized per batch (0 is treated as the default)
     @param[in] config Parquet writing options
+    @param[in] n_threads OpenMP threads for the per-batch build: 1 = serial (default),
+                         0 = all available cores (honors @c OMP_NUM_THREADS), N = fixed
     @return true on success, false on error
   */
   static bool exportToParquetStreaming(
     const ConsensusMap& cmap,
     const std::string& filename,
     size_t batch_size = 1000000,
-    const ParquetWriteConfig& config = ParquetWriteConfig{});
+    const ParquetWriteConfig& config = ParquetWriteConfig{},
+    int n_threads = 1);
 };
 
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
@@ -12,7 +12,11 @@
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h>
 #include <OpenMS/ANALYSIS/ID/Scores.h>
+#include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CHEMISTRY/ModificationsDB.h>
 #include <OpenMS/CHEMISTRY/ProForma.h>
+#include <OpenMS/CHEMISTRY/ResidueDB.h>
+#include <OpenMS/METADATA/MetaInfoRegistry.h>
 #include <OpenMS/METADATA/SpectrumLookup.h>
 #include <OpenMS/METADATA/SpectrumNativeIDParser.h>
 
@@ -23,11 +27,16 @@
 #include <parquet/properties.h>
 
 #include <algorithm>
+#include <exception>
 #include <limits>
 #include <map>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 
 namespace OpenMS
 {
@@ -46,6 +55,19 @@ namespace // anonymous
     }
     boost::regex scan_regex(regex_str);
     return SpectrumNativeIDParser::extractScanNumber(native_id, scan_regex, true);
+  }
+
+  /// Resolve a MetaInfo index to its registered name, caching results in @p cache.
+  /// MetaInfoRegistry::getName() takes an `omp critical` lock, so caching by index pays
+  /// that lock at most once per unique key for the whole range instead of once per
+  /// metavalue per feature (as getKeys()/getMetaValue() would). Registered names are
+  /// non-empty, so an empty cache slot reliably means "not yet resolved".
+  inline const std::string& cachedMetaName_(UInt index, std::vector<std::string>& cache)
+  {
+    if (index >= cache.size()) { cache.resize(static_cast<size_t>(index) + 1); }
+    std::string& name = cache[index];
+    if (name.empty()) { name = MetaInfoInterface::metaRegistry().getName(index); }
+    return name;
   }
 } // anonymous namespace
 
@@ -336,6 +358,32 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
 
   IDScoreSwitcherAlgorithm idsa;
 
+  // Lazily-filled MetaInfo index->name cache shared across all features in this range
+  // (see cachedMetaName_). Per-call (hence per OpenMP partition) → thread-safe.
+  std::vector<std::string> meta_name_cache;
+
+  // Pre-resolve the fixed dedicated-column metavalue names to registry indices ONCE for this range.
+  // String-keyed exists()/getValue() take the MetaInfoRegistry omp-critical lock via getIndex() on
+  // every call; resolving once and using the index overloads (lock-free flat_map lookups) keeps the
+  // parallel build from serializing on that lock. UInt(-1) = name never registered on any object =>
+  // treated as absent (matches the sentinel check in the string-keyed exists()).
+  auto& mreg = MetaInfoInterface::metaRegistry();
+  const UInt idx_target_decoy       = mreg.getIndex("target_decoy");
+  const UInt idx_predicted_RT       = mreg.getIndex("predicted_RT");
+  const UInt idx_predicted_rt       = mreg.getIndex("predicted_rt");
+  const UInt idx_ion_mobility       = mreg.getIndex("ion_mobility");
+  const UInt idx_IM                 = mreg.getIndex("IM");
+  const UInt idx_spectrum_reference = mreg.getIndex("spectrum_reference");
+  const UInt idx_missed_cleavages   = mreg.getIndex("missed_cleavages");
+  const UInt idx_start_ion_mobility = mreg.getIndex("start_ion_mobility");
+  const UInt idx_stop_ion_mobility  = mreg.getIndex("stop_ion_mobility");
+  const UInt idx_rt_start           = mreg.getIndex("rt_start");
+  const UInt idx_rt_stop            = mreg.getIndex("rt_stop");
+  // Presence check against a pre-resolved index; UInt(-1) is guarded because the index overload of
+  // metaValueExists() does not special-case the sentinel the way the string overload does.
+  auto metaHas = [](const MetaInfoInterface& m, UInt idx) -> bool
+  { return idx != static_cast<UInt>(-1) && m.metaValueExists(idx); };
+
   for (size_t feat_idx = range_begin; feat_idx < range_end; ++feat_idx)
   {
     const auto& cf = cmap[feat_idx];
@@ -484,15 +532,17 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     if (has_id)
     {
       auto result = idsa.findScoreType(pep_ids[0], IDScoreSwitcherAlgorithm::ScoreType::PEP);
+      // Resolve the (dynamic) PEP score name to an index once per feature (lock-free use below).
+      const UInt idx_pep = result.score_name.empty() ? static_cast<UInt>(-1) : mreg.getIndex(result.score_name);
       if (!result.score_name.empty() && best_hit)
       {
         if (result.is_main_score_type)
         {
           (void)pep_builder.Append(best_hit->getScore());
         }
-        else if (best_hit->metaValueExists(result.score_name))
+        else if (metaHas(*best_hit, idx_pep))
         {
-          (void)pep_builder.Append(static_cast<double>(best_hit->getMetaValue(result.score_name)));
+          (void)pep_builder.Append(static_cast<double>(best_hit->getMetaValue(idx_pep)));
         }
         else
         {
@@ -510,9 +560,9 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     }
 
     // === is_decoy ===
-    if (best_hit && best_hit->metaValueExists("target_decoy"))
+    if (best_hit && metaHas(*best_hit, idx_target_decoy))
     {
-      std::string td = best_hit->getMetaValue("target_decoy").toString();
+      std::string td = best_hit->getMetaValue(idx_target_decoy).toString();
       (void)is_decoy_builder.Append(StringUtils::substr(td, 0, 5) == "decoy");
     }
     else
@@ -524,13 +574,16 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     (void)additional_scores_builder.Append();
     if (best_hit)
     {
-      std::vector<std::string> keys;
-      best_hit->getKeys(keys);
-      for (const auto& key : keys)
+      // Single index-based pass over the hit's metavalues (avoids getKeys()/getMetaValue(string),
+      // which take the MetaInfoRegistry lock per key); names resolved via the shared cache. Same
+      // iteration order (by index) and same filtering as the previous getKeys() loop.
+      for (auto mv_it = best_hit->metaBegin(); mv_it != best_hit->metaEnd(); ++mv_it)
       {
+        const std::string& key = cachedMetaName_(mv_it->first, meta_name_cache);
         if (excluded_hit_mvs.contains(key)) continue;
-        const DataValue& val = best_hit->getMetaValue(key);
-        if ((val.valueType() == DataValue::INT_VALUE || val.valueType() == DataValue::DOUBLE_VALUE)
+        const DataValue& val = mv_it->second;
+        const auto vt = val.valueType();
+        if ((vt == DataValue::INT_VALUE || vt == DataValue::DOUBLE_VALUE)
             && Scores::isKnownScoreType(key))
         {
           (void)as_struct_b->Append();
@@ -550,13 +603,13 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     }
 
     // === predicted_rt ===
-    if (best_hit && best_hit->metaValueExists("predicted_RT"))
+    if (best_hit && metaHas(*best_hit, idx_predicted_RT))
     {
-      (void)predicted_rt_builder.Append(static_cast<float>(static_cast<double>(best_hit->getMetaValue("predicted_RT"))));
+      (void)predicted_rt_builder.Append(static_cast<float>(static_cast<double>(best_hit->getMetaValue(idx_predicted_RT))));
     }
-    else if (best_hit && best_hit->metaValueExists("predicted_rt"))
+    else if (best_hit && metaHas(*best_hit, idx_predicted_rt))
     {
-      (void)predicted_rt_builder.Append(static_cast<float>(static_cast<double>(best_hit->getMetaValue("predicted_rt"))));
+      (void)predicted_rt_builder.Append(static_cast<float>(static_cast<double>(best_hit->getMetaValue(idx_predicted_rt))));
     }
     else
     {
@@ -590,9 +643,9 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
       {
         // Prefer the dedicated member, fall back to metavalue
         spec_ref = pep_ids[0].getSpectrumReference();
-        if (spec_ref.empty() && pep_ids[0].metaValueExists("spectrum_reference"))
+        if (spec_ref.empty() && metaHas(pep_ids[0], idx_spectrum_reference))
         {
-          spec_ref = pep_ids[0].getMetaValue("spectrum_reference").toString();
+          spec_ref = pep_ids[0].getMetaValue(idx_spectrum_reference).toString();
         }
       }
 
@@ -611,31 +664,31 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     (void)cv_params_builder.AppendNull();
 
     // === ion_mobility, start/stop ===
-    if (!pep_ids.empty() && pep_ids[0].metaValueExists("ion_mobility"))
+    if (!pep_ids.empty() && metaHas(pep_ids[0], idx_ion_mobility))
     {
-      (void)ion_mobility_builder.Append(static_cast<float>(static_cast<double>(pep_ids[0].getMetaValue("ion_mobility"))));
+      (void)ion_mobility_builder.Append(static_cast<float>(static_cast<double>(pep_ids[0].getMetaValue(idx_ion_mobility))));
     }
-    else if (!pep_ids.empty() && pep_ids[0].metaValueExists("IM"))
+    else if (!pep_ids.empty() && metaHas(pep_ids[0], idx_IM))
     {
-      (void)ion_mobility_builder.Append(static_cast<float>(static_cast<double>(pep_ids[0].getMetaValue("IM"))));
+      (void)ion_mobility_builder.Append(static_cast<float>(static_cast<double>(pep_ids[0].getMetaValue(idx_IM))));
     }
     else
     {
       (void)ion_mobility_builder.AppendNull();
     }
 
-    if (cf.metaValueExists("start_ion_mobility"))
+    if (metaHas(cf, idx_start_ion_mobility))
     {
-      (void)im_start_builder.Append(static_cast<float>(static_cast<double>(cf.getMetaValue("start_ion_mobility"))));
+      (void)im_start_builder.Append(static_cast<float>(static_cast<double>(cf.getMetaValue(idx_start_ion_mobility))));
     }
     else
     {
       (void)im_start_builder.AppendNull();
     }
 
-    if (cf.metaValueExists("stop_ion_mobility"))
+    if (metaHas(cf, idx_stop_ion_mobility))
     {
-      (void)im_stop_builder.Append(static_cast<float>(static_cast<double>(cf.getMetaValue("stop_ion_mobility"))));
+      (void)im_stop_builder.Append(static_cast<float>(static_cast<double>(cf.getMetaValue(idx_stop_ion_mobility))));
     }
     else
     {
@@ -643,9 +696,9 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     }
 
     // === missed_cleavages ===
-    if (best_hit && best_hit->metaValueExists("missed_cleavages"))
+    if (best_hit && metaHas(*best_hit, idx_missed_cleavages))
     {
-      (void)missed_cleavages_builder.Append(static_cast<int16_t>(static_cast<int>(best_hit->getMetaValue("missed_cleavages"))));
+      (void)missed_cleavages_builder.Append(static_cast<int16_t>(static_cast<int>(best_hit->getMetaValue(idx_missed_cleavages))));
     }
     else
     {
@@ -796,9 +849,9 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     }
 
     // === rt_start / rt_stop ===
-    if (cf.metaValueExists("rt_start"))
+    if (metaHas(cf, idx_rt_start))
     {
-      (void)rt_start_builder.Append(static_cast<float>(static_cast<double>(cf.getMetaValue("rt_start"))));
+      (void)rt_start_builder.Append(static_cast<float>(static_cast<double>(cf.getMetaValue(idx_rt_start))));
     }
     else if (cf.getWidth() > 0)
     {
@@ -809,9 +862,9 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
       (void)rt_start_builder.AppendNull();
     }
 
-    if (cf.metaValueExists("rt_stop"))
+    if (metaHas(cf, idx_rt_stop))
     {
-      (void)rt_stop_builder.Append(static_cast<float>(static_cast<double>(cf.getMetaValue("rt_stop"))));
+      (void)rt_stop_builder.Append(static_cast<float>(static_cast<double>(cf.getMetaValue(idx_rt_stop))));
     }
     else if (cf.getWidth() > 0)
     {
@@ -970,12 +1023,30 @@ bool ConsensusMapArrowExport::exportToParquetStreaming(
   const ConsensusMap& cmap,
   const std::string& filename,
   size_t batch_size,
-  const ParquetWriteConfig& config)
+  const ParquetWriteConfig& config,
+  int n_threads)
 {
   if (batch_size == 0) { batch_size = 1000000; } // guard: a zero step would never advance
 
+  // Resolve the number of OpenMP threads used to build each batch's partitions.
+  // 1 = serial (default), 0 = all cores, N = fixed. Without OpenMP, always serial.
+  int threads = n_threads;
+#ifdef _OPENMP
+  if (threads <= 0) { threads = omp_get_max_threads(); }
+#endif
+  if (threads < 1) { threads = 1; }
+
   // Prebuild the per-map protein-group/gene lookups once; reused for every batch.
   const auto id_lut = buildFeatureIdLookups(cmap);
+
+  // Pre-warm lazily-initialized singletons/statics touched by the per-feature build, so first-touch
+  // cannot race across the OpenMP workers below. Runs once, serially. (ProForma and the
+  // SpectrumNativeIDParser scan path resolve through ModificationsDB/ResidueDB/AASequence, which are
+  // warmed here — the same set the PSM streaming path pre-warms.)
+  ModificationsDB::getInstance();
+  ResidueDB::getInstance();
+  (void)Scores::isKnownScoreType("q-value");
+  (void)AASequence::fromString("PEPTIDEK").getMZ(2); // inits AASequence static residue path
 
   // The writer's schema must match each batch table's schema exactly. buildFeatureTableRange()
   // stamps QPXFeatureSchema::schema() on every batch, so open the writer with the same schema.
@@ -1005,22 +1076,61 @@ bool ConsensusMapArrowExport::exportToParquetStreaming(
 
   const int64_t rg = static_cast<int64_t>(config.row_group_size);
 
-  // Build one feature range [b, e) into a self-contained table and flush it. Peak memory stays
-  // bounded by one batch (one batch's rows) instead of the whole map's ~N-row table at once.
+  // Build one feature batch [b, e): partition it into W contiguous sub-ranges, build each sub-table
+  // in parallel (OpenMP), then write them in index order (serial — the FileWriter is not thread-safe).
+  // Peak memory stays batch-bounded (the W sub-tables together hold one batch's rows). Row content and
+  // order are identical to the serial path (contiguous, in-order), so output is deterministic for any
+  // thread count.
   auto write_batch = [&](size_t b, size_t e) -> bool
   {
-    auto batch = buildFeatureTableRange(cmap, id_lut, b, e);
-    if (!batch)
+    const size_t rows = e - b;
+    const int W = static_cast<int>(std::min<size_t>(static_cast<size_t>(threads), std::max<size_t>(rows, 1)));
+    std::vector<std::shared_ptr<arrow::Table>> parts(W);
+    std::vector<std::exception_ptr> errs(W);
+
+    #pragma omp parallel for num_threads(W) schedule(static)
+    for (int t = 0; t < W; ++t)
     {
-      OPENMS_LOG_ERROR << "ConsensusMapArrowExport: Failed to build feature batch [" << b << ", " << e << ")" << std::endl;
-      return false;
+      try
+      {
+        const size_t base = rows / W, rem = rows % W;
+        const size_t sb = b + t * base + std::min<size_t>(static_cast<size_t>(t), rem);
+        const size_t se = sb + base + (static_cast<size_t>(t) < rem ? 1 : 0);
+        parts[t] = buildFeatureTableRange(cmap, id_lut, sb, se);
+      }
+      catch (...)
+      {
+        errs[t] = std::current_exception(); // never let an exception escape the OpenMP region
+      }
     }
-    auto st = writer->WriteTable(*batch, rg);
-    if (!st.ok())
+
+    // Surface any worker exception as a logged failure (convert to the bool error contract).
+    for (int t = 0; t < W; ++t)
     {
-      OPENMS_LOG_ERROR << "ConsensusMapArrowExport: Failed to write feature batch to " << filename << ": "
-                       << st.ToString() << std::endl;
-      return false;
+      if (errs[t])
+      {
+        try { std::rethrow_exception(errs[t]); }
+        catch (const std::exception& ex) { OPENMS_LOG_ERROR << "ConsensusMapArrowExport: feature batch build threw: " << ex.what() << std::endl; }
+        catch (...)                      { OPENMS_LOG_ERROR << "ConsensusMapArrowExport: feature batch build threw (unknown exception)" << std::endl; }
+        return false;
+      }
+    }
+
+    // Write partitions in index order (serial — the FileWriter is not thread-safe).
+    for (int t = 0; t < W; ++t)
+    {
+      if (!parts[t])
+      {
+        OPENMS_LOG_ERROR << "ConsensusMapArrowExport: Failed to build feature batch partition " << t << std::endl;
+        return false;
+      }
+      auto st = writer->WriteTable(*parts[t], rg);
+      if (!st.ok())
+      {
+        OPENMS_LOG_ERROR << "ConsensusMapArrowExport: Failed to write feature batch to " << filename << ": "
+                         << st.ToString() << std::endl;
+        return false;
+      }
     }
     return true;
   };

--- a/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
@@ -190,7 +190,7 @@ START_SECTION(exportToArrow - empty consensus map)
   TEST_NOT_EQUAL(table, nullptr)
   TEST_EQUAL(table->num_rows(), 0)
   // Schema should still be present
-  TEST_EQUAL(table->num_columns() > 0, true)
+  TEST_TRUE(table->num_columns() > 0)
 }
 END_SECTION
 
@@ -205,13 +205,13 @@ START_SECTION(exportToArrow - basic export)
 
   // Check schema has expected columns
   auto schema = table->schema();
-  TEST_EQUAL(schema->GetFieldIndex("sequence") >= 0, true)
-  TEST_EQUAL(schema->GetFieldIndex("peptidoform") >= 0, true)
-  TEST_EQUAL(schema->GetFieldIndex("observed_mz") >= 0, true)
-  TEST_EQUAL(schema->GetFieldIndex("rt") >= 0, true)
-  TEST_EQUAL(schema->GetFieldIndex("charge") >= 0, true)
-  TEST_EQUAL(schema->GetFieldIndex("intensities") >= 0, true)
-  TEST_EQUAL(schema->GetFieldIndex("pg_accessions") >= 0, true)
+  TEST_TRUE(schema->GetFieldIndex("sequence") >= 0)
+  TEST_TRUE(schema->GetFieldIndex("peptidoform") >= 0)
+  TEST_TRUE(schema->GetFieldIndex("observed_mz") >= 0)
+  TEST_TRUE(schema->GetFieldIndex("rt") >= 0)
+  TEST_TRUE(schema->GetFieldIndex("charge") >= 0)
+  TEST_TRUE(schema->GetFieldIndex("intensities") >= 0)
+  TEST_TRUE(schema->GetFieldIndex("pg_accessions") >= 0)
 }
 END_SECTION
 
@@ -290,11 +290,11 @@ START_SECTION(exportToParquet - basic export)
   filename += ".parquet";
 
   bool success = ConsensusMapArrowExport::exportToParquet(cmap, filename);
-  TEST_EQUAL(success, true)
+  TEST_TRUE(success)
 
   // Verify file was created
-  TEST_EQUAL(File::exists(filename), true)
-  TEST_EQUAL(File::empty(filename), false)
+  TEST_TRUE(File::exists(filename))
+  TEST_FALSE(File::empty(filename))
 }
 END_SECTION
 
@@ -307,10 +307,10 @@ START_SECTION(exportToParquet - empty consensus map)
   filename += ".parquet";
 
   bool success = ConsensusMapArrowExport::exportToParquet(cmap, filename);
-  TEST_EQUAL(success, true)
+  TEST_TRUE(success)
 
   // Verify file was created (even for empty data)
-  TEST_EQUAL(File::exists(filename), true)
+  TEST_TRUE(File::exists(filename))
 }
 END_SECTION
 
@@ -327,10 +327,10 @@ START_SECTION(exportToParquet - with compression options)
   pq_config.compression = ParquetWriteConfig::Compression::SNAPPY;
 
   bool success = ConsensusMapArrowExport::exportToParquet(cmap, filename, pq_config);
-  TEST_EQUAL(success, true)
+  TEST_TRUE(success)
 
   // Verify file was created
-  TEST_EQUAL(File::exists(filename), true)
+  TEST_TRUE(File::exists(filename))
 }
 END_SECTION
 
@@ -347,9 +347,9 @@ START_SECTION(exportToParquet - ZSTD compression)
   pq_config.compression_level = 9;
 
   bool success = ConsensusMapArrowExport::exportToParquet(cmap, filename, pq_config);
-  TEST_EQUAL(success, true)
+  TEST_TRUE(success)
 
-  TEST_EQUAL(File::exists(filename), true)
+  TEST_TRUE(File::exists(filename))
 }
 END_SECTION
 
@@ -365,9 +365,9 @@ START_SECTION(exportToParquet - no compression)
   pq_config.compression = ParquetWriteConfig::Compression::NONE;
 
   bool success = ConsensusMapArrowExport::exportToParquet(cmap, filename, pq_config);
-  TEST_EQUAL(success, true)
+  TEST_TRUE(success)
 
-  TEST_EQUAL(File::exists(filename), true)
+  TEST_TRUE(File::exists(filename))
 }
 END_SECTION
 
@@ -447,7 +447,7 @@ START_SECTION((static bool exportToParquetStreaming(const ConsensusMap& cmap, co
   for (int nt : {0, 1, 2, 8})
   {
     std::string stream_file; NEW_TMP_FILE(stream_file)
-    TEST_EQUAL(ConsensusMapArrowExport::exportToParquetStreaming(cmap, stream_file, 1000, ParquetWriteConfig{}, nt), true)
+    TEST_TRUE(ConsensusMapArrowExport::exportToParquetStreaming(cmap, stream_file, 1000, ParquetWriteConfig{}, nt))
     auto st_table = read_combined(stream_file);
     TEST_NOT_EQUAL(st_table, nullptr)
     TEST_EQUAL(st_table->num_rows(), (int64_t)N)
@@ -467,23 +467,23 @@ START_SECTION((static bool exportToParquetStreaming(const ConsensusMap& cmap, co
       if (rt_s->Value(r)      != rt_r->Value(r))      { all_eq = false; break; } // order-sensitive
       if (dec_s->Value(r)     != dec_r->Value(r))     { all_eq = false; break; }
     }
-    TEST_EQUAL(all_eq, true)
+    TEST_TRUE(all_eq)
 
     // Full logical equivalence: also covers nested/list columns (modifications, intensities,
     // pg_accessions, gg_*) and lookup-derived columns (pg_global_qvalue). Both tables were
     // CombineChunks()ed and round-tripped through parquet the same way, so schema (incl. nested
     // types) and values must match; ignore schema metadata.
-    TEST_EQUAL(st_table->Equals(*ref_table), true)
+    TEST_TRUE(st_table->Equals(*ref_table))
   }
 
   // --- batch_size >= N: single batch built across all threads, still correct ---
   {
     std::string one_batch; NEW_TMP_FILE(one_batch)
-    TEST_EQUAL(ConsensusMapArrowExport::exportToParquetStreaming(cmap, one_batch, N + 1000, ParquetWriteConfig{}, 8), true)
+    TEST_TRUE(ConsensusMapArrowExport::exportToParquetStreaming(cmap, one_batch, N + 1000, ParquetWriteConfig{}, 8))
     auto t = read_combined(one_batch);
     TEST_NOT_EQUAL(t, nullptr)
     TEST_EQUAL(t->num_rows(), (int64_t)N)
-    TEST_EQUAL(t->Equals(*ref_table), true)
+    TEST_TRUE(t->Equals(*ref_table))
   }
 
   // --- batch_size == 0 guard: treated as default, valid file ---
@@ -586,31 +586,31 @@ START_SECTION([EXTRA] exportToArrow - dedicated metavalue columns resolve to cor
   auto pgq      = std::static_pointer_cast<arrow::DoubleArray>(table->GetColumnByName("pg_global_qvalue")->chunk(0));
   auto as_col   = std::static_pointer_cast<arrow::ListArray>(table->GetColumnByName("additional_scores")->chunk(0));
 
-  TEST_EQUAL(is_decoy->Value(0), true)
-  TEST_EQUAL(pep->IsNull(0), false)
+  TEST_TRUE(is_decoy->Value(0))
+  TEST_FALSE(pep->IsNull(0))
   TEST_REAL_SIMILAR(pep->Value(0), 0.02)
-  TEST_EQUAL(mc->IsNull(0), false)
+  TEST_FALSE(mc->IsNull(0))
   TEST_EQUAL(mc->Value(0), 1)
-  TEST_EQUAL(pgq->IsNull(0), false)
+  TEST_FALSE(pgq->IsNull(0))
   TEST_REAL_SIMILAR(pgq->Value(0), 0.02)
 
-  TEST_EQUAL(f32("predicted_rt")->IsNull(0), false)
+  TEST_FALSE(f32("predicted_rt")->IsNull(0))
   TEST_REAL_SIMILAR(f32("predicted_rt")->Value(0), 319.0)
-  TEST_EQUAL(f32("ion_mobility")->IsNull(0), false)
+  TEST_FALSE(f32("ion_mobility")->IsNull(0))
   TEST_REAL_SIMILAR(f32("ion_mobility")->Value(0), 0.85)
-  TEST_EQUAL(f32("ion_mobility_start")->IsNull(0), false)
+  TEST_FALSE(f32("ion_mobility_start")->IsNull(0))
   TEST_REAL_SIMILAR(f32("ion_mobility_start")->Value(0), 0.80)
-  TEST_EQUAL(f32("ion_mobility_stop")->IsNull(0), false)
+  TEST_FALSE(f32("ion_mobility_stop")->IsNull(0))
   TEST_REAL_SIMILAR(f32("ion_mobility_stop")->Value(0), 0.90)
-  TEST_EQUAL(f32("rt_start")->IsNull(0), false)
+  TEST_FALSE(f32("rt_start")->IsNull(0))
   TEST_REAL_SIMILAR(f32("rt_start")->Value(0), 300.0)
-  TEST_EQUAL(f32("rt_stop")->IsNull(0), false)
+  TEST_FALSE(f32("rt_stop")->IsNull(0))
   TEST_REAL_SIMILAR(f32("rt_stop")->Value(0), 340.0)
 
   // Row 1: fallback precedence (predicted_rt lowercase, IM) must resolve to the right column/value.
-  TEST_EQUAL(f32("predicted_rt")->IsNull(1), false)
+  TEST_FALSE(f32("predicted_rt")->IsNull(1))
   TEST_REAL_SIMILAR(f32("predicted_rt")->Value(1), 405.0)
-  TEST_EQUAL(f32("ion_mobility")->IsNull(1), false)
+  TEST_FALSE(f32("ion_mobility")->IsNull(1))
   TEST_REAL_SIMILAR(f32("ion_mobility")->Value(1), 1.10)
 
   // additional_scores: only the known "q-value" is emitted via the index-based metaBegin pass; the
@@ -625,8 +625,8 @@ START_SECTION([EXTRA] exportToArrow - dedicated metavalue columns resolve to cor
     const int64_t off = as_col->value_offset(0);
     TEST_EQUAL(sname->GetString(off), "q-value")
     TEST_REAL_SIMILAR(sval->Value(off), 0.05)
-    TEST_EQUAL(shb->IsNull(off), false)
-    TEST_EQUAL(shb->Value(off), false)
+    TEST_FALSE(shb->IsNull(off))
+    TEST_FALSE(shb->Value(off))
   }
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
@@ -434,29 +434,28 @@ START_SECTION((static bool exportToParquetStreaming(const ConsensusMap& cmap, co
     cmap.push_back(cf);
   }
 
-  // --- Streaming write with a small batch (multiple row groups: 2500 / 1000) ---
-  std::string stream_file; NEW_TMP_FILE(stream_file)
-  TEST_TRUE(ConsensusMapArrowExport::exportToParquetStreaming(cmap, stream_file, 1000))
-  auto st_table = read_combined(stream_file);
-  TEST_NOT_EQUAL(st_table, nullptr)
-  TEST_EQUAL(st_table->num_rows(), (int64_t)N)
-
   // --- One-shot reference ---
   std::string ref_file; NEW_TMP_FILE(ref_file)
   TEST_TRUE(ConsensusMapArrowExport::exportToParquet(cmap, ref_file))
   auto ref_table = read_combined(ref_file);
   TEST_NOT_EQUAL(ref_table, nullptr)
-  TEST_EQUAL(ref_table->num_rows(), st_table->num_rows())
-  TEST_EQUAL(st_table->num_columns(), ref_table->num_columns())
+  TEST_EQUAL(ref_table->num_rows(), (int64_t)N)
 
-  // --- Column-wise, order-sensitive equivalence on representative columns ---
+  // --- Streaming must equal the one-shot output for ANY thread count (deterministic build).
+  //     Small batch (1000) forces multiple row groups; n_threads exercises serial (1), fixed
+  //     parallel (2, 8), and the production auto path (0 = omp_get_max_threads, used by IsobaricWorkflow). ---
+  for (int nt : {0, 1, 2, 8})
   {
+    std::string stream_file; NEW_TMP_FILE(stream_file)
+    TEST_EQUAL(ConsensusMapArrowExport::exportToParquetStreaming(cmap, stream_file, 1000, ParquetWriteConfig{}, nt), true)
+    auto st_table = read_combined(stream_file);
+    TEST_NOT_EQUAL(st_table, nullptr)
+    TEST_EQUAL(st_table->num_rows(), (int64_t)N)
+    TEST_EQUAL(st_table->num_columns(), ref_table->num_columns())
+
+    // Order-sensitive scalar check (unique rt) — catches any partition reordering under threads.
     auto seq_s = std::static_pointer_cast<arrow::StringArray>(st_table->GetColumnByName("sequence")->chunk(0));
     auto seq_r = std::static_pointer_cast<arrow::StringArray>(ref_table->GetColumnByName("sequence")->chunk(0));
-    auto pf_s  = std::static_pointer_cast<arrow::StringArray>(st_table->GetColumnByName("peptidoform")->chunk(0));
-    auto pf_r  = std::static_pointer_cast<arrow::StringArray>(ref_table->GetColumnByName("peptidoform")->chunk(0));
-    auto chg_s = std::static_pointer_cast<arrow::Int16Array>(st_table->GetColumnByName("charge")->chunk(0));
-    auto chg_r = std::static_pointer_cast<arrow::Int16Array>(ref_table->GetColumnByName("charge")->chunk(0));
     auto rt_s  = std::static_pointer_cast<arrow::FloatArray>(st_table->GetColumnByName("rt")->chunk(0));
     auto rt_r  = std::static_pointer_cast<arrow::FloatArray>(ref_table->GetColumnByName("rt")->chunk(0));
     auto dec_s = std::static_pointer_cast<arrow::BooleanArray>(st_table->GetColumnByName("is_decoy")->chunk(0));
@@ -465,27 +464,26 @@ START_SECTION((static bool exportToParquetStreaming(const ConsensusMap& cmap, co
     for (int64_t r = 0; r < st_table->num_rows(); ++r)
     {
       if (seq_s->GetString(r) != seq_r->GetString(r)) { all_eq = false; break; }
-      if (pf_s->GetString(r)  != pf_r->GetString(r))  { all_eq = false; break; }
-      if (chg_s->Value(r)     != chg_r->Value(r))     { all_eq = false; break; }
       if (rt_s->Value(r)      != rt_r->Value(r))      { all_eq = false; break; } // order-sensitive
       if (dec_s->Value(r)     != dec_r->Value(r))     { all_eq = false; break; }
     }
-    TEST_TRUE(all_eq)
+    TEST_EQUAL(all_eq, true)
+
+    // Full logical equivalence: also covers nested/list columns (modifications, intensities,
+    // pg_accessions, gg_*) and lookup-derived columns (pg_global_qvalue). Both tables were
+    // CombineChunks()ed and round-tripped through parquet the same way, so schema (incl. nested
+    // types) and values must match; ignore schema metadata.
+    TEST_EQUAL(st_table->Equals(*ref_table), true)
   }
 
-  // --- Full logical equivalence: also covers nested/list columns (modifications,
-  // intensities, pg_accessions, gg_*) and lookup-derived columns (pg_global_qvalue).
-  // Both tables were CombineChunks()ed and round-tripped through parquet the same way,
-  // so schema (incl. nested types) and values must match; ignore schema metadata. ---
-  TEST_TRUE(st_table->Equals(*ref_table))
-
-  // --- batch_size >= N: single batch, still correct ---
+  // --- batch_size >= N: single batch built across all threads, still correct ---
   {
     std::string one_batch; NEW_TMP_FILE(one_batch)
-    TEST_TRUE(ConsensusMapArrowExport::exportToParquetStreaming(cmap, one_batch, N + 1000))
+    TEST_EQUAL(ConsensusMapArrowExport::exportToParquetStreaming(cmap, one_batch, N + 1000, ParquetWriteConfig{}, 8), true)
     auto t = read_combined(one_batch);
     TEST_NOT_EQUAL(t, nullptr)
     TEST_EQUAL(t->num_rows(), (int64_t)N)
+    TEST_EQUAL(t->Equals(*ref_table), true)
   }
 
   // --- batch_size == 0 guard: treated as default, valid file ---
@@ -507,6 +505,128 @@ START_SECTION((static bool exportToParquetStreaming(const ConsensusMap& cmap, co
     TEST_NOT_EQUAL(t, nullptr)
     TEST_EQUAL(t->num_rows(), 0)
     TEST_TRUE(t->num_columns() > 0)
+  }
+}
+END_SECTION
+
+START_SECTION([EXTRA] exportToArrow - dedicated metavalue columns resolve to correct values)
+{
+  // Guards the index-based (lock-free) metavalue reads in buildFeatureTableRange: one identified
+  // feature with every dedicated metavalue set to a known value; assert each exported column. The
+  // streaming<->one-shot equivalence test cannot catch an index-name typo here, since both paths
+  // now share buildFeatureTableRange.
+  ConsensusMap cmap;
+  ConsensusMap::ColumnHeaders headers;
+  ConsensusMap::ColumnHeader ch0; ch0.filename = "run.mzML"; headers[0] = ch0;
+  cmap.setColumnHeaders(headers);
+
+  ProteinIdentification prot_id; prot_id.setIdentifier("PI_0");
+  ProteinHit ph; ph.setAccession("PROT_A"); ph.setScore(0.9);
+  prot_id.setHits({ph});
+  ProteinIdentification::ProteinGroup pgrp; pgrp.probability = 0.02; pgrp.accessions = {"PROT_A"};
+  prot_id.insertProteinGroup(pgrp);
+  cmap.setProteinIdentifications({prot_id});
+
+  ConsensusFeature cf;
+  cf.setMZ(555.5); cf.setRT(321.0); cf.setCharge(2);
+  cf.setMetaValue("start_ion_mobility", 0.80);
+  cf.setMetaValue("stop_ion_mobility", 0.90);
+  cf.setMetaValue("rt_start", 300.0);
+  cf.setMetaValue("rt_stop", 340.0);
+  BaseFeature bf; bf.setIntensity(10.0f); bf.setMZ(555.5); bf.setRT(321.0);
+  cf.insert(0, bf);
+
+  PeptideIdentification pid;
+  pid.setScoreType("Posterior Error Probability"); pid.setHigherScoreBetter(false);
+  pid.setMetaValue("ion_mobility", 0.85);
+  PeptideHit hit;
+  hit.setSequence(AASequence::fromString("PEPTIDEK"));
+  hit.setCharge(2);
+  hit.setScore(0.02);                       // main score -> posterior_error_probability
+  hit.setMetaValue("target_decoy", "decoy");
+  hit.setMetaValue("predicted_RT", 319.0);
+  hit.setMetaValue("missed_cleavages", 1);
+  hit.setMetaValue("q-value", 0.05);        // known score (QVAL, lower-better) -> additional_scores
+  hit.setMetaValue("zzz_custom_flag", 7);   // int, but NOT a known score -> filtered out
+  hit.setMetaValue("zzz_custom_note", "x"); // string -> filtered out (not INT/DOUBLE)
+  PeptideEvidence ev; ev.setProteinAccession("PROT_A");
+  hit.setPeptideEvidences({ev});
+  pid.setHits({hit});
+  cf.setPeptideIdentifications({pid});
+  cmap.push_back(cf);
+
+  // Second feature exercises the FALLBACK precedence branches: predicted_rt (lowercase, only reached
+  // when predicted_RT is absent) and IM (only reached when ion_mobility is absent). A predicted_RT<->
+  // predicted_rt or ion_mobility<->IM index-name swap would still pass row 0 but fails here.
+  ConsensusFeature cf2;
+  cf2.setMZ(600.0); cf2.setRT(400.0); cf2.setCharge(2);
+  BaseFeature bf2; bf2.setIntensity(5.0f); bf2.setMZ(600.0); bf2.setRT(400.0);
+  cf2.insert(0, bf2);
+  PeptideIdentification pid2;
+  pid2.setScoreType("Posterior Error Probability"); pid2.setHigherScoreBetter(false);
+  pid2.setMetaValue("IM", 1.10);            // fallback path (no "ion_mobility")
+  PeptideHit hit2;
+  hit2.setSequence(AASequence::fromString("PEPTIDEK"));
+  hit2.setCharge(2); hit2.setScore(0.03);
+  hit2.setMetaValue("predicted_rt", 405.0); // fallback path (lowercase, no "predicted_RT")
+  PeptideEvidence ev2; ev2.setProteinAccession("PROT_A");
+  hit2.setPeptideEvidences({ev2});
+  pid2.setHits({hit2});
+  cf2.setPeptideIdentifications({pid2});
+  cmap.push_back(cf2);
+
+  auto table = ConsensusMapArrowExport::exportToArrow(cmap);
+  TEST_NOT_EQUAL(table, nullptr)
+  TEST_EQUAL(table->num_rows(), 2)
+
+  auto f32 = [&](const char* n){ return std::static_pointer_cast<arrow::FloatArray>(table->GetColumnByName(n)->chunk(0)); };
+  auto is_decoy = std::static_pointer_cast<arrow::BooleanArray>(table->GetColumnByName("is_decoy")->chunk(0));
+  auto pep      = std::static_pointer_cast<arrow::DoubleArray>(table->GetColumnByName("posterior_error_probability")->chunk(0));
+  auto mc       = std::static_pointer_cast<arrow::Int16Array>(table->GetColumnByName("missed_cleavages")->chunk(0));
+  auto pgq      = std::static_pointer_cast<arrow::DoubleArray>(table->GetColumnByName("pg_global_qvalue")->chunk(0));
+  auto as_col   = std::static_pointer_cast<arrow::ListArray>(table->GetColumnByName("additional_scores")->chunk(0));
+
+  TEST_EQUAL(is_decoy->Value(0), true)
+  TEST_EQUAL(pep->IsNull(0), false)
+  TEST_REAL_SIMILAR(pep->Value(0), 0.02)
+  TEST_EQUAL(mc->IsNull(0), false)
+  TEST_EQUAL(mc->Value(0), 1)
+  TEST_EQUAL(pgq->IsNull(0), false)
+  TEST_REAL_SIMILAR(pgq->Value(0), 0.02)
+
+  TEST_EQUAL(f32("predicted_rt")->IsNull(0), false)
+  TEST_REAL_SIMILAR(f32("predicted_rt")->Value(0), 319.0)
+  TEST_EQUAL(f32("ion_mobility")->IsNull(0), false)
+  TEST_REAL_SIMILAR(f32("ion_mobility")->Value(0), 0.85)
+  TEST_EQUAL(f32("ion_mobility_start")->IsNull(0), false)
+  TEST_REAL_SIMILAR(f32("ion_mobility_start")->Value(0), 0.80)
+  TEST_EQUAL(f32("ion_mobility_stop")->IsNull(0), false)
+  TEST_REAL_SIMILAR(f32("ion_mobility_stop")->Value(0), 0.90)
+  TEST_EQUAL(f32("rt_start")->IsNull(0), false)
+  TEST_REAL_SIMILAR(f32("rt_start")->Value(0), 300.0)
+  TEST_EQUAL(f32("rt_stop")->IsNull(0), false)
+  TEST_REAL_SIMILAR(f32("rt_stop")->Value(0), 340.0)
+
+  // Row 1: fallback precedence (predicted_rt lowercase, IM) must resolve to the right column/value.
+  TEST_EQUAL(f32("predicted_rt")->IsNull(1), false)
+  TEST_REAL_SIMILAR(f32("predicted_rt")->Value(1), 405.0)
+  TEST_EQUAL(f32("ion_mobility")->IsNull(1), false)
+  TEST_REAL_SIMILAR(f32("ion_mobility")->Value(1), 1.10)
+
+  // additional_scores: only the known "q-value" is emitted via the index-based metaBegin pass; the
+  // non-score int and the string metavalue are filtered out. Pin the exact struct fields (name, value,
+  // and higher_better = false for a q-value, which the score-type switcher maps to QVAL).
+  TEST_EQUAL(as_col->value_length(0), 1)
+  {
+    auto structs = std::static_pointer_cast<arrow::StructArray>(as_col->values());
+    auto sname = std::static_pointer_cast<arrow::StringArray>(structs->GetFieldByName("score_name"));
+    auto sval  = std::static_pointer_cast<arrow::DoubleArray>(structs->GetFieldByName("score_value"));
+    auto shb   = std::static_pointer_cast<arrow::BooleanArray>(structs->GetFieldByName("higher_better"));
+    const int64_t off = as_col->value_offset(0);
+    TEST_EQUAL(sname->GetString(off), "q-value")
+    TEST_REAL_SIMILAR(sval->Value(off), 0.05)
+    TEST_EQUAL(shb->IsNull(off), false)
+    TEST_EQUAL(shb->Value(off), false)
   }
 }
 END_SECTION

--- a/src/topp/IsobaricWorkflow.cpp
+++ b/src/topp/IsobaricWorkflow.cpp
@@ -910,7 +910,11 @@ protected:
         // Feature-level export: stream in batches so peak memory stays bounded. For isobaric
         // data there is ~one consensus feature per PSM, so the feature table has millions of
         // rows; the one-shot path builds it all in memory at once and drives large runs into swap.
-        if (!ConsensusMapArrowExport::exportToParquetStreaming(cmap, out_qpx + "/quantms.feature.parquet"))
+        // n_threads=0 builds each batch's partitions in parallel across all available cores.
+        if (!ConsensusMapArrowExport::exportToParquetStreaming(cmap, out_qpx + "/quantms.feature.parquet",
+                                                               /*batch_size=*/1000000,
+                                                               ParquetWriteConfig{},
+                                                               /*n_threads=*/0))
         {
           OPENMS_LOG_ERROR << "Failed to write features Parquet file" << std::endl;
           return CANNOT_WRITE_OUTPUT_FILE;


### PR DESCRIPTION
Stacked on #9698 (base branch `perf/qpx-feature-streaming-export`). Review/merge that one first; this PR's diff is only the parallelization delta.

## Motivation

#9698 made the QPX **feature** export stream in batches so peak memory stays bounded (fixing the isobaric OOM where `quantms.feature.parquet` was never created). That version builds each batch **serially**. The per-feature build (ProForma + modifications + mass math) is the bulk of export time, so this follow-up ports the OpenMP parallel batch build that the merged PSM PR #9697 already uses — same pattern, applied to the feature path.

## What this does

- **Parallel batch build.** `ConsensusMapArrowExport::exportToParquetStreaming` gains `n_threads` (1 = serial default, 0 = all cores honoring `OMP_NUM_THREADS`, N = fixed). Each batch `[b, e)` is split into `W` contiguous sub-ranges built in parallel via `#pragma omp parallel for` and written **in index order** (the `parquet::arrow::FileWriter` stays serial). Worker exceptions are contained per partition via `std::exception_ptr` and surfaced as the existing bool failure. A pre-warm block touches the lazily-initialized singletons (`ModificationsDB`/`ResidueDB`/`Scores`/`AASequence`) before the parallel region so first-touch cannot race. **Output rows and their order are identical for any thread count** (deterministic); only the Parquet row-group layout may differ.
- **Lock-free metavalue reads.** `buildFeatureTableRange` resolves the fixed dedicated-column metavalue names (`target_decoy`, `predicted_RT/rt`, `ion_mobility/IM`, `spectrum_reference`, `missed_cleavages`, `start/stop_ion_mobility`, `rt_start/stop`) to `MetaInfoRegistry` indices once per range and reads them via the lock-free `UInt` overloads behind a `metaHas()` sentinel guard; the dynamic PEP score name is resolved once per feature; and `additional_scores` switched from `getKeys()`+`getMetaValue(string)` to a single `metaBegin()/metaEnd()` pass with a `cachedMetaName_` index→name cache. This removes the per-row `omp critical` `MetaInfoRegistry` lock that would otherwise serialize the parallel build. Same values, same iteration order.
- **IsobaricWorkflow** opts the feature export into `n_threads=0`.

## Correctness / determinism

- Workers share only `const` state (`cmap`, `id_lut`); Arrow builders, `IDScoreSwitcherAlgorithm`, and the `meta_name_cache` are per `buildFeatureTableRange()` call. No shared mutable state.
- The index-based reads preserve the string-keyed semantics exactly (`UInt(-1)` guarded; same object per site; `predicted_RT`/`predicted_rt` etc. variants kept). `getKeys()` and `metaBegin()` both iterate the same index-sorted `MetaInfo` map, so `additional_scores` order is unchanged.
- Every lazy singleton reachable from the parallel region is pre-warmed (the same set #9697 warms; `SpectrumNativeIDParser`/`boost::regex` and `ProForma` resolve through those chemistry DBs).

## Tests

The streaming↔one-shot equivalence now runs across `n_threads {1, 2, 8}` plus a single all-threads batch (full `Table::Equals` over combined chunks, order-sensitive via unique RT). A new section pins the exact exported values of every index-resolved dedicated column and the `additional_scores` struct fields, and asserts non-score / non-numeric metavalues are filtered out. `ConsensusMapArrowExport_test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HcY3LMYuUDF2psYat9uUYN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parquet streaming export of consensus feature data now supports an `n_threads` setting to parallelize batch preparation (Parquet writing remains serial).
* **Bug Fixes**
  * Improved metadata handling during export using more reliable field resolution (including alternate-name fallbacks) for better nullness and value selection.
  * Ensures deterministic row order matches standard export across thread counts.
* **Tests**
  * Streaming export tests now verify deterministic results across multiple `n_threads` values and strengthen column/row equivalence checks.
  * Added Arrow export coverage for dedicated metavalue and score columns, including filtering and exact value validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->