### PR TITLE
Add UUID v4 generation to UniqueIdGenerator

### DIFF
--- a/src/openms/include/OpenMS/CONCEPT/UniqueIdGenerator.h
+++ b/src/openms/include/OpenMS/CONCEPT/UniqueIdGenerator.h
@@ -39,8 +39,12 @@ public:
     /// Returns a new unique id
     static UInt64 getUniqueId();
 
-    /// Returns a new random UUID (version 4), formatted as the standard
-    /// 36-character string "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".
+    /**
+      @brief Returns a new random UUID (version 4)
+
+      Formatted as the standard 36-character string
+      "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".
+    */
     static std::string getUUID();
 
     /// Initializes random generator using the given value.

--- a/src/openms/include/OpenMS/CONCEPT/UniqueIdGenerator.h
+++ b/src/openms/include/OpenMS/CONCEPT/UniqueIdGenerator.h
@@ -14,6 +14,8 @@
 #include <boost/random/variate_generator.hpp>
 #include <boost/random/uniform_int.hpp>
 
+#include <string>
+
 
 namespace OpenMS
 {
@@ -36,6 +38,10 @@ public:
 
     /// Returns a new unique id
     static UInt64 getUniqueId();
+
+    /// Returns a new random UUID (version 4), formatted as the standard
+    /// 36-character string "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".
+    static std::string getUUID();
 
     /// Initializes random generator using the given value.
     static void setSeed(const UInt64);

--- a/src/openms/source/CONCEPT/UniqueIdGenerator.cpp
+++ b/src/openms/source/CONCEPT/UniqueIdGenerator.cpp
@@ -12,7 +12,6 @@
 
 #include <boost/date_time/posix_time/posix_time_types.hpp> //no i/o just types
 
-#include <cstdint>
 #include <cstdio>
 #include <cstring>
 
@@ -46,7 +45,7 @@ namespace OpenMS
     // depend on std::random_device's entropy quality on every single call).
     UInt64 hi = getUniqueId();
     UInt64 lo = getUniqueId();
-    uint8_t bytes[16];
+    Byte bytes[16];
     std::memcpy(bytes, &hi, 8);
     std::memcpy(bytes + 8, &lo, 8);
     bytes[6] = (bytes[6] & 0x0F) | 0x40; // version 4

--- a/src/openms/source/CONCEPT/UniqueIdGenerator.cpp
+++ b/src/openms/source/CONCEPT/UniqueIdGenerator.cpp
@@ -12,6 +12,10 @@
 
 #include <boost/date_time/posix_time/posix_time_types.hpp> //no i/o just types
 
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
 namespace OpenMS
 {
   UInt64 UniqueIdGenerator::seed_ = 0;
@@ -33,6 +37,28 @@ namespace OpenMS
 #else
     return (*instance.dist_)(*instance.rng_);
 #endif
+  }
+
+  std::string UniqueIdGenerator::getUUID()
+  {
+    // Two independent 64-bit draws from the shared, once-seeded generator give us
+    // the 128 bits of a UUID without reseeding a fresh RNG per call (which would
+    // depend on std::random_device's entropy quality on every single call).
+    UInt64 hi = getUniqueId();
+    UInt64 lo = getUniqueId();
+    uint8_t bytes[16];
+    std::memcpy(bytes, &hi, 8);
+    std::memcpy(bytes + 8, &lo, 8);
+    bytes[6] = (bytes[6] & 0x0F) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3F) | 0x80; // variant 1
+    char buf[37];
+    std::snprintf(buf, sizeof(buf),
+      "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+      bytes[0], bytes[1], bytes[2], bytes[3],
+      bytes[4], bytes[5], bytes[6], bytes[7],
+      bytes[8], bytes[9], bytes[10], bytes[11],
+      bytes[12], bytes[13], bytes[14], bytes[15]);
+    return std::string(buf);
   }
 
   UInt64 UniqueIdGenerator::getSeed()

--- a/src/openms/source/FORMAT/ArrowIOHelpers.cpp
+++ b/src/openms/source/FORMAT/ArrowIOHelpers.cpp
@@ -9,6 +9,7 @@
 #include <OpenMS/FORMAT/ArrowIOHelpers.h>
 
 #include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/CONCEPT/UniqueIdGenerator.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/METADATA/MetaInfoInterface.h>
 
@@ -19,9 +20,6 @@
 #include <parquet/properties.h>
 
 #include <cstdint>
-#include <cstdio>
-#include <cstring>
-#include <random>
 
 namespace OpenMS
 {
@@ -30,25 +28,7 @@ namespace ArrowIOHelpers
 
 std::string generateUuidV4()
 {
-  std::random_device rd;
-  std::mt19937 gen(rd());
-  std::uniform_int_distribution<uint32_t> dist;
-  uint8_t bytes[16];
-  for (int i = 0; i < 4; ++i)
-  {
-    uint32_t r = dist(gen);
-    std::memcpy(bytes + i * 4, &r, 4);
-  }
-  bytes[6] = (bytes[6] & 0x0F) | 0x40; // version 4
-  bytes[8] = (bytes[8] & 0x3F) | 0x80; // variant 1
-  char buf[37];
-  std::snprintf(buf, sizeof(buf),
-    "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-    bytes[0], bytes[1], bytes[2], bytes[3],
-    bytes[4], bytes[5], bytes[6], bytes[7],
-    bytes[8], bytes[9], bytes[10], bytes[11],
-    bytes[12], bytes[13], bytes[14], bytes[15]);
-  return std::string(buf);
+  return UniqueIdGenerator::getUUID();
 }
 
 namespace

--- a/src/tests/class_tests/openms/source/UniqueIdGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/UniqueIdGenerator_test.cpp
@@ -70,15 +70,15 @@ START_SECTION((static std::string getUUID()))
   std::string u = OpenMS::UniqueIdGenerator::getUUID();
   STATUS("OpenMS::UniqueIdGenerator::getUUID(): " << u);
   TEST_EQUAL(u.size(), 36)
-  TEST_EQUAL(u[8] == '-' && u[13] == '-' && u[18] == '-' && u[23] == '-', true)
+  TEST_TRUE(u[8] == '-' && u[13] == '-' && u[18] == '-' && u[23] == '-')
 
   // version nibble must be '4' (UUIDv4)
   TEST_EQUAL(u[14], '4')
 
   // variant nibble encodes the 10xx bits -> one of 8, 9, a, b
   const char var = u[19];
-  TEST_EQUAL(var == '8' || var == '9' || var == 'a' || var == 'b' ||
-             var == 'A' || var == 'B', true)
+  TEST_TRUE(var == '8' || var == '9' || var == 'a' || var == 'b' ||
+            var == 'A' || var == 'B')
 
   // every non-hyphen character is a hex digit
   bool all_hex = true;
@@ -89,7 +89,7 @@ START_SECTION((static std::string getUUID()))
     const bool hex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
     if (!hex) { all_hex = false; break; }
   }
-  TEST_EQUAL(all_hex, true)
+  TEST_TRUE(all_hex)
 
   // uniqueness across many draws (no reseeding per call -> collisions negligible)
   std::set<std::string> seen;

--- a/src/tests/class_tests/openms/source/UniqueIdGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/UniqueIdGenerator_test.cpp
@@ -13,6 +13,8 @@
 #include <OpenMS/CONCEPT/UniqueIdGenerator.h>
 #include <ctime>
 #include <algorithm> // for std::sort and std::adjacent_find
+#include <set>
+#include <string>
 // array_wrapper needs to be included before it is used
 // only in boost1.64+. See issue #2790
 #if OPENMS_BOOST_VERSION_MINOR >= 64
@@ -60,6 +62,39 @@ START_SECTION((static UInt64 getUniqueId()))
   // check if the generated ids contain (at least) two equal ones
   std::vector<OpenMS::UInt64>::iterator iter = std::adjacent_find(ids.begin(), ids.end());
   TEST_EQUAL(iter == ids.end(), true);
+}
+END_SECTION
+
+START_SECTION((static std::string getUUID()))
+{
+  std::string u = OpenMS::UniqueIdGenerator::getUUID();
+  STATUS("OpenMS::UniqueIdGenerator::getUUID(): " << u);
+  TEST_EQUAL(u.size(), 36)
+  TEST_EQUAL(u[8] == '-' && u[13] == '-' && u[18] == '-' && u[23] == '-', true)
+
+  // version nibble must be '4' (UUIDv4)
+  TEST_EQUAL(u[14], '4')
+
+  // variant nibble encodes the 10xx bits -> one of 8, 9, a, b
+  const char var = u[19];
+  TEST_EQUAL(var == '8' || var == '9' || var == 'a' || var == 'b' ||
+             var == 'A' || var == 'B', true)
+
+  // every non-hyphen character is a hex digit
+  bool all_hex = true;
+  for (size_t i = 0; i < u.size(); ++i)
+  {
+    if (i == 8 || i == 13 || i == 18 || i == 23) continue;
+    const char c = u[i];
+    const bool hex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+    if (!hex) { all_hex = false; break; }
+  }
+  TEST_EQUAL(all_hex, true)
+
+  // uniqueness across many draws (no reseeding per call -> collisions negligible)
+  std::set<std::string> seen;
+  for (int i = 0; i < 1000; ++i) seen.insert(OpenMS::UniqueIdGenerator::getUUID());
+  TEST_EQUAL(seen.size(), 1000)
 }
 END_SECTION
 


### PR DESCRIPTION
## Description

This PR adds UUID v4 generation capability to the `UniqueIdGenerator` class and refactors existing UUID generation code to use this new centralized implementation.

### Changes

- **New `getUUID()` method**: Added a static method to `UniqueIdGenerator` that generates RFC 4122 compliant UUID v4 strings in the standard 36-character format (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`)
  - Leverages the existing seeded random number generator to avoid per-call entropy source dependency
  - Uses two consecutive `getUniqueId()` calls to obtain 128 bits of randomness
  - Sets version nibble to '4' and variant bits to '10' as per RFC 4122

- **Refactored `ArrowIOHelpers`**: Replaced the local `generateUuidV4()` implementation with a call to `UniqueIdGenerator::getUUID()`, eliminating code duplication and ensuring consistent UUID generation across the codebase

- **Comprehensive unit tests**: Added tests validating:
  - Correct UUID format (36 characters with hyphens at positions 8, 13, 18, 23)
  - Version nibble is '4'
  - Variant nibble is one of {8, 9, a, b, A, B}
  - All non-hyphen characters are valid hexadecimal digits
  - Uniqueness across 1000 consecutive generations

### Benefits

- Centralized UUID generation logic reduces maintenance burden
- Consistent random seeding behavior across the application
- Eliminates dependency on `std::random_device` per UUID call in ArrowIOHelpers
- Provides a public API for UUID generation throughout OpenMS

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

https://claude.ai/code/session_01EPSZbWojHGSiXY2EQ2v9hY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared UUID generator that returns standard 36-character UUID v4 strings in `xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx` format.
  * Updated UUID creation in supported components to use the common generator for consistent formatting.

* **Tests**
  * Added tests validating UUID string length and hyphen placement, correct v4 version and variant bits, hex-only characters, and uniqueness across 1000 generated values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->