### PR TITLE
Fix pyOpenMS enum bindings out of sync with C++ enums

### DIFF
--- a/src/pyOpenMS/bindings/bind_chemistry.cpp
+++ b/src/pyOpenMS/bindings/bind_chemistry.cpp
@@ -1723,6 +1723,7 @@ Sets the modification by monoisotopic mass difference in Da; checks if present i
         .value("EMBOSS", OpenMS::ProteomicsPkaScale::EMBOSS)
         .value("SILLERO", OpenMS::ProteomicsPkaScale::SILLERO)
         .value("BJELLQVIST", OpenMS::ProteomicsPkaScale::BJELLQVIST)
+        .value("SIZE_OF_PROTEOMICS_PKA_SCALES", OpenMS::ProteomicsPkaScale::SIZE_OF_PROTEOMICS_PKA_SCALES)
         .export_values();
 
     // IsoelectricPoint
@@ -2072,8 +2073,16 @@ the fixed and variable modifications given to the constructor
         .value("YIon", OpenMS::NASequence::NASFragmentType::YIon)
         .value("ZIon", OpenMS::NASequence::NASFragmentType::ZIon)
         .value("Precursor", OpenMS::NASequence::NASFragmentType::Precursor)
+        .value("BIonMinusH20", OpenMS::NASequence::NASFragmentType::BIonMinusH20)
+        .value("YIonMinusH20", OpenMS::NASequence::NASFragmentType::YIonMinusH20)
+        .value("BIonMinusNH3", OpenMS::NASequence::NASFragmentType::BIonMinusNH3)
+        .value("YIonMinusNH3", OpenMS::NASequence::NASFragmentType::YIonMinusNH3)
+        .value("NonIdentified", OpenMS::NASequence::NASFragmentType::NonIdentified)
+        .value("Unannotated", OpenMS::NASequence::NASFragmentType::Unannotated)
         .value("WIon", OpenMS::NASequence::NASFragmentType::WIon)
+        .value("AminusB", OpenMS::NASequence::NASFragmentType::AminusB)
         .value("DIon", OpenMS::NASequence::NASFragmentType::DIon)
+        .value("SizeOfNASFragmentType", OpenMS::NASequence::NASFragmentType::SizeOfNASFragmentType)
         ;
 
     // -----------------------------------------------------------------------

--- a/src/pyOpenMS/bindings/bind_datastructures.cpp
+++ b/src/pyOpenMS/bindings/bind_datastructures.cpp
@@ -566,9 +566,17 @@ Returns the objective value of the solution
         .value("FORMAT_GLPK", OpenMS::LPWrapper::WriteFormat::FORMAT_GLPK)
         .export_values();
     // SOLVER enum nested under LPWrapper
-    nb::enum_<OpenMS::LPWrapper::SOLVER>(lpwrapper_class, "SOLVER", nb::is_arithmetic())
-        .value("SOLVER_GLPK", OpenMS::LPWrapper::SOLVER::SOLVER_GLPK)
-        .export_values();
+    {
+    auto solver_enum = nb::enum_<OpenMS::LPWrapper::SOLVER>(lpwrapper_class, "SOLVER", nb::is_arithmetic());
+    solver_enum.value("SOLVER_GLPK", OpenMS::LPWrapper::SOLVER::SOLVER_GLPK);
+#ifdef OPENMS_HAS_COINOR
+    solver_enum.value("SOLVER_COINOR", OpenMS::LPWrapper::SOLVER::SOLVER_COINOR);
+#endif
+#ifdef OPENMS_HAS_HIGHS
+    solver_enum.value("SOLVER_HIGHS", OpenMS::LPWrapper::SOLVER::SOLVER_HIGHS);
+#endif
+    solver_enum.export_values();
+    }
     // SolverStatus enum nested under LPWrapper
     nb::enum_<OpenMS::LPWrapper::SolverStatus>(lpwrapper_class, "SolverStatus", nb::is_arithmetic())
         .value("UNDEFINED", OpenMS::LPWrapper::SolverStatus::UNDEFINED)
@@ -1402,6 +1410,7 @@ sum1 and sum2 are the sum of the intensities squared for each peak of both spect
         .value("PEPTIDE", OpenMS::OSWHierarchy::Level::PEPTIDE)
         .value("FEATURE", OpenMS::OSWHierarchy::Level::FEATURE)
         .value("TRANSITION", OpenMS::OSWHierarchy::Level::TRANSITION)
+        .value("SIZE_OF_VALUES", OpenMS::OSWHierarchy::Level::SIZE_OF_VALUES)
         .export_values();
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Description

A routine audit of all 108 `nb::enum_<...>` registrations in `src/pyOpenMS/bindings/*.cpp` against their C++ enum definitions found 4 enums where the Python binding was missing enumerators present in the C++ header. This means those values were entirely inaccessible from Python (not a value-corruption issue — the bound values were correct, just incomplete). No ordering/value-mismatch issues were found anywhere else in the sweep (nanobind binds by explicit `CppEnum::VALUE`, not registration order, so omission is the only failure mode).

Fixes:
- **`NASequence::NASFragmentType`** (`CHEMISTRY/NASequence.h`) — added 8 missing values: `BIonMinusH20`, `YIonMinusH20`, `BIonMinusNH3`, `YIonMinusNH3`, `NonIdentified`, `Unannotated`, `AminusB`, `SizeOfNASFragmentType`. Python users could not construct/compare these nucleic-acid fragment ion types.
- **`ProteomicsPkaScale`** (`CHEMISTRY/IsoelectricPoint.h`) — added the missing `SIZE_OF_PROTEOMICS_PKA_SCALES` sentinel, for consistency with every other `SIZE_OF_*`/`NUMBER_OF_*` sentinel bound elsewhere in the codebase.
- **`OSWHierarchy::Level`** (`DATASTRUCTURES/OSWData.h`) — added the missing `SIZE_OF_VALUES` sentinel, which is used by `OSWIndexTrace::lowest` as the "not set" marker.
- **`LPWrapper::SOLVER`** (`DATASTRUCTURES/LPWrapper.h`) — `SOLVER_COINOR`/`SOLVER_HIGHS` exist in the C++ enum under `#ifdef OPENMS_HAS_COINOR`/`OPENMS_HAS_HIGHS` but were never bound in Python. Added them under matching `#ifdef` guards (the macros are already visible in this translation unit via `LPWrapper.h`'s own `#include <OpenMS/config.h>`).

Only `.value(...)` binding lines were added; no existing bindings were reordered or changed, so this cannot affect any currently-working Python code.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas (n/a — mechanical binding additions, self-explanatory)
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] Updated or added python bindings for changed or new classes
- [ ] New and existing unit tests pass locally with my changes — **not verified in this environment** (no local build directory / submodules not initialized in this session); relies on CI to confirm compilation, especially the conditional `OPENMS_HAS_COINOR`/`OPENMS_HAS_HIGHS` branches of `LPWrapper::SOLVER`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GhhgiwwEafRKTMtWeKSaEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Python-accessible enum options for chemistry and data-structure APIs, including additional fragment types and size markers.
  * Added support for more solver options in Python when those libraries are available.

* **Bug Fixes**
  * Exposed previously missing enum values so Python users can access the full set of supported constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->