### PR TITLE
re-add progress to FileInfo TOPP Tool

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/FileInfo.h
+++ b/src/openms/include/OpenMS/FORMAT/FileInfo.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <OpenMS/config.h>
+#include <OpenMS/CONCEPT/ProgressLogger.h>  // ProgressLogger::LogType (nested enum; cannot be forward-declared)
 #include <OpenMS/CONCEPT/Types.h>           // Int / UInt / UInt64
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/MATH/StatisticFunctions.h> // Math::SummaryStatistics
@@ -251,6 +252,8 @@ namespace OpenMS
       bool check_corrupt = false; ///< -c
       bool validate = false;      ///< -v
       bool check_index = false;   ///< -i
+      /// progress-logging verbosity forwarded to the underlying loaders (== CLI -no_progress)
+      ProgressLogger::LogType log_type = ProgressLogger::NONE; ///< NONE keeps library/pyOpenMS silent
     };
 
     // ---------------------------------------------------------------------

--- a/src/openms/source/FORMAT/FileInfo.cpp
+++ b/src/openms/source/FORMAT/FileInfo.cpp
@@ -854,6 +854,7 @@ namespace OpenMS
     {
       vector<FASTAFile::FASTAEntry> entries;
       FASTAFile file;
+      file.setLogType(options.log_type);
 
       // loading input
       file.load(in, entries);
@@ -1080,7 +1081,7 @@ namespace OpenMS
       ff.getFeatOptions().setLoadSubordinates(false); // SO's currently not needed here
 
       // reading input
-      ff.loadFeatures(in, feat, {FileTypes::FEATUREXML});
+      ff.loadFeatures(in, feat, {FileTypes::FEATUREXML}, options.log_type);
 
       feat.updateRanges();
 
@@ -1145,7 +1146,7 @@ namespace OpenMS
     else if (in_type == FileTypes::CONSENSUSXML) //consensus features
     {
       // reading input
-      FileHandler().loadConsensusFeatures(in, cons, {FileTypes::CONSENSUSXML});
+      FileHandler().loadConsensusFeatures(in, cons, {FileTypes::CONSENSUSXML}, options.log_type);
 
       cons.updateRanges();
 
@@ -1324,7 +1325,7 @@ namespace OpenMS
       // reading input
       if (in_type == FileTypes::MZIDENTML)
       {
-        FileHandler().loadIdentifications(in, id_data.proteins, id_data.peptides, {FileTypes::MZIDENTML});
+        FileHandler().loadIdentifications(in, id_data.proteins, id_data.peptides, {FileTypes::MZIDENTML}, options.log_type);
       }
       else
       {
@@ -1518,6 +1519,7 @@ namespace OpenMS
     {
       TargetedExperiment targeted_exp;
       TransitionPQPFile pqp_reader;
+      pqp_reader.setLogType(options.log_type);
       pqp_reader.convertPQPToTargetedExperiment(in.c_str(), targeted_exp, true);
       const auto summary = targeted_exp.getSummary();
       os << summary;
@@ -1529,7 +1531,7 @@ namespace OpenMS
     }
     else // peaks
     {
-      fh.loadExperiment(in, exp, {in_type}, ProgressLogger::NONE, false, false);
+      fh.loadExperiment(in, exp, {in_type}, options.log_type, false, false);
 
       // update range information and retrieve which MS levels were recorded
       exp.updateRanges();

--- a/src/pyOpenMS/bindings/bind_format.cpp
+++ b/src/pyOpenMS/bindings/bind_format.cpp
@@ -3225,7 +3225,8 @@ or chromatograms only (SRM/MRM) and forwards to the appropriate loader.
           .def_rw("detailed", &FileInfo::Options::detailed)
           .def_rw("check_corrupt", &FileInfo::Options::check_corrupt)
           .def_rw("validate", &FileInfo::Options::validate)
-          .def_rw("check_index", &FileInfo::Options::check_index);
+          .def_rw("check_index", &FileInfo::Options::check_index)
+          .def_rw("log_type", &FileInfo::Options::log_type);
 
       fi.def(nb::init<>())
         .def("__copy__", [](const FileInfo& self){ return FileInfo(self); })

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -133,6 +133,7 @@ protected:
     opt.check_corrupt = getFlag_("c");
     opt.validate      = getFlag_("v");
     opt.check_index   = getFlag_("i");
+    opt.log_type      = log_type_; // TOPPBase member: CMD by default, NONE under -no_progress
 
     FileInfo fi;
     FileInfo::Result r = fi.run(in, opt);


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option to control progress-logging behavior when reading file information.
  * Python users can now configure the same logging setting through the exposed options.

* **Bug Fixes**
  * File loading now consistently respects the selected logging mode across supported input formats.
  * The command-line file info tool now forwards its logging setting correctly to underlying processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->