### PR TITLE
Improve isotope/adduct RT grouping for low-intensity mass traces (#4483)

### DIFF
--- a/src/openms/include/OpenMS/FEATUREFINDER/FeatureFindingMetabo.h
+++ b/src/openms/include/OpenMS/FEATUREFINDER/FeatureFindingMetabo.h
@@ -268,10 +268,14 @@ private:
     /** @brief Perform retention time scoring of two multiple mass traces
      *
      * Computes the similarity of the two peak shapes using cosine similarity
-     * (see computeCosineSim_) if some conditions are fulfilled. Mainly the
-     * overlap between the two peaks at FHWM needs to exceed a certain
-     * threshold. The threshold is set at 0.7 (i.e. 70 % overlap) as also
-     * described in Kenar et al.
+     * (see computeCosineSim_) if some conditions are fulfilled. The shorter of
+     * the two mass traces (in RT, at FWHM) must overlap the longer one by at
+     * least the fraction given by the 'min_isotope_rt_overlap' parameter
+     * (default 0.95); low-intensity isotope traces are usually much shorter
+     * than the monoisotopic trace, so the overlap is measured against the
+     * shorter trace. In addition, the apex (most intense peak) of the longer
+     * trace must fall within the RT range of the shorter trace, otherwise the
+     * two traces are not considered to belong together.
      *
      * @note this only works for equally sampled mass traces, e.g. they need to
      * come from the same map (not for SRM measurements for example).

--- a/src/openms/include/OpenMS/FEATUREFINDER/FeatureFindingMetabo.h
+++ b/src/openms/include/OpenMS/FEATUREFINDER/FeatureFindingMetabo.h
@@ -268,14 +268,16 @@ private:
     /** @brief Perform retention time scoring of two multiple mass traces
      *
      * Computes the similarity of the two peak shapes using cosine similarity
-     * (see computeCosineSim_) if some conditions are fulfilled. The shorter of
-     * the two mass traces (in RT, at FWHM) must overlap the longer one by at
-     * least the fraction given by the 'min_isotope_rt_overlap' parameter
-     * (default 0.95); low-intensity isotope traces are usually much shorter
-     * than the monoisotopic trace, so the overlap is measured against the
-     * shorter trace. In addition, the apex (most intense peak) of the longer
-     * trace must fall within the RT range of the shorter trace, otherwise the
-     * two traces are not considered to belong together.
+     * (see computeCosineSim_) if some conditions are fulfilled. The RT overlap
+     * of the two peaks at FWHM must exceed the fraction given by the
+     * 'min_isotope_rt_overlap' parameter. By default ('isotope_rt_overlap_reference'
+     * = "longer") the overlap is measured against the longer trace with a
+     * threshold of 0.7 (i.e. 70 % overlap), as described in Kenar et al. When
+     * 'isotope_rt_overlap_reference' is set to "shorter", the overlap is measured
+     * against the shorter trace instead (better for low-intensity isotope traces
+     * that are much shorter than the monoisotopic trace) and, additionally, the
+     * apex (most intense peak) of the longer trace must fall within the RT range
+     * of the shorter trace.
      *
      * @note this only works for equally sampled mass traces, e.g. they need to
      * come from the same map (not for SRM measurements for example).
@@ -329,6 +331,7 @@ private:
     bool report_summed_ints_;
     bool enable_RT_filtering_;
     double min_isotope_rt_overlap_;
+    bool isotope_rt_overlap_use_shorter_;
     std::string isotope_filtering_model_;
     bool use_smoothed_intensities_;
     bool report_smoothed_intensities_;

--- a/src/openms/include/OpenMS/FEATUREFINDER/FeatureFindingMetabo.h
+++ b/src/openms/include/OpenMS/FEATUREFINDER/FeatureFindingMetabo.h
@@ -324,6 +324,7 @@ private:
 
     bool report_summed_ints_;
     bool enable_RT_filtering_;
+    double min_isotope_rt_overlap_;
     std::string isotope_filtering_model_;
     bool use_smoothed_intensities_;
     bool report_smoothed_intensities_;

--- a/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
@@ -120,6 +120,8 @@ namespace OpenMS
     defaults_.setValue("min_rt_overlap", 0.66, "Minimum overlap of the convex hull' RT intersection measured against the union from two features (if CHs are given)");
     defaults_.setMinFloat("min_rt_overlap", 0);
     defaults_.setMaxFloat("min_rt_overlap", 1);
+    defaults_.setValue("rt_overlap_reference", "union", "Reference used to compute the RT overlap fraction that is compared against 'min_rt_overlap': 'union' divides the RT intersection by the union of both features' RT ranges (default, historic behavior); 'shorter' divides it by the shorter of the two features' RT ranges, which still groups adducts with strongly differing intensities and elution widths (e.g. an intense [M+H]+ and a weak [M+Na]+), see issue #4483.", {"advanced"});
+    defaults_.setValidStrings("rt_overlap_reference", {"union", "shorter"});
 
     defaults_.setValue("intensity_filter", "false", "Enable the intensity filter, which will only allow edges between two equally charged features if the intensity of the feature with less likely adducts is smaller than that of the other feature. It is not used for features of different charge.");
     defaults_.setValidStrings("intensity_filter", {"true","false"});
@@ -378,6 +380,7 @@ namespace OpenMS
     double mz_diff_max = param_.getValue("mass_max_diff");
 
     double rt_min_overlap = param_.getValue("min_rt_overlap");
+    bool rt_overlap_use_shorter = (param_.getValue("rt_overlap_reference") == "shorter");
 
 
     // search for most & least probable adduct to fix p threshold
@@ -455,7 +458,20 @@ namespace OpenMS
           double union_length = f_end2 - f_start1;
           double intersect_length = std::max(0., f_end1 - f_start2);
 
-          if (intersect_length / union_length < rt_min_overlap)
+          // Reference length the RT overlap is measured against. By default this is
+          // the union of both RT ranges. Optionally the shorter feature's RT range is
+          // used, so that adducts with strongly differing intensities/elution widths
+          // still group (the union is then dominated by the longer, more intense
+          // feature and would reject the pair); see issue #4483.
+          double reference_length = union_length;
+          if (rt_overlap_use_shorter)
+          {
+            double f1_length = f1.getConvexHull().getBoundingBox().maxX() - f1.getConvexHull().getBoundingBox().minX();
+            double f2_length = f2.getConvexHull().getBoundingBox().maxX() - f2.getConvexHull().getBoundingBox().minX();
+            reference_length = std::min(f1_length, f2_length);
+          }
+
+          if (reference_length > 0.0 && intersect_length / reference_length < rt_min_overlap)
             continue;
         }
 

--- a/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
@@ -469,9 +469,14 @@ namespace OpenMS
             double f1_length = f1.getConvexHull().getBoundingBox().maxX() - f1.getConvexHull().getBoundingBox().minX();
             double f2_length = f2.getConvexHull().getBoundingBox().maxX() - f2.getConvexHull().getBoundingBox().minX();
             reference_length = std::min(f1_length, f2_length);
+
+            // A degenerate (zero-width) feature has no RT extent to overlap with;
+            // fail closed and reject the pair instead of skipping the check.
+            if (reference_length <= 0.0)
+              continue;
           }
 
-          if (reference_length > 0.0 && intersect_length / reference_length < rt_min_overlap)
+          if (intersect_length / reference_length < rt_min_overlap)
             continue;
         }
 

--- a/src/openms/source/FEATUREFINDER/FeatureFindingMetabo.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFindingMetabo.cpp
@@ -663,7 +663,7 @@ namespace OpenMS
     {
       // Historic behavior: the overlap must exceed the given fraction of the
       // longer trace (default 0.7, i.e. 70 %, as described in Kenar et al.).
-      double proportion(overlap / max_length);
+      double proportion = (max_length > 0.0) ? (overlap / max_length) : 0.0;
       if (proportion < min_isotope_rt_overlap_)
       {
         return 0.0;

--- a/src/openms/source/FEATUREFINDER/FeatureFindingMetabo.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFindingMetabo.cpp
@@ -271,6 +271,10 @@ namespace OpenMS
     defaults_.setValue("enable_RT_filtering", "true", "Require sufficient overlap in RT while assembling mass traces. Disable for direct injection data..");
     defaults_.setValidStrings("enable_RT_filtering", {"false","true"});
 
+    defaults_.setValue("min_isotope_rt_overlap", 0.95, "Minimum fraction of the shorter co-eluting mass trace (in RT, within FWHM) that must overlap the longer trace to be grouped as isotopes. Low-intensity isotope traces are usually much shorter than the monoisotopic trace, so the overlap is measured against the shorter trace. Only used if 'enable_RT_filtering' is enabled.", {"advanced"});
+    defaults_.setMinFloat("min_isotope_rt_overlap", 0.0);
+    defaults_.setMaxFloat("min_isotope_rt_overlap", 1.0);
+
     defaults_.setValue("isotope_filtering_model", "metabolites (5% RMS)", "Remove/score candidate assemblies based on isotope intensities. SVM isotope models for metabolites were trained with either 2% or 5% RMS error. For peptides, an averagine cosine scoring is used. Select the appropriate noise model according to the quality of measurement or MS device.");
     defaults_.setValidStrings("isotope_filtering_model", {"metabolites (2% RMS)","metabolites (5% RMS)","peptides","none"});
 
@@ -317,6 +321,7 @@ namespace OpenMS
 
     report_summed_ints_ = param_.getValue("report_summed_ints").toBool();
     enable_RT_filtering_ = param_.getValue("enable_RT_filtering").toBool();
+    min_isotope_rt_overlap_ = (double)param_.getValue("min_isotope_rt_overlap");
     
     isotope_filtering_model_ = param_.getValue("isotope_filtering_model").toString();
     use_smoothed_intensities_ = param_.getValue("use_smoothed_intensities").toBool();
@@ -616,7 +621,13 @@ namespace OpenMS
 
     double tr1_length(tr1.getFWHM());
     double tr2_length(tr2.getFWHM());
-    double max_length = (tr1_length > tr2_length) ? tr1_length : tr2_length;
+    double min_length = std::min(tr1_length, tr2_length);
+
+    // The longer mass trace is expected to be the more intense one (usually, but
+    // not necessarily, the monoisotopic trace); the shorter one is e.g. a low
+    // intensity isotope trace.
+    const MassTrace& longer_trace = (tr1_length >= tr2_length) ? tr1 : tr2;
+    const MassTrace& shorter_trace = (tr1_length >= tr2_length) ? tr2 : tr1;
 
     // std::cout << "tr1 " << tr1_length << " tr2 " << tr2_length << '\n';
 
@@ -630,7 +641,7 @@ namespace OpenMS
       coinciding_rts[tr2[i].getRT()].push_back(tr2[i].getIntensity());
     }
 
-    // Look at peaks at the same RT 
+    // Look at peaks at the same RT
     // TODO: this only works if both traces are sampled with equal rate at the same RT
     std::vector<double> x, y, overlap_rts;
     for (std::map<double, std::vector<double> >::const_iterator m_it = coinciding_rts.begin(); m_it != coinciding_rts.end(); ++m_it)
@@ -643,17 +654,6 @@ namespace OpenMS
       }
     }
 
-    //    if (x.size() < std::floor(0.8*max_length))
-    //        {
-    //            return 0.0;
-    //        }
-    // double rt_range(0.0)
-    // if (coinciding_rts.size() > 0)
-    // {
-    //     rt_range = std::fabs(coinciding_rts.rbegin()->first - coinciding_rts.begin()->first);
-    // }
-
-
     double overlap(0.0);
     if (!overlap_rts.empty())
     {
@@ -661,11 +661,28 @@ namespace OpenMS
       overlap = std::fabs(end_rt - start_rt);
     }
 
-    double proportion(overlap / max_length);
-    if (proportion < 0.7)
+    // Require the shorter mass trace to lie almost entirely within the longer one.
+    // Measuring the overlap against the shorter trace (instead of the longer trace,
+    // as done previously) still groups low-intensity isotope traces that are much
+    // shorter than the monoisotopic trace (see issue #4483).
+    double proportion = (min_length > 0.0) ? (overlap / min_length) : 0.0;
+    if (proportion < min_isotope_rt_overlap_)
     {
       return 0.0;
     }
+
+    // Additionally require the apex (most intense peak) of the longer trace to fall
+    // within the RT range of the shorter trace. If the dominant peak is not present
+    // where the shorter trace elutes, the two traces most likely do not belong together.
+    std::pair<Size, Size> shorter_fwhm_idx(shorter_trace.getFWHMborders());
+    double shorter_start_rt(shorter_trace[shorter_fwhm_idx.first].getRT());
+    double shorter_end_rt(shorter_trace[shorter_fwhm_idx.second].getRT());
+    double longer_apex_rt(longer_trace[longer_trace.findMaxByIntPeak(use_smoothed_intensities_)].getRT());
+    if (longer_apex_rt < shorter_start_rt || longer_apex_rt > shorter_end_rt)
+    {
+      return 0.0;
+    }
+
     return computeCosineSim_(x, y);
   }
 

--- a/src/openms/source/FEATUREFINDER/FeatureFindingMetabo.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFindingMetabo.cpp
@@ -271,7 +271,9 @@ namespace OpenMS
     defaults_.setValue("enable_RT_filtering", "true", "Require sufficient overlap in RT while assembling mass traces. Disable for direct injection data..");
     defaults_.setValidStrings("enable_RT_filtering", {"false","true"});
 
-    defaults_.setValue("min_isotope_rt_overlap", 0.95, "Minimum fraction of the shorter co-eluting mass trace (in RT, within FWHM) that must overlap the longer trace to be grouped as isotopes. Low-intensity isotope traces are usually much shorter than the monoisotopic trace, so the overlap is measured against the shorter trace. Only used if 'enable_RT_filtering' is enabled.", {"advanced"});
+    defaults_.setValue("isotope_rt_overlap_reference", "longer", "Reference trace the RT overlap is measured against when scoring two co-eluting mass traces (only used if 'enable_RT_filtering' is enabled): 'longer' measures the overlap against the longer trace (default, historic behavior); 'shorter' measures it against the shorter trace and additionally requires the apex of the longer trace to fall within the RT range of the shorter trace. Since low-intensity isotope traces are usually much shorter than the monoisotopic trace, 'shorter' better groups them (see issue #4483).", {"advanced"});
+    defaults_.setValidStrings("isotope_rt_overlap_reference", {"longer", "shorter"});
+    defaults_.setValue("min_isotope_rt_overlap", 0.7, "Minimum fraction of the reference trace (see 'isotope_rt_overlap_reference') in RT (within FWHM) that must overlap the other trace so the two are scored as isotopes. Only used if 'enable_RT_filtering' is enabled.", {"advanced"});
     defaults_.setMinFloat("min_isotope_rt_overlap", 0.0);
     defaults_.setMaxFloat("min_isotope_rt_overlap", 1.0);
 
@@ -322,6 +324,7 @@ namespace OpenMS
     report_summed_ints_ = param_.getValue("report_summed_ints").toBool();
     enable_RT_filtering_ = param_.getValue("enable_RT_filtering").toBool();
     min_isotope_rt_overlap_ = (double)param_.getValue("min_isotope_rt_overlap");
+    isotope_rt_overlap_use_shorter_ = (param_.getValue("isotope_rt_overlap_reference") == "shorter");
     
     isotope_filtering_model_ = param_.getValue("isotope_filtering_model").toString();
     use_smoothed_intensities_ = param_.getValue("use_smoothed_intensities").toBool();
@@ -621,13 +624,8 @@ namespace OpenMS
 
     double tr1_length(tr1.getFWHM());
     double tr2_length(tr2.getFWHM());
+    double max_length = std::max(tr1_length, tr2_length);
     double min_length = std::min(tr1_length, tr2_length);
-
-    // The longer mass trace is expected to be the more intense one (usually, but
-    // not necessarily, the monoisotopic trace); the shorter one is e.g. a low
-    // intensity isotope trace.
-    const MassTrace& longer_trace = (tr1_length >= tr2_length) ? tr1 : tr2;
-    const MassTrace& shorter_trace = (tr1_length >= tr2_length) ? tr2 : tr1;
 
     // std::cout << "tr1 " << tr1_length << " tr2 " << tr2_length << '\n';
 
@@ -661,10 +659,25 @@ namespace OpenMS
       overlap = std::fabs(end_rt - start_rt);
     }
 
-    // Require the shorter mass trace to lie almost entirely within the longer one.
-    // Measuring the overlap against the shorter trace (instead of the longer trace,
-    // as done previously) still groups low-intensity isotope traces that are much
-    // shorter than the monoisotopic trace (see issue #4483).
+    if (!isotope_rt_overlap_use_shorter_)
+    {
+      // Historic behavior: the overlap must exceed the given fraction of the
+      // longer trace (default 0.7, i.e. 70 %, as described in Kenar et al.).
+      double proportion(overlap / max_length);
+      if (proportion < min_isotope_rt_overlap_)
+      {
+        return 0.0;
+      }
+      return computeCosineSim_(x, y);
+    }
+
+    // 'shorter' reference: require the shorter mass trace to lie almost entirely
+    // within the longer one. Measuring the overlap against the shorter trace still
+    // groups low-intensity isotope traces that are much shorter than the
+    // monoisotopic trace (see issue #4483).
+    const MassTrace& longer_trace = (tr1_length >= tr2_length) ? tr1 : tr2;
+    const MassTrace& shorter_trace = (tr1_length >= tr2_length) ? tr2 : tr1;
+
     double proportion = (min_length > 0.0) ? (overlap / min_length) : 0.0;
     if (proportion < min_isotope_rt_overlap_)
     {


### PR DESCRIPTION
## Description

Fixes #4483.

Low-intensity isotope and adduct mass traces are usually much **shorter in RT** than the intense monoisotopic / `[M+H]+` trace. The previous RT-overlap criteria measured the overlap against the *longer* trace (isotope grouping) or the *union* of both RT ranges (adduct grouping), so these genuine peaks were often rejected — the union/longer length is dominated by the long, intense trace while the intersection is bounded by the short one. This is especially relevant for metabolites containing Cl, F, Br, etc.

Both changes are **opt-in and default to the historic behavior**, so existing results and reference tests are unchanged (see the note at the bottom).

### `FeatureFindingMetabo::scoreRT_` (isotope grouping)
- New advanced parameter **`isotope_rt_overlap_reference`** (`longer` | `shorter`, default `longer`):
  - `longer` — historic behavior: overlap must be ≥ `min_isotope_rt_overlap` of the **longer** trace.
  - `shorter` — overlap is measured against the **shorter** trace, and additionally the **apex of the longer trace must fall within the RT range of the shorter trace**. This groups low-intensity isotope traces that are much shorter than the monoisotopic trace.
- New advanced parameter **`min_isotope_rt_overlap`** (default `0.7`, range `[0, 1]`) exposes the overlap threshold that was previously hard-coded to `0.7`. With `isotope_rt_overlap_reference=shorter`, `0.95`–`0.99` is recommended (per the issue discussion).

### `MetaboliteFeatureDeconvolution` (adduct grouping)
- New advanced parameter **`rt_overlap_reference`** (`union` | `shorter`, default `union`):
  - `union` — historic behavior (intersection / union of both RT ranges).
  - `shorter` — intersection / shorter feature RT range, which groups adducts with strongly differing intensities/elution widths (e.g. an intense `[M+H]+` and a weak `[M+Na]+`). Fails closed for degenerate zero-width features.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

> **Note on defaults:** Both improvements ship **off by default** so that no reference outputs change and CI stays green. Making the `shorter` behavior the *default* would change `FeatureFindingMetabo`'s output (feature counts / `FeatureFindingMetabo_output1.featureXML` and the `TOPP_FeatureFinderMetabo_{1,5,6}_out` references), which should be regenerated and validated on representative data by a maintainer. Happy to flip the defaults and update the reference data if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added advanced RT overlap controls for feature deconvolution, including a “shorter” normalization option.
  * Introduced advanced isotopic RT overlap settings for isotopic mass-trace grouping, with selectable overlap reference and a configurable minimum overlap threshold.
* **Bug Fixes**
  * Improved isotopic RT scoring to honor the selected overlap reference and to prevent grouping when the longer trace apex RT falls outside the shorter trace’s FWHM-elution range.
* **Documentation**
  * Updated parameter descriptions for isotopic RT overlap gating to reflect the new reference and threshold behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->