### PR TITLE
Make Xerces-C++ a private link dependency of libOpenMS

### DIFF
--- a/cmake/OpenMSConfig.cmake.in
+++ b/cmake/OpenMSConfig.cmake.in
@@ -24,6 +24,15 @@ endif()
 #TODO somehow add the same/compatible versions that were found by OpenMS? And what about static vs dynamic? E.g. if we link to static zlib in OpenMS(.dll) what (if at all) can/should the consumer link against?
 find_dependency(CURL)
 find_dependency(XercesC)
+# Boost::boost (header-only) is part of OpenMS's PUBLIC link interface because
+# the installed public header config.h includes <boost/current_function.hpp>
+# (via Macros.h). Its imported target must therefore exist before the targets
+# file below is included, otherwise consumers configuring against the install
+# tree (e.g. the pyOpenMS wheel build with NO_DEPENDENCIES=ON) fail with
+# "target Boost::boost not found". Only the header-only target is public; the
+# compiled components (date_time/iostreams/regex) stay PRIVATE and are not
+# needed here.
+find_dependency(Boost 1.81.0)
 # Find Eigen
 # Try the version range first (CMake 3.19+ with compatible Eigen config)
 # Use find_package instead of find_dependency so QUIET failures don't abort
@@ -33,8 +42,8 @@ if(NOT TARGET Eigen3::Eigen)
     find_dependency(Eigen3 3.4.0 REQUIRED)
 endif()
 
-# Rest are private linked libraries
-#find_dependency(Boost COMPONENTS @OpenMS_BOOST_COMPONENTS@)
+# Rest are private linked libraries (compiled Boost components are PRIVATE, only
+# the header-only Boost::boost target found above is part of the public interface)
 #find_dependency(LIBSVM 2.91) # now PRIVATE: not exposed in the public API, encapsulated by SimpleSVM (see #8547)
 #find_dependency(COIN)
 #find_dependency(GLPK)

--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -65,11 +65,11 @@ add_subdirectory(thirdparty/percolator)
 
 #------------------------------------------------------------------------------
 # all the dependency libraries are linked into libOpenMS.so
-## Note: XercesC::XercesC is PUBLIC because Xerces types are part of the public API
-## (e.g. Internal::XMLHandler derives from xercesc::DefaultHandler and takes
-## xercesc::Attributes in method signatures), so downstream consumers need it (see #8547).
+## Note: XercesC::XercesC is PRIVATE — Xerces is fully encapsulated behind the
+## Xerces-free XMLHandler / XMLAttributes / StringManager public API and the
+## internal SAX2HandlerAdapter, so it no longer appears in any installed header
+## and downstream consumers neither include nor link it (see #8547).
 set(OPENMS_DEP_LIBRARIES
-  XercesC::XercesC
   CURL::libcurl
 )
 
@@ -79,6 +79,7 @@ set(OPENMS_DEP_LIBRARIES
 ## Note: LibSVM::LibSVM is PRIVATE because LIBSVM types are not exposed in the public API;
 ##       they are fully encapsulated by the SimpleSVM wrapper (Pimpl) (see #8547).
 set(OPENMS_DEP_PRIVATE_LIBRARIES
+  XercesC::XercesC
   $<$<BOOL:${WITH_HDF5}>:HDF5::HDF5>
   ${LPTARGET}
   BZip2::BZip2
@@ -127,12 +128,13 @@ set(OPENMS_DEP_PRIVATE_LIBRARIES
     )
 endif()
 
-# Xerces requires linking against CoreFoundation&CoreServices on macOS
+# Xerces requires linking against CoreFoundation&CoreServices on macOS.
+# Xerces is now a PRIVATE dependency, so these frameworks are private too.
 # TODO check if this is still the case
 if(APPLE)
   find_library(CoreFoundation_LIBRARY CoreFoundation )
   find_library(CoreServices_LIBRARY CoreServices )
-  set(OPENMS_DEP_LIBRARIES ${OPENMS_DEP_LIBRARIES}
+  list(APPEND OPENMS_DEP_PRIVATE_LIBRARIES
                            ${CoreFoundation_LIBRARY}
                            ${CoreServices_LIBRARY})
 endif()

--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -69,8 +69,14 @@ add_subdirectory(thirdparty/percolator)
 ## Xerces-free XMLHandler / XMLAttributes / StringManager public API and the
 ## internal SAX2HandlerAdapter, so it no longer appears in any installed header
 ## and downstream consumers neither include nor link it (see #8547).
+## Note: Boost::boost (header-only) is PUBLIC because the installed public header
+## config.h includes <boost/current_function.hpp> (via Macros.h), so consumers
+## (e.g. pyOpenMS) need Boost's include dir. Only the header-only target is
+## public — it propagates include dirs but no link libraries; the compiled Boost
+## components (date_time/iostreams/regex) stay PRIVATE below.
 set(OPENMS_DEP_LIBRARIES
   CURL::libcurl
+  Boost::boost
 )
 
 ## setup the arguments to 'target_link_libraries(OpenMS PRIVATE ${OPENMS_DEP_PRIVATE_LIBRARIES})'
@@ -83,7 +89,6 @@ set(OPENMS_DEP_PRIVATE_LIBRARIES
   $<$<BOOL:${WITH_HDF5}>:HDF5::HDF5>
   ${LPTARGET}
   BZip2::BZip2
-  Boost::boost
   Boost::date_time
   Boost::iostreams
   Boost::regex

--- a/src/openms/include/OpenMS/FORMAT/CVMappingFile.h
+++ b/src/openms/include/OpenMS/FORMAT/CVMappingFile.h
@@ -54,13 +54,13 @@ public:
 protected:
 
     // Docu in base class
-    void startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes) override;
+    void onStartElement(const char16_t* qname, const Internal::XMLAttributes& attributes) override;
 
     // Docu in base class
-    void endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname) override;
+    void onEndElement(const char16_t* qname) override;
 
     // Docu in base class
-    void characters(const XMLCh* const chars, const XMLSize_t /*length*/) override;
+    void onCharacters(const char16_t* chars, Size /*length*/) override;
 
 private:
 

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ConsensusXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ConsensusXMLHandler.h
@@ -60,13 +60,13 @@ public:
 protected:
 
     // Docu in base class
-    void endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname) override;
+    void onEndElement(const char16_t* qname) override;
 
     // Docu in base class
-    void startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes) override;
+    void onStartElement(const char16_t* qname, const XMLAttributes& attributes) override;
 
     // Docu in base class
-    void characters(const XMLCh* const chars, const XMLSize_t length) override;
+    void onCharacters(const char16_t* chars, Size length) override;
 
     /// Writes a peptide identification to a stream (for assigned/unassigned peptide identifications)
     void writePeptideIdentification_(const std::string& filename, std::ostream& os, const PeptideIdentification& id, const std::string& tag_name, UInt indentation_level);

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/FeatureXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/FeatureXMLHandler.h
@@ -84,13 +84,13 @@ protected:
     void resetMembers_();
 
     // Docu in base class
-    void endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname) override;
+    void onEndElement(const char16_t* qname) override;
 
     // Docu in base class
-    void startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes) override;
+    void onStartElement(const char16_t* qname, const XMLAttributes& attributes) override;
 
     // Docu in base class
-    void characters(const XMLCh* const chars, const XMLSize_t length) override;
+    void onCharacters(const char16_t* chars, Size length) override;
 
     /// Writes a feature to a stream
     void writeFeature_(const std::string& filename, std::ostream& os, const Feature& feat, const std::string& identifier_prefix, UInt64 identifier, UInt indentation_level);

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLHandler.h
@@ -118,14 +118,9 @@ namespace Internal
     // SAX2 overrides (MzMLHandler is called through for MS:* terms)
     // ------------------------------------------------------------------
 
-    void startElement(const XMLCh*               uri,
-                      const XMLCh*               localname,
-                      const XMLCh*               qname,
-                      const xercesc::Attributes& attrs) override;
+    void onStartElement(const char16_t* qname, const XMLAttributes& attrs) override;
 
-    void endElement(const XMLCh* uri,
-                    const XMLCh* localname,
-                    const XMLCh* qname) override;
+    void onEndElement(const char16_t* qname) override;
 
   private:
 

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLHandler.h
@@ -54,8 +54,7 @@ namespace Internal
 
     @b Inheritance diagram:
     @code
-    xercesc::DefaultHandler
-      └─ OpenMS::Internal::XMLHandler
+    OpenMS::Internal::XMLHandler
             └─ OpenMS::Internal::MzMLHandler
                   └─ OpenMS::Internal::ImzMLHandler  ← this class
                         └─ ImzMLInterceptConsumer : IMSDataConsumer

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MascotXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MascotXMLHandler.h
@@ -41,13 +41,13 @@ public:
       ~MascotXMLHandler() override;
 
       // Docu in base class
-      void endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname) override;
+      void onEndElement(const char16_t* qname) override;
 
       // Docu in base class
-      void startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes) override;
+      void onStartElement(const char16_t* qname, const XMLAttributes& attributes) override;
 
       // Docu in base class
-      void characters(const XMLCh* const chars, const XMLSize_t /*length*/) override;
+      void onCharacters(const char16_t* chars, Size /*length*/) override;
       
       /// Split modification search parameter if for more than one amino acid specified e.g. Phospho (ST)
       static std::vector<std::string> splitModificationBySpecifiedAA(const std::string& mod);

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzDataHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzDataHandler.h
@@ -54,13 +54,13 @@ public:
 
 
       // Docu in base class
-      void endElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname) override;
+      void onEndElement(const char16_t* qname) override;
 
       // Docu in base class
-      void startElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname, const xercesc::Attributes & attributes) override;
+      void onStartElement(const char16_t* qname, const XMLAttributes& attributes) override;
 
       // Docu in base class
-      void characters(const XMLCh * const chars, const XMLSize_t length) override;
+      void onCharacters(const char16_t* chars, Size length) override;
 
       /// Writes the contents to a stream
       void writeTo(std::ostream & os) override;

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzIdentMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzIdentMLHandler.h
@@ -259,13 +259,13 @@ public:
 
 
       // Docu in base class
-      void endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname) override;
+      void onEndElement(const char16_t* qname) override;
 
       // Docu in base class
-      void startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes) override;
+      void onStartElement(const char16_t* qname, const XMLAttributes& attributes) override;
 
       // Docu in base class
-      void characters(const XMLCh* const chars, const XMLSize_t length) override;
+      void onCharacters(const char16_t* chars, Size length) override;
 
       //Docu in base class
       void writeTo(std::ostream& os) override;
@@ -302,7 +302,7 @@ protected:
       IdentificationHit current_id_hit_;
 
       /// Handles CV terms
-      void handleCVParam_(const std::string& parent_parent_tag, const std::string& parent_tag, const std::string& accession, /* const std::string& name, */ /* const std::string& value, */ const xercesc::Attributes& attributes, const std::string& cv_ref /* ,  const std::string& unit_accession="" */);
+      void handleCVParam_(const std::string& parent_parent_tag, const std::string& parent_tag, const std::string& accession, /* const std::string& name, */ /* const std::string& value, */ const XMLAttributes& attributes, const std::string& cv_ref /* ,  const std::string& unit_accession="" */);
 
       /// Handles user terms
       void handleUserParam_(const std::string& parent_parent_tag, const std::string& parent_tag, const std::string& name, const std::string& type, const std::string& value);

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
@@ -114,13 +114,13 @@ public:
       //@{
 
       /// Docu in base class XMLHandler::endElement
-      void endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname) override;
+      void onEndElement(const char16_t* qname) override;
 
       /// Docu in base class XMLHandler::startElelement
-      void startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes) override;
+      void onStartElement(const char16_t* qname, const XMLAttributes& attributes) override;
 
       /// Docu in base class XMLHandler::characters
-      void characters(const XMLCh* const chars, const XMLSize_t length) override;
+      void onCharacters(const char16_t* chars, Size length) override;
 
       /// Docu in base class XMLHandler::writeTo
       void writeTo(std::ostream& os) override;

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLSpectrumDecoder.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLSpectrumDecoder.h
@@ -16,7 +16,6 @@
 #include <OpenMS/METADATA/MetaInfoDescription.h>
 
 #include <string>
-#include <xercesc/dom/DOMNode.hpp>
 
 #include <OpenMS/FORMAT/HANDLERS/MzMLHandlerHelper.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
@@ -70,10 +69,12 @@ namespace OpenMS
       a binaryDataArray tag and store the result as a BinaryData object. The
       result will be appended to the data vector.
 
-      @param[in] indexListNode DOMNode of type binaryDataArray
+      @param[in] indexListNode Opaque pointer to a Xerces @c DOMNode of type
+                 binaryDataArray (typed as @c void* so this public header stays
+                 Xerces-free; recovered internally in the .cpp).
       @param[in] data Binary data extracted from the string
     */
-    void handleBinaryDataArray_(xercesc::DOMNode* indexListNode, std::vector<BinaryData>& data);
+    void handleBinaryDataArray_(void* indexListNode, std::vector<BinaryData>& data);
 
     /**
       @brief Extract data from a string containing multiple \<binaryDataArray\> tags.

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzXMLHandler.h
@@ -60,13 +60,13 @@ public:
       void setLoadDetail(const LOADDETAIL d) override;
 
       // Docu in base class
-      void endElement(const XMLCh* const uri, const XMLCh* const local_name, const XMLCh* const qname) override;
+      void onEndElement(const char16_t* qname) override;
 
       // Docu in base class
-      void startElement(const XMLCh* const uri, const XMLCh* const local_name, const XMLCh* const qname, const xercesc::Attributes& attributes) override;
+      void onStartElement(const char16_t* qname, const XMLAttributes& attributes) override;
 
       // Docu in base class
-      void characters(const XMLCh* const chars, const XMLSize_t length) override;
+      void onCharacters(const char16_t* chars, Size length) override;
 
       /// Write the contents to a stream
       void writeTo(std::ostream& os) override;

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/PTMXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/PTMXMLHandler.h
@@ -35,13 +35,13 @@ public:
       void writeTo(std::ostream & os) override;
 
       // Docu in base class
-      void endElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname) override;
+      void onEndElement(const char16_t* qname) override;
 
       // Docu in base class
-      void startElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname, const xercesc::Attributes & attributes) override;
+      void onStartElement(const char16_t* qname, const XMLAttributes& attributes) override;
 
       // Docu in base class
-      void characters(const XMLCh * const chars, const XMLSize_t /*length*/) override;
+      void onCharacters(const char16_t* chars, Size /*length*/) override;
 
 protected:
       std::map<std::string, std::pair<std::string, std::string> > & ptm_informations_;

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ParamXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ParamXMLHandler.h
@@ -32,10 +32,10 @@ public:
       ~ParamXMLHandler() override;
 
       // Docu in base class
-      void endElement(const XMLCh* const uri, const XMLCh* const local_name, const XMLCh* const qname) override;
+      void onEndElement(const char16_t* qname) override;
 
       // Docu in base class
-      void startElement(const XMLCh* const uri, const XMLCh* const local_name, const XMLCh* const qname, const xercesc::Attributes& attributes) override;
+      void onStartElement(const char16_t* qname, const XMLAttributes& attributes) override;
 
 protected:
       /// The current absolute path (concatenation of nodes_ with <i>:</i> in between)

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/SAX2HandlerAdapter.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/SAX2HandlerAdapter.h
@@ -43,7 +43,7 @@ namespace OpenMS::Internal
     void startElement(const XMLCh* const /*uri*/, const XMLCh* const /*localname*/,
                       const XMLCh* const qname, const xercesc::Attributes& attrs) override
     {
-      handler_.onStartElement(reinterpret_cast<const char16_t*>(qname), XMLAttributes(attrs));
+      handler_.onStartElement(reinterpret_cast<const char16_t*>(qname), XMLAttributes(static_cast<const void*>(&attrs)));
     }
 
     void endElement(const XMLCh* const /*uri*/, const XMLCh* const /*localname*/,

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/SAX2HandlerAdapter.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/SAX2HandlerAdapter.h
@@ -1,0 +1,84 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+// NOTE: This is a private (non-installed) libOpenMS header. It bridges the
+// Xerces SAX2 interface to OpenMS' Xerces-free XMLHandler callbacks and must only
+// be included from libOpenMS .cpp translation units (never from a public header).
+
+#pragma once
+
+#include <OpenMS/FORMAT/HANDLERS/StringManager.h>
+#include <OpenMS/FORMAT/HANDLERS/XMLAttributes.h>
+#include <OpenMS/FORMAT/HANDLERS/XMLHandler.h>
+
+#include <xercesc/sax2/Attributes.hpp>
+#include <xercesc/sax2/DefaultHandler.hpp>
+#include <xercesc/sax/SAXParseException.hpp>
+
+namespace OpenMS::Internal
+{
+  /**
+    @brief Adapts an OpenMS @ref XMLHandler to the Xerces SAX2 @c DefaultHandler interface.
+
+    Xerces owns the SAX callback interface; OpenMS handlers expose the Xerces-free
+    @c onStartElement / @c onEndElement / @c onCharacters callbacks (and OpenMS-typed
+    error handlers). This adapter is installed as the Xerces content+error handler and
+    forwards each callback to the wrapped @ref XMLHandler. XMLCh is guaranteed to be
+    char16_t-sized, so the reinterpret_casts at this boundary are well-defined views.
+
+    The forwarding methods are intentionally not @c noexcept: subclass callbacks may
+    throw (e.g. XMLHandler::EndParsingSoftly to abort parsing early), and that
+    exception must unwind through Xerces' parse() exactly as before.
+  */
+  class SAX2HandlerAdapter : public xercesc::DefaultHandler
+  {
+  public:
+    explicit SAX2HandlerAdapter(XMLHandler& handler) : handler_(handler) {}
+
+    void startElement(const XMLCh* const /*uri*/, const XMLCh* const /*localname*/,
+                      const XMLCh* const qname, const xercesc::Attributes& attrs) override
+    {
+      handler_.onStartElement(reinterpret_cast<const char16_t*>(qname), XMLAttributes(attrs));
+    }
+
+    void endElement(const XMLCh* const /*uri*/, const XMLCh* const /*localname*/,
+                    const XMLCh* const qname) override
+    {
+      handler_.onEndElement(reinterpret_cast<const char16_t*>(qname));
+    }
+
+    void characters(const XMLCh* const chars, const XMLSize_t length) override
+    {
+      handler_.onCharacters(reinterpret_cast<const char16_t*>(chars), length);
+    }
+
+    void fatalError(const xercesc::SAXParseException& e) override
+    {
+      handler_.fatalError(XMLHandler::LOAD, message_(e), (UInt)e.getLineNumber(), (UInt)e.getColumnNumber());
+    }
+
+    void error(const xercesc::SAXParseException& e) override
+    {
+      handler_.error(XMLHandler::LOAD, message_(e), (UInt)e.getLineNumber(), (UInt)e.getColumnNumber());
+    }
+
+    void warning(const xercesc::SAXParseException& e) override
+    {
+      handler_.warning(XMLHandler::LOAD, message_(e), (UInt)e.getLineNumber(), (UInt)e.getColumnNumber());
+    }
+
+  private:
+    static std::string message_(const xercesc::SAXParseException& e)
+    {
+      return StringManager::convert(reinterpret_cast<const char16_t*>(e.getMessage()));
+    }
+
+    XMLHandler& handler_;
+  };
+
+} // namespace OpenMS::Internal

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/StringManager.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/StringManager.h
@@ -1,0 +1,250 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Marc Sturm, Chris Bielow $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/CONCEPT/Types.h>
+
+#include <memory>
+#include <string>
+
+namespace OpenMS::Internal
+{
+  /// Compile-time UTF-16 string literal, usable wherever a @c XMLCh* is expected
+  /// (XMLCh is guaranteed to be char16_t-compatible; see StringManager.cpp).
+  #define CONST_XMLCH(s) (u ## s)
+
+  //Adapted from https://www.codeproject.com/articles/99551/redux-raii-adapter-for-xerces
+  //Copyright 2010 Orjan Westin
+  //Under BSD license
+  //========================================================================================================
+  template<typename T>
+  class OPENMS_DLLAPI shared_xerces_ptr
+  {
+    // Function to release Xerces data type with a release member function
+    template<typename U>
+    static void doRelease_(U* item)
+    {
+      // Only release this if it has no owner
+      if (nullptr == item->getOwnerDocument())
+        item->release();
+    }
+
+    static void doRelease_(char* item);
+    static void doRelease_(char16_t* item);
+
+    // The actual data we're holding
+    std::shared_ptr<T> item_;
+  public:
+    // Default constructor
+    shared_xerces_ptr() = default;
+    // Assignment constructor
+    shared_xerces_ptr(T* item)
+        : item_(item, doRelease_ )
+    {}
+    // Assignment of data to guard
+    shared_xerces_ptr& operator=(T* item)
+    {
+      assign(item);
+      return *this;
+    }
+    // Give up hold on data
+    void reset()
+    {
+      item_.reset();
+    }
+    // Release currently held data, if any, to hold another
+    void assign(T* item)
+    {
+      item_.reset(item, doRelease_ );
+    }
+    // Get pointer to the currently held data, if any
+    T* get()
+    {
+      return item_.get();
+    }
+    const T* get() const
+    {
+      return item_.get();
+    }
+    // Return true if no data is held
+    bool is_released() const
+    {
+      return (nullptr == item_.get());
+    }
+  };
+
+  template <typename T>
+  class OPENMS_DLLAPI unique_xerces_ptr
+  {
+  private:
+
+    template<typename U>
+    static void doRelease_(U*& item)
+    {
+      // Only release this if it has no parent (otherwise
+      // parent will release it)
+      if (nullptr == item->getOwnerDocument())
+        item->release();
+    }
+
+    static void doRelease_(char*& item);
+    static void doRelease_(char16_t*& item);
+
+    T* item_;
+
+  public:
+
+    // Hide copy constructor and assignment operator
+    unique_xerces_ptr(const unique_xerces_ptr<T>&) = delete;
+    unique_xerces_ptr& operator=(const unique_xerces_ptr<T>&) = delete;
+
+    unique_xerces_ptr()
+        : item_(nullptr)
+    {}
+
+    explicit unique_xerces_ptr(T* i)
+        : item_(i)
+    {}
+
+    ~unique_xerces_ptr()
+    {
+      xerces_release();
+    }
+
+    unique_xerces_ptr(unique_xerces_ptr<T>&& other) noexcept
+        : item_(nullptr)
+    {
+      this->swap(other);
+    }
+
+    void swap(unique_xerces_ptr<T>& other) noexcept
+    {
+      std::swap(item_, other.item_);
+    }
+
+    // Assignment of data to guard (not chainable)
+    void operator=(T* i)
+    {
+      reassign(i);
+    }
+
+    // Release held data (i.e. delete/free it)
+    void xerces_release()
+    {
+      if (!is_released())
+      {
+        // Use type-specific release mechanism
+        doRelease_(item_);
+        item_ = nullptr;
+      }
+    }
+
+    // Give up held data (i.e. return data without releasing)
+    T* yield()
+    {
+      T* tempItem = item_;
+      item_ = nullptr;
+      return tempItem;
+    }
+
+    // Release currently held data, if any, to hold another
+    void assign(T* i)
+    {
+      xerces_release();
+      item_ = i;
+    }
+
+    // Get pointer to the currently held data, if any
+    T* get() const
+    {
+      return item_;
+    }
+
+    // Return true if no data is held
+    bool is_released() const
+    {
+      return (nullptr == item_);
+    }
+  };
+
+  //========================================================================================================
+
+  /**
+   * @brief Helper class for XML parsing that handles the conversions of Xerces strings
+   *
+   * It provides the convert() function which internally calls
+   * XMLString::transcode and ensures that the memory is released properly
+   * through XMLString::release internally. It returns a std::string or
+   * std::basic_string<char16_t> to the caller who takes ownership of the data.
+   *
+   * The public interface uses @c char16_t (UTF-16 code units), which is
+   * guaranteed to match Xerces' @c XMLCh, so this header stays Xerces-free.
+  */
+  class OPENMS_DLLAPI StringManager
+  {
+    typedef std::basic_string<char16_t> XercesString;
+
+    /// Converts from a narrow-character string to a wide-character string.
+    static unique_xerces_ptr<char16_t> fromNative_(const char* str);
+
+    /// Converts from a narrow-character string to a wide-character string.
+    static unique_xerces_ptr<char16_t> fromNative_(const std::string& str);
+
+    /// Converts from a wide-character string to a narrow-character string.
+    static std::string toNative_(const char16_t* str);
+
+    /// Converts from a wide-character string to a narrow-character string.
+    static std::string toNative_(const unique_xerces_ptr<char16_t>& str);
+
+protected:
+    /// Compresses eight 8x16bit Chars in char16_t* to 8x8bit Chars by cutting upper byte
+    static void compress64_ (const char16_t * input_it, char* output_it);
+
+public:
+    /// Constructor
+    StringManager();
+
+    /// Destructor
+    ~StringManager();
+
+    /// Calculates the length of a char16_t* string using SIMDe
+    // https://github.com/OpenMS/OpenMS/issues/8122
+    static Size strLength(const char16_t* input_ptr);
+
+    /// Transcode the supplied C string to a UTF-16 string
+    static XercesString convert(const char * str);
+
+    /// Transcode the supplied C++ string to a UTF-16 string
+    static XercesString convert(const std::string & str);
+
+    /// Transcode the supplied C string to a UTF-16 string pointer
+    static unique_xerces_ptr<char16_t> convertPtr(const char * str);
+
+    /// Transcode the supplied C++ string to a UTF-16 string pointer
+    static unique_xerces_ptr<char16_t> convertPtr(const std::string & str);
+
+    /// Transcode the supplied char16_t* to a std::string
+    static std::string convert(const char16_t * str);
+
+    /// Parse an integer from a UTF-16 numeric string (as Xerces' XMLString::parseInt would).
+    static Int parseInt(const char16_t * str);
+
+    /// Checks if supplied chars in char16_t* can be encoded with ASCII (i.e. the upper byte of each char is 0)
+    static bool isASCII(const char16_t * chars, const Size length);
+
+    /**
+     * @brief Transcodes the supplied char16_t* and appends it to the OpenMS String
+     *
+     * @note Assumes that the char16_t* only contains ASCII characters
+     *
+    */
+    static void appendASCII(const char16_t * str, const Size length, std::string & result);
+  };
+
+} // namespace OpenMS::Internal

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ToolDescriptionHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ToolDescriptionHandler.h
@@ -41,13 +41,13 @@ public:
 
 
       // Docu in base class
-      void endElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname) override;
+      void onEndElement(const char16_t* qname) override;
 
       // Docu in base class
-      void startElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname, const xercesc::Attributes & attributes) override;
+      void onStartElement(const char16_t* qname, const XMLAttributes& attributes) override;
 
       // Docu in base class
-      void characters(const XMLCh * const chars, const XMLSize_t length) override;
+      void onCharacters(const char16_t* chars, Size length) override;
 
       // NOT IMPLEMENTED
       void writeTo(std::ostream & os) override;

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/TraMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/TraMLHandler.h
@@ -54,13 +54,13 @@ public:
 
 
       // Docu in base class
-      void endElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname) override;
+      void onEndElement(const char16_t* qname) override;
 
       // Docu in base class
-      void startElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname, const xercesc::Attributes & attributes) override;
+      void onStartElement(const char16_t* qname, const XMLAttributes& attributes) override;
 
       // Docu in base class
-      void characters(const XMLCh * const chars, const XMLSize_t length) override;
+      void onCharacters(const char16_t* chars, Size length) override;
 
       //Docu in base class
       void writeTo(std::ostream & os) override;

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/UniProtXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/UniProtXMLHandler.h
@@ -58,11 +58,9 @@ namespace OpenMS::Internal
     /// Destructor.
     ~UniProtXMLHandler() override;
 
-    void startElement(const XMLCh* const uri, const XMLCh* const local_name,
-                      const XMLCh* const qname, const xercesc::Attributes& attrs) override;
-    void endElement(const XMLCh* const uri, const XMLCh* const local_name,
-                    const XMLCh* const qname) override;
-    void characters(const XMLCh* const chars, const XMLSize_t length) override;
+    void onStartElement(const char16_t* qname, const XMLAttributes& attrs) override;
+    void onEndElement(const char16_t* qname) override;
+    void onCharacters(const char16_t* chars, Size length) override;
 
   private:
     EntryCallback callback_;

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/UnimodXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/UnimodXMLHandler.h
@@ -33,13 +33,13 @@ public:
       ~UnimodXMLHandler() override;
 
       // Docu in base class
-      void endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname) override;
+      void onEndElement(const char16_t* qname) override;
 
       // Docu in base class
-      void startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes) override;
+      void onStartElement(const char16_t* qname, const XMLAttributes& attributes) override;
 
       // Docu in base class
-      void characters(const XMLCh* const chars, const XMLSize_t /*length*/) override;
+      void onCharacters(const char16_t* chars, Size /*length*/) override;
 
 private:
 

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLAttributes.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLAttributes.h
@@ -10,8 +10,6 @@
 
 #include <OpenMS/CONCEPT/Types.h>
 
-#include <type_traits>
-
 namespace OpenMS::Internal
 {
   /**
@@ -39,15 +37,12 @@ namespace OpenMS::Internal
     /**
       @brief Wrap a live attribute list (non-owning).
 
-      Templated so a @c xercesc::Attributes& (the SAX callback argument) converts
-      transparently without this header having to name any Xerces type. The
-      overload is disabled for @c XMLAttributes itself so copy construction is not
-      hijacked.
+      Takes an opaque handle so this header need not name any Xerces type. The
+      only caller is the internal SAX2HandlerAdapter, which passes the address of
+      the live @c xercesc::Attributes (recovered internally in @ref XMLAttributes.cpp).
     */
-    template <typename AttributesT,
-              typename = std::enable_if_t<!std::is_same_v<std::decay_t<AttributesT>, XMLAttributes>>>
-    XMLAttributes(const AttributesT& attributes) noexcept :
-      attributes_(static_cast<const void*>(&attributes))
+    explicit XMLAttributes(const void* attributes) noexcept :
+      attributes_(attributes)
     {
     }
 

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLAttributes.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLAttributes.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/CONCEPT/Types.h>
+
+#include <type_traits>
+
+namespace OpenMS::Internal
+{
+  /**
+    @brief Xerces-free, lightweight view over the attribute list of an XML element.
+
+    Wraps a live @c xercesc::Attributes (owned by the SAX parser and valid only
+    for the duration of the @c startElement callback). It exposes only the small
+    surface the OpenMS handlers actually use (value-by-name, index-by-name,
+    value-by-index), so that Xerces types never appear in a public header.
+
+    The underlying attribute list is held as an opaque pointer, so this header
+    pulls in no Xerces declarations — consumers of libOpenMS need Xerces neither
+    on their include path nor at link time. The accessor implementations
+    (in @c XMLAttributes.cpp) recover the concrete Xerces type internally.
+
+    The wrapper is a non-owning view: it stores a pointer to the parser-owned
+    attribute list and must not outlive the callback it was created for.
+  */
+  class OPENMS_DLLAPI XMLAttributes
+  {
+  public:
+    XMLAttributes(const XMLAttributes&) = default;
+    XMLAttributes& operator=(const XMLAttributes&) = default;
+
+    /**
+      @brief Wrap a live attribute list (non-owning).
+
+      Templated so a @c xercesc::Attributes& (the SAX callback argument) converts
+      transparently without this header having to name any Xerces type. The
+      overload is disabled for @c XMLAttributes itself so copy construction is not
+      hijacked.
+    */
+    template <typename AttributesT,
+              typename = std::enable_if_t<!std::is_same_v<std::decay_t<AttributesT>, XMLAttributes>>>
+    XMLAttributes(const AttributesT& attributes) noexcept :
+      attributes_(static_cast<const void*>(&attributes))
+    {
+    }
+
+    /// Value of the attribute named @p qname (UTF-16 code units), or @c nullptr if absent.
+    const char16_t* value(const char16_t* qname) const;
+
+    /// Value of the attribute named @p qname (narrow name, transcoded internally), or @c nullptr if absent.
+    const char16_t* value(const char* qname) const;
+
+    /// Index of the attribute named @p qname, or a negative value if absent.
+    SignedSize index(const char16_t* qname) const;
+
+    /// Value of the attribute at position @p i (UTF-16 code units).
+    const char16_t* valueByIndex(Size i) const;
+
+    /// Opaque handle to the underlying attribute list (libOpenMS-internal use).
+    const void* handle() const noexcept { return attributes_; }
+
+  private:
+    const void* attributes_;
+  };
+
+} // namespace OpenMS::Internal

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLAttributes.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLAttributes.h
@@ -39,7 +39,7 @@ namespace OpenMS::Internal
 
       Takes an opaque handle so this header need not name any Xerces type. The
       only caller is the internal SAX2HandlerAdapter, which passes the address of
-      the live @c xercesc::Attributes (recovered internally in @ref XMLAttributes.cpp).
+      the live @c xercesc::Attributes (recovered internally in @c XMLAttributes.cpp).
     */
     explicit XMLAttributes(const void* attributes) noexcept :
       attributes_(attributes)

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
@@ -391,7 +391,7 @@ public:
       /// Parsing method for closing tags
       virtual void onEndElement(const char16_t * qname);
       /// Parsing method for character data
-      virtual void onCharacters(std::u16string_view chars);
+      virtual void onCharacters(const char16_t * chars, Size length);
       //@}
 
       /// Writes the contents to a stream.

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
@@ -230,6 +230,10 @@ protected:
       /// Returns if two Xerces strings are equal
       inline bool equal_(const char16_t * a, const char16_t * b) const
       {
+        // Guard null pointers before constructing views: u16string_view(nullptr)
+        // is UB, whereas the previous XMLString::compareString tolerated nulls
+        // (both null => equal, one null => unequal), which this reproduces.
+        if (a == nullptr || b == nullptr) return a == b;
         return std::u16string_view(a) == std::u16string_view(b);
       }
 

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
@@ -14,16 +14,12 @@
  
 #include <OpenMS/DATASTRUCTURES/DateTime.h>
 #include <OpenMS/DATASTRUCTURES/DataValue.h>
+#include <OpenMS/FORMAT/HANDLERS/StringManager.h>
 #include <OpenMS/FORMAT/HANDLERS/XMLAttributes.h>
-
-#include <xercesc/sax2/Attributes.hpp>
-#include <xercesc/sax2/DefaultHandler.hpp>
-#include <xercesc/util/XMLString.hpp>
 
 #include <iosfwd>
 #include <string>
 #include <string_view>
-#include <memory>
 
 
 namespace OpenMS
@@ -36,284 +32,13 @@ namespace OpenMS
   namespace Internal
   {
 
-    #define CONST_XMLCH(s) reinterpret_cast<const ::XMLCh*>(u ## s)
-
-    static_assert(sizeof(::XMLCh) == sizeof(char16_t),
-                  "XMLCh is not sized correctly for UTF-16.");
-
-    //Adapted from https://www.codeproject.com/articles/99551/redux-raii-adapter-for-xerces
-    //Copyright 2010 Orjan Westin
-    //Under BSD license
-    //========================================================================================================
-    template<typename T>
-    class OPENMS_DLLAPI shared_xerces_ptr
-    {
-      // Function to release Xerces data type with a release member function
-      template<typename U>
-      static void doRelease_(U* item)
-      {
-        // Only release this if it has no owner
-        if (nullptr == item->getOwnerDocument())
-          item->release();
-      }
-
-      static void doRelease_(char* item);
-      static void doRelease_(XMLCh* item);
-
-      // The actual data we're holding
-      std::shared_ptr<T> item_;
-    public:
-      // Default constructor
-      shared_xerces_ptr() = default;
-      // Assignment constructor
-      shared_xerces_ptr(T* item)
-          : item_(item, doRelease_ )
-      {}
-      // Assignment of data to guard
-      shared_xerces_ptr& operator=(T* item)
-      {
-        assign(item);
-        return *this;
-      }
-      // Give up hold on data
-      void reset()
-      {
-        item_.reset();
-      }
-      // Release currently held data, if any, to hold another
-      void assign(T* item)
-      {
-        item_.reset(item, doRelease_ );
-      }
-      // Get pointer to the currently held data, if any
-      T* get()
-      {
-        return item_.get();
-      }
-      const T* get() const
-      {
-        return item_.get();
-      }
-      // Return true if no data is held
-      bool is_released() const
-      {
-        return (nullptr == item_.get());
-      }
-    };
-
-    template <typename T>
-    class OPENMS_DLLAPI unique_xerces_ptr
-    {
-    private:
-
-      template<typename U>
-      static void doRelease_(U*& item)
-      {
-        // Only release this if it has no parent (otherwise
-        // parent will release it)
-        if (nullptr == item->getOwnerDocument())
-          item->release();
-      }
-
-      static void doRelease_(char*& item);
-      static void doRelease_(XMLCh*& item);
-
-      T* item_;
-
-    public:
-
-      // Hide copy constructor and assignment operator
-      unique_xerces_ptr(const unique_xerces_ptr<T>&) = delete;
-      unique_xerces_ptr& operator=(const unique_xerces_ptr<T>&) = delete;
-
-      unique_xerces_ptr()
-          : item_(nullptr)
-      {}
-
-      explicit unique_xerces_ptr(T* i)
-          : item_(i)
-      {}
-
-      ~unique_xerces_ptr()
-      {
-        xerces_release();
-      }
-
-      unique_xerces_ptr(unique_xerces_ptr<T>&& other) noexcept
-          : item_(nullptr)
-      {
-        this->swap(other);
-      }
-
-      void swap(unique_xerces_ptr<T>& other) noexcept
-      {
-        std::swap(item_, other.item_);
-      }
-
-      // Assignment of data to guard (not chainable)
-      void operator=(T* i)
-      {
-        reassign(i);
-      }
-
-      // Release held data (i.e. delete/free it)
-      void xerces_release()
-      {
-        if (!is_released())
-        {
-          // Use type-specific release mechanism
-          doRelease_(item_);
-          item_ = nullptr;
-        }
-      }
-
-      // Give up held data (i.e. return data without releasing)
-      T* yield()
-      {
-        T* tempItem = item_;
-        item_ = nullptr;
-        return tempItem;
-      }
-
-      // Release currently held data, if any, to hold another
-      void assign(T* i)
-      {
-        xerces_release();
-        item_ = i;
-      }
-
-      // Get pointer to the currently held data, if any
-      T* get() const
-      {
-        return item_;
-      }
-
-      // Return true if no data is held
-      bool is_released() const
-      {
-        return (nullptr == item_);
-      }
-    };
-
-    //========================================================================================================
-
-    /*
-     * @brief Helper class for XML parsing that handles the conversions of Xerces strings
-     *
-     * It provides the convert() function which internally calls
-     * XMLString::transcode and ensures that the memory is released properly
-     * through XMLString::release internally. It returns a std::string or
-     * std::basic_string<XMLCh> to the caller who takes ownership of the data.
-     *
-    */
-    class OPENMS_DLLAPI StringManager
-    {
-
-      typedef std::basic_string<XMLCh> XercesString;
-
-      /// Converts from a narrow-character string to a wide-character string.
-      inline static unique_xerces_ptr<XMLCh> fromNative_(const char* str)
-      {
-        return unique_xerces_ptr<XMLCh>(xercesc::XMLString::transcode(str));
-      }
-
-      /// Converts from a narrow-character string to a wide-character string.
-      inline static unique_xerces_ptr<XMLCh> fromNative_(const std::string& str)
-      {
-        return fromNative_(str.c_str());
-      }
-
-      /// Converts from a wide-character string to a narrow-character string.
-      inline static std::string toNative_(const XMLCh* str)
-      { 
-        std::string r;
-        XMLSize_t l = strLength(str);
-        if(isASCII(str, l))
-        {
-          appendASCII(str,l,r);
-        }
-        else
-        {
-          r = (unique_xerces_ptr<char>(xercesc::XMLString::transcode(str)).get());
-        }
-        return r;
-      }
-
-      /// Converts from a wide-character string to a narrow-character string.
-      inline static std::string toNative_(const unique_xerces_ptr<XMLCh>& str)
-      {
-        return toNative_(str.get());
-      }
-
-protected:
-      /// Compresses eight 8x16bit Chars in XMLCh* to 8x8bit Chars by cutting upper byte
-      static void compress64_ (const XMLCh * input_it, char* output_it);
-
-public:
-      /// Constructor
-      StringManager();
-
-      /// Destructor
-      ~StringManager();
-
-      /// Calculates the length of a XMLCh* string using SIMDe
-      // https://github.com/OpenMS/OpenMS/issues/8122
-      #if defined(__GNUC__)
-      __attribute__((no_sanitize("address")))
-      #elif defined(_MSC_VER)
-      __declspec(no_sanitize_address) 
-      #endif
-      static XMLSize_t strLength(const XMLCh* input_ptr);
-
-      /// Transcode the supplied C string to a xerces string
-      inline static XercesString convert(const char * str)
-      {
-        return fromNative_(str).get();
-      }
-
-      /// Transcode the supplied C++ string to a xerces string
-      inline static XercesString convert(const std::string & str)
-      {
-        return fromNative_(str.c_str()).get();
-      }
-
-      /// Transcode the supplied C string to a xerces string pointer
-      inline static unique_xerces_ptr<XMLCh> convertPtr(const char * str)
-      {
-        return fromNative_(str);
-      }
-
-      /// Transcode the supplied C++ string to a xerces string pointer
-      inline static unique_xerces_ptr<XMLCh> convertPtr(const std::string & str)
-      {
-        return fromNative_(str.c_str());
-      }
-
-      /// Transcode the supplied XMLCh* to a String
-      inline static std::string convert(const XMLCh * str)
-      {
-        return toNative_(str);
-      }
-      /// Checks if supplied chars in XMLCh* can be encoded with ASCII (i.e. the upper byte of each char is 0)
-      static bool isASCII(const XMLCh * chars, const XMLSize_t length);
-
-      
-      
-      /**
-       * @brief Transcodes the supplied XMLCh* and appends it to the OpenMS String
-       *
-       * @note Assumes that the XMLCh* only contains ASCII characters
-       *
-      */
-      static void appendASCII(const XMLCh * str, const XMLSize_t length, std::string & result);
-
-    };
+    // XMLCh string handling lives in StringManager (Xerces-free public API);
+    // shared_xerces_ptr / unique_xerces_ptr / CONST_XMLCH are declared there.
 
     /**
         @brief Base class for XML handlers.
     */
-    class OPENMS_DLLAPI XMLHandler :
-      public xercesc::DefaultHandler
+    class OPENMS_DLLAPI XMLHandler
     {
 public:
 
@@ -347,22 +72,10 @@ public:
       /// Default constructor
       XMLHandler(const std::string & filename, const std::string & version);
       /// Destructor
-      ~XMLHandler() override;
+      virtual ~XMLHandler();
 
       /// Release internal memory used for parsing (call
       void reset();
-
-
-      /**
-          @name Reimplemented XERCES-C error handlers
-
-          These methods forward the error message to our own error handlers below.
-      */
-      //@{
-      void fatalError(const xercesc::SAXParseException & exception) override;
-      void error(const xercesc::SAXParseException & exception) override;
-      void warning(const xercesc::SAXParseException & exception) override;
-      //@}
 
       /// Fatal error handler. Throws a ParseError exception
       void fatalError(ActionMode mode, const std::string & msg, UInt line = 0, UInt column = 0) const;
@@ -371,19 +84,13 @@ public:
       /// Warning handler.
       void warning(ActionMode mode, const std::string & msg, UInt line = 0, UInt column = 0) const;
 
-      /// Parsing method for character data (Xerces callback; forwards to the native overload below)
-      void characters(const XMLCh * const chars, const XMLSize_t length) override;
-      /// Parsing method for opening tags (Xerces callback; forwards to the native overload below)
-      void startElement(const XMLCh * const uri, const XMLCh * const localname, const XMLCh * const qname, const xercesc::Attributes & attrs) override;
-      /// Parsing method for closing tags (Xerces callback; forwards to the native overload below)
-      void endElement(const XMLCh * const uri, const XMLCh * const localname, const XMLCh * const qname) override;
-
       /**
           @name Native (Xerces-free) SAX callbacks
 
-          Subclasses override these instead of the Xerces-typed callbacks above.
-          @c qname / @c chars are UTF-16 code units (as delivered by the parser);
-          attributes are exposed through the Xerces-free @ref XMLAttributes view.
+          Subclasses override these. @c qname / @c chars are UTF-16 code units (as
+          delivered by the parser); attributes are exposed through the Xerces-free
+          @ref XMLAttributes view. The Xerces SAX parser is bridged to these
+          callbacks by the internal SAX2HandlerAdapter.
       */
       //@{
       /// Parsing method for opening tags
@@ -521,9 +228,9 @@ protected:
 
 
       /// Returns if two Xerces strings are equal
-      inline bool equal_(const XMLCh * a, const XMLCh * b) const
+      inline bool equal_(const char16_t * a, const char16_t * b) const
       {
-        return xercesc::XMLString::compareString(a, b) == 0;
+        return std::u16string_view(a) == std::u16string_view(b);
       }
 
       ///@name General MetaInfo handling (for idXML, featureXML, consensusXML)
@@ -565,9 +272,9 @@ protected:
       }
 
       /// Conversion of a Xerces string to an integer value
-      inline Int asInt_(const XMLCh * in) const
+      inline Int asInt_(const char16_t * in) const
       {
-        return xercesc::XMLString::parseInt(in);
+        return sm_.parseInt(in);
       }
 
       /// Conversion of a std::string to an unsigned integer value
@@ -673,7 +380,7 @@ protected:
       /// Converts an attribute to a String
       inline std::string attributeAsString_(const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
+        const char16_t * val = a.value(name);
         if (val == nullptr) fatalError(LOAD,std::string("Required attribute '") + name + "' not present!");
         return sm_.convert(val);
       }
@@ -681,15 +388,15 @@ protected:
       /// Converts an attribute to a Int
       inline Int attributeAsInt_(const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
+        const char16_t * val = a.value(name);
         if (val == nullptr) fatalError(LOAD,std::string("Required attribute '") + name + "' not present!");
-        return xercesc::XMLString::parseInt(val);
+        return sm_.parseInt(val);
       }
 
       /// Converts an attribute to a double
       inline double attributeAsDouble_(const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
+        const char16_t * val = a.value(name);
         if (val == nullptr) fatalError(LOAD,std::string("Required attribute '") + name + "' not present!");
         return StringUtils::toDouble(sm_.convert(val));
       }
@@ -710,7 +417,7 @@ protected:
       */
       inline bool optionalAttributeAsString_(std::string & value, const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
+        const char16_t * val = a.value(name);
         if (val != nullptr)
         {
           value = sm_.convert(val);
@@ -726,10 +433,10 @@ protected:
       */
       inline bool optionalAttributeAsInt_(Int & value, const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
+        const char16_t * val = a.value(name);
         if (val != nullptr)
         {
-          value = xercesc::XMLString::parseInt(val);
+          value = sm_.parseInt(val);
           return true;
         }
         return false;
@@ -742,10 +449,10 @@ protected:
       */
       inline bool optionalAttributeAsUInt_(UInt & value, const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
+        const char16_t * val = a.value(name);
         if (val != nullptr)
         {
-          value = xercesc::XMLString::parseInt(val);
+          value = sm_.parseInt(val);
           return true;
         }
         return false;
@@ -758,7 +465,7 @@ protected:
       */
       inline bool optionalAttributeAsDouble_(double & value, const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
+        const char16_t * val = a.value(name);
         if (val != nullptr)
         {
           value =StringUtils::toDouble(sm_.convert(val));
@@ -774,7 +481,7 @@ protected:
       */
       inline bool optionalAttributeAsDoubleList_(DoubleList & value, const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
+        const char16_t * val = a.value(name);
         if (val != nullptr)
         {
           value = attributeAsDoubleList_(a, name);
@@ -790,7 +497,7 @@ protected:
       */
       inline bool optionalAttributeAsStringList_(StringList & value, const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
+        const char16_t * val = a.value(name);
         if (val != nullptr)
         {
           value = attributeAsStringList_(a, name);
@@ -806,7 +513,7 @@ protected:
       */
       inline bool optionalAttributeAsIntList_(IntList & value, const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
+        const char16_t * val = a.value(name);
         if (val != nullptr)
         {
           value = attributeAsIntList_(a, name);
@@ -816,42 +523,42 @@ protected:
       }
 
       /// Converts an attribute to a String
-      inline std::string attributeAsString_(const XMLAttributes & a, const XMLCh * name) const
+      inline std::string attributeAsString_(const XMLAttributes & a, const char16_t * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
+        const char16_t * val = a.value(name);
         if (val == nullptr) fatalError(LOAD,std::string("Required attribute '") + sm_.convert(name) + "' not present!");
         return sm_.convert(val);
       }
 
       /// Converts an attribute to a Int
-      inline Int attributeAsInt_(const XMLAttributes & a, const XMLCh * name) const
+      inline Int attributeAsInt_(const XMLAttributes & a, const char16_t * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
+        const char16_t * val = a.value(name);
         if (val == nullptr) fatalError(LOAD,std::string("Required attribute '") + sm_.convert(name) + "' not present!");
-        return xercesc::XMLString::parseInt(val);
+        return sm_.parseInt(val);
       }
 
       /// Converts an attribute to a double
-      inline double attributeAsDouble_(const XMLAttributes & a, const XMLCh * name) const
+      inline double attributeAsDouble_(const XMLAttributes & a, const char16_t * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
+        const char16_t * val = a.value(name);
         if (val == nullptr) fatalError(LOAD,std::string("Required attribute '") + sm_.convert(name) + "' not present!");
         return StringUtils::toDouble(sm_.convert(val));
       }
 
       /// Converts an attribute to a DoubleList
-      DoubleList attributeAsDoubleList_(const XMLAttributes & a, const XMLCh * name) const;
+      DoubleList attributeAsDoubleList_(const XMLAttributes & a, const char16_t * name) const;
 
       /// Converts an attribute to a IntList
-      IntList attributeAsIntList_(const XMLAttributes & a, const XMLCh * name) const;
+      IntList attributeAsIntList_(const XMLAttributes & a, const char16_t * name) const;
 
       /// Converts an attribute to a StringList
-      StringList attributeAsStringList_(const XMLAttributes & a, const XMLCh * name) const;
+      StringList attributeAsStringList_(const XMLAttributes & a, const char16_t * name) const;
 
       /// Assigns the attribute content to the String @a value if the attribute is present
-      inline bool optionalAttributeAsString_(std::string& value, const XMLAttributes & a, const XMLCh * name) const
+      inline bool optionalAttributeAsString_(std::string& value, const XMLAttributes & a, const char16_t * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
+        const char16_t * val = a.value(name);
         if (val != nullptr)
         {
           value = sm_.convert(val);
@@ -861,33 +568,33 @@ protected:
       }
 
       /// Assigns the attribute content to the Int @a value if the attribute is present
-      inline bool optionalAttributeAsInt_(Int & value, const XMLAttributes & a, const XMLCh * name) const
+      inline bool optionalAttributeAsInt_(Int & value, const XMLAttributes & a, const char16_t * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
+        const char16_t * val = a.value(name);
         if (val != nullptr)
         {
-          value = xercesc::XMLString::parseInt(val);
+          value = sm_.parseInt(val);
           return true;
         }
         return false;
       }
 
       /// Assigns the attribute content to the UInt @a value if the attribute is present
-      inline bool optionalAttributeAsUInt_(UInt & value, const XMLAttributes & a, const XMLCh * name) const
+      inline bool optionalAttributeAsUInt_(UInt & value, const XMLAttributes & a, const char16_t * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
+        const char16_t * val = a.value(name);
         if (val != nullptr)
         {
-          value = xercesc::XMLString::parseInt(val);
+          value = sm_.parseInt(val);
           return true;
         }
         return false;
       }
 
       /// Assigns the attribute content to the double @a value if the attribute is present
-      inline bool optionalAttributeAsDouble_(double & value, const XMLAttributes & a, const XMLCh * name) const
+      inline bool optionalAttributeAsDouble_(double & value, const XMLAttributes & a, const char16_t * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
+        const char16_t * val = a.value(name);
         if (val != nullptr)
         {
           value = StringUtils::toDouble(sm_.convert(val));
@@ -901,9 +608,9 @@ protected:
 
           @return if the attribute was present
       */
-      inline bool optionalAttributeAsDoubleList_(DoubleList & value, const XMLAttributes & a, const XMLCh * name) const
+      inline bool optionalAttributeAsDoubleList_(DoubleList & value, const XMLAttributes & a, const char16_t * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
+        const char16_t * val = a.value(name);
         if (val != nullptr)
         {
           value = attributeAsDoubleList_(a, name);
@@ -917,9 +624,9 @@ protected:
 
           @return if the attribute was present
       */
-      inline bool optionalAttributeAsIntList_(IntList & value, const XMLAttributes & a, const XMLCh * name) const
+      inline bool optionalAttributeAsIntList_(IntList & value, const XMLAttributes & a, const char16_t * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
+        const char16_t * val = a.value(name);
         if (val != nullptr)
         {
           value = attributeAsIntList_(a, name);
@@ -933,9 +640,9 @@ protected:
 
           @return if the attribute was present
       */
-      inline bool optionalAttributeAsStringList_(StringList & value, const XMLAttributes & a, const XMLCh * name) const
+      inline bool optionalAttributeAsStringList_(StringList & value, const XMLAttributes & a, const char16_t * name) const
       {
-        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
+        const char16_t * val = a.value(name);
         if (val != nullptr)
         {
           value = attributeAsStringList_(a, name);

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
@@ -14,6 +14,7 @@
  
 #include <OpenMS/DATASTRUCTURES/DateTime.h>
 #include <OpenMS/DATASTRUCTURES/DataValue.h>
+#include <OpenMS/FORMAT/HANDLERS/XMLAttributes.h>
 
 #include <xercesc/sax2/Attributes.hpp>
 #include <xercesc/sax2/DefaultHandler.hpp>
@@ -21,6 +22,7 @@
 
 #include <iosfwd>
 #include <string>
+#include <string_view>
 #include <memory>
 
 
@@ -369,12 +371,28 @@ public:
       /// Warning handler.
       void warning(ActionMode mode, const std::string & msg, UInt line = 0, UInt column = 0) const;
 
-      /// Parsing method for character data
+      /// Parsing method for character data (Xerces callback; forwards to the native overload below)
       void characters(const XMLCh * const chars, const XMLSize_t length) override;
-      /// Parsing method for opening tags
+      /// Parsing method for opening tags (Xerces callback; forwards to the native overload below)
       void startElement(const XMLCh * const uri, const XMLCh * const localname, const XMLCh * const qname, const xercesc::Attributes & attrs) override;
-      /// Parsing method for closing tags
+      /// Parsing method for closing tags (Xerces callback; forwards to the native overload below)
       void endElement(const XMLCh * const uri, const XMLCh * const localname, const XMLCh * const qname) override;
+
+      /**
+          @name Native (Xerces-free) SAX callbacks
+
+          Subclasses override these instead of the Xerces-typed callbacks above.
+          @c qname / @c chars are UTF-16 code units (as delivered by the parser);
+          attributes are exposed through the Xerces-free @ref XMLAttributes view.
+      */
+      //@{
+      /// Parsing method for opening tags
+      virtual void onStartElement(const char16_t * qname, const XMLAttributes & attributes);
+      /// Parsing method for closing tags
+      virtual void onEndElement(const char16_t * qname);
+      /// Parsing method for character data
+      virtual void onCharacters(std::u16string_view chars);
+      //@}
 
       /// Writes the contents to a stream.
       virtual void writeTo(std::ostream & /*os*/);
@@ -653,46 +671,46 @@ protected:
       //@{
 
       /// Converts an attribute to a String
-      inline std::string attributeAsString_(const xercesc::Attributes & a, const char * name) const
+      inline std::string attributeAsString_(const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convertPtr(name).get());
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
         if (val == nullptr) fatalError(LOAD,std::string("Required attribute '") + name + "' not present!");
         return sm_.convert(val);
       }
 
       /// Converts an attribute to a Int
-      inline Int attributeAsInt_(const xercesc::Attributes & a, const char * name) const
+      inline Int attributeAsInt_(const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convertPtr(name).get());
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
         if (val == nullptr) fatalError(LOAD,std::string("Required attribute '") + name + "' not present!");
         return xercesc::XMLString::parseInt(val);
       }
 
       /// Converts an attribute to a double
-      inline double attributeAsDouble_(const xercesc::Attributes & a, const char * name) const
+      inline double attributeAsDouble_(const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convertPtr(name).get());
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
         if (val == nullptr) fatalError(LOAD,std::string("Required attribute '") + name + "' not present!");
         return StringUtils::toDouble(sm_.convert(val));
       }
 
       /// Converts an attribute to a DoubleList
-      DoubleList attributeAsDoubleList_(const xercesc::Attributes & a, const char * name) const;
+      DoubleList attributeAsDoubleList_(const XMLAttributes & a, const char * name) const;
 
       /// Converts an attribute to an IntList
-      IntList attributeAsIntList_(const xercesc::Attributes & a, const char * name) const;
+      IntList attributeAsIntList_(const XMLAttributes & a, const char * name) const;
 
       /// Converts an attribute to an StringList
-      StringList attributeAsStringList_(const xercesc::Attributes & a, const char * name) const;
+      StringList attributeAsStringList_(const XMLAttributes & a, const char * name) const;
 
       /**
           @brief Assigns the attribute content to the String @a value if the attribute is present
 
           @return if the attribute was present
       */
-      inline bool optionalAttributeAsString_(std::string & value, const xercesc::Attributes & a, const char * name) const
+      inline bool optionalAttributeAsString_(std::string & value, const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convertPtr(name).get());
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
         if (val != nullptr)
         {
           value = sm_.convert(val);
@@ -706,9 +724,9 @@ protected:
 
           @return if the attribute was present
       */
-      inline bool optionalAttributeAsInt_(Int & value, const xercesc::Attributes & a, const char * name) const
+      inline bool optionalAttributeAsInt_(Int & value, const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convertPtr(name).get());
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
         if (val != nullptr)
         {
           value = xercesc::XMLString::parseInt(val);
@@ -722,9 +740,9 @@ protected:
 
           @return if the attribute was present
       */
-      inline bool optionalAttributeAsUInt_(UInt & value, const xercesc::Attributes & a, const char * name) const
+      inline bool optionalAttributeAsUInt_(UInt & value, const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convertPtr(name).get());
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
         if (val != nullptr)
         {
           value = xercesc::XMLString::parseInt(val);
@@ -738,9 +756,9 @@ protected:
 
           @return if the attribute was present
       */
-      inline bool optionalAttributeAsDouble_(double & value, const xercesc::Attributes & a, const char * name) const
+      inline bool optionalAttributeAsDouble_(double & value, const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convertPtr(name).get());
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
         if (val != nullptr)
         {
           value =StringUtils::toDouble(sm_.convert(val));
@@ -754,9 +772,9 @@ protected:
 
           @return if the attribute was present
       */
-      inline bool optionalAttributeAsDoubleList_(DoubleList & value, const xercesc::Attributes & a, const char * name) const
+      inline bool optionalAttributeAsDoubleList_(DoubleList & value, const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convertPtr(name).get());
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
         if (val != nullptr)
         {
           value = attributeAsDoubleList_(a, name);
@@ -770,9 +788,9 @@ protected:
 
           @return if the attribute was present
       */
-      inline bool optionalAttributeAsStringList_(StringList & value, const xercesc::Attributes & a, const char * name) const
+      inline bool optionalAttributeAsStringList_(StringList & value, const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convertPtr(name).get());
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
         if (val != nullptr)
         {
           value = attributeAsStringList_(a, name);
@@ -786,9 +804,9 @@ protected:
 
           @return if the attribute was present
       */
-      inline bool optionalAttributeAsIntList_(IntList & value, const xercesc::Attributes & a, const char * name) const
+      inline bool optionalAttributeAsIntList_(IntList & value, const XMLAttributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convertPtr(name).get());
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(sm_.convertPtr(name).get());
         if (val != nullptr)
         {
           value = attributeAsIntList_(a, name);
@@ -798,42 +816,42 @@ protected:
       }
 
       /// Converts an attribute to a String
-      inline std::string attributeAsString_(const xercesc::Attributes & a, const XMLCh * name) const
+      inline std::string attributeAsString_(const XMLAttributes & a, const XMLCh * name) const
       {
-        const XMLCh * val = a.getValue(name);
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
         if (val == nullptr) fatalError(LOAD,std::string("Required attribute '") + sm_.convert(name) + "' not present!");
         return sm_.convert(val);
       }
 
       /// Converts an attribute to a Int
-      inline Int attributeAsInt_(const xercesc::Attributes & a, const XMLCh * name) const
+      inline Int attributeAsInt_(const XMLAttributes & a, const XMLCh * name) const
       {
-        const XMLCh * val = a.getValue(name);
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
         if (val == nullptr) fatalError(LOAD,std::string("Required attribute '") + sm_.convert(name) + "' not present!");
         return xercesc::XMLString::parseInt(val);
       }
 
       /// Converts an attribute to a double
-      inline double attributeAsDouble_(const xercesc::Attributes & a, const XMLCh * name) const
+      inline double attributeAsDouble_(const XMLAttributes & a, const XMLCh * name) const
       {
-        const XMLCh * val = a.getValue(name);
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
         if (val == nullptr) fatalError(LOAD,std::string("Required attribute '") + sm_.convert(name) + "' not present!");
         return StringUtils::toDouble(sm_.convert(val));
       }
 
       /// Converts an attribute to a DoubleList
-      DoubleList attributeAsDoubleList_(const xercesc::Attributes & a, const XMLCh * name) const;
+      DoubleList attributeAsDoubleList_(const XMLAttributes & a, const XMLCh * name) const;
 
       /// Converts an attribute to a IntList
-      IntList attributeAsIntList_(const xercesc::Attributes & a, const XMLCh * name) const;
+      IntList attributeAsIntList_(const XMLAttributes & a, const XMLCh * name) const;
 
       /// Converts an attribute to a StringList
-      StringList attributeAsStringList_(const xercesc::Attributes & a, const XMLCh * name) const;
+      StringList attributeAsStringList_(const XMLAttributes & a, const XMLCh * name) const;
 
       /// Assigns the attribute content to the String @a value if the attribute is present
-      inline bool optionalAttributeAsString_(std::string& value, const xercesc::Attributes & a, const XMLCh * name) const
+      inline bool optionalAttributeAsString_(std::string& value, const XMLAttributes & a, const XMLCh * name) const
       {
-        const XMLCh * val = a.getValue(name);
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
         if (val != nullptr)
         {
           value = sm_.convert(val);
@@ -843,9 +861,9 @@ protected:
       }
 
       /// Assigns the attribute content to the Int @a value if the attribute is present
-      inline bool optionalAttributeAsInt_(Int & value, const xercesc::Attributes & a, const XMLCh * name) const
+      inline bool optionalAttributeAsInt_(Int & value, const XMLAttributes & a, const XMLCh * name) const
       {
-        const XMLCh * val = a.getValue(name);
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
         if (val != nullptr)
         {
           value = xercesc::XMLString::parseInt(val);
@@ -855,9 +873,9 @@ protected:
       }
 
       /// Assigns the attribute content to the UInt @a value if the attribute is present
-      inline bool optionalAttributeAsUInt_(UInt & value, const xercesc::Attributes & a, const XMLCh * name) const
+      inline bool optionalAttributeAsUInt_(UInt & value, const XMLAttributes & a, const XMLCh * name) const
       {
-        const XMLCh * val = a.getValue(name);
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
         if (val != nullptr)
         {
           value = xercesc::XMLString::parseInt(val);
@@ -867,9 +885,9 @@ protected:
       }
 
       /// Assigns the attribute content to the double @a value if the attribute is present
-      inline bool optionalAttributeAsDouble_(double & value, const xercesc::Attributes & a, const XMLCh * name) const
+      inline bool optionalAttributeAsDouble_(double & value, const XMLAttributes & a, const XMLCh * name) const
       {
-        const XMLCh * val = a.getValue(name);
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
         if (val != nullptr)
         {
           value = StringUtils::toDouble(sm_.convert(val));
@@ -883,9 +901,9 @@ protected:
 
           @return if the attribute was present
       */
-      inline bool optionalAttributeAsDoubleList_(DoubleList & value, const xercesc::Attributes & a, const XMLCh * name) const
+      inline bool optionalAttributeAsDoubleList_(DoubleList & value, const XMLAttributes & a, const XMLCh * name) const
       {
-        const XMLCh * val = a.getValue(name);
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
         if (val != nullptr)
         {
           value = attributeAsDoubleList_(a, name);
@@ -899,9 +917,9 @@ protected:
 
           @return if the attribute was present
       */
-      inline bool optionalAttributeAsIntList_(IntList & value, const xercesc::Attributes & a, const XMLCh * name) const
+      inline bool optionalAttributeAsIntList_(IntList & value, const XMLAttributes & a, const XMLCh * name) const
       {
-        const XMLCh * val = a.getValue(name);
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
         if (val != nullptr)
         {
           value = attributeAsIntList_(a, name);
@@ -915,9 +933,9 @@ protected:
 
           @return if the attribute was present
       */
-      inline bool optionalAttributeAsStringList_(StringList & value, const xercesc::Attributes & a, const XMLCh * name) const
+      inline bool optionalAttributeAsStringList_(StringList & value, const XMLAttributes & a, const XMLCh * name) const
       {
-        const XMLCh * val = a.getValue(name);
+        const XMLCh * val = static_cast<const xercesc::Attributes*>(a.handle())->getValue(name);
         if (val != nullptr)
         {
           value = attributeAsStringList_(a, name);

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XQuestResultXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XQuestResultXMLHandler.h
@@ -171,7 +171,7 @@ namespace OpenMS
 
       /**
        * @brief Gets the link location of a xQuest xlinkPositionString.
-       * @param[in] attributes XML attributes of Xerces.
+       * @param[in] attributes XML attributes of the current element.
        * @param[out] pair Pair to be populated with the xlinkposition in xQuest.
        */
       void getLinkPosition_(const XMLAttributes & attributes, std::pair<SignedSize, SignedSize> & pair);

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XQuestResultXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XQuestResultXMLHandler.h
@@ -48,10 +48,10 @@ namespace OpenMS
       ~XQuestResultXMLHandler() override;
 
       // Docu in base class
-      void endElement(const XMLCh * const uri, const XMLCh * const local_name, const XMLCh * const qname) override;
+      void onEndElement(const char16_t* qname) override;
 
       // Docu in base class
-      void startElement(const XMLCh * const uri, const XMLCh * const local_name, const XMLCh * const qname, const xercesc::Attributes & attributes) override;
+      void onStartElement(const char16_t* qname, const XMLAttributes& attributes) override;
 
       /**
        * @brief Returns the minimum score encountered in the file.
@@ -174,7 +174,7 @@ namespace OpenMS
        * @param[in] attributes XML attributes of Xerces.
        * @param[out] pair Pair to be populated with the xlinkposition in xQuest.
        */
-      void getLinkPosition_(const xercesc::Attributes & attributes, std::pair<SignedSize, SignedSize> & pair);
+      void getLinkPosition_(const XMLAttributes & attributes, std::pair<SignedSize, SignedSize> & pair);
 
       /**
        * @brief Sets the peptide evidence for Alpha and Beta.

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/sources.cmake
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/sources.cmake
@@ -30,6 +30,7 @@ ToolDescriptionHandler.h
 TraMLHandler.h
 UnimodXMLHandler.h
 UniProtXMLHandler.h
+XMLAttributes.h
 XMLHandler.h
 XQuestResultXMLHandler.h
 )

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/sources.cmake
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/sources.cmake
@@ -15,7 +15,6 @@ ImzMLWriter.h
 IndexedMzMLHandler.h
 MascotXMLHandler.h
 MzDataHandler.h
-MzIdentMLDOMHandler.h
 MzIdentMLHandler.h
 MzMLHandler.h
 MzMLHandlerHelper.h
@@ -30,6 +29,7 @@ ToolDescriptionHandler.h
 TraMLHandler.h
 UnimodXMLHandler.h
 UniProtXMLHandler.h
+StringManager.h
 XMLAttributes.h
 XMLHandler.h
 XQuestResultXMLHandler.h
@@ -45,4 +45,20 @@ endforeach(i)
 source_group("Header Files\\OpenMS\\FORMAT\\HANDLERS" FILES ${sources_h})
 
 set(OpenMS_sources_h ${OpenMS_sources_h} ${sources_h})
+
+### Private (non-installed) headers: internal to libOpenMS, never installed,
+### exported, or wrapped. SAX2HandlerAdapter bridges Xerces SAX to the Xerces-free
+### XMLHandler; MzIdentMLDOMHandler embeds a Xerces DOM parser (used only by
+### MzIdentMLFile.cpp). Keeping them off OpenMS_sources_h is what lets Xerces be a
+### PRIVATE link dependency.
+set(private_headers_list_h
+SAX2HandlerAdapter.h
+MzIdentMLDOMHandler.h
+)
+set(private_sources_h)
+foreach(i ${private_headers_list_h})
+	list(APPEND private_sources_h ${directory}/${i})
+endforeach(i)
+source_group("Header Files\\OpenMS\\FORMAT\\HANDLERS" FILES ${private_sources_h})
+set(OpenMS_private_headers ${OpenMS_private_headers} ${private_sources_h})
 

--- a/src/openms/include/OpenMS/FORMAT/IdXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/IdXMLFile.h
@@ -86,10 +86,10 @@ public:
 
 protected:
     // Docu in base class
-    void endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname) override;
+    void onEndElement(const char16_t* qname) override;
 
     // Docu in base class
-    void startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes) override;
+    void onStartElement(const char16_t* qname, const Internal::XMLAttributes& attributes) override;
 
     /// Add data from ProteinGroups to a MetaInfoInterface
     /// Since it can be used during load and store, it needs to take a param for the current mode (LOAD/STORE)

--- a/src/openms/include/OpenMS/FORMAT/OMSSAXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/OMSSAXMLFile.h
@@ -69,13 +69,13 @@ public:
 
 protected:
     // Docu in base class
-    void endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname) override;
+    void onEndElement(const char16_t* qname) override;
 
     // Docu in base class
-    void startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes) override;
+    void onStartElement(const char16_t* qname, const Internal::XMLAttributes& attributes) override;
 
     // Docu in base class
-    void characters(const XMLCh* const chars, const XMLSize_t /*length*/) override;
+    void onCharacters(const char16_t* chars, Size /*length*/) override;
 
 private:
 

--- a/src/openms/include/OpenMS/FORMAT/PepXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/PepXMLFile.h
@@ -109,10 +109,10 @@ public:
 protected:
 
     /// Docu in base class
-    void endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname) override;
+    void onEndElement(const char16_t* qname) override;
 
     /// Docu in base class
-    void startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes) override;
+    void onStartElement(const char16_t* qname, const Internal::XMLAttributes& attributes) override;
 
 private:
 
@@ -120,7 +120,7 @@ private:
     void makeScanMap_();
 
     /// Read RT, m/z, charge information from attributes of "spectrum_query"
-    void readRTMZCharge_(const xercesc::Attributes& attributes);
+    void readRTMZCharge_(const Internal::XMLAttributes& attributes);
 
     struct AminoAcidModification
     {

--- a/src/openms/include/OpenMS/FORMAT/PepXMLFileMascot.h
+++ b/src/openms/include/OpenMS/FORMAT/PepXMLFileMascot.h
@@ -45,10 +45,10 @@ public:
 protected:
 
     // Docu in base class
-    void endElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname) override;
+    void onEndElement(const char16_t* qname) override;
 
     // Docu in base class
-    void startElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname, const xercesc::Attributes & attributes) override;
+    void onStartElement(const char16_t* qname, const Internal::XMLAttributes& attributes) override;
 
     void matchModification_(double mass, std::string & modification_description);
 

--- a/src/openms/include/OpenMS/FORMAT/ProtXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ProtXMLFile.h
@@ -77,10 +77,10 @@ protected:
     void resetMembers_();
 
     /// Docu in base class
-    void endElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname) override;
+    void onEndElement(const char16_t* qname) override;
 
     /// Docu in base class
-    void startElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname, const xercesc::Attributes & attributes) override;
+    void onStartElement(const char16_t* qname, const Internal::XMLAttributes& attributes) override;
 
     /// Creates a new protein entry (if not already present) and appends it to the current group
     void registerProtein_(const std::string & protein_name);

--- a/src/openms/include/OpenMS/FORMAT/QcMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/QcMLFile.h
@@ -174,13 +174,13 @@ public:
 
 protected:
     // Docu in base class
-    void endElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname) override;
+    void onEndElement(const char16_t* qname) override;
 
     // Docu in base class
-    void startElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname, const xercesc::Attributes & attributes) override;
+    void onStartElement(const char16_t* qname, const Internal::XMLAttributes& attributes) override;
 
     // Docu in base class
-    void characters(const XMLCh * const chars, const XMLSize_t length) override;
+    void onCharacters(const char16_t* chars, Size length) override;
 
     std::map<std::string, std::vector< QualityParameter > > runQualityQPs_; //TODO run name attribute to schema of RunQuality
     std::map<std::string, std::vector< Attachment > > runQualityAts_;

--- a/src/openms/include/OpenMS/FORMAT/TransformationXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/TransformationXMLFile.h
@@ -59,7 +59,7 @@ public:
 
 protected:
     // Docu in base class
-    void startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes) override;
+    void onStartElement(const char16_t* qname, const Internal::XMLAttributes& attributes) override;
 
     /// @name Members for use during loading data
     //@{

--- a/src/openms/include/OpenMS/FORMAT/VALIDATORS/MzMLValidator.h
+++ b/src/openms/include/OpenMS/FORMAT/VALIDATORS/MzMLValidator.h
@@ -54,7 +54,7 @@ public:
 protected:
 
       // Docu in base class
-      void startElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname, const xercesc::Attributes & attributes) override;
+      void onStartElement(const char16_t* qname, const XMLAttributes& attributes) override;
 
       // Docu in base class
       std::string getPath_(UInt remove_from_end = 0) const override;

--- a/src/openms/include/OpenMS/FORMAT/VALIDATORS/SemanticValidator.h
+++ b/src/openms/include/OpenMS/FORMAT/VALIDATORS/SemanticValidator.h
@@ -111,19 +111,19 @@ public:
 protected:
 
       // Docu in base class
-      void startElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname, const xercesc::Attributes & attributes) override;
+      void onStartElement(const char16_t* qname, const XMLAttributes& attributes) override;
 
       // Docu in base class
-      void endElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname) override;
+      void onEndElement(const char16_t* qname) override;
 
       // Docu in base class
-      void characters(const XMLCh * const chars, const XMLSize_t /*length*/) override;
+      void onCharacters(const char16_t* chars, Size /*length*/) override;
 
       /// Returns the current element path
       virtual std::string getPath_(UInt remove_from_end = 0) const;
 
       /// Parses the CV term accession (required), name (required) and value (optional) from the XML attributes
-      virtual void getCVTerm_(const xercesc::Attributes & attributes, CVTerm & parsed_term);
+      virtual void getCVTerm_(const XMLAttributes & attributes, CVTerm & parsed_term);
 
       //~ forward dekl. of a inner struct/class not possible in C++ - or our Library is overtemplated
       //~ /// make a SemanticValidator::CVTerm from a ControlledVocabulary::CVTerm (without any value or unit), needed for writing only cvs at the right places in the xml (i.e. with cvmapping)

--- a/src/openms/include/OpenMS/FORMAT/VALIDATORS/XMLValidator.h
+++ b/src/openms/include/OpenMS/FORMAT/VALIDATORS/XMLValidator.h
@@ -10,8 +10,6 @@
 
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 
-#include <xercesc/sax/ErrorHandler.hpp>
-
 #include <iostream>
 
 namespace OpenMS
@@ -23,8 +21,7 @@ namespace OpenMS
 
     @ingroup FileIO
   */
-  class OPENMS_DLLAPI XMLValidator :
-    private xercesc::ErrorHandler
+  class OPENMS_DLLAPI XMLValidator
   {
 public:
     /// Constructor
@@ -52,14 +49,12 @@ protected:
     //output stream reference (for error messages)
     std::ostream* os_;
 
-    /// @name Implementation of Xerces ErrorHandler methods
-    //@{
-    void warning(const xercesc::SAXParseException& exception) override;
-    void error(const xercesc::SAXParseException& exception) override;
-    void fatalError(const xercesc::SAXParseException& exception) override;
-    void resetErrors() override;
-    //@}
+    /// Record a validation problem. Called by the internal Xerces ErrorHandler
+    /// bridge (defined in the .cpp); keeps Xerces out of this public header.
+    void logError_(const std::string& kind, const std::string& message, unsigned long line, unsigned long column);
+
+    /// The internal Xerces ErrorHandler bridge needs access to @c logError_.
+    friend class XMLValidatorErrorHandler_;
   };
 
 } // namespace OpenMS
-

--- a/src/openms/include/OpenMS/FORMAT/XTandemXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/XTandemXMLFile.h
@@ -57,13 +57,13 @@ public:
 protected:
 
     // Docu in base class
-    void startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes) override;
+    void onStartElement(const char16_t* qname, const Internal::XMLAttributes& attributes) override;
 
     // Docu in base class
-    void endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname) override;
+    void onEndElement(const char16_t* qname) override;
 
     // Docu in base class
-    void characters(const XMLCh* const chars, const XMLSize_t /*length*/) override;
+    void onCharacters(const char16_t* chars, Size /*length*/) override;
 
     XTandemXMLFile(const XTandemXMLFile& rhs);
 

--- a/src/openms/include/OpenMS/FORMAT/sources.cmake
+++ b/src/openms/include/OpenMS/FORMAT/sources.cmake
@@ -20,10 +20,8 @@ AbsoluteQuantitationMethodFile.h
 AbsoluteQuantitationStandardsFile.h
 Base64.h
 Bzip2Ifstream.h
-Bzip2InputStream.h
 CachedMzML.h
 ChromeleonFile.h
-CompressedInputSource.h
 CVMappingFile.h
 ConsensusXMLFile.h
 ControlledVocabulary.h
@@ -42,9 +40,7 @@ GNPSMetaValueFile.h
 GNPSMGFFile.h
 GNPSQuantificationFile.h
 GzipIfstream.h
-GzipInputStream.h
 ZipIfstream.h
-ZipInputStream.h
 IBSpectraFile.h
 IdXMLFile.h
 ImzMLFile.h
@@ -160,3 +156,19 @@ endforeach(i)
 source_group("Header Files\\OpenMS\\FORMAT" FILES ${sources_h})
 
 set(OpenMS_sources_h ${OpenMS_sources_h} ${sources_h})
+
+### Private (non-installed) headers: the Xerces InputSource / BinInputStream
+### adapters are internal plumbing used only by XMLFile.cpp / CompressedInputSource.cpp.
+### Keeping them off OpenMS_sources_h is what lets Xerces be a PRIVATE link dependency.
+set(private_headers_list_h
+Bzip2InputStream.h
+CompressedInputSource.h
+GzipInputStream.h
+ZipInputStream.h
+)
+set(private_sources_h)
+foreach(i ${private_headers_list_h})
+	list(APPEND private_sources_h ${directory}/${i})
+endforeach(i)
+source_group("Header Files\\OpenMS\\FORMAT" FILES ${private_sources_h})
+set(OpenMS_private_headers ${OpenMS_private_headers} ${private_sources_h})

--- a/src/openms/include/OpenMS/config.h.in
+++ b/src/openms/include/OpenMS/config.h.in
@@ -24,8 +24,6 @@
 // include OPENMS_DLLAPI macros
 #include <OpenMS/OpenMSConfig.h>
 
-#include <boost/current_function.hpp>
-
 // Here are some global configuration flags for OpenMS
 
 // Define compiler specifics (used in VERY few places only)
@@ -34,8 +32,19 @@
 // GNU g++
 #cmakedefine OPENMS_COMPILER_GXX
 
-// __PRETTY_FUNCTION__ is a GNU G++ extension so we use the alternative in boost
-#define OPENMS_PRETTY_FUNCTION BOOST_CURRENT_FUNCTION
+// The most descriptive, compiler-provided name of the enclosing function. This
+// mirrors what boost/current_function.hpp (BOOST_CURRENT_FUNCTION) selected, but
+// uses the compiler builtins directly so no Boost header is pulled in here (this
+// header is included by almost every OpenMS TU). __PRETTY_FUNCTION__ (GCC/Clang)
+// and __FUNCSIG__ (MSVC) carry the full demangled signature; __func__ is the
+// standard fallback.
+#if defined(_MSC_VER)
+#  define OPENMS_PRETTY_FUNCTION __FUNCSIG__
+#elif defined(__GNUC__) || defined(__clang__)
+#  define OPENMS_PRETTY_FUNCTION __PRETTY_FUNCTION__
+#else
+#  define OPENMS_PRETTY_FUNCTION __func__
+#endif
 
 // __FILENAME__ prints the path that is used during compilation of the object. Per default in CMake it is the full absolute path.
 // This is confusing for debug logs from executables on user machines and unnecessary.

--- a/src/openms/source/FORMAT/Bzip2InputStream.cpp
+++ b/src/openms/source/FORMAT/Bzip2InputStream.cpp
@@ -9,6 +9,7 @@
 
 #include <OpenMS/FORMAT/Bzip2InputStream.h>
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
+#include <xercesc/util/XMLString.hpp>
 
 using namespace xercesc;
 

--- a/src/openms/source/FORMAT/CVMappingFile.cpp
+++ b/src/openms/source/FORMAT/CVMappingFile.cpp
@@ -45,7 +45,7 @@ namespace OpenMS
     return;
   }
 
-  void CVMappingFile::startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const Attributes& attributes)
+  void CVMappingFile::onStartElement(const char16_t* qname, const Internal::XMLAttributes& attributes)
   {
 
     tag_ =std::string(sm_.convert(qname));
@@ -197,7 +197,7 @@ namespace OpenMS
     return;
   }
 
-  void CVMappingFile::endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname)
+  void CVMappingFile::onEndElement(const char16_t* qname)
   {
     tag_ =std::string(sm_.convert(qname));
 
@@ -211,7 +211,7 @@ namespace OpenMS
     return;
   }
 
-  void CVMappingFile::characters(const XMLCh* const /*chars*/, const XMLSize_t /*length*/)
+  void CVMappingFile::onCharacters(const char16_t* /*chars*/, Size /*length*/)
   {
     // good XML format, nothing to do here
   }

--- a/src/openms/source/FORMAT/CVMappingFile.cpp
+++ b/src/openms/source/FORMAT/CVMappingFile.cpp
@@ -12,7 +12,6 @@
 #include <OpenMS/DATASTRUCTURES/DataValue.h>
 #include <OpenMS/SYSTEM/File.h>
 
-using namespace xercesc;
 using namespace std;
 
 namespace OpenMS

--- a/src/openms/source/FORMAT/CompressedInputSource.cpp
+++ b/src/openms/source/FORMAT/CompressedInputSource.cpp
@@ -14,6 +14,8 @@
 #include <OpenMS/FORMAT/HANDLERS/XMLHandler.h>
 
 #include <xercesc/util/XMLUniDefs.hpp>
+#include <xercesc/util/XMLString.hpp>
+#include <xercesc/framework/MemoryManager.hpp>
 
 
 using namespace xercesc;

--- a/src/openms/source/FORMAT/GzipInputStream.cpp
+++ b/src/openms/source/FORMAT/GzipInputStream.cpp
@@ -10,6 +10,7 @@
 
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/FORMAT/GzipIfstream.h>
+#include <xercesc/util/XMLString.hpp>
 
 using namespace xercesc;
 

--- a/src/openms/source/FORMAT/HANDLERS/ConsensusXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ConsensusXMLHandler.cpp
@@ -483,10 +483,9 @@ namespace OpenMS::Internal
       pep_hit_.setSequence(AASequence::fromString(std::string(attributeAsString_(attributes, "sequence"))));
 
       //parse optional protein ids to determine accessions
-      const char16_t* refs = attributes.value(sm_.convert("protein_refs").c_str());
-      if (refs != nullptr)
+      std::string accession_string;
+      if (optionalAttributeAsString_(accession_string, attributes, "protein_refs"))
       {
-        std::string accession_string = sm_.convert(refs);
         StringUtils::trim(accession_string);
         vector<std::string> accessions;
         StringUtils::split(accession_string, ' ', accessions);

--- a/src/openms/source/FORMAT/HANDLERS/ConsensusXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ConsensusXMLHandler.cpp
@@ -59,7 +59,7 @@ namespace OpenMS::Internal
     return options_;
   }
 
-  void ConsensusXMLHandler::endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname)
+  void ConsensusXMLHandler::onEndElement(const char16_t* qname)
   {
     std::string tag = sm_.convert(qname);
     open_tags_.pop_back();
@@ -126,11 +126,11 @@ namespace OpenMS::Internal
     }
   }
 
-  void ConsensusXMLHandler::characters(const XMLCh* const /*chars*/, const XMLSize_t /*length*/)
+  void ConsensusXMLHandler::onCharacters(const char16_t* /*chars*/, Size /*length*/)
   {
   }
 
-  void ConsensusXMLHandler::startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes)
+  void ConsensusXMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& attributes)
   {
     const std::string& parent_tag = (open_tags_.empty() ? "" : open_tags_.back());
     open_tags_.push_back(sm_.convert(qname));
@@ -483,7 +483,7 @@ namespace OpenMS::Internal
       pep_hit_.setSequence(AASequence::fromString(std::string(attributeAsString_(attributes, "sequence"))));
 
       //parse optional protein ids to determine accessions
-      const XMLCh* refs = attributes.getValue(sm_.convert("protein_refs").c_str());
+      const char16_t* refs = attributes.value(sm_.convert("protein_refs").c_str());
       if (refs != nullptr)
       {
         std::string accession_string = sm_.convert(refs);

--- a/src/openms/source/FORMAT/HANDLERS/FeatureXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/FeatureXMLHandler.cpp
@@ -599,10 +599,9 @@ namespace OpenMS::Internal
       pep_hit_.setSequence(AASequence::fromString(std::string(attributeAsString_(attributes, "sequence"))));
 
       //parse optional protein ids to determine accessions
-      const char16_t* refs = attributes.value(sm_.convert("protein_refs").c_str());
-      if (refs != nullptr)
+      std::string accession_string;
+      if (optionalAttributeAsString_(accession_string, attributes, "protein_refs"))
       {
-        std::string accession_string = sm_.convert(refs);
         StringUtils::trim(accession_string);
         vector<std::string> accessions;
         StringUtils::split(accession_string, ' ', accessions);

--- a/src/openms/source/FORMAT/HANDLERS/FeatureXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/FeatureXMLHandler.cpp
@@ -240,17 +240,17 @@ namespace OpenMS::Internal
 
   void FeatureXMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& attributes)
   {
-    static const XMLCh* s_dim = xercesc::XMLString::transcode("dim");
-    static const XMLCh* s_name = xercesc::XMLString::transcode("name");
-    static const XMLCh* s_version = xercesc::XMLString::transcode("version");
-    static const XMLCh* s_value = xercesc::XMLString::transcode("value");
-    static const XMLCh* s_type = xercesc::XMLString::transcode("type");
-    static const XMLCh* s_completion_time = xercesc::XMLString::transcode("completion_time");
-    static const XMLCh* s_document_id = xercesc::XMLString::transcode("document_id");
-    static const XMLCh* s_id = xercesc::XMLString::transcode("id");
+    static const char16_t* s_dim = u"dim";
+    static const char16_t* s_name = u"name";
+    static const char16_t* s_version = u"version";
+    static const char16_t* s_value = u"value";
+    static const char16_t* s_type = u"type";
+    static const char16_t* s_completion_time = u"completion_time";
+    static const char16_t* s_document_id = u"document_id";
+    static const char16_t* s_id = u"id";
 
     // TODO The next line should be removed in OpenMS 1.7 or so!
-    static const XMLCh* s_unique_id = xercesc::XMLString::transcode("unique_id");
+    static const char16_t* s_unique_id = u"unique_id";
 
     std::string tag = sm_.convert(qname);
 

--- a/src/openms/source/FORMAT/HANDLERS/FeatureXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/FeatureXMLHandler.cpp
@@ -238,7 +238,7 @@ namespace OpenMS::Internal
     options_ = options;
   }
 
-  void FeatureXMLHandler::startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes)
+  void FeatureXMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& attributes)
   {
     static const XMLCh* s_dim = xercesc::XMLString::transcode("dim");
     static const XMLCh* s_name = xercesc::XMLString::transcode("name");
@@ -599,7 +599,7 @@ namespace OpenMS::Internal
       pep_hit_.setSequence(AASequence::fromString(std::string(attributeAsString_(attributes, "sequence"))));
 
       //parse optional protein ids to determine accessions
-      const XMLCh* refs = attributes.getValue(sm_.convert("protein_refs").c_str());
+      const char16_t* refs = attributes.value(sm_.convert("protein_refs").c_str());
       if (refs != nullptr)
       {
         std::string accession_string = sm_.convert(refs);
@@ -700,7 +700,7 @@ namespace OpenMS::Internal
     }
   }
 
-  void FeatureXMLHandler::endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname)
+  void FeatureXMLHandler::onEndElement(const char16_t* qname)
   {
     std::string tag = sm_.convert(qname);
 
@@ -833,7 +833,7 @@ namespace OpenMS::Internal
     }
   }
 
-  void FeatureXMLHandler::characters(const XMLCh* const chars, const XMLSize_t /*length*/)
+  void FeatureXMLHandler::onCharacters(const char16_t* chars, Size /*length*/)
   {
     // handle skipping of whole sections
     if (disable_parsing_)

--- a/src/openms/source/FORMAT/HANDLERS/ImzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ImzMLHandler.cpp
@@ -309,10 +309,7 @@ void ImzMLHandler::openIBD(const std::string& ibd_path)
 // SAX2 overrides
 // ===========================================================================
 
-void ImzMLHandler::startElement(const XMLCh*               uri,
-                                 const XMLCh*               localname,
-                                 const XMLCh*               qname,
-                                 const xercesc::Attributes& attrs)
+void ImzMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& attrs)
 {
   const std::string tag = sm_.convert(qname);
 
@@ -364,12 +361,10 @@ void ImzMLHandler::startElement(const XMLCh*               uri,
     // Fall through: MzMLHandler still processes MS:* terms below
   }
 
-  MzMLHandler::startElement(uri, localname, qname, attrs);
+  MzMLHandler::onStartElement(qname, attrs);
 }
 
-void ImzMLHandler::endElement(const XMLCh* uri,
-                               const XMLCh* localname,
-                               const XMLCh* qname)
+void ImzMLHandler::onEndElement(const char16_t* qname)
 {
   const std::string tag = sm_.convert(qname);
 
@@ -451,7 +446,7 @@ void ImzMLHandler::endElement(const XMLCh* uri,
     cur_ref_id_.clear();
   }
 
-  MzMLHandler::endElement(uri, localname, qname);
+  MzMLHandler::onEndElement(qname);
 
   if (tag == "spectrum")
   {

--- a/src/openms/source/FORMAT/HANDLERS/IndexedMzMLDecoder.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/IndexedMzMLDecoder.cpp
@@ -20,6 +20,7 @@
 #include <xercesc/parsers/XercesDOMParser.hpp>
 #include <xercesc/dom/DOMElement.hpp>
 #include <xercesc/dom/DOMNodeList.hpp>
+#include <xercesc/util/XMLString.hpp>
 
 namespace OpenMS
 {

--- a/src/openms/source/FORMAT/HANDLERS/MascotXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MascotXMLHandler.cpp
@@ -10,7 +10,6 @@
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
 
 using namespace std;
-using namespace xercesc;
 
 namespace OpenMS::Internal
 {
@@ -28,9 +27,9 @@ namespace OpenMS::Internal
 
     void MascotXMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& attributes)
     {
-      static const XMLCh* s_protein_accession = xercesc::XMLString::transcode("accession");
-      static const XMLCh* s_queries_query_number = xercesc::XMLString::transcode("number");
-      static const XMLCh* s_peptide_query = xercesc::XMLString::transcode("query");
+      static const char16_t* s_protein_accession = u"accession";
+      static const char16_t* s_queries_query_number = u"number";
+      static const char16_t* s_peptide_query = u"query";
 
       tag_ =std::string(sm_.convert(qname));
       // cerr << "open: " << tag_ << endl;

--- a/src/openms/source/FORMAT/HANDLERS/MascotXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MascotXMLHandler.cpp
@@ -26,7 +26,7 @@ namespace OpenMS::Internal
     MascotXMLHandler::~MascotXMLHandler()
     = default;
 
-    void MascotXMLHandler::startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const Attributes& attributes)
+    void MascotXMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& attributes)
     {
       static const XMLCh* s_protein_accession = xercesc::XMLString::transcode("accession");
       static const XMLCh* s_queries_query_number = xercesc::XMLString::transcode("number");
@@ -64,7 +64,7 @@ namespace OpenMS::Internal
       }
     }
 
-    void MascotXMLHandler::endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname)
+    void MascotXMLHandler::onEndElement(const char16_t* qname)
     {
       tag_ =StringUtils::trimmed(std::string(sm_.convert(qname)));
       // cerr << "close: " << tag_ << endl;
@@ -598,7 +598,7 @@ namespace OpenMS::Internal
       character_buffer_.clear();
     }
 
-    void MascotXMLHandler::characters(const XMLCh* const chars, const XMLSize_t /*length*/)
+    void MascotXMLHandler::onCharacters(const char16_t* chars, Size /*length*/)
     {
       // do not care about chars after internal tags, e.g.
       // <header>

--- a/src/openms/source/FORMAT/HANDLERS/MzDataHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzDataHandler.cpp
@@ -82,7 +82,7 @@ namespace OpenMS::Internal
       StringUtils::split("CID;PSD;PD;SID", ';', cv_terms_[18]);
     }
 
-    void MzDataHandler::characters(const XMLCh * const chars, const XMLSize_t /*length*/)
+    void MzDataHandler::onCharacters(const char16_t* chars, Size /*length*/)
     {
       // skip current spectrum
       if (skip_spectrum_)
@@ -180,7 +180,7 @@ namespace OpenMS::Internal
       }
     }
 
-    void MzDataHandler::startElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname, const xercesc::Attributes & attributes)
+    void MzDataHandler::onStartElement(const char16_t* qname, const XMLAttributes& attributes)
     {
       static const XMLCh * s_name = xercesc::XMLString::transcode("name");
       static const XMLCh * s_accession = xercesc::XMLString::transcode("accession");
@@ -240,9 +240,9 @@ namespace OpenMS::Internal
       else if (tag == "software")
       {
         data_processing_ = DataProcessingPtr(new DataProcessing);
-        if (attributes.getIndex(sm_.convert("completionTime").c_str()) != -1)
+        if (attributes.index(sm_.convert("completionTime").c_str()) != -1)
         {
-          data_processing_->setCompletionTime(asDateTime_(sm_.convert(attributes.getValue(sm_.convert("completionTime").c_str())).c_str()));
+          data_processing_->setCompletionTime(asDateTime_(sm_.convert(attributes.value(sm_.convert("completionTime").c_str())).c_str()));
         }
       }
       else if (tag == "precursor")
@@ -430,7 +430,7 @@ namespace OpenMS::Internal
       //std::cout << "end startelement" << std::endl;
     }
 
-    void MzDataHandler::endElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname)
+    void MzDataHandler::onEndElement(const char16_t* qname)
     {
       static UInt scan_count = 0;
 

--- a/src/openms/source/FORMAT/HANDLERS/MzDataHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzDataHandler.cpp
@@ -240,9 +240,10 @@ namespace OpenMS::Internal
       else if (tag == "software")
       {
         data_processing_ = DataProcessingPtr(new DataProcessing);
-        if (attributes.index(sm_.convert("completionTime").c_str()) != -1)
+        std::string completion_time;
+        if (optionalAttributeAsString_(completion_time, attributes, "completionTime"))
         {
-          data_processing_->setCompletionTime(asDateTime_(sm_.convert(attributes.value(sm_.convert("completionTime").c_str())).c_str()));
+          data_processing_->setCompletionTime(asDateTime_(completion_time));
         }
       }
       else if (tag == "precursor")

--- a/src/openms/source/FORMAT/HANDLERS/MzDataHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzDataHandler.cpp
@@ -182,23 +182,23 @@ namespace OpenMS::Internal
 
     void MzDataHandler::onStartElement(const char16_t* qname, const XMLAttributes& attributes)
     {
-      static const XMLCh * s_name = xercesc::XMLString::transcode("name");
-      static const XMLCh * s_accession = xercesc::XMLString::transcode("accession");
-      static const XMLCh * s_value = xercesc::XMLString::transcode("value");
-      static const XMLCh * s_id = xercesc::XMLString::transcode("id");
-      static const XMLCh * s_count = xercesc::XMLString::transcode("count");
-      static const XMLCh * s_spectrumtype = xercesc::XMLString::transcode("spectrumType");
-      static const XMLCh * s_methodofcombination = xercesc::XMLString::transcode("methodOfCombination");
-      static const XMLCh * s_acqnumber = xercesc::XMLString::transcode("acqNumber");
-      static const XMLCh * s_mslevel = xercesc::XMLString::transcode("msLevel");
-      static const XMLCh * s_mzrangestart = xercesc::XMLString::transcode("mzRangeStart");
-      static const XMLCh * s_mzrangestop = xercesc::XMLString::transcode("mzRangeStop");
-      static const XMLCh * s_supdataarrayref = xercesc::XMLString::transcode("supDataArrayRef");
-      static const XMLCh * s_precision = xercesc::XMLString::transcode("precision");
-      static const XMLCh * s_endian = xercesc::XMLString::transcode("endian");
-      static const XMLCh * s_length = xercesc::XMLString::transcode("length");
-      static const XMLCh * s_comment = xercesc::XMLString::transcode("comment");
-      static const XMLCh * s_accessionnumber = xercesc::XMLString::transcode("accessionNumber");
+      static const char16_t* s_name = u"name";
+      static const char16_t* s_accession = u"accession";
+      static const char16_t* s_value = u"value";
+      static const char16_t* s_id = u"id";
+      static const char16_t* s_count = u"count";
+      static const char16_t* s_spectrumtype = u"spectrumType";
+      static const char16_t* s_methodofcombination = u"methodOfCombination";
+      static const char16_t* s_acqnumber = u"acqNumber";
+      static const char16_t* s_mslevel = u"msLevel";
+      static const char16_t* s_mzrangestart = u"mzRangeStart";
+      static const char16_t* s_mzrangestop = u"mzRangeStop";
+      static const char16_t* s_supdataarrayref = u"supDataArrayRef";
+      static const char16_t* s_precision = u"precision";
+      static const char16_t* s_endian = u"endian";
+      static const char16_t* s_length = u"length";
+      static const char16_t* s_comment = u"comment";
+      static const char16_t* s_accessionnumber = u"accessionNumber";
 
       std::string tag = sm_.convert(qname);
       open_tags_.push_back(tag);
@@ -434,8 +434,8 @@ namespace OpenMS::Internal
     {
       static UInt scan_count = 0;
 
-      static const XMLCh * s_spectrum = xercesc::XMLString::transcode("spectrum");
-      static const XMLCh * s_mzdata = xercesc::XMLString::transcode("mzData");
+      static const char16_t* s_spectrum = u"spectrum";
+      static const char16_t* s_mzdata = u"mzData";
 
       open_tags_.pop_back();
       //std::cout << "End: '" << sm_.convert(qname) << "'" << std::endl;

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -22,6 +22,7 @@
 #include <sys/stat.h>
 #include <cerrno>
 #include <limits>
+#include <xercesc/util/XMLString.hpp>
 
 using namespace std;
 using namespace xercesc;

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -240,7 +240,7 @@ namespace OpenMS::Internal
     MzIdentMLHandler::~MzIdentMLHandler()
     = default;
 
-    void MzIdentMLHandler::startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes)
+    void MzIdentMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& attributes)
     {
       tag_ = sm_.convert(qname);
       open_tags_.push_back(tag_);
@@ -386,7 +386,7 @@ namespace OpenMS::Internal
       error(LOAD, "MzIdentMLHandler::startElement: Unknown element found: '" + tag_ + "' in tag '" + parent_tag + "', ignoring.");
     }
 
-    void MzIdentMLHandler::characters(const XMLCh* const chars, const XMLSize_t /*length*/)
+    void MzIdentMLHandler::onCharacters(const char16_t* chars, Size /*length*/)
     {
       if (tag_ == "Customizations")
       {
@@ -412,7 +412,7 @@ namespace OpenMS::Internal
       //error(LOAD, "MzIdentMLHandler::characters: Unknown character section found: '" + tag_ + "', ignoring.");
     }
 
-    void MzIdentMLHandler::endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname)
+    void MzIdentMLHandler::onEndElement(const char16_t* qname)
     {
       static set<std::string> to_ignore;
       if (to_ignore.empty())
@@ -463,7 +463,7 @@ namespace OpenMS::Internal
       error(LOAD, "MzIdentMLHandler::endElement: Unknown element found: '" + tag_ + "', ignoring.");
     }
 
-    void MzIdentMLHandler::handleCVParam_(const std::string& /* parent_parent_tag*/, const std::string& parent_tag, const std::string& accession, /* const std::string& name, */ /* const std::string& value, */ const xercesc::Attributes& attributes, const std::string& cv_ref /* , const std::string& unit_accession */)
+    void MzIdentMLHandler::handleCVParam_(const std::string& /* parent_parent_tag*/, const std::string& parent_tag, const std::string& accession, /* const std::string& name, */ /* const std::string& value, */ const XMLAttributes& attributes, const std::string& cv_ref /* , const std::string& unit_accession */)
     {
       if (parent_tag == "Modification")
       {

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -270,11 +270,11 @@ namespace OpenMS::Internal
 
       if (tag_ == "cvParam")
       {
-        static const XMLCh* s_value = xercesc::XMLString::transcode("value");
-        static const XMLCh* s_unit_accession = xercesc::XMLString::transcode("unitAccession");
-        static const XMLCh* s_cv_ref = xercesc::XMLString::transcode("cvRef");
-        //~ static const XMLCh* s_name = xercesc::XMLString::transcode("name");
-        static const XMLCh* s_accession = xercesc::XMLString::transcode("accession");
+        static const char16_t* s_value = u"value";
+        static const char16_t* s_unit_accession = u"unitAccession";
+        static const char16_t* s_cv_ref = u"cvRef";
+        //~ static const char16_t* s_name = u"name";
+        static const char16_t* s_accession = u"accession";
 
         std::string value, unit_accession, cv_ref;
         optionalAttributeAsString_(value, attributes, s_value);

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -20,6 +20,7 @@
 
 #include <atomic>
 #include <map>
+#include <xercesc/util/XMLString.hpp>
 
 namespace OpenMS::Internal
 {

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -690,7 +690,7 @@ namespace OpenMS::Internal
     }
 
 
-    void MzMLHandler::characters(const XMLCh* const chars, const XMLSize_t length)
+    void MzMLHandler::onCharacters(const char16_t* chars, Size length)
     {
       if (skip_spectrum_ || skip_chromatogram_)
       {
@@ -725,7 +725,7 @@ namespace OpenMS::Internal
     }
 
 
-    void MzMLHandler::startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes)
+    void MzMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& attributes)
     {
       constexpr XMLCh s_count[] = {'c','o','u','n','t', 0};
       constexpr XMLCh s_default_array_length[] = { 'd','e','f','a','u','l','t','A','r','r','a','y','L','e','n','g','t','h' , 0};
@@ -1269,7 +1269,7 @@ namespace OpenMS::Internal
       }
     }
 
-    void MzMLHandler::endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname)
+    void MzMLHandler::onEndElement(const char16_t* qname)
     {
       constexpr XMLCh s_spectrum[] = { 's','p','e','c','t','r','u','m' , 0};
       constexpr XMLCh s_chromatogram[] = { 'c','h','r','o','m','a','t','o','g','r','a','m' , 0};

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSpectrumDecoder.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSpectrumDecoder.cpp
@@ -16,6 +16,7 @@
 #include <xercesc/dom/DOMNodeList.hpp>
 
 #include <memory>
+#include <xercesc/util/XMLString.hpp>
 
 namespace OpenMS
 {
@@ -422,8 +423,9 @@ namespace OpenMS
     return sptr;
   }
 
-  void MzMLSpectrumDecoder::handleBinaryDataArray_(xercesc::DOMNode* indexListNode, std::vector<BinaryData>& data)
+  void MzMLSpectrumDecoder::handleBinaryDataArray_(void* indexListNode_opaque, std::vector<BinaryData>& data)
   {
+    xercesc::DOMNode* indexListNode = static_cast<xercesc::DOMNode*>(indexListNode_opaque);
     // access result through data.back()
     data.emplace_back();
 

--- a/src/openms/source/FORMAT/HANDLERS/MzXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzXMLHandler.cpp
@@ -14,6 +14,7 @@
 
 #include <atomic>
 #include <stack>
+#include <xercesc/util/XMLString.hpp>
 
 namespace OpenMS::Internal
 {
@@ -515,8 +516,8 @@ namespace OpenMS::Internal
 
       //std::cout << " -- End -- " << sm_.convert(qname) << " -- " << "\n";
 
-      static const XMLCh* s_mzxml = xercesc::XMLString::transcode("mzXML");
-      static const XMLCh* s_scan = xercesc::XMLString::transcode("scan");
+      static const char16_t* s_mzxml = u"mzXML";
+      static const char16_t* s_scan = u"scan";
 
       open_tags_.pop_back();
 

--- a/src/openms/source/FORMAT/HANDLERS/MzXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzXMLHandler.cpp
@@ -78,9 +78,7 @@ namespace OpenMS::Internal
       load_detail_ = d;
     }
 
-    void MzXMLHandler::startElement(const XMLCh* const /*uri*/,
-      const XMLCh* const /*local_name*/, const XMLCh* const qname,
-      const xercesc::Attributes& attributes)
+    void MzXMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& attributes)
     {
       constexpr XMLCh s_value_[] = {'v', 'a', 'l', 'u', 'e', 0};
       constexpr XMLCh s_count_[] = {'s', 'c', 'a', 'n', 'C', 'o', 'u', 'n', 't', 0};
@@ -511,7 +509,7 @@ namespace OpenMS::Internal
       //std::cout << " -- !Start -- " << "\n";
     }
 
-    void MzXMLHandler::endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname)
+    void MzXMLHandler::onEndElement(const char16_t* qname)
     {
       OPENMS_PRECONDITION(nesting_level_ >= 0, "Nesting level needs to be zero or more")
 
@@ -545,7 +543,7 @@ namespace OpenMS::Internal
       //std::cout << " -- End -- " << "\n";
     }
 
-    void MzXMLHandler::characters(const XMLCh* const chars, const XMLSize_t length)
+    void MzXMLHandler::onCharacters(const char16_t* chars, Size length)
     {
       //Abort if this spectrum should be skipped
       if (skip_spectrum_)

--- a/src/openms/source/FORMAT/HANDLERS/PTMXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/PTMXMLHandler.cpp
@@ -37,20 +37,20 @@ namespace OpenMS::Internal
       os << "</PTMs>" << "\n";
     }
 
-    void PTMXMLHandler::startElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname, const Attributes & /*attributes*/)
+    void PTMXMLHandler::onStartElement(const char16_t * const qname, const XMLAttributes & /*attributes*/)
     {
       tag_ =StringUtils::trimmed(std::string(sm_.convert(qname)));
       open_tag_ = true;
     }
 
-    void PTMXMLHandler::endElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const /*qname*/)
+    void PTMXMLHandler::onEndElement(const char16_t* /*qname*/)
     {
 //          tag_ =StringUtils::trimmed(StringUtils::toStr(sm_.convert(qname)));
       tag_ = "";
       open_tag_ = false;
     }
 
-    void PTMXMLHandler::characters(const XMLCh * const chars, const XMLSize_t /*length*/)
+    void PTMXMLHandler::onCharacters(const char16_t* chars, Size /*length*/)
     {
       if (open_tag_)
       {

--- a/src/openms/source/FORMAT/HANDLERS/PTMXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/PTMXMLHandler.cpp
@@ -9,7 +9,6 @@
 #include <OpenMS/FORMAT/HANDLERS/PTMXMLHandler.h>
 
 using namespace std;
-using namespace xercesc;
 
 namespace OpenMS::Internal
 {

--- a/src/openms/source/FORMAT/HANDLERS/ParamXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ParamXMLHandler.cpp
@@ -26,7 +26,7 @@ namespace OpenMS::Internal
     ParamXMLHandler::~ParamXMLHandler()
     = default;
 
-    void ParamXMLHandler::startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const Attributes& attributes)
+    void ParamXMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& attributes)
     {
       static const XMLCh* s_restrictions = xercesc::XMLString::transcode("restrictions");
       static const XMLCh* s_supported_formats = xercesc::XMLString::transcode("supported_formats");
@@ -110,10 +110,10 @@ namespace OpenMS::Internal
         else
         {
           // parse restrictions if present
-          Int restrictions_index = attributes.getIndex(s_restrictions);
+          Int restrictions_index = attributes.index(s_restrictions);
           if (restrictions_index != -1)
           {
-            std::string val = sm_.convert(attributes.getValue(restrictions_index));
+            std::string val = sm_.convert(attributes.valueByIndex(restrictions_index));
             std::vector<std::string> parts;
             if (type == "int")
             {
@@ -171,10 +171,10 @@ namespace OpenMS::Internal
         // check for supported_formats -> supported_formats overwrites restrictions in case of files
         if ((ListUtils::contains(tags, "input file") || ListUtils::contains(tags, "output file")) && (type == "string" || type == "input-file" || type == "output-file"))
         {
-          Int supported_formats_index = attributes.getIndex(s_supported_formats);
+          Int supported_formats_index = attributes.index(s_supported_formats);
           if (supported_formats_index != -1)
           {
-            std::string val = sm_.convert(attributes.getValue(supported_formats_index));
+            std::string val = sm_.convert(attributes.valueByIndex(supported_formats_index));
             std::vector<std::string> parts;
 
             StringUtils::split(val, ',', parts);
@@ -242,20 +242,20 @@ namespace OpenMS::Internal
           list_.tags.emplace_back("required");
         }
         
-        list_.restrictions_index = attributes.getIndex(s_restrictions);
+        list_.restrictions_index = attributes.index(s_restrictions);
         if (list_.restrictions_index != -1)
         {
-          list_.restrictions = sm_.convert(attributes.getValue(list_.restrictions_index));
+          list_.restrictions = sm_.convert(attributes.valueByIndex(list_.restrictions_index));
         }
 
         // check for supported_formats -> supported_formats overwrites restrictions in case of files
         if ((ListUtils::contains(list_.tags, "input file") || ListUtils::contains(list_.tags, "output file")) && list_.type == "string")
         {
-          Int supported_formats_index = attributes.getIndex(s_supported_formats);
+          Int supported_formats_index = attributes.index(s_supported_formats);
           if (supported_formats_index != -1)
           {
             list_.restrictions_index = supported_formats_index;
-            list_.restrictions = sm_.convert(attributes.getValue(list_.restrictions_index));
+            list_.restrictions = sm_.convert(attributes.valueByIndex(list_.restrictions_index));
           }
         }
       }
@@ -296,7 +296,7 @@ namespace OpenMS::Internal
       }
     }
 
-    void ParamXMLHandler::endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname)
+    void ParamXMLHandler::onEndElement(const char16_t* qname)
     {
       std::string element = sm_.convert(qname);
       if (element == "NODE")

--- a/src/openms/source/FORMAT/HANDLERS/ParamXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ParamXMLHandler.cpp
@@ -10,7 +10,6 @@
 #include <OpenMS/CONCEPT/VersionInfo.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 
-using namespace xercesc;
 using namespace std;
 
 namespace OpenMS::Internal
@@ -28,8 +27,8 @@ namespace OpenMS::Internal
 
     void ParamXMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& attributes)
     {
-      static const XMLCh* s_restrictions = xercesc::XMLString::transcode("restrictions");
-      static const XMLCh* s_supported_formats = xercesc::XMLString::transcode("supported_formats");
+      static const char16_t* s_restrictions = u"restrictions";
+      static const char16_t* s_supported_formats = u"supported_formats";
 
       std::string element = sm_.convert(qname);
       if (element == "ITEM")

--- a/src/openms/source/FORMAT/HANDLERS/StringManager.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/StringManager.cpp
@@ -8,6 +8,7 @@
 
 #include <OpenMS/FORMAT/HANDLERS/StringManager.h>
 
+#include <cmath> // MSVC: SIMDe's simde-math.h needs std::isnormal/isnan/... in scope
 #include <OpenMS/SYSTEM/SIMDe.h>
 
 #include <xercesc/util/XMLString.hpp>

--- a/src/openms/source/FORMAT/HANDLERS/StringManager.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/StringManager.cpp
@@ -1,0 +1,258 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Marc Sturm, Chris Bielow $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/FORMAT/HANDLERS/StringManager.h>
+
+#include <OpenMS/SYSTEM/SIMDe.h>
+
+#include <xercesc/util/XMLString.hpp>
+
+#include <bit>
+#include <cstdint>
+
+using namespace xercesc;
+
+namespace OpenMS::Internal
+{
+  // XMLCh is the Xerces UTF-16 code unit; it is guaranteed to match char16_t in
+  // size and, on the supported toolchains, is char16_t. The StringManager public
+  // API is expressed in char16_t so its header stays Xerces-free.
+  static_assert(sizeof(::XMLCh) == sizeof(char16_t), "XMLCh is not sized correctly for UTF-16.");
+
+  // Specializations for character types, released by XMLString::release
+  template<> void shared_xerces_ptr<char>::doRelease_(char* item)
+  {
+    xercesc::XMLString::release(&item);
+  }
+
+  template<> void shared_xerces_ptr<char16_t>::doRelease_(char16_t* item)
+  {
+    xercesc::XMLString::release(reinterpret_cast<XMLCh**>(&item));
+  }
+
+  // Specializations for character types, which needs to be released by XMLString::release
+  template <>
+  void unique_xerces_ptr<char>::doRelease_(char*& item)
+  {
+    xercesc::XMLString::release(&item);
+  }
+
+  template <>
+  void unique_xerces_ptr<char16_t>::doRelease_(char16_t*& item)
+  {
+    xercesc::XMLString::release(reinterpret_cast<XMLCh**>(&item));
+  }
+
+  unique_xerces_ptr<char16_t> StringManager::fromNative_(const char* str)
+  {
+    return unique_xerces_ptr<char16_t>(reinterpret_cast<char16_t*>(xercesc::XMLString::transcode(str)));
+  }
+
+  unique_xerces_ptr<char16_t> StringManager::fromNative_(const std::string& str)
+  {
+    return fromNative_(str.c_str());
+  }
+
+  std::string StringManager::toNative_(const char16_t* str)
+  {
+    std::string r;
+    Size l = strLength(str);
+    if (isASCII(str, l))
+    {
+      appendASCII(str, l, r);
+    }
+    else
+    {
+      r = (unique_xerces_ptr<char>(xercesc::XMLString::transcode(reinterpret_cast<const XMLCh*>(str))).get());
+    }
+    return r;
+  }
+
+  std::string StringManager::toNative_(const unique_xerces_ptr<char16_t>& str)
+  {
+    return toNative_(str.get());
+  }
+
+  StringManager::XercesString StringManager::convert(const char* str)
+  {
+    return fromNative_(str).get();
+  }
+
+  StringManager::XercesString StringManager::convert(const std::string& str)
+  {
+    return fromNative_(str.c_str()).get();
+  }
+
+  unique_xerces_ptr<char16_t> StringManager::convertPtr(const char* str)
+  {
+    return fromNative_(str);
+  }
+
+  unique_xerces_ptr<char16_t> StringManager::convertPtr(const std::string& str)
+  {
+    return fromNative_(str.c_str());
+  }
+
+  std::string StringManager::convert(const char16_t* str)
+  {
+    return toNative_(str);
+  }
+
+  Int StringManager::parseInt(const char16_t* str)
+  {
+    return xercesc::XMLString::parseInt(reinterpret_cast<const XMLCh*>(str));
+  }
+
+  // https://github.com/OpenMS/OpenMS/issues/8122
+  #if defined(__GNUC__)
+  __attribute__((no_sanitize("address")))
+  #elif defined(_MSC_VER)
+  __declspec(no_sanitize_address)
+  #endif
+  Size StringManager::strLength(const char16_t* input_ptr)
+  {
+    if (input_ptr == nullptr) {
+        return 0;
+    }
+
+    Size processed_chars = 0;
+    const char16_t* pos_ptr = input_ptr;
+
+    // find number of characters until we reach a 16-byte aligned address
+    uintptr_t ptr_value = reinterpret_cast<uintptr_t>(pos_ptr);
+    size_t misalignment = ptr_value & 15; // modulo 16 to find misalignment
+    int chars_to_align = misalignment ? (16 - misalignment) / sizeof(char16_t) : 0;
+
+    // process one by one until we reach a 16-byte aligned address (where a SIMD load can be used)
+    for (int i = 0; i < chars_to_align; ++i)
+    {
+        if (*pos_ptr == 0) {
+            return i;
+        }
+        ++pos_ptr;
+    }
+    processed_chars = chars_to_align;
+
+    // SIMD loop: find the first zero character in blocks of 8 UTF-16 characters (16 bytes each)
+    const simde__m128i zero = simde_mm_setzero_si128();
+    while (true)
+    {
+        simde__m128i bits = simde_mm_load_si128(reinterpret_cast<const simde__m128i*>(pos_ptr));
+        simde__m128i cmp_zero = simde_mm_cmpeq_epi16(bits, zero); // sets bits to 0xFFFF (2 bytes) for each character that is zero
+        uint16_t zero_mask = simde_mm_movemask_epi8(cmp_zero);    // extracts MSB from each byte
+
+        if (zero_mask != 0)
+        { // Found a zero character
+            auto byte_pos_zero = std::countr_zero(zero_mask); // count trailing zeros to find the first zero character
+            auto char_pos_zero = byte_pos_zero / 2;           // each UTF-16 character is 2 bytes, so divide by 2 to get character position
+            return processed_chars + char_pos_zero;
+        }
+
+        // 8 chars (each 2 bytes) had no zero
+        pos_ptr += 8;
+        processed_chars += 8;
+    }
+
+    // never reached
+    return processed_chars;
+  }
+
+  void StringManager::compress64_(const char16_t* inputIt, char* outputIt)
+  {
+    simde__m128i bits = simde_mm_loadu_si128(reinterpret_cast<const simde__m128i*>(inputIt));
+
+    // Select every second byte (little-endian lower byte of each UTF-16 character)
+    const simde__m128i shuffleMask = simde_mm_setr_epi8(
+      0, 2, 4, 6, 8, 10, 12, 14,
+      -1, -1, -1, -1, -1, -1, -1, -1
+    );
+
+    simde__m128i compressed = simde_mm_shuffle_epi8(bits, shuffleMask);
+
+    // Store the lower 64 bits (8 ASCII characters)
+    simde_mm_storel_epi64(reinterpret_cast<simde__m128i*>(outputIt), compressed);
+  }
+
+  bool StringManager::isASCII(const char16_t* chars, const Size length)
+  {
+    if (length == 0)
+    {
+      return true;
+    }
+
+    Size fullBlocks = length / 8;
+    Size remainder = length % 8;
+
+    const char16_t* inputPtr = chars;
+    simde__m128i mask = simde_mm_set1_epi16(0xFF00);
+
+    // Process blocks of 8 UTF-16 characters using SIMD
+    for (Size i = 0; i < fullBlocks; ++i)
+    {
+      simde__m128i bits = simde_mm_loadu_si128(reinterpret_cast<const simde__m128i*>(inputPtr));
+      simde__m128i zero = simde_mm_setzero_si128();
+      simde__m128i andOp = simde_mm_and_si128(bits, mask);
+      simde__m128i cmp = simde_mm_cmpeq_epi16(andOp, zero);
+
+      if (simde_mm_movemask_epi8(cmp) != 0xFFFF)
+      {
+        return false;
+      }
+
+      inputPtr += 8;
+    }
+
+    // Check remaining characters individually
+    for (Size i = 0; i < remainder; ++i)
+    {
+      if (inputPtr[i] & 0xFF00)
+      {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  void StringManager::appendASCII(const char16_t* chars, const Size length, std::string& result)
+  {
+    // char16_t are characters in UTF16.
+    // We know that the Base64 string here can only contain plain ASCII
+    // and all bytes except the least significant one will be zero. Thus
+    // we can convert to char directly (only keeping the least
+    // significant byte).
+
+    Size fullBlocks = length / 8;
+    Size remainder = length % 8;
+
+    const char16_t* inputPtr = chars;
+
+    Size currentSize = result.size();
+    result.resize(currentSize + length);
+    char* outputPtr = &result[currentSize];
+
+    // Copy blocks of 8 characters at a time
+    for (Size i = 0; i < fullBlocks; ++i)
+    {
+      compress64_(inputPtr, outputPtr);
+      inputPtr += 8;
+      outputPtr += 8;
+    }
+
+    // Copy any remaining characters individually
+    for (Size i = 0; i < remainder; ++i)
+    {
+      outputPtr[i] = static_cast<char>(inputPtr[i] & 0xFF);
+    }
+  }
+
+  StringManager::StringManager() = default;
+
+  StringManager::~StringManager() = default;
+
+} // namespace OpenMS::Internal

--- a/src/openms/source/FORMAT/HANDLERS/StringManager.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/StringManager.cpp
@@ -117,8 +117,9 @@ namespace OpenMS::Internal
   #endif
   Size StringManager::strLength(const char16_t* input_ptr)
   {
-    if (input_ptr == nullptr) {
-        return 0;
+    if (input_ptr == nullptr)
+    {
+      return 0;
     }
 
     Size processed_chars = 0;
@@ -132,10 +133,11 @@ namespace OpenMS::Internal
     // process one by one until we reach a 16-byte aligned address (where a SIMD load can be used)
     for (int i = 0; i < chars_to_align; ++i)
     {
-        if (*pos_ptr == 0) {
-            return i;
-        }
-        ++pos_ptr;
+      if (*pos_ptr == 0)
+      {
+        return i;
+      }
+      ++pos_ptr;
     }
     processed_chars = chars_to_align;
 
@@ -143,20 +145,20 @@ namespace OpenMS::Internal
     const simde__m128i zero = simde_mm_setzero_si128();
     while (true)
     {
-        simde__m128i bits = simde_mm_load_si128(reinterpret_cast<const simde__m128i*>(pos_ptr));
-        simde__m128i cmp_zero = simde_mm_cmpeq_epi16(bits, zero); // sets bits to 0xFFFF (2 bytes) for each character that is zero
-        uint16_t zero_mask = simde_mm_movemask_epi8(cmp_zero);    // extracts MSB from each byte
+      simde__m128i bits = simde_mm_load_si128(reinterpret_cast<const simde__m128i*>(pos_ptr));
+      simde__m128i cmp_zero = simde_mm_cmpeq_epi16(bits, zero); // sets bits to 0xFFFF (2 bytes) for each character that is zero
+      uint16_t zero_mask = simde_mm_movemask_epi8(cmp_zero);    // extracts MSB from each byte
 
-        if (zero_mask != 0)
-        { // Found a zero character
-            auto byte_pos_zero = std::countr_zero(zero_mask); // count trailing zeros to find the first zero character
-            auto char_pos_zero = byte_pos_zero / 2;           // each UTF-16 character is 2 bytes, so divide by 2 to get character position
-            return processed_chars + char_pos_zero;
-        }
+      if (zero_mask != 0)
+      { // Found a zero character
+        auto byte_pos_zero = std::countr_zero(zero_mask); // count trailing zeros to find the first zero character
+        auto char_pos_zero = byte_pos_zero / 2;           // each UTF-16 character is 2 bytes, so divide by 2 to get character position
+        return processed_chars + char_pos_zero;
+      }
 
-        // 8 chars (each 2 bytes) had no zero
-        pos_ptr += 8;
-        processed_chars += 8;
+      // 8 chars (each 2 bytes) had no zero
+      pos_ptr += 8;
+      processed_chars += 8;
     }
 
     // never reached

--- a/src/openms/source/FORMAT/HANDLERS/ToolDescriptionHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ToolDescriptionHandler.cpp
@@ -27,11 +27,11 @@ namespace OpenMS::Internal
     ToolDescriptionHandler::~ToolDescriptionHandler()
     = default;
 
-    void ToolDescriptionHandler::startElement(const XMLCh * const uri, const XMLCh * const local_name, const XMLCh * const qname, const xercesc::Attributes & attributes)
+    void ToolDescriptionHandler::onStartElement(const char16_t* qname, const XMLAttributes& attributes)
     {
       if (in_ini_section_)
       {
-        ParamXMLHandler::startElement(uri, local_name, qname, attributes);
+        ParamXMLHandler::onStartElement(qname, attributes);
         return;
       }
 
@@ -111,11 +111,11 @@ namespace OpenMS::Internal
       error(LOAD, "ToolDescriptionHandler::startElement(): Unknown element found: '" + tag_ + "', ignoring.");
     }
 
-    void ToolDescriptionHandler::characters(const XMLCh * const chars, const XMLSize_t length)
+    void ToolDescriptionHandler::onCharacters(const char16_t* chars, Size length)
     {
       if (in_ini_section_)
       {
-        ParamXMLHandler::characters(chars, length);
+        ParamXMLHandler::onCharacters(chars, length);
         return;
       }
 
@@ -171,12 +171,12 @@ namespace OpenMS::Internal
       }
     }
 
-    void ToolDescriptionHandler::endElement(const XMLCh * const uri, const XMLCh * const local_name, const XMLCh * const qname)
+    void ToolDescriptionHandler::onEndElement(const char16_t* qname)
     {
       std::string endtag_ = sm_.convert(qname);
       if (in_ini_section_ && endtag_ != "ini_param")
       {
-        ParamXMLHandler::endElement(uri, local_name, qname);
+        ParamXMLHandler::onEndElement(qname);
         return;
       }
 

--- a/src/openms/source/FORMAT/HANDLERS/TraMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/TraMLHandler.cpp
@@ -43,14 +43,14 @@ namespace OpenMS::Internal
 
     void TraMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& attributes)
     {
-      static const XMLCh* s_type = xercesc::XMLString::transcode("type");
-      static const XMLCh* s_value = xercesc::XMLString::transcode("value");
-      static const XMLCh* s_name = xercesc::XMLString::transcode("name");
-      static const XMLCh* s_id = xercesc::XMLString::transcode("id");
-      static const XMLCh* s_sequence = xercesc::XMLString::transcode("sequence");
-      static const XMLCh* s_fullName = xercesc::XMLString::transcode("fullName");
-      static const XMLCh* s_version = xercesc::XMLString::transcode("version");
-      static const XMLCh* s_URI = xercesc::XMLString::transcode("URI");
+      static const char16_t* s_type = u"type";
+      static const char16_t* s_value = u"value";
+      static const char16_t* s_name = u"name";
+      static const char16_t* s_id = u"id";
+      static const char16_t* s_sequence = u"sequence";
+      static const char16_t* s_fullName = u"fullName";
+      static const char16_t* s_version = u"version";
+      static const char16_t* s_URI = u"URI";
 
       tag_ = sm_.convert(qname);
       open_tags_.push_back(tag_);
@@ -103,11 +103,11 @@ namespace OpenMS::Internal
       if (tag_ == "cvParam")
       {
         // These are here because of cppcheck
-        static const XMLCh* s_accession = xercesc::XMLString::transcode("accession");
-        static const XMLCh* s_unit_accession = xercesc::XMLString::transcode("unitAccession");
-        static const XMLCh* s_unit_name = xercesc::XMLString::transcode("unitName");
-        static const XMLCh* s_unit_cvref = xercesc::XMLString::transcode("unitCvRef");
-        static const XMLCh* s_unit_ref = xercesc::XMLString::transcode("cvRef");
+        static const char16_t* s_accession = u"accession";
+        static const char16_t* s_unit_accession = u"unitAccession";
+        static const char16_t* s_unit_name = u"unitName";
+        static const char16_t* s_unit_cvref = u"unitCvRef";
+        static const char16_t* s_unit_ref = u"cvRef";
 
         std::string value, cv_ref, unit_accession, unit_name, unit_cv_ref;
         optionalAttributeAsString_(value, attributes, s_value);

--- a/src/openms/source/FORMAT/HANDLERS/TraMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/TraMLHandler.cpp
@@ -41,7 +41,7 @@ namespace OpenMS::Internal
     TraMLHandler::~TraMLHandler()
     = default;
 
-    void TraMLHandler::startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes)
+    void TraMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& attributes)
     {
       static const XMLCh* s_type = xercesc::XMLString::transcode("type");
       static const XMLCh* s_value = xercesc::XMLString::transcode("value");
@@ -272,7 +272,7 @@ namespace OpenMS::Internal
       return;
     }
 
-    void TraMLHandler::characters(const XMLCh* const chars, const XMLSize_t /*length*/)
+    void TraMLHandler::onCharacters(const char16_t* chars, Size /*length*/)
     {
       if (open_tags_.back() == "Sequence")
       {
@@ -282,7 +282,7 @@ namespace OpenMS::Internal
       return;
     }
 
-    void TraMLHandler::endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname)
+    void TraMLHandler::onEndElement(const char16_t* qname)
     {
       tag_ = sm_.convert(qname);
 

--- a/src/openms/source/FORMAT/HANDLERS/UniProtXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/UniProtXMLHandler.cpp
@@ -11,6 +11,7 @@
 #include <cctype>
 #include <cstdlib>
 #include <utility>
+#include <xercesc/util/XMLString.hpp>
 
 namespace OpenMS::Internal
 {

--- a/src/openms/source/FORMAT/HANDLERS/UniProtXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/UniProtXMLHandler.cpp
@@ -152,11 +152,10 @@ namespace OpenMS::Internal
   void UniProtXMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& attrs)
   {
     ++depth_;
-    // Prefer local_name when the parser populates it (namespace-aware mode); fall back to
-    // qname otherwise. Real UniProtKB XML carries `xmlns="http://uniprot.org/uniprot"`, so
-    // a future switch to namespace-aware Xerces would deliver qname as `uniprot:entry` and
-    // local_name as `entry`; comparing against local_name keeps this handler working in both
-    // configurations.
+    // The SAX parser runs namespace-unaware (see XMLFile.cpp), so the element tag
+    // is delivered in qname (unprefixed). Real UniProtKB XML carries a default
+    // namespace (xmlns="http://uniprot.org/uniprot") with no prefixes, so qname
+    // equals the local name here.
     const std::string tag = xmlchToString(qname);
 
     // Inside the alternative-products comment? swallow the whole subtree.

--- a/src/openms/source/FORMAT/HANDLERS/UniProtXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/UniProtXMLHandler.cpp
@@ -20,10 +20,10 @@ namespace OpenMS::Internal
     std::string xmlchToString(const XMLCh* ch);
 
     /// Read a Xerces attribute by name (qname), return "" if absent.
-    std::string attrValue(const xercesc::Attributes& attrs, const char* name)
+    std::string attrValue(const XMLAttributes& attrs, const char* name)
     {
       XMLCh* qname = xercesc::XMLString::transcode(name);
-      const XMLCh* value = attrs.getValue(qname);
+      const char16_t* value = attrs.value(qname);
       xercesc::XMLString::release(&qname);
       if (value == nullptr) return std::string();
       return xmlchToString(value);
@@ -148,8 +148,7 @@ namespace OpenMS::Internal
     return static_cast<int>(value);
   }
 
-  void UniProtXMLHandler::startElement(const XMLCh* const /*uri*/, const XMLCh* const local_name,
-                                       const XMLCh* const qname, const xercesc::Attributes& attrs)
+  void UniProtXMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& attrs)
   {
     ++depth_;
     // Prefer local_name when the parser populates it (namespace-aware mode); fall back to
@@ -157,7 +156,7 @@ namespace OpenMS::Internal
     // a future switch to namespace-aware Xerces would deliver qname as `uniprot:entry` and
     // local_name as `entry`; comparing against local_name keeps this handler working in both
     // configurations.
-    const std::string tag = xmlchToString(isEmpty(local_name) ? qname : local_name);
+    const std::string tag = xmlchToString(qname);
 
     // Inside the alternative-products comment? swallow the whole subtree.
     if (alt_products_depth_ != 0) return;
@@ -305,7 +304,7 @@ namespace OpenMS::Internal
     }
   }
 
-  void UniProtXMLHandler::characters(const XMLCh* const chars, const XMLSize_t length)
+  void UniProtXMLHandler::onCharacters(const char16_t* chars, Size length)
   {
     if (capture_ == CaptureTarget::None) return;
     // Use the length-aware UTF-16 → UTF-8 helper so we don't depend on a
@@ -313,10 +312,9 @@ namespace OpenMS::Internal
     appendXmlchUtf8(char_buf_, chars, length);
   }
 
-  void UniProtXMLHandler::endElement(const XMLCh* const /*uri*/, const XMLCh* const local_name,
-                                     const XMLCh* const qname)
+  void UniProtXMLHandler::onEndElement(const char16_t* qname)
   {
-    const std::string tag = xmlchToString(isEmpty(local_name) ? qname : local_name);
+    const std::string tag = xmlchToString(qname);
 
     // Close the alt-products skip gate at its matching </comment>.
     if (alt_products_depth_ != 0)

--- a/src/openms/source/FORMAT/HANDLERS/UnimodXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/UnimodXMLHandler.cpp
@@ -28,7 +28,7 @@ namespace OpenMS::Internal
     UnimodXMLHandler::~UnimodXMLHandler()
     = default;
 
-    void UnimodXMLHandler::startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const Attributes& attributes)
+    void UnimodXMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& attributes)
     {
 
       tag_ =std::string(sm_.convert(qname));
@@ -116,16 +116,16 @@ namespace OpenMS::Internal
       if (tag_ == "umod:delta" || tag_ == "delta")
       {
         // avge_mass="-0.9848" mono_mass="-0.984016" composition="H N O(-1)" >
-        avge_mass_ = StringUtils::toDouble(sm_.convert(attributes.getValue(attributes.getIndex(sm_.convert("avge_mass").c_str()))));
-        mono_mass_ = StringUtils::toDouble(sm_.convert(attributes.getValue(attributes.getIndex(sm_.convert("mono_mass").c_str()))));
+        avge_mass_ = StringUtils::toDouble(sm_.convert(attributes.valueByIndex(attributes.index(sm_.convert("avge_mass").c_str()))));
+        mono_mass_ = StringUtils::toDouble(sm_.convert(attributes.valueByIndex(attributes.index(sm_.convert("mono_mass").c_str()))));
         return;
       }
 
       // <umod:element symbol="H" number="1"/>
       if (tag_ == "umod:element")
       {
-        std::string symbol = sm_.convert(attributes.getValue(attributes.getIndex(sm_.convert("symbol").c_str())));
-        std::string num = sm_.convert(attributes.getValue(attributes.getIndex(sm_.convert("number").c_str())));
+        std::string symbol = sm_.convert(attributes.valueByIndex(attributes.index(sm_.convert("symbol").c_str())));
+        std::string num = sm_.convert(attributes.valueByIndex(attributes.index(sm_.convert("number").c_str())));
         std::string isotope, tmp_symbol;
         for (Size i = 0; i != symbol.size(); ++i)
         {
@@ -152,7 +152,7 @@ namespace OpenMS::Internal
       }
     }
 
-    void UnimodXMLHandler::endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname)
+    void UnimodXMLHandler::onEndElement(const char16_t* qname)
     {
       tag_ =std::string(sm_.convert(qname));
 
@@ -207,7 +207,7 @@ namespace OpenMS::Internal
       }
     }
 
-    void UnimodXMLHandler::characters(const XMLCh* const /*chars*/, const XMLSize_t /*length*/)
+    void UnimodXMLHandler::onCharacters(const char16_t* /*chars*/, Size /*length*/)
     {
       // nothing to do here
     }

--- a/src/openms/source/FORMAT/HANDLERS/UnimodXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/UnimodXMLHandler.cpp
@@ -10,7 +10,6 @@
 #include <OpenMS/FORMAT/HANDLERS/UnimodXMLHandler.h>
 
 using namespace std;
-using namespace xercesc;
 
 namespace OpenMS::Internal
 {

--- a/src/openms/source/FORMAT/HANDLERS/XMLAttributes.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XMLAttributes.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/FORMAT/HANDLERS/XMLAttributes.h>
+
+#include <xercesc/sax2/Attributes.hpp>
+#include <xercesc/util/XMLString.hpp>
+
+namespace OpenMS::Internal
+{
+  // XMLCh is guaranteed to match char16_t in size; the attribute values are
+  // consumed purely as UTF-16 code units, so the reinterpret_cast at this
+  // boundary is well-defined for our use.
+  static_assert(sizeof(::XMLCh) == sizeof(char16_t), "XMLCh is not sized correctly for UTF-16.");
+
+  namespace
+  {
+    inline const xercesc::Attributes* attrs(const void* handle)
+    {
+      return static_cast<const xercesc::Attributes*>(handle);
+    }
+  }
+
+  const char16_t* XMLAttributes::value(const char16_t* qname) const
+  {
+    return reinterpret_cast<const char16_t*>(attrs(attributes_)->getValue(reinterpret_cast<const ::XMLCh*>(qname)));
+  }
+
+  const char16_t* XMLAttributes::value(const char* qname) const
+  {
+    ::XMLCh* transcoded = xercesc::XMLString::transcode(qname);
+    const ::XMLCh* val = attrs(attributes_)->getValue(transcoded);
+    xercesc::XMLString::release(&transcoded);
+    return reinterpret_cast<const char16_t*>(val);
+  }
+
+  SignedSize XMLAttributes::index(const char16_t* qname) const
+  {
+    return static_cast<SignedSize>(attrs(attributes_)->getIndex(reinterpret_cast<const ::XMLCh*>(qname)));
+  }
+
+  const char16_t* XMLAttributes::valueByIndex(Size i) const
+  {
+    return reinterpret_cast<const char16_t*>(attrs(attributes_)->getValue(static_cast<XMLSize_t>(i)));
+  }
+
+} // namespace OpenMS::Internal

--- a/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
@@ -152,15 +152,33 @@ namespace OpenMS::Internal
 
     }
 
-    void XMLHandler::characters(const XMLCh * const /*chars*/, const XMLSize_t /*length*/)
+    // Xerces callbacks — forward to the native (Xerces-free) overloads. XMLCh is
+    // guaranteed char16_t-sized, so the reinterpret_cast is a well-defined view.
+    void XMLHandler::characters(const XMLCh * const chars, const XMLSize_t length)
+    {
+      onCharacters(std::u16string_view(reinterpret_cast<const char16_t*>(chars), length));
+    }
+
+    void XMLHandler::startElement(const XMLCh * const /*uri*/, const XMLCh * const /*localname*/, const XMLCh * const qname, const Attributes & attrs)
+    {
+      onStartElement(reinterpret_cast<const char16_t*>(qname), XMLAttributes(attrs));
+    }
+
+    void XMLHandler::endElement(const XMLCh * const /*uri*/, const XMLCh * const /*localname*/, const XMLCh * const qname)
+    {
+      onEndElement(reinterpret_cast<const char16_t*>(qname));
+    }
+
+    // Native default implementations (overridden by migrated subclasses).
+    void XMLHandler::onStartElement(const char16_t * /*qname*/, const XMLAttributes & /*attributes*/)
     {
     }
 
-    void XMLHandler::startElement(const XMLCh * const /*uri*/, const XMLCh * const /*localname*/, const XMLCh * const /*qname*/, const Attributes & /*attrs*/)
+    void XMLHandler::onEndElement(const char16_t * /*qname*/)
     {
     }
 
-    void XMLHandler::endElement(const XMLCh * const /*uri*/, const XMLCh * const /*localname*/, const XMLCh * const /*qname*/)
+    void XMLHandler::onCharacters(std::u16string_view /*chars*/)
     {
     }
 
@@ -566,19 +584,19 @@ namespace OpenMS::Internal
 
     //*******************************************************************************************************************
 
-    DoubleList XMLHandler::attributeAsDoubleList_(const xercesc::Attributes & a, const char * name) const
+    DoubleList XMLHandler::attributeAsDoubleList_(const XMLAttributes & a, const char * name) const
     {
       std::string tmp(expectList_(attributeAsString_(a, name)));
       return ListUtils::create<double>(StringUtils::substr(tmp, 1, tmp.size() - 2));
     }
 
-    IntList XMLHandler::attributeAsIntList_(const xercesc::Attributes & a, const char * name) const
+    IntList XMLHandler::attributeAsIntList_(const XMLAttributes & a, const char * name) const
     {
       std::string tmp(expectList_(attributeAsString_(a, name)));
       return ListUtils::create<Int>(StringUtils::substr(tmp, 1, tmp.size() - 2));
     }
 
-    StringList XMLHandler::attributeAsStringList_(const xercesc::Attributes & a, const char * name) const
+    StringList XMLHandler::attributeAsStringList_(const XMLAttributes & a, const char * name) const
     {
       std::string tmp(expectList_(attributeAsString_(a, name)));
       StringList tmp_list = ListUtils::create<std::string>(StringUtils::substr(tmp, 1, tmp.size() - 2)); // between [ and ]
@@ -593,19 +611,19 @@ namespace OpenMS::Internal
       return tmp_list;
     }
 
-    DoubleList XMLHandler::attributeAsDoubleList_(const xercesc::Attributes & a, const XMLCh * name) const
+    DoubleList XMLHandler::attributeAsDoubleList_(const XMLAttributes & a, const XMLCh * name) const
     {
       std::string tmp(expectList_(attributeAsString_(a, name)));
       return ListUtils::create<double>(StringUtils::substr(tmp, 1, tmp.size() - 2));
     }
 
-    IntList XMLHandler::attributeAsIntList_(const xercesc::Attributes & a, const XMLCh * name) const
+    IntList XMLHandler::attributeAsIntList_(const XMLAttributes & a, const XMLCh * name) const
     {
       std::string tmp(expectList_(attributeAsString_(a, name)));
       return ListUtils::create<Int>(StringUtils::substr(tmp, 1, tmp.size() - 2));
     }
 
-    StringList XMLHandler::attributeAsStringList_(const xercesc::Attributes & a, const XMLCh * name) const
+    StringList XMLHandler::attributeAsStringList_(const XMLAttributes & a, const XMLCh * name) const
     {
       std::string tmp(expectList_(attributeAsString_(a, name)));
       StringList tmp_list = ListUtils::create<std::string>(StringUtils::substr(tmp, 1, tmp.size() - 2)); // between [ and ]

--- a/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
@@ -21,35 +21,9 @@
 #include <set>
 
 using namespace std;
-using namespace xercesc;
 
 namespace OpenMS::Internal
 {
-
-    // Specializations for character types, released by XMLString::release
-    template<> void shared_xerces_ptr<char>::doRelease_(char* item)
-    {
-      xercesc::XMLString::release(&item);
-    }
-
-    template<> void shared_xerces_ptr<XMLCh>::doRelease_(XMLCh* item)
-    {
-      xercesc::XMLString::release(&item);
-    }
-
-    // Specializations for character types, which needs to be
-    // released by XMLString::release
-    template <>
-    void unique_xerces_ptr<char>::doRelease_(char*& item)
-    {
-      xercesc::XMLString::release(&item);
-    }
-
-    template <>
-    void unique_xerces_ptr<XMLCh>::doRelease_(XMLCh*& item)
-    {
-      xercesc::XMLString::release(&item);
-    }
 
     XMLHandler::XMLHandler(const std::string & filename, const std::string & version) :
       file_(filename),
@@ -62,21 +36,6 @@ namespace OpenMS::Internal
 
     void XMLHandler::reset()
     {
-    }
-
-    void XMLHandler::fatalError(const SAXParseException & exception)
-    {
-      fatalError(LOAD, sm_.convert(exception.getMessage()), exception.getLineNumber(), exception.getColumnNumber());
-    }
-
-    void XMLHandler::error(const SAXParseException & exception)
-    {
-      error(LOAD, sm_.convert(exception.getMessage()), exception.getLineNumber(), exception.getColumnNumber());
-    }
-
-    void XMLHandler::warning(const SAXParseException & exception)
-    {
-      warning(LOAD, sm_.convert(exception.getMessage()), exception.getLineNumber(), exception.getColumnNumber());
     }
 
     void XMLHandler::fatalError(ActionMode mode, const std::string & msg, UInt line, UInt column) const
@@ -150,23 +109,6 @@ namespace OpenMS::Internal
       OPENMS_LOG_DEBUG << error_message << std::endl;
 #endif
 
-    }
-
-    // Xerces callbacks — forward to the native (Xerces-free) overloads. XMLCh is
-    // guaranteed char16_t-sized, so the reinterpret_cast is a well-defined view.
-    void XMLHandler::characters(const XMLCh * const chars, const XMLSize_t length)
-    {
-      onCharacters(reinterpret_cast<const char16_t*>(chars), length);
-    }
-
-    void XMLHandler::startElement(const XMLCh * const /*uri*/, const XMLCh * const /*localname*/, const XMLCh * const qname, const Attributes & attrs)
-    {
-      onStartElement(reinterpret_cast<const char16_t*>(qname), XMLAttributes(attrs));
-    }
-
-    void XMLHandler::endElement(const XMLCh * const /*uri*/, const XMLCh * const /*localname*/, const XMLCh * const qname)
-    {
-      onEndElement(reinterpret_cast<const char16_t*>(qname));
     }
 
     // Native default implementations (overridden by migrated subclasses).
@@ -438,149 +380,6 @@ namespace OpenMS::Internal
       }
     }
 
-    // https://github.com/OpenMS/OpenMS/issues/8122
-    #if defined(__GNUC__)
-    __attribute__((no_sanitize("address")))
-    #elif defined(_MSC_VER)
-    __declspec(no_sanitize_address)
-    #endif
-    size_t StringManager::strLength(const XMLCh* input_ptr)
-    {
-      if (input_ptr == nullptr) {
-          return 0;
-      }
-  
-      XMLSize_t processed_chars = 0;
-      const XMLCh* pos_ptr = input_ptr;
-  
-      // find number of characters until we reach a 16-byte aligned address
-      uintptr_t ptr_value = reinterpret_cast<uintptr_t>(pos_ptr);
-      size_t misalignment = ptr_value & 15; // modulo 16 to find misalignment
-      int chars_to_align = misalignment ? (16 - misalignment) / sizeof(XMLCh) : 0;
-  
-      // process one by one until we reach a 16-byte aligned address (where a SIMD load can be used)
-      for (int i = 0; i < chars_to_align; ++i)
-      {
-          if (*pos_ptr == 0) {
-              return i;
-          }
-          ++pos_ptr;
-      }
-      processed_chars = chars_to_align;
-  
-      // SIMD loop: find the first zero character in blocks of 8 UTF-16 characters (16 bytes each)
-      const simde__m128i zero = simde_mm_setzero_si128();
-      while (true)
-      {
-          simde__m128i bits = simde_mm_load_si128(reinterpret_cast<const simde__m128i*>(pos_ptr));
-          simde__m128i cmp_zero = simde_mm_cmpeq_epi16(bits, zero); // sets bits to 0xFFFF (2 bytes) for each character that is zero
-          uint16_t zero_mask = simde_mm_movemask_epi8(cmp_zero);    // extracts MSB from each byte 
-  
-          if (zero_mask != 0)
-          { // Found a zero character
-              auto byte_pos_zero = std::countr_zero(zero_mask); // count trailing zeros to find the first zero character
-              auto char_pos_zero = byte_pos_zero / 2;           // each UTF-16 character is 2 bytes, so divide by 2 to get character position
-              return processed_chars + char_pos_zero;
-          }
-  
-          // 8 chars (each 2 bytes) had no zero
-          pos_ptr += 8;
-          processed_chars += 8;
-      }
-  
-      // never reached
-      return processed_chars;
-    }
-
-    void StringManager::compress64_(const XMLCh* inputIt, char* outputIt)
-    {
-      simde__m128i bits = simde_mm_loadu_si128(reinterpret_cast<const simde__m128i*>(inputIt));
-    
-      // Select every second byte (little-endian lower byte of each UTF-16 character)
-      const simde__m128i shuffleMask = simde_mm_setr_epi8(
-        0, 2, 4, 6, 8, 10, 12, 14,
-        -1, -1, -1, -1, -1, -1, -1, -1
-      );
-    
-      simde__m128i compressed = simde_mm_shuffle_epi8(bits, shuffleMask);
-    
-      // Store the lower 64 bits (8 ASCII characters)
-      simde_mm_storel_epi64(reinterpret_cast<simde__m128i*>(outputIt), compressed);
-    }
-
-    bool StringManager::isASCII(const XMLCh* chars, const XMLSize_t length)
-    {
-      if (length == 0)
-      {
-        return true;
-      }
-
-      Size fullBlocks = length / 8;
-      Size remainder = length % 8;
-
-      const XMLCh* inputPtr = chars;
-      simde__m128i mask = simde_mm_set1_epi16(0xFF00);
-
-      // Process blocks of 8 UTF-16 characters using SIMD
-      for (Size i = 0; i < fullBlocks; ++i)
-      {
-        simde__m128i bits = simde_mm_loadu_si128(reinterpret_cast<const simde__m128i*>(inputPtr));
-        simde__m128i zero = simde_mm_setzero_si128();
-        simde__m128i andOp = simde_mm_and_si128(bits, mask);
-        simde__m128i cmp = simde_mm_cmpeq_epi16(andOp, zero);
-
-        if (simde_mm_movemask_epi8(cmp) != 0xFFFF)
-        {
-          return false;
-        }
-
-        inputPtr += 8;
-      }
-
-      // Check remaining characters individually
-      for (Size i = 0; i < remainder; ++i)
-      {
-        if (inputPtr[i] & 0xFF00)
-        {
-          return false;
-        }
-      }
-
-      return true;
-    }
-
-    void StringManager::appendASCII(const XMLCh* chars, const XMLSize_t length, std::string& result)
-    {
-      // XMLCh are characters in UTF16 (usually stored as 16-bit unsigned
-      // short but this is not guaranteed).
-      // We know that the Base64 string here can only contain plain ASCII
-      // and all bytes except the least significant one will be zero. Thus
-      // we can convert to char directly (only keeping the least
-      // significant byte).
-    
-      Size fullBlocks = length / 8;
-      Size remainder = length % 8;
-    
-      const XMLCh* inputPtr = chars;
-    
-      Size currentSize = result.size();
-      result.resize(currentSize + length);
-      char* outputPtr = &result[currentSize];
-    
-      // Copy blocks of 8 characters at a time
-      for (Size i = 0; i < fullBlocks; ++i)
-      {
-        compress64_(inputPtr, outputPtr);
-        inputPtr += 8;
-        outputPtr += 8;
-      }
-    
-      // Copy any remaining characters individually
-      for (Size i = 0; i < remainder; ++i)
-      {
-        outputPtr[i] = static_cast<char>(inputPtr[i] & 0xFF);
-      }
-    }
 
     //*******************************************************************************************************************
 
@@ -611,19 +410,19 @@ namespace OpenMS::Internal
       return tmp_list;
     }
 
-    DoubleList XMLHandler::attributeAsDoubleList_(const XMLAttributes & a, const XMLCh * name) const
+    DoubleList XMLHandler::attributeAsDoubleList_(const XMLAttributes & a, const char16_t * name) const
     {
       std::string tmp(expectList_(attributeAsString_(a, name)));
       return ListUtils::create<double>(StringUtils::substr(tmp, 1, tmp.size() - 2));
     }
 
-    IntList XMLHandler::attributeAsIntList_(const XMLAttributes & a, const XMLCh * name) const
+    IntList XMLHandler::attributeAsIntList_(const XMLAttributes & a, const char16_t * name) const
     {
       std::string tmp(expectList_(attributeAsString_(a, name)));
       return ListUtils::create<Int>(StringUtils::substr(tmp, 1, tmp.size() - 2));
     }
 
-    StringList XMLHandler::attributeAsStringList_(const XMLAttributes & a, const XMLCh * name) const
+    StringList XMLHandler::attributeAsStringList_(const XMLAttributes & a, const char16_t * name) const
     {
       std::string tmp(expectList_(attributeAsString_(a, name)));
       StringList tmp_list = ListUtils::create<std::string>(StringUtils::substr(tmp, 1, tmp.size() - 2)); // between [ and ]
@@ -638,8 +437,5 @@ namespace OpenMS::Internal
       return tmp_list;
     }
 
-    StringManager::StringManager() = default;
-
-    StringManager::~StringManager() = default;
 
 } // namespace OpenMS::Internal

--- a/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
@@ -156,7 +156,7 @@ namespace OpenMS::Internal
     // guaranteed char16_t-sized, so the reinterpret_cast is a well-defined view.
     void XMLHandler::characters(const XMLCh * const chars, const XMLSize_t length)
     {
-      onCharacters(std::u16string_view(reinterpret_cast<const char16_t*>(chars), length));
+      onCharacters(reinterpret_cast<const char16_t*>(chars), length);
     }
 
     void XMLHandler::startElement(const XMLCh * const /*uri*/, const XMLCh * const /*localname*/, const XMLCh * const qname, const Attributes & attrs)
@@ -178,7 +178,7 @@ namespace OpenMS::Internal
     {
     }
 
-    void XMLHandler::onCharacters(std::u16string_view /*chars*/)
+    void XMLHandler::onCharacters(const char16_t * /*chars*/, Size /*length*/)
     {
     }
 

--- a/src/openms/source/FORMAT/HANDLERS/XQuestResultXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XQuestResultXMLHandler.cpp
@@ -116,7 +116,7 @@ namespace OpenMS::Internal
     }
 
     // Extracts the position of the Cross-Link for intralinks and crosslinks
-    void XQuestResultXMLHandler::getLinkPosition_(const xercesc::Attributes & attributes, std::pair<SignedSize, SignedSize> & pair)
+    void XQuestResultXMLHandler::getLinkPosition_(const XMLAttributes & attributes, std::pair<SignedSize, SignedSize> & pair)
     {
       std::string xlink_position = this->attributeAsString_(attributes, "xlinkposition");
       StringList xlink_position_split;
@@ -187,7 +187,7 @@ namespace OpenMS::Internal
       return this->n_hits_;
     }
 
-    void XQuestResultXMLHandler::endElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname)
+    void XQuestResultXMLHandler::onEndElement(const char16_t* qname)
     {
       std::string tag = StringManager::convert(qname);
       if (tag == "xquest_results")
@@ -207,7 +207,7 @@ namespace OpenMS::Internal
       }
     }
 
-    void XQuestResultXMLHandler::startElement(const XMLCh * const, const XMLCh * const, const XMLCh * const qname, const Attributes &attributes)
+    void XQuestResultXMLHandler::onStartElement(const char16_t * const qname, const XMLAttributes &attributes)
     {
       std::string tag = StringManager::convert(qname);
       // Extract meta information from the xquest_results tag

--- a/src/openms/source/FORMAT/HANDLERS/XQuestResultXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XQuestResultXMLHandler.cpp
@@ -20,7 +20,6 @@
 #include <cassert>
 
 using namespace std;
-using namespace xercesc;
 
 namespace OpenMS::Internal
 {

--- a/src/openms/source/FORMAT/HANDLERS/sources.cmake
+++ b/src/openms/source/FORMAT/HANDLERS/sources.cmake
@@ -30,6 +30,7 @@ set(sources_list
   TraMLHandler.cpp
   UnimodXMLHandler.cpp
   UniProtXMLHandler.cpp
+  StringManager.cpp
   XMLAttributes.cpp
   XMLHandler.cpp
   XQuestResultXMLHandler.cpp

--- a/src/openms/source/FORMAT/HANDLERS/sources.cmake
+++ b/src/openms/source/FORMAT/HANDLERS/sources.cmake
@@ -30,6 +30,7 @@ set(sources_list
   TraMLHandler.cpp
   UnimodXMLHandler.cpp
   UniProtXMLHandler.cpp
+  XMLAttributes.cpp
   XMLHandler.cpp
   XQuestResultXMLHandler.cpp
 )

--- a/src/openms/source/FORMAT/IdXMLFile.cpp
+++ b/src/openms/source/FORMAT/IdXMLFile.cpp
@@ -422,7 +422,7 @@ namespace OpenMS
     proteinid_to_accession_.clear();
   }
 
-  void IdXMLFile::startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes)
+  void IdXMLFile::onStartElement(const char16_t* qname, const Internal::XMLAttributes& attributes)
   {
     std::string tag = sm_.convert(qname);
 
@@ -632,7 +632,7 @@ namespace OpenMS
       pep_hit_.setSequence(AASequence::fromString(std::string(attributeAsString_(attributes, "sequence"))));
 
       //parse optional protein ids to determine accessions
-      const XMLCh* refs = attributes.getValue(sm_.convert("protein_refs").c_str());
+      const char16_t* refs = attributes.value(sm_.convert("protein_refs").c_str());
       if (refs != nullptr)
       {
         std::string accession_string = sm_.convert(refs);
@@ -814,7 +814,7 @@ namespace OpenMS
     }
   }
 
-  void IdXMLFile::endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname)
+  void IdXMLFile::onEndElement(const char16_t* qname)
   {
     std::string tag = sm_.convert(qname);
 

--- a/src/openms/source/FORMAT/ImzMLFile.cpp
+++ b/src/openms/source/FORMAT/ImzMLFile.cpp
@@ -8,6 +8,7 @@
 
 #include <OpenMS/FORMAT/ImzMLFile.h>
 #include <OpenMS/FORMAT/HANDLERS/ImzMLHandler.h>
+#include <OpenMS/FORMAT/HANDLERS/SAX2HandlerAdapter.h>
 #include <OpenMS/FORMAT/HANDLERS/ImzMLWriter.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
@@ -502,8 +503,9 @@ void ImzMLFile::loadImpl_(const std::string& filename,
   reader->setFeature(xercesc::XMLUni::fgXercesDisableDefaultEntityResolution, true);
   reader->setFeature(xercesc::XMLUni::fgXercesSchema, false);
   reader->setFeature(xercesc::XMLUni::fgXercesSchemaFullChecking, false);
-  reader->setContentHandler(&handler);
-  reader->setErrorHandler(&handler);
+  Internal::SAX2HandlerAdapter adapter(handler);
+  reader->setContentHandler(&adapter);
+  reader->setErrorHandler(&adapter);
 
   try
   {

--- a/src/openms/source/FORMAT/MascotXMLFile.cpp
+++ b/src/openms/source/FORMAT/MascotXMLFile.cpp
@@ -8,7 +8,6 @@
 
 #include <OpenMS/FORMAT/MascotXMLFile.h>
 
-using namespace xercesc;
 using namespace std;
 
 namespace OpenMS

--- a/src/openms/source/FORMAT/OMSSAXMLFile.cpp
+++ b/src/openms/source/FORMAT/OMSSAXMLFile.cpp
@@ -88,12 +88,12 @@ namespace OpenMS
     // search parameters are also not available
   }
 
-  void OMSSAXMLFile::startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& /*attributes*/)
+  void OMSSAXMLFile::onStartElement(const char16_t* const qname, const Internal::XMLAttributes& /*attributes*/)
   {
     tag_ = StringUtils::trimmed(std::string(sm_.convert(qname)));
   }
 
-  void OMSSAXMLFile::endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname)
+  void OMSSAXMLFile::onEndElement(const char16_t* qname)
   {
     tag_ = StringUtils::trimmed(std::string(sm_.convert(qname)));
 
@@ -159,7 +159,7 @@ namespace OpenMS
     tag_ = "";
   }
 
-  void OMSSAXMLFile::characters(const XMLCh* const chars, const XMLSize_t /*length*/)
+  void OMSSAXMLFile::onCharacters(const char16_t* chars, Size /*length*/)
   {
     if (tag_.empty()) return;
 

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -921,7 +921,7 @@ namespace OpenMS
     f.close();
   }
 
-  void PepXMLFile::readRTMZCharge_(const xercesc::Attributes& attributes)
+  void PepXMLFile::readRTMZCharge_(const Internal::XMLAttributes& attributes)
   {
     double mass = attributeAsDouble_(attributes, "precursor_neutral_mass");
     charge_ = attributeAsInt_(attributes, "assumed_charge");
@@ -1082,10 +1082,7 @@ namespace OpenMS
     know that the last - and only - element should be the correct one.
   */
 
-  void PepXMLFile::startElement(const XMLCh* const /*uri*/,
-                                const XMLCh* const /*local_name*/,
-                                const XMLCh* const qname,
-                                const xercesc::Attributes& attributes)
+  void PepXMLFile::onStartElement(const char16_t* qname, const Internal::XMLAttributes& attributes)
   {
     std::string element = sm_.convert(qname);
 
@@ -2041,9 +2038,7 @@ namespace OpenMS
     return found;
   }
 
-  void PepXMLFile::endElement(const XMLCh* const /*uri*/,
-                              const XMLCh* const /*local_name*/,
-                              const XMLCh* const qname)
+  void PepXMLFile::onEndElement(const char16_t* qname)
   {
     std::string element = sm_.convert(qname);
 

--- a/src/openms/source/FORMAT/PepXMLFileMascot.cpp
+++ b/src/openms/source/FORMAT/PepXMLFileMascot.cpp
@@ -63,7 +63,7 @@ namespace OpenMS
     }
   }
 
-  void PepXMLFileMascot::startElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname, const xercesc::Attributes & attributes)
+  void PepXMLFileMascot::onStartElement(const char16_t* qname, const Internal::XMLAttributes& attributes)
   {
     std::string element = sm_.convert(qname);
 
@@ -121,7 +121,7 @@ namespace OpenMS
     }
   }
 
-  void PepXMLFileMascot::endElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname)
+  void PepXMLFileMascot::onEndElement(const char16_t* qname)
   {
     std::string element = sm_.convert(qname);
 

--- a/src/openms/source/FORMAT/ProtXMLFile.cpp
+++ b/src/openms/source/FORMAT/ProtXMLFile.cpp
@@ -57,7 +57,7 @@ namespace OpenMS
     protein_group_ = ProteinGroup();
   }
 
-  void ProtXMLFile::startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes)
+  void ProtXMLFile::onStartElement(const char16_t* qname, const Internal::XMLAttributes& attributes)
   {
     std::string tag = sm_.convert(qname);
 
@@ -218,7 +218,7 @@ namespace OpenMS
     }
   }
 
-  void ProtXMLFile::endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname)
+  void ProtXMLFile::onEndElement(const char16_t* qname)
   {
     std::string tag = sm_.convert(qname);
 

--- a/src/openms/source/FORMAT/QcMLFile.cpp
+++ b/src/openms/source/FORMAT/QcMLFile.cpp
@@ -776,7 +776,7 @@ namespace OpenMS
     parse_(filename, this);
   }
 
-  void QcMLFile::startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes)
+  void QcMLFile::onStartElement(const char16_t* qname, const Internal::XMLAttributes& attributes)
   {
     tag_ = sm_.convert(qname);
     std::string parent_tag;
@@ -869,7 +869,7 @@ namespace OpenMS
     }
   }
 
-  void QcMLFile::characters(const XMLCh* const chars, const XMLSize_t /*length*/)
+  void QcMLFile::onCharacters(const char16_t* chars, Size /*length*/)
   {
     if (tag_ == "tableRowValues")
     {
@@ -896,7 +896,7 @@ namespace OpenMS
     }
   }
 
-  void QcMLFile::endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname)
+  void QcMLFile::onEndElement(const char16_t* qname)
   {
     static set<std::string> to_ignore;
     if (to_ignore.empty())

--- a/src/openms/source/FORMAT/TransformationXMLFile.cpp
+++ b/src/openms/source/FORMAT/TransformationXMLFile.cpp
@@ -123,7 +123,7 @@ namespace OpenMS
     os.close();
   }
 
-  void TransformationXMLFile::startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes)
+  void TransformationXMLFile::onStartElement(const char16_t* qname, const Internal::XMLAttributes& attributes)
   {
 
     std::string element = sm_.convert(qname);

--- a/src/openms/source/FORMAT/UnimodXMLFile.cpp
+++ b/src/openms/source/FORMAT/UnimodXMLFile.cpp
@@ -10,7 +10,6 @@
 #include <OpenMS/FORMAT/HANDLERS/UnimodXMLHandler.h>
 #include <OpenMS/SYSTEM/File.h>
 
-using namespace xercesc;
 using namespace std;
 
 namespace OpenMS

--- a/src/openms/source/FORMAT/VALIDATORS/MzDataValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/MzDataValidator.cpp
@@ -12,7 +12,6 @@
 
 #include <OpenMS/FORMAT/ControlledVocabulary.h>
 
-using namespace xercesc;
 using namespace std;
 
 namespace OpenMS::Internal

--- a/src/openms/source/FORMAT/VALIDATORS/MzIdentMLValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/MzIdentMLValidator.cpp
@@ -10,7 +10,6 @@
 
 #include <OpenMS/FORMAT/ControlledVocabulary.h>
 
-using namespace xercesc;
 using namespace std;
 
 namespace OpenMS::Internal

--- a/src/openms/source/FORMAT/VALIDATORS/MzMLValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/MzMLValidator.cpp
@@ -31,7 +31,7 @@ namespace OpenMS::Internal
     // - check CV term values
     // - handle referenceableParamGroups
     // - check if binaryDataArray name and type match
-    void MzMLValidator::startElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname, const Attributes & attributes)
+    void MzMLValidator::onStartElement(const char16_t* qname, const XMLAttributes& attributes)
     {
       std::string tag = sm_.convert(qname);
       std::string parent_tag;

--- a/src/openms/source/FORMAT/VALIDATORS/MzMLValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/MzMLValidator.cpp
@@ -10,7 +10,6 @@
 #include <OpenMS/FORMAT/VALIDATORS/MzMLValidator.h>
 #include <OpenMS/FORMAT/ControlledVocabulary.h>
 
-using namespace xercesc;
 using namespace std;
 
 namespace OpenMS::Internal

--- a/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
@@ -109,7 +109,7 @@ namespace OpenMS::Internal
       return errors_.empty();
     }
 
-    void SemanticValidator::startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const Attributes& attributes)
+    void SemanticValidator::onStartElement(const char16_t* qname, const XMLAttributes& attributes)
     {
       std::string tag = sm_.convert(qname);
       std::string path = getPath_() + "/" + cv_tag_ + "/@" + accession_att_;
@@ -139,7 +139,7 @@ namespace OpenMS::Internal
       }
     }
 
-    void SemanticValidator::endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname)
+    void SemanticValidator::onEndElement(const char16_t* qname)
     {
       std::string tag = sm_.convert(qname);
       std::string path = getPath_() + "/" + cv_tag_ + "/@" + accession_att_;
@@ -223,7 +223,7 @@ namespace OpenMS::Internal
       open_tags_.pop_back();
     }
 
-    void SemanticValidator::characters(const XMLCh* const /*chars*/, const XMLSize_t /*length*/)
+    void SemanticValidator::onCharacters(const char16_t* /*chars*/, Size /*length*/)
     {
       //nothing to do here
     }
@@ -236,7 +236,7 @@ namespace OpenMS::Internal
       return path;
     }
 
-    void SemanticValidator::getCVTerm_(const Attributes& attributes, CVTerm& parsed_term)
+    void SemanticValidator::getCVTerm_(const XMLAttributes& attributes, CVTerm& parsed_term)
     {
       parsed_term.accession = attributeAsString_(attributes, accession_att_.c_str());
       parsed_term.name = attributeAsString_(attributes, name_att_.c_str());

--- a/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
@@ -13,7 +13,6 @@
 #include <OpenMS/DATASTRUCTURES/CVMappingTerm.h>
 #include <map>
 
-using namespace xercesc;
 using namespace std;
 
 namespace OpenMS::Internal

--- a/src/openms/source/FORMAT/VALIDATORS/TraMLValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/TraMLValidator.cpp
@@ -8,7 +8,6 @@
 
 #include <OpenMS/FORMAT/VALIDATORS/TraMLValidator.h>
 
-using namespace xercesc;
 using namespace std;
 
 namespace OpenMS::Internal

--- a/src/openms/source/FORMAT/VALIDATORS/XMLValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/XMLValidator.cpp
@@ -13,12 +13,34 @@
 #include <xercesc/sax2/SAX2XMLReader.hpp>
 #include <xercesc/framework/LocalFileInputSource.hpp>
 #include <xercesc/sax2/XMLReaderFactory.hpp>
+#include <xercesc/sax/ErrorHandler.hpp>
+#include <xercesc/sax/SAXParseException.hpp>
+#include <xercesc/util/XMLString.hpp>
 
 using namespace xercesc;
 using namespace std;
 
 namespace OpenMS
 {
+  // Internal bridge: adapts the Xerces ErrorHandler interface to XMLValidator so
+  // that Xerces types stay out of the public XMLValidator header.
+  class XMLValidatorErrorHandler_ : public xercesc::ErrorHandler
+  {
+  public:
+    explicit XMLValidatorErrorHandler_(XMLValidator& v) : v_(v) {}
+    void warning(const SAXParseException& e) override { report_("warning", e); }
+    void error(const SAXParseException& e) override { report_("error", e); }
+    void fatalError(const SAXParseException& e) override { report_("error", e); }
+    void resetErrors() override { v_.valid_ = true; }
+  private:
+    void report_(const std::string& kind, const SAXParseException& e)
+    {
+      v_.logError_(kind, Internal::StringManager::convert(reinterpret_cast<const char16_t*>(e.getMessage())),
+                   (unsigned long)e.getLineNumber(), (unsigned long)e.getColumnNumber());
+    }
+    XMLValidator& v_;
+  };
+
   XMLValidator::XMLValidator() :
     valid_(true),
     os_(nullptr)
@@ -55,8 +77,9 @@ namespace OpenMS
     parser->setFeature(XMLUni::fgXercesSchema, true);
     parser->setFeature(XMLUni::fgXercesSchemaFullChecking, true);
 
-    //set this class as error handler
-    parser->setErrorHandler(this);
+    //set the internal Xerces error-handler bridge
+    XMLValidatorErrorHandler_ error_handler(*this);
+    parser->setErrorHandler(&error_handler);
     parser->setContentHandler(nullptr);
     parser->setEntityResolver(nullptr);
 
@@ -81,36 +104,11 @@ namespace OpenMS
     return valid_;
   }
 
-  void XMLValidator::warning(const SAXParseException & exception)
+  void XMLValidator::logError_(const std::string& kind, const std::string& message, unsigned long line, unsigned long column)
   {
-    char * message = XMLString::transcode(exception.getMessage());
-    std::string error_message =std::string("Validation warning in file '") + filename_ + "' line " + (UInt) exception.getLineNumber() + " column " + (UInt) exception.getColumnNumber() + ": " + message;
+    std::string error_message = std::string("Validation ") + kind + " in file '" + filename_ + "' line " + (UInt)line + " column " + (UInt)column + ": " + message;
     (*os_) << error_message << endl;
     valid_ = false;
-    XMLString::release(&message);
-  }
-
-  void XMLValidator::error(const SAXParseException & exception)
-  {
-    char * message = XMLString::transcode(exception.getMessage());
-    std::string error_message =std::string("Validation error in file '") + filename_ + "' line " + (UInt) exception.getLineNumber() + " column " + (UInt) exception.getColumnNumber() + ": " + message;
-    (*os_) << error_message << endl;
-    valid_ = false;
-    XMLString::release(&message);
-  }
-
-  void XMLValidator::fatalError(const SAXParseException & exception)
-  {
-    char * message = XMLString::transcode(exception.getMessage());
-    std::string error_message =std::string("Validation error in file '") + filename_ + "' line " + (UInt) exception.getLineNumber() + " column " + (UInt) exception.getColumnNumber() + ": " + message;
-    (*os_) << error_message << endl;
-    valid_ = false;
-    XMLString::release(&message);
-  }
-
-  void XMLValidator::resetErrors()
-  {
-    valid_ = true;
   }
 
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/XMLFile.cpp
+++ b/src/openms/source/FORMAT/XMLFile.cpp
@@ -11,6 +11,7 @@
 #include <OpenMS/CONCEPT/Macros.h>
 
 #include <OpenMS/FORMAT/HANDLERS/XMLHandler.h>
+#include <OpenMS/FORMAT/HANDLERS/SAX2HandlerAdapter.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/FORMAT/VALIDATORS/XMLValidator.h>
 
@@ -30,6 +31,7 @@
 #include <streambuf>
 
 #include <memory>
+#include <xercesc/util/XMLString.hpp>
 
 using namespace std;
 
@@ -80,8 +82,10 @@ private:
       parser->setFeature(xercesc::XMLUni::fgSAX2CoreNameSpaces, false);
       parser->setFeature(xercesc::XMLUni::fgSAX2CoreNameSpacePrefixes, false);
 
-      parser->setContentHandler(handler);
-      parser->setErrorHandler(handler);
+      // XMLHandler exposes only Xerces-free callbacks; bridge it to the SAX parser.
+      SAX2HandlerAdapter adapter(*handler);
+      parser->setContentHandler(&adapter);
+      parser->setErrorHandler(&adapter);
 
 
       // try to parse file

--- a/src/openms/source/FORMAT/XTandemXMLFile.cpp
+++ b/src/openms/source/FORMAT/XTandemXMLFile.cpp
@@ -10,7 +10,6 @@
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 
-using namespace xercesc;
 using namespace std;
 
 namespace OpenMS

--- a/src/openms/source/FORMAT/XTandemXMLFile.cpp
+++ b/src/openms/source/FORMAT/XTandemXMLFile.cpp
@@ -83,7 +83,7 @@ namespace OpenMS
     mod_def_set = mod_def_set_;
   }
 
-  void XTandemXMLFile::startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const Attributes& attributes)
+  void XTandemXMLFile::onStartElement(const char16_t* qname, const Internal::XMLAttributes& attributes)
   {
     tag_ =std::string(sm_.convert(qname));
 
@@ -265,10 +265,10 @@ namespace OpenMS
       if (type == "model")
       {
         group_type_stack_.push(GroupType::MODEL);
-        Int index = attributes.getIndex(sm_.convert("z").c_str());
+        Int index = attributes.index(sm_.convert("z").c_str());
         if (index >= 0)
         {
-          current_charge_ = StringUtils::toInt32(std::string(sm_.convert(attributes.getValue(index))));
+          current_charge_ = StringUtils::toInt32(std::string(sm_.convert(attributes.valueByIndex(index))));
         }
         previous_seq_ = "";
       }
@@ -326,7 +326,7 @@ namespace OpenMS
 
   }
 
-  void XTandemXMLFile::endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname)
+  void XTandemXMLFile::onEndElement(const char16_t* qname)
   {
     tag_ =std::string(sm_.convert(qname));
     if (tag_ == "group")
@@ -335,7 +335,7 @@ namespace OpenMS
     }
   }
 
-  void XTandemXMLFile::characters(const XMLCh* const chars, const XMLSize_t /*length*/)
+  void XTandemXMLFile::onCharacters(const char16_t* chars, Size /*length*/)
   {
     if (tag_ == "note")
     {

--- a/src/openms/source/FORMAT/ZipInputStream.cpp
+++ b/src/openms/source/FORMAT/ZipInputStream.cpp
@@ -10,6 +10,7 @@
 
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/FORMAT/ZipIfstream.h>
+#include <xercesc/util/XMLString.hpp>
 
 using namespace xercesc;
 

--- a/src/pyOpenMS/bindings/bind_misc.cpp
+++ b/src/pyOpenMS/bindings/bind_misc.cpp
@@ -5097,8 +5097,6 @@ This Class is supposed to internally collect the data for the qcML File
         .def("store", [](const OpenMS::QcMLFile& self, const std::string& filename) { return self.store(filename); }, "filename"_a, "Store the qcML file")
         .def("load", [](OpenMS::QcMLFile& self, const std::string& filename) { return self.load(filename); }, "filename"_a, "Load a QCFile")
         .def("reset", [](OpenMS::QcMLFile& self) { return self.reset(); })
-        .def("error", [](OpenMS::QcMLFile& self, const xercesc::SAXParseException& exception) { return self.error(exception); }, "exception"_a)
-        .def("warning", [](OpenMS::QcMLFile& self, const xercesc::SAXParseException& exception) { return self.warning(exception); }, "exception"_a)
         ;
     def_ProgressLogger<OpenMS::QcMLFile>(qcmlfile_class);
 

--- a/src/tests/class_tests/openms/CMakeLists.txt
+++ b/src/tests/class_tests/openms/CMakeLists.txt
@@ -113,6 +113,13 @@ endforeach()
 
 target_link_libraries(Base64_test ZLIB::ZLIB)
 target_link_libraries(Libzip_test libzip::zip)
+# Xerces is a PRIVATE dependency of libOpenMS. These tests exercise the internal
+# Xerces InputSource / BinInputStream adapters directly, so they must link Xerces
+# themselves.
+target_link_libraries(ZipInputStream_test XercesC::XercesC)
+target_link_libraries(GzipInputStream_test XercesC::XercesC)
+target_link_libraries(Bzip2InputStream_test XercesC::XercesC)
+target_link_libraries(CompressedInputSource_test XercesC::XercesC)
 target_link_libraries(ZipRandomAccessFile_test libzip::zip)
 target_link_libraries(LPWrapper_test ${LPTARGET})
 target_link_libraries(SpectraSTSimilarityScore_test Eigen3::Eigen)

--- a/src/tests/class_tests/openms/source/XMLHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/XMLHandler_test.cpp
@@ -28,17 +28,17 @@ START_TEST(StringManager, "$Id$")
 
 
 const XMLCh russianHello[] = {
-    0x041F, 0x0440, 0x0438, 0x0432, 0x0435, 0x0442, 0x043C, 
+    0x041F, 0x0440, 0x0438, 0x0432, 0x0435, 0x0442, 0x043C,
     0x0438, 0x0440,0x0000 // "Привет мир" (Hello World in Russian)
 };
 size_t r_length = StringManager::strLength(russianHello);
 
-const XMLCh ascii[] = { 
+const XMLCh ascii[] = {
     0x0048,0x0065,0x006C,0x006C,0x006F,0x002C,0x0057,0x006F,
     0x0072,0x006C,0x0064,0x0021, 0x0000};
-size_t a_length = StringManager::strLength(ascii); 
+size_t a_length = StringManager::strLength(ascii);
 
-const XMLCh mixed[] = { 
+const XMLCh mixed[] = {
     0x0048, 0x0065,0x0432, 0x0435, 0x0442, 0x043C, 0x006F,
     0x0072,0x006C,0x0064, 0x0021, 0x0000 };
 size_t m_length = StringManager::strLength(mixed);
@@ -90,14 +90,14 @@ START_SECTION(compress64 (const XMLCh* input_it, char* output_it))
     StringManager_test::compress64(eight_block,o1_str.data());
     std::string res1_str = "Hello,Wo";
     TEST_STRING_EQUAL(o1_str,res1_str);
-    
-   
-    std::string o2_str(8,'\0'); 
+
+
+    std::string o2_str(8,'\0');
     StringManager_test::compress64(eight_block_negative,o2_str.data());
     std::string res2_str = res1_str;
     TEST_STRING_EQUAL(o2_str, res2_str);
 
-    
+
     std::string o3_str(8,'\0');
     StringManager_test::compress64(eight_block_mixed,o3_str.data());
     std::string res3_str = {0x42,0x45,0x4C,0x41,0x42,0x45,0x4C,0x41};
@@ -108,7 +108,7 @@ START_SECTION(compress64 (const XMLCh* input_it, char* output_it))
     o4_str [1]  ='B';
     o4_str [2]  ='R';
     o4_str [3]  ='A';
-    
+
     StringManager_test::compress64(eight_block_kadabra,((o4_str.data())+4));
     std::string res4_str = "ABRAKADABRA!";
     TEST_STRING_EQUAL(o4_str, res4_str);
@@ -137,7 +137,7 @@ START_SECTION(appendASCII(const XMLCh * chars, const size_t length, String & res
 
     StringManager::appendASCII(empty,e_length,o7_str);
     TEST_STRING_EQUAL(o7_str, res7_str);
-    
+
 
 END_SECTION
 XMLCh* nullPointer = nullptr;
@@ -155,5 +155,5 @@ END_SECTION
 END_TEST
 
 
-    
+
 

--- a/src/tests/class_tests/openms/source/XMLHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/XMLHandler_test.cpp
@@ -31,27 +31,27 @@ const XMLCh russianHello[] = {
     0x041F, 0x0440, 0x0438, 0x0432, 0x0435, 0x0442, 0x043C, 
     0x0438, 0x0440,0x0000 // "Привет мир" (Hello World in Russian)
 };
-XMLSize_t r_length = xercesc::XMLString::stringLen(russianHello);
+size_t r_length = StringManager::strLength(russianHello);
 
 const XMLCh ascii[] = { 
     0x0048,0x0065,0x006C,0x006C,0x006F,0x002C,0x0057,0x006F,
     0x0072,0x006C,0x0064,0x0021, 0x0000};
-XMLSize_t a_length = xercesc::XMLString::stringLen(ascii); 
+size_t a_length = StringManager::strLength(ascii); 
 
 const XMLCh mixed[] = { 
     0x0048, 0x0065,0x0432, 0x0435, 0x0442, 0x043C, 0x006F,
     0x0072,0x006C,0x0064, 0x0021, 0x0000 };
-XMLSize_t m_length = xercesc::XMLString::stringLen(mixed);
+size_t m_length = StringManager::strLength(mixed);
 
 const XMLCh empty[] = {0};
-XMLSize_t e_length = xercesc::XMLString::stringLen(empty);
+size_t e_length = StringManager::strLength(empty);
 
 const XMLCh upperBoundary [] = {0x00FF,0x00FF,0x0000};
-XMLSize_t u_length = xercesc::XMLString::stringLen(upperBoundary);
+size_t u_length = StringManager::strLength(upperBoundary);
 
 bool isAscii = false;
 
-START_SECTION(isASCII(const XMLCh * chars, const XMLSize_t length))
+START_SECTION(isASCII(const XMLCh * chars, const size_t length))
   isAscii = StringManager::isASCII(ascii,a_length);
   TEST_TRUE(isAscii)
 
@@ -127,7 +127,7 @@ std::string o7_str;
 std::string res7_str;
 
 
-START_SECTION(appendASCII(const XMLCh * chars, const XMLSize_t length, String & result))
+START_SECTION(appendASCII(const XMLCh * chars, const size_t length, String & result))
 
     StringManager::appendASCII(ascii,a_length,o5_str);
     TEST_STRING_EQUAL(o5_str, res5_str);


### PR DESCRIPTION
## What & why

Makes **Xerces-C++ a PRIVATE link dependency** of `libOpenMS`. Previously `XercesC::XercesC` was linked **PUBLIC** because Xerces types leaked out of installed headers — the SAX handler base `Internal::XMLHandler` derived from `xercesc::DefaultHandler`, subclasses overrode `startElement(..., const xercesc::Attributes&)`, input-source adapters derived from `xercesc::InputSource`/`BinInputStream`, and a few signatures named `xercesc::SAXParseException` / `DOMNode`. As a result **every** consumer of the OpenMS target (pyOpenMS, the GUI, 29 TOPP tools, class tests, third parties) inherited Xerces on its include and link path.

After this PR, Xerces appears in **no installed OpenMS header**; downstream consumers neither include nor link it, while `libOpenMS.so` still uses Xerces internally. Closes the Xerces part of #8547.

## How

Xerces is encapsulated behind a Xerces-free public API + an internal bridge:

- **`XMLHandler` no longer derives from `xercesc::DefaultHandler`.** New native callbacks `onStartElement(const char16_t* qname, const XMLAttributes&)`, `onEndElement(const char16_t*)`, `onCharacters(const char16_t*, Size)` replace the Xerces SAX callbacks. A new **internal, non-installed** `SAX2HandlerAdapter` bridges the Xerces SAX2 interface to these (installed as the content+error handler in `XMLFile.cpp` and `ImzMLFile.cpp`). `EndParsingSoftly` still unwinds through `parse()` unchanged (adapter overrides are intentionally not `noexcept`).
- **`XMLAttributes`** — a new Xerces-free, opaque (`void*`-backed) view over `xercesc::Attributes` exposing `value(name)` / `index(name)` / `valueByIndex(i)`.
- **`StringManager`** extracted into its own Xerces-free header with a `char16_t` API (transcode bodies + `doRelease_` specializations moved to `StringManager.cpp`). `CONST_XMLCH` is now a plain `u""` literal.
- **~28 handler / `*File` / validator subclasses migrated** to the native callbacks (unused `uri`/`localname` dropped — the SAX parser runs namespace-unaware; the handlers only ever used `qname`).
- **`XMLValidator`** pimpl'd (internal `ErrorHandler` bridge in the `.cpp`); **`MzMLSpectrumDecoder`**'s private `handleBinaryDataArray_` takes `void*` instead of `xercesc::DOMNode*`.
- **`MzIdentMLDOMHandler.h`** and the four Xerces input-source adapter headers moved to `OpenMS_private_headers` (compiled, never installed).
- **CMake:** `XercesC::XercesC` (and the macOS CoreFoundation/CoreServices frameworks) moved to `OPENMS_DEP_PRIVATE_LIBRARIES`. The five class tests that exercise the internal Xerces input-source adapters link Xerces explicitly.
- Dropped the two pyOpenMS `QcMLFile.error/warning(SAXParseException)` bindings.

Commits are split by phase (A: additive native surface → B: migrate subclasses → C: cut the base + secondary leaks → D: flip CMake), each building green, so the diff is reviewable phase-by-phase.

## Verification

- **Functional:** the full parser/validator/handler round-trip suite passes unchanged — `MzMLFile`, `MzXMLFile`, `MzDataFile`, `FeatureXMLFile`, `ConsensusXMLFile`, `IdXMLFile`, `MzIdentMLFile`, `TraMLFile`, `PepXMLFile`, `XTandemXMLFile`, `UnimodXMLFile`, `ParamXMLFile`, `ImzMLFile`, `XQuestResultXMLFile`, `SemanticValidator`, `MzMLValidator`, `XMLValidator`, `MzMLSpectrumDecoder`, `XMLHandler`, and the four input-stream tests (26/26).
- **Acceptance test:** force-recompiling `FileInfo` (which transitively includes `MzMLFile.h` etc.) succeeds with **no Xerces include dir** on its command line, while `ldd libOpenMS.so` still shows `libxerces-c`. TOPP tools and **pyOpenMS** build against the cleaned headers.
- Reviewed by Codex and an independent agent pass: no correctness regressions found.

## Note

`XMLCh` is assumed to be `char16_t` (guaranteed on Xerces-C++ ≥3.2, the supported config; a `sizeof` static_assert guards the boundary casts). On a hypothetical `XMLCh = unsigned short` build this would be a compile error, not a silent runtime bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved XML import consistency across multiple file formats via a unified, UTF-16–based handler callback model and a shared attribute wrapper.
* **Bug Fixes**
  * More reliable XML parsing/validation behavior with centralized attribute/text handling and updated error/warning/fatal-error routing.
* **Compatibility**
  * Python bindings: removed exception-exposing `error` and `warning` methods from the `QcMLFile` wrapper.
* **Build/Platform**
  * Refined dependency visibility (including macOS linkage) and updated test/build wiring for internal XML adapters and private headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->