### PR TITLE
ci(bioconda): overlay dev recipes onto master instead of rebasing (fixes #9721)

### DIFF
--- a/.github/workflows/bioconda_deploy.yaml
+++ b/.github/workflows/bioconda_deploy.yaml
@@ -48,14 +48,29 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
 
-      - name: Clone Bioconda recipes repository and add our changes (e.g., version with 'dev') on top of it
+      - name: Clone Bioconda recipes and overlay our dev recipes onto current bioconda/master
         run: |
           git clone https://github.com/OpenMS/bioconda-recipes.git bioconda-recipes
           cd bioconda-recipes
-          git checkout -b nightly origin/nightly
           git remote add bioconda https://github.com/bioconda/bioconda-recipes.git
           git fetch bioconda master
-          git rebase bioconda/master
+          # Start from a pristine, current bioconda/master (up-to-date build tooling,
+          # global config and common scripts) and overlay ONLY the two recipe
+          # directories OpenMS maintains. This replaces the previous
+          # `git rebase bioconda/master`, which recurrently hard-failed with a merge
+          # conflict whenever upstream touched recipes/pyopenms/meta.yaml -- e.g. right
+          # after a new pyopenms release landed in master -- because the carried
+          # dev-version commit could no longer be replayed cleanly onto the drifted base.
+          # Overlaying the recipe dirs wholesale keeps the hand-maintained dev recipe as
+          # the source of truth (no fragile patch regeneration) and can never conflict.
+          # --no-overlay makes each dir an EXACT mirror of the nightly version, so any
+          # master-only files in those dirs (e.g. a stale upstream build_failure.*.yaml
+          # for the released version) are removed rather than silently retained.
+          # See OpenMS/OpenMS#9721 (and the earlier recurrences #6989, #6201).
+          git checkout -B nightly bioconda/master
+          git checkout --no-overlay origin/nightly -- recipes/pyopenms recipes/openms-meta
+          echo "=== OpenMS dev recipes overlaid on top of bioconda/master ==="
+          git --no-pager diff --stat bioconda/master -- recipes/pyopenms recipes/openms-meta
 
       - name: Lint and build OpenMS Bioconda packages
         run: |


### PR DESCRIPTION
## Problem

Fixes #9721. The nightly **Deploy to Bioconda** workflow (`.github/workflows/bioconda_deploy.yaml`) clones the `OpenMS/bioconda-recipes` fork and ran `git rebase bioconda/master` to replay the fork's `nightly` branch onto upstream master. The `nightly` branch carries OpenMS's dev-version patch as a **single commit** touching only `recipes/pyopenms/` and `recipes/openms-meta/`.

That rebase recurrently **hard-fails with a merge conflict** in `recipes/pyopenms/meta.yaml` whenever upstream touches those files — most recently right after **pyopenms 3.5.0 landed in `bioconda/master`**:

```
CONFLICT (content): Merge conflict in recipes/pyopenms/meta.yaml
error: could not apply 3968e92688... Re-sync nightly recipes onto bioconda/master
```

The carried commit sits on a base that has drifted far behind master and can no longer be replayed cleanly. This is the **same failure mode as #6989 and #6201** and required manual surgery on the fork's `nightly` branch each time it recurred.

## Fix

Stop rebasing a divergent branch. Instead, start from a pristine **current** `bioconda/master` and overlay an **exact mirror** of only the two recipe directories OpenMS maintains:

```bash
git checkout -B nightly bioconda/master
git checkout --no-overlay origin/nightly -- recipes/pyopenms recipes/openms-meta
```

- Keeps the hand-maintained dev recipe as the source of truth — **no fragile patch regeneration** (which was raised as a possible alternative in the issue but is just as brittle).
- Inherits up-to-date bioconda build tooling / global config from master.
- **Can never produce a merge conflict.**
- `--no-overlay` makes each dir an exact mirror of the `nightly` version, so a stale master-only file in those dirs (e.g. an upstream `build_failure.*.yaml` for the released version) is removed rather than silently retained.

## Verification

Simulated the new logic locally against the **live** `OpenMS/bioconda-recipes` and `bioconda/bioconda-recipes` repos:

- Resulting version is `3.6.0dev` in both `recipes/pyopenms/meta.yaml` and `recipes/openms-meta/meta.yaml`.
- The two recipe dirs match the `nightly` file set exactly (including `openms-meta/conda_build_config.yaml`).
- **Zero conflict markers** — precisely where the old `git rebase` aborts.
- `--no-overlay` is available on the runner's git (needs ≥ 2.23; `ubuntu-latest` ships 2.43).

## Notes / scope

- This resolves the recurring in-CI rebase failure **entirely within `OpenMS/OpenMS`** — the manual fork-branch reset the issue describes is no longer needed to unblock the deploy.
- Semantic tradeoff (unchanged from before): the fork's version of the two recipe dirs always wins over upstream. This matches prior behavior — a successful rebase also kept our commit's version of those files — and `bioconda-utils lint` still runs against the result. The `nightly` branch will still need ordinary recipe maintenance if bioconda's build tooling or a referenced dependency changes, but not the auto-rebase conflict.
- The pre-existing `|| true` on the build steps is left untouched (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Bioconda deployment workflow to prepare nightly package recipes more reliably.
  * Ensured the PyOpenMS and OpenMS meta-package recipes exactly match their nightly versions during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->