### PR TITLE
ci(pyopenms): pin pyarrow away from 25.0.0 (macOS arm64 segfault)

### DIFF
--- a/src/pyOpenMS/pyproject.toml
+++ b/src/pyOpenMS/pyproject.toml
@@ -75,8 +75,12 @@ dataframes = ["pandas"]
 # pyarrow 24.0.0 on PyPI only shipped cp310 wheels (no source distribution),
 # breaking uv sync on cp311/cp312/cp313 runners. Pin out of 24.0.0 until a
 # release with complete wheel coverage lands.
-arrow = ["pyarrow!=24.0.0"]
-all = ["pandas", "pyarrow!=24.0.0"]
+# pyarrow 25.0.0 segfaults on macOS arm64 (cp310) when reading a parquet
+# dataset via pyarrow.dataset/parquet.core.read_table (crashes on import of
+# pyarrow.dataset, see OpenMS test_XIPMParquetFile.py::test_xipm_run_dict).
+# Pin out of 25.0.0 until upstream fixes the crash.
+arrow = ["pyarrow!=24.0.0,!=25.0.0"]
+all = ["pandas", "pyarrow!=24.0.0,!=25.0.0"]
 
 # Dependency groups (PEP 735) - installable with: uv sync --only-group <name>
 [dependency-groups]
@@ -93,7 +97,7 @@ test = [
     "pytest",
     "pytest-cov",
     "pandas",  # tests need pandas for DataFrame functionality
-    "pyarrow!=24.0.0",  # see [project.optional-dependencies].arrow for the 24.0.0 exclusion rationale
+    "pyarrow!=24.0.0,!=25.0.0",  # see [project.optional-dependencies].arrow for the exclusion rationale
 ]
 dev = [
     {include-group = "build"},
@@ -158,7 +162,7 @@ build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
 skip = "*-win32 *-musllinux_*"
 
 # Test the wheel after building
-test-requires = ["pytest", "numpy", "pandas", "pyarrow!=24.0.0"]
+test-requires = ["pytest", "numpy", "pandas", "pyarrow!=24.0.0,!=25.0.0"]
 test-command = "pytest \"{package}/tests\" --import-mode=importlib"
 build-verbosity = 1
 


### PR DESCRIPTION
The nightly pyopenms-wheels-cibuildwheel build-wheels-macos job started segfaulting on cp310-macosx_arm64 in test_XIPMParquetFile.py::test_xipm_run_dict, crashing inside pyarrow.dataset/parquet.core.read_table. This started around 2026-07-10 once pyarrow 25.0.0 became the resolved version (previously green through 2026-07-09). Exclude 25.0.0 the same way 24.0.0 is already excluded until upstream fixes the crash.

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented installation and testing with the incompatible `pyarrow` 25.0.0 release.
  * Updated optional dependency and wheel-testing configurations to use a compatible `pyarrow` version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->