### PR TITLE
fix(docker): point Arrow APT source at packages.apache.org, not stale Maven mirror

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/* \
   && update-ca-certificates \
   && apt-get update && apt-get install -y --no-install-recommends wget \
-  && wget https://repo1.maven.org/maven2/org/apache/arrow/ubuntu/apache-arrow-apt-source-latest-noble.deb \
+  && wget https://packages.apache.org/artifactory/arrow/ubuntu/apache-arrow-apt-source-latest-noble.deb \
   && apt-get install -y --no-install-recommends ./apache-arrow-apt-source-latest-noble.deb \
   # Pin Arrow/Parquet to v23 so build-time dev libs match the runtime SONAME (libarrow2300/libparquet2300)
   && printf 'Package: libarrow* libparquet*\nPin: version 23.*\nPin-Priority: 999\n' > /etc/apt/preferences.d/arrow \
@@ -206,7 +206,7 @@ RUN apt-get update \
     libboost-random1.83.0 \
     # ICU is required by the .NET runtime that hosts the openms-thermo-bridge (amd64)
     libicu74 \
-  && wget https://repo1.maven.org/maven2/org/apache/arrow/ubuntu/apache-arrow-apt-source-latest-noble.deb \
+  && wget https://packages.apache.org/artifactory/arrow/ubuntu/apache-arrow-apt-source-latest-noble.deb \
   && apt-get install -y --no-install-recommends ./apache-arrow-apt-source-latest-noble.deb \
   && apt-get update && apt-get install -y --no-install-recommends --no-install-suggests \
     libarrow2300 \


### PR DESCRIPTION
## Description

The nightly "Deploy container images" workflow (`containerdeploy.yml`) has been failing since 2026-07-11 while building `dockerfiles/Dockerfile`:

```
Get:5 https://apache.jfrog.io/artifactory/arrow/ubuntu noble InRelease [7291 B]
Err:5 https://apache.jfrog.io/artifactory/arrow/ubuntu noble InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 9E922B2D60E9FD1C
W: GPG error: https://apache.jfrog.io/artifactory/arrow/ubuntu noble InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 9E922B2D60E9FD1C
E: The repository 'https://apache.jfrog.io/artifactory/arrow/ubuntu noble InRelease' is not signed.
```

Failing run: https://github.com/OpenMS/OpenMS/actions/runs/29175696514

**Root cause:** the Dockerfile downloads the Arrow APT source package from `repo1.maven.org` (`https://repo1.maven.org/maven2/org/apache/arrow/ubuntu/apache-arrow-apt-source-latest-noble.deb`). Maven Central does not allow overwriting a previously-published artifact, so this mirror still serves an old copy of the "latest" `.deb` — one that embeds a `sources.list` entry pointing at `apache.jfrog.io`, a host Apache Arrow has since moved away from and which is no longer reliably signed/verifiable.

Apache Arrow's current official install instructions (https://arrow.apache.org/install/) point at `packages.apache.org` instead of `repo1.maven.org`/`apache.jfrog.io`. I downloaded both `.deb` files and diffed them: the `packages.apache.org` copy embeds `URIs: https://packages.apache.org/artifactory/arrow/ubuntu/` in `/etc/apt/sources.list.d/apache-arrow.sources`, while the `repo1.maven.org` copy still embeds the old `apache.jfrog.io` URI — confirming the Maven mirror is stale.

This change points both the `base` and `library` Docker stages at `packages.apache.org` (matching Arrow's current docs), fixing the underlying cause rather than working around the signature check.

Note: the same nightly run also showed a failing `bioconda_deploy.yaml` job, but that failure is a git merge conflict on the separate `OpenMS/bioconda-recipes` fork (rebasing its `nightly` branch onto `bioconda/master` conflicts in `recipes/pyopenms/meta.yaml`) and isn't something this repository's code can fix — it needs to be resolved directly on that fork.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes (no Docker daemon available in this environment to run a live build; verified by downloading/diffing the two `.deb` packages instead — see description)
- [x] Updated or added python bindings for changed or new classes (not applicable, Dockerfile-only change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NNh5u2f5UQovbHLUeZku2C)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Docker build to retrieve Apache Arrow packages from a more reliable source.
  * Preserved existing Arrow and Parquet installation and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->