### PR TITLE
Add .NET 8 runtime documentation for Thermo RAW file reading

### DIFF
--- a/doc/doxygen/install/common-cmake-parameters.doxygen
+++ b/doc/doxygen/install/common-cmake-parameters.doxygen
@@ -146,6 +146,12 @@ The most important CMake variables are:
     On Windows and macOS the required <code>nethost</code> library is bundled with the .NET SDK/runtime installer.
     On Linux you may need to install the additional <code>libnethost-dev</code> (Debian/Ubuntu) or
     <code>dotnet-runtime-8.0</code> package explicitly.
+    At run time the bridge's <code>nethost</code>/<code>hostfxr</code> locates the installed runtime
+    automatically when .NET sits in a standard location. If you installed .NET to a non-default
+    directory (for example via the <code>dotnet-install.sh</code> script or a self-contained/xcopy
+    install), set the <code>DOTNET_ROOT</code> environment variable to that directory &mdash; the folder
+    that contains the <code>dotnet</code> host and the <code>shared/</code> sub-directory
+    (e.g. <code>export DOTNET_ROOT=/usr/share/dotnet</code>) &mdash; so the runtime can be found.
     Disabled automatically on Linux/aarch64 targets.
     (Default: On on supported platforms)</td>
   </tr>

--- a/doc/doxygen/install/common-cmake-parameters.doxygen
+++ b/doc/doxygen/install/common-cmake-parameters.doxygen
@@ -141,15 +141,15 @@ The most important CMake variables are:
     <td>Enable native reading of Thermo Fisher RAW files via the openms-thermo-bridge C++/.NET library
     (fetched automatically via CMake FetchContent from GitHub).
     Requires a .NET runtime to be present at run time so that the managed bridge DLLs can be loaded.
-    Install .NET 8 (or later) from <a href="https://dotnet.microsoft.com/download">https://dotnet.microsoft.com/download</a>,
-    or install the <code>dotnet-runtime-8.0</code> (or newer) package from your distribution's package manager.
+    Install the .NET 8 runtime from <a href="https://dotnet.microsoft.com/download">https://dotnet.microsoft.com/download</a>,
+    or install the <code>dotnet-runtime-8.0</code> package from your distribution's package manager.
     On Windows and macOS the required <code>nethost</code> library is bundled with the .NET SDK/runtime installer.
     On Linux you may need to install the additional <code>libnethost-dev</code> (Debian/Ubuntu) or
     <code>dotnet-runtime-8.0</code> package explicitly.
     At run time the bridge's <code>nethost</code>/<code>hostfxr</code> locates the installed runtime
     automatically when .NET sits in a standard location. If you installed .NET to a non-default
-    directory (for example via the <code>dotnet-install.sh</code> script or a self-contained/xcopy
-    install), set the <code>DOTNET_ROOT</code> environment variable to that directory &mdash; the folder
+    directory (for example via the <code>dotnet-install.sh</code> script or an xcopy install of the
+    runtime), set the <code>DOTNET_ROOT</code> environment variable to that directory &mdash; the folder
     that contains the <code>dotnet</code> host and the <code>shared/</code> sub-directory
     (e.g. <code>export DOTNET_ROOT=/usr/share/dotnet</code>) &mdash; so the runtime can be found.
     Disabled automatically on Linux/aarch64 targets.

--- a/doc/openms/docs/about/installation/installation-on-gnu-linux.md
+++ b/doc/openms/docs/about/installation/installation-on-gnu-linux.md
@@ -74,8 +74,7 @@ If you encounter errors with unavailable packages, troubleshoot using the follow
 
 OpenMS reads Thermo Fisher `.raw` files natively through the openms-thermo-bridge, which is
 enabled by default in the release binaries on supported platforms. This requires a **.NET 8
-(or newer) runtime** to be present at run time so that the managed bridge libraries can be
-loaded.
+runtime** to be present at run time so that the managed bridge libraries can be loaded.
 
 Install it from the [.NET download page](https://dotnet.microsoft.com/download) or via your
 distribution's package manager, for example:

--- a/doc/openms/docs/about/installation/installation-on-gnu-linux.md
+++ b/doc/openms/docs/about/installation/installation-on-gnu-linux.md
@@ -70,6 +70,35 @@ If you encounter errors with unavailable packages, troubleshoot using the follow
 :start-after: "% start-after"
 ```
 
+## Reading Thermo Fisher RAW files
+
+OpenMS reads Thermo Fisher `.raw` files natively through the openms-thermo-bridge, which is
+enabled by default in the release binaries on supported platforms. This requires a **.NET 8
+(or newer) runtime** to be present at run time so that the managed bridge libraries can be
+loaded.
+
+Install it from the [.NET download page](https://dotnet.microsoft.com/download) or via your
+distribution's package manager, for example:
+
+```bash
+# Debian/Ubuntu
+sudo apt-get install dotnet-runtime-8.0
+```
+
+If .NET is installed to a non-standard location (for example via the `dotnet-install.sh`
+script), point the `DOTNET_ROOT` environment variable at the install directory — the folder
+that contains the `dotnet` host and the `shared/` sub-directory — so the bridge can locate the
+runtime:
+
+```bash
+export DOTNET_ROOT=/usr/share/dotnet
+```
+
+```{note}
+Native Thermo RAW reading is not available on Linux/aarch64 (ARM64), because Thermo's
+RawFileReader does not ship native dependencies for that platform.
+```
+
 ## Build OpenMS from source
 
 To build OpenMS from source, follow the build instructions for [Linux](https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/install_linux.html).

--- a/doc/openms/docs/about/installation/installation-on-macos.md
+++ b/doc/openms/docs/about/installation/installation-on-macos.md
@@ -112,6 +112,28 @@ To use {term}`TOPP` as regular app in the shell, add the following lines to the 
 :start-after: "% start-after"
 ```
 
+## Reading Thermo Fisher RAW files
+
+OpenMS reads Thermo Fisher `.raw` files natively through the openms-thermo-bridge, which is
+enabled by default in the release binaries. This requires a **.NET 8 (or newer) runtime** to be
+present at run time so that the managed bridge libraries can be loaded.
+
+Install it from the [.NET download page](https://dotnet.microsoft.com/download), or with
+Homebrew:
+
+```bash
+brew install dotnet
+```
+
+If .NET is installed to a non-standard location (the official installer uses
+`/usr/local/share/dotnet`; Homebrew on Apple Silicon installs under `/opt/homebrew`), point the
+`DOTNET_ROOT` environment variable at the install directory — the folder that contains the
+`dotnet` host and the `shared/` sub-directory — so the bridge can locate the runtime:
+
+```bash
+export DOTNET_ROOT=/usr/local/share/dotnet
+```
+
 ## Build OpenMS from source
 
 To build OpenMS from source, follow the build instructions for [macOS](https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/install_mac.html).

--- a/doc/openms/docs/about/installation/installation-on-macos.md
+++ b/doc/openms/docs/about/installation/installation-on-macos.md
@@ -115,7 +115,7 @@ To use {term}`TOPP` as regular app in the shell, add the following lines to the 
 ## Reading Thermo Fisher RAW files
 
 OpenMS reads Thermo Fisher `.raw` files natively through the openms-thermo-bridge, which is
-enabled by default in the release binaries. This requires a **.NET 8 (or newer) runtime** to be
+enabled by default in the release binaries. This requires a **.NET 8 runtime** to be
 present at run time so that the managed bridge libraries can be loaded.
 
 Install it from the [.NET download page](https://dotnet.microsoft.com/download), or with
@@ -125,13 +125,16 @@ Homebrew:
 brew install dotnet
 ```
 
-If .NET is installed to a non-standard location (the official installer uses
-`/usr/local/share/dotnet`; Homebrew on Apple Silicon installs under `/opt/homebrew`), point the
-`DOTNET_ROOT` environment variable at the install directory — the folder that contains the
-`dotnet` host and the `shared/` sub-directory — so the bridge can locate the runtime:
+If .NET is installed to a non-standard location, point the `DOTNET_ROOT` environment variable
+at the install directory — the folder that contains the `dotnet` host and the `shared/`
+sub-directory — so the bridge can locate the runtime. Homebrew keeps the runtime under its
+`libexec` directory, while the official installer uses `/usr/local/share/dotnet`:
 
 ```bash
-export DOTNET_ROOT=/usr/local/share/dotnet
+# Homebrew (the path reported by `brew info dotnet`)
+export DOTNET_ROOT="$(brew --prefix)/opt/dotnet/libexec"
+# or, for the official .NET installer:
+# export DOTNET_ROOT=/usr/local/share/dotnet
 ```
 
 ## Build OpenMS from source

--- a/doc/openms/docs/about/installation/installation-on-windows.md
+++ b/doc/openms/docs/about/installation/installation-on-windows.md
@@ -52,7 +52,7 @@ The windows installer works with Windows 10 and 11 (older versions might still w
 ## Reading Thermo Fisher RAW files
 
 OpenMS reads Thermo Fisher `.raw` files natively through the openms-thermo-bridge, which is
-enabled by default in the release binaries. This requires a **.NET 8 (or newer) runtime** to be
+enabled by default in the release binaries. This requires a **.NET 8 runtime** to be
 present at run time so that the managed bridge libraries can be loaded. This is the modern,
 cross-platform .NET runtime and is **not** the same as the .NET Framework 3.5 required by
 ProteoWizard (see the known issues above).
@@ -61,7 +61,7 @@ Download and install it from the [.NET download page](https://dotnet.microsoft.c
 The official installer registers the runtime globally, so no further configuration is normally
 needed.
 
-If you use a non-standard deployment (for example an xcopy/self-contained install), set the
-`DOTNET_ROOT` environment variable to the install directory — the folder that contains
-`dotnet.exe` and the `shared\` sub-directory — so the bridge can locate the runtime, e.g.
-`DOTNET_ROOT=C:\Program Files\dotnet`.
+If you installed the runtime to a non-standard location (for example an xcopy install of the
+.NET runtime), set the `DOTNET_ROOT` environment variable to the install directory — the folder
+that contains `dotnet.exe` and the `shared\` sub-directory — so the bridge can locate the
+runtime, e.g. `DOTNET_ROOT=C:\Program Files\dotnet`.

--- a/doc/openms/docs/about/installation/installation-on-windows.md
+++ b/doc/openms/docs/about/installation/installation-on-windows.md
@@ -48,3 +48,20 @@ The windows installer works with Windows 10 and 11 (older versions might still w
    that `.net3.5` does not get properly installed during the process.
 
    Fix is to enable the .NET Framework 3.5 yourself through Control Panel. See this [Microsoft help page](https://docs.microsoft.com/en-us/dotnet/framework/install/dotnet-35-windows).aspx#ControlPanel) for detailed information. Even if this step fails, this does not affect the functionality of OpenMS, except for the executability of included third party tools (ProteoWizard).
+
+## Reading Thermo Fisher RAW files
+
+OpenMS reads Thermo Fisher `.raw` files natively through the openms-thermo-bridge, which is
+enabled by default in the release binaries. This requires a **.NET 8 (or newer) runtime** to be
+present at run time so that the managed bridge libraries can be loaded. This is the modern,
+cross-platform .NET runtime and is **not** the same as the .NET Framework 3.5 required by
+ProteoWizard (see the known issues above).
+
+Download and install it from the [.NET download page](https://dotnet.microsoft.com/download).
+The official installer registers the runtime globally, so no further configuration is normally
+needed.
+
+If you use a non-standard deployment (for example an xcopy/self-contained install), set the
+`DOTNET_ROOT` environment variable to the install directory — the folder that contains
+`dotnet.exe` and the `shared\` sub-directory — so the bridge can locate the runtime, e.g.
+`DOTNET_ROOT=C:\Program Files\dotnet`.


### PR DESCRIPTION
## Description

This PR adds comprehensive documentation for the .NET 8 runtime requirement needed to read Thermo Fisher `.raw` files natively through the openms-thermo-bridge. The documentation covers installation and configuration across all three supported platforms (Linux, macOS, and Windows).

### Changes

- **Linux installation guide**: Added section explaining .NET 8 requirement, installation via package manager, and `DOTNET_ROOT` environment variable configuration for non-standard installations. Includes platform limitation note for Linux/aarch64.
- **macOS installation guide**: Added section with .NET 8 installation instructions via both official download page and Homebrew, with `DOTNET_ROOT` configuration examples for standard and Homebrew locations.
- **Windows installation guide**: Added section clarifying that .NET 8 (modern runtime) is distinct from .NET Framework 3.5 (required by ProteoWizard), with download and installation instructions and `DOTNET_ROOT` configuration for non-standard deployments.
- **CMake documentation**: Enhanced the `OPENMS_THERMO_BRIDGE` parameter documentation with runtime configuration details and `DOTNET_ROOT` environment variable guidance.

### Rationale

Users building or running OpenMS with Thermo RAW file support need clear guidance on the .NET 8 runtime dependency, which is not obvious and differs from existing .NET Framework requirements. This documentation prevents confusion and enables users to properly configure their environment for native Thermo RAW file reading.

## Checklist
- [x] Documentation only - no code changes requiring AUTHORS or CHANGELOG updates
- [x] No unit tests affected
- [x] No Python bindings changes needed

https://claude.ai/code/session_01FNBAWgeJYmHw9LwtRkLhoQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added “Reading Thermo Fisher RAW files” guidance to Windows, macOS, and GNU/Linux installation docs.
  - Documented that `openms-thermo-bridge` is enabled in release binaries, requires .NET 8 (or newer) at runtime, and provided `DOTNET_ROOT` instructions for non-standard .NET installs.
  - Noted platform limitation: native RAW reading isn’t available on Linux/aarch64.
  - Expanded CMake option documentation to help locate .NET host components when installed outside default paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->