### PR TITLE
Make SQLite a fully private dependency (no SQLite type in installed headers)

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TransitionPQPFile.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TransitionPQPFile.h
@@ -12,9 +12,10 @@
 
 namespace OpenMS
 {
+  class SqliteConnector;
 
   /**
-      @brief This class supports reading and writing of PQP files. 
+      @brief This class supports reading and writing of PQP files.
 
       The PQP files are SQLite databases consisting of several tables
       representing the data contained in TraML files. For another file format that stores transitions, see also
@@ -207,13 +208,13 @@ private:
      * This helper builds the SQL query used by both readPQPInput_ and
      * streamPQPToLightTargetedExperiment_ to avoid code duplication.
      *
-     * @param[in] db Opaque native SQLite handle (sqlite3*), passed as void* so this
-     *               installed header stays free of any SQLite type (see SqliteConnector_impl.h)
+     * @param[in] conn Open SQLite connection (SQLite-type-free; the native handle is
+     *                 resolved in the .cpp via SqliteConnector_impl.h)
      * @param[in] legacy_traml_id Whether to use legacy TraML IDs
      * @param[in] stable_order Whether to apply the legacy deterministic row order
      * @return PQPSqlQueryInfo containing the query and column availability flags
      */
-    PQPSqlQueryInfo buildPQPSelectQuery_(void* db, bool legacy_traml_id, bool stable_order) const;
+    PQPSqlQueryInfo buildPQPSelectQuery_(SqliteConnector& conn, bool legacy_traml_id, bool stable_order) const;
 
     /** @brief Read PQP SQLite file
      *

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TransitionPQPFile.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TransitionPQPFile.h
@@ -10,9 +10,6 @@
 
 #include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVFile.h>
 
-// Forward declaration for SQLite
-struct sqlite3;
-
 namespace OpenMS
 {
 
@@ -210,12 +207,13 @@ private:
      * This helper builds the SQL query used by both readPQPInput_ and
      * streamPQPToLightTargetedExperiment_ to avoid code duplication.
      *
-     * @param[in] db The SQLite database connection
+     * @param[in] db Opaque native SQLite handle (sqlite3*), passed as void* so this
+     *               installed header stays free of any SQLite type (see SqliteConnector_impl.h)
      * @param[in] legacy_traml_id Whether to use legacy TraML IDs
      * @param[in] stable_order Whether to apply the legacy deterministic row order
      * @return PQPSqlQueryInfo containing the query and column availability flags
      */
-    PQPSqlQueryInfo buildPQPSelectQuery_(sqlite3* db, bool legacy_traml_id, bool stable_order) const;
+    PQPSqlQueryInfo buildPQPSelectQuery_(void* db, bool legacy_traml_id, bool stable_order) const;
 
     /** @brief Read PQP SQLite file
      *

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLSqliteHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLSqliteHandler.h
@@ -16,6 +16,7 @@
 namespace OpenMS
 {
   class ProgressLogger;
+  class SqliteConnector;
 
   namespace Internal
   {
@@ -144,19 +145,20 @@ public:
 
 protected:
 
-      // @p db is an opaque native SQLite handle (sqlite3*), passed as void* so that
-      // this installed header stays free of any SQLite type. See SqliteConnector_impl.h.
-      void populateChromatogramsWithData_(void* db, std::vector<MSChromatogram>& chromatograms) const;
+      // These helpers operate on an open SQLite connection. They take the SqliteConnector
+      // (a SQLite-type-free type) rather than a raw sqlite3*, so this installed header names
+      // no SQLite type; the native handle is resolved in the .cpp via SqliteConnector_impl.h.
+      void populateChromatogramsWithData_(SqliteConnector& conn, std::vector<MSChromatogram>& chromatograms) const;
 
-      void populateChromatogramsWithData_(void* db, std::vector<MSChromatogram>& chromatograms, const std::vector<int> & indices) const;
+      void populateChromatogramsWithData_(SqliteConnector& conn, std::vector<MSChromatogram>& chromatograms, const std::vector<int> & indices) const;
 
-      void populateSpectraWithData_(void* db, std::vector<MSSpectrum>& spectra) const;
+      void populateSpectraWithData_(SqliteConnector& conn, std::vector<MSSpectrum>& spectra) const;
 
-      void populateSpectraWithData_(void* db, std::vector<MSSpectrum>& spectra, const std::vector<int> & indices) const;
+      void populateSpectraWithData_(SqliteConnector& conn, std::vector<MSSpectrum>& spectra, const std::vector<int> & indices) const;
 
-      void prepareChroms_(void* db, std::vector<MSChromatogram>& chromatograms, const std::vector<int> & indices = {}) const;
+      void prepareChroms_(SqliteConnector& conn, std::vector<MSChromatogram>& chromatograms, const std::vector<int> & indices = {}) const;
 
-      void prepareSpectra_(void* db, std::vector<MSSpectrum>& spectra, const std::vector<int> & indices = {}) const;
+      void prepareSpectra_(SqliteConnector& conn, std::vector<MSSpectrum>& spectra, const std::vector<int> & indices = {}) const;
       //@}
 
 public:

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLSqliteHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLSqliteHandler.h
@@ -13,10 +13,6 @@
 
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/SwathMap.h>
 
-// forward declarations
-struct sqlite3;
-struct sqlite3_stmt;
-
 namespace OpenMS
 {
   class ProgressLogger;
@@ -148,17 +144,19 @@ public:
 
 protected:
 
-      void populateChromatogramsWithData_(sqlite3 *db, std::vector<MSChromatogram>& chromatograms) const;
+      // @p db is an opaque native SQLite handle (sqlite3*), passed as void* so that
+      // this installed header stays free of any SQLite type. See SqliteConnector_impl.h.
+      void populateChromatogramsWithData_(void* db, std::vector<MSChromatogram>& chromatograms) const;
 
-      void populateChromatogramsWithData_(sqlite3 *db, std::vector<MSChromatogram>& chromatograms, const std::vector<int> & indices) const;
+      void populateChromatogramsWithData_(void* db, std::vector<MSChromatogram>& chromatograms, const std::vector<int> & indices) const;
 
-      void populateSpectraWithData_(sqlite3 *db, std::vector<MSSpectrum>& spectra) const;
+      void populateSpectraWithData_(void* db, std::vector<MSSpectrum>& spectra) const;
 
-      void populateSpectraWithData_(sqlite3 *db, std::vector<MSSpectrum>& spectra, const std::vector<int> & indices) const;
+      void populateSpectraWithData_(void* db, std::vector<MSSpectrum>& spectra, const std::vector<int> & indices) const;
 
-      void prepareChroms_(sqlite3 *db, std::vector<MSChromatogram>& chromatograms, const std::vector<int> & indices = {}) const;
+      void prepareChroms_(void* db, std::vector<MSChromatogram>& chromatograms, const std::vector<int> & indices = {}) const;
 
-      void prepareSpectra_(sqlite3 *db, std::vector<MSSpectrum>& spectra, const std::vector<int> & indices = {}) const;
+      void prepareSpectra_(void* db, std::vector<MSSpectrum>& spectra, const std::vector<int> & indices = {}) const;
       //@}
 
 public:

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLSqliteSwathHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLSqliteSwathHandler.h
@@ -13,9 +13,6 @@
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/SwathMap.h>
 
-// forward declarations
-struct sqlite3;
-
 namespace OpenMS
 {
 

--- a/src/openms/include/OpenMS/FORMAT/SqliteConnector.h
+++ b/src/openms/include/OpenMS/FORMAT/SqliteConnector.h
@@ -9,14 +9,10 @@
 #pragma once
 
 #include <OpenMS/KERNEL/StandardTypes.h>
-#include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/CONCEPT/Exception.h>
 
-#include <type_traits> // for is_same
-
-// forward declarations
-struct sqlite3;
-struct sqlite3_stmt;
+#include <string>
+#include <vector>
 
 namespace OpenMS
 {
@@ -24,6 +20,13 @@ namespace OpenMS
     @brief File adapter for Sqlite files
 
     This class contains certain helper functions to deal with Sqlite files.
+
+    @note This is the public, SQLite-free interface. The raw SQLite C API
+    (`sqlite3*`/`sqlite3_stmt*` handling and the @c Internal::SqliteHelper
+    statement helpers) lives in the non-installed implementation header
+    <OpenMS/FORMAT/SqliteConnector_impl.h>, which must only be included from
+    .cpp files inside libOpenMS. Keeping the SQLite types out of this header is
+    what allows SQLite to be a fully private dependency of OpenMS.
 
     @ingroup FileIO
   */
@@ -52,19 +55,24 @@ namespace OpenMS
     /// Destructor
     ~SqliteConnector();
 
+    /// @cond INTERNAL
     /**
-      @brief Returns the raw pointer to the database
+      @brief Returns the raw native SQLite handle as an opaque pointer.
 
-      @note The pointer is tied to the lifetime of the SqliteConnector object,
+      The returned pointer is really an @c sqlite3*; it is exposed here as a
+      @c void* so that this installed header stays free of any SQLite type.
+      To obtain the typed handle, include the non-installed
+      <OpenMS/FORMAT/SqliteConnector_impl.h> and call
+      @c Internal::SqliteHelper::getNativeHandle(*this).
+
+      @note The handle is tied to the lifetime of the SqliteConnector object;
       do not use it after the object has gone out of scope!
-
-      @returns SQLite database ptr
-
     */
-    sqlite3* getDB()
+    void* nativeHandle() const
     {
       return db_;
     }
+    /// @endcond
 
     /**
       @brief Checks whether the given table exists
@@ -73,10 +81,7 @@ namespace OpenMS
 
       @returns Whether the table exists or not
     */
-    bool tableExists(const std::string& tablename)
-    {
-      return tableExists(db_, tablename);
-    }
+    bool tableExists(const std::string& tablename);
 
     /// Counts the number of entries in SQL table @p table_name
     /// @throws Exception::SqlOperationFailed if table is unknown
@@ -90,10 +95,7 @@ namespace OpenMS
 
       @returns Whether the column exists or not
     */
-    bool columnExists(const std::string& tablename, const std::string& colname)
-    {
-      return columnExists(db_, tablename, colname);
-    }
+    bool columnExists(const std::string& tablename, const std::string& colname);
 
     /**
       @brief Executes a given SQL statement (insert statement)
@@ -104,10 +106,7 @@ namespace OpenMS
 
       @exception Exception::IllegalArgument is thrown if the SQL command fails.
     */
-    void executeStatement(const std::string& statement)
-    {
-      executeStatement(db_, statement);
-    }
+    void executeStatement(const std::string& statement);
 
     /**
       @brief Executes raw data SQL statements (insert statements)
@@ -120,117 +119,12 @@ namespace OpenMS
 
       See also https://www.sqlite.org/c3ref/bind_blob.html
 
-      @p statement The SQL statement
+      @p prepare_statement The SQL statement
       @p data The data to bind
 
       @exception Exception::IllegalArgument is thrown if the SQL command fails.
     */
-    void executeBindStatement(const std::string& prepare_statement, const std::vector<std::string>& data)
-    {
-      executeBindStatement(db_, prepare_statement, data);
-    }
-
-    /**
-      @brief Prepares a SQL statement
-
-      This is useful for handling errors in a consistent manner.
-
-      @p db The sqlite database (needs to be open)
-      @p statement The SQL statement
-      @p data The data to bind
-
-      @exception Exception::IllegalArgument is thrown if the SQL command fails.
-    */
-    void prepareStatement(sqlite3_stmt** stmt, const std::string& prepare_statement)
-    {
-      prepareStatement(db_, stmt, prepare_statement);
-    }
-
-    /**
-      @brief Checks whether the given table exists
-
-      @p db The sqlite database (needs to be open)
-      @p tablename The name of the table to be checked
-
-      @returns Whether the table exists or not
-    */
-    static bool tableExists(sqlite3* db, const std::string& tablename);
-
-    /**
-      @brief Checks whether the given table contains a certain column
-
-      @p db The sqlite database (needs to be open)
-      @p tablename The name of the table (needs to exist)
-      @p colname The name of the column to be checked
-
-      @returns Whether the column exists or not
-    */
-    static bool columnExists(sqlite3* db, const std::string& tablename, const std::string& colname);
-
-    /**
-      @brief Executes a given SQL statement (insert statement)
-
-      This is useful for writing a single row of data. It wraps sqlite3_exec with proper error handling.
-
-      @p db The sqlite database (needs to be open)
-      @p statement The SQL statement
-
-      @exception Exception::IllegalArgument is thrown if the SQL command fails.
-    */
-    static void executeStatement(sqlite3* db, const std::stringstream& statement);
-
-    /**
-      @brief Executes a given SQL statement (insert statement)
-
-      This is useful for writing a single row of data. It wraps sqlite3_exec with proper error handling.
-
-      @p db The sqlite database (needs to be open)
-      @p statement The SQL statement
-
-      @exception Exception::IllegalArgument is thrown if the SQL command fails.
-    */
-    static void executeStatement(sqlite3* db, const std::string& statement);
-
-    /**
-      @brief Converts an SQL statement into a prepared statement
-
-      This routine converts SQL text into a prepared statement object and
-      returns a pointer to that object. This interface requires a database
-      connection created by a prior call to sqlite3_open() and a text string
-      containing the SQL statement to be prepared. This API does not actually
-      evaluate the SQL statement. It merely prepares the SQL statement for
-      evaluation.
-
-      This is useful for handling errors in a consistent manner. Internally
-      calls sqlite3_prepare_v2.
-
-      @p db The sqlite database (needs to be open)
-      @p stmt The prepared statement (output)
-      @p prepare_statement The SQL statement to prepare (input)
-
-      @exception Exception::IllegalArgument is thrown if the SQL command fails.
-    */
-    static void prepareStatement(sqlite3* db, sqlite3_stmt** stmt, const std::string& prepare_statement);
-
-
-    /**
-      @brief Executes raw data SQL statements (insert statements)
-
-      This is useful for a case where raw data should be inserted into sqlite
-      databases, and the raw data needs to be passed separately as it cannot be
-      part of a true SQL statement
-
-        INSERT INTO TBL (ID, DATA) VALUES (100, ?1), (101, ?2), (102, ?3)"
-
-      See also https://www.sqlite.org/c3ref/bind_blob.html
-
-      @p db The sqlite database (needs to be open)
-      @p statement The SQL statement
-      @p data The data to bind
-
-      @exception Exception::IllegalArgument is thrown if the SQL command fails.
-    */
-    static void executeBindStatement(sqlite3* db, const std::string& prepare_statement, const std::vector<std::string>& data);
+    void executeBindStatement(const std::string& prepare_statement, const std::vector<std::string>& data);
 
   protected:
 
@@ -244,110 +138,8 @@ namespace OpenMS
     */
     void openDatabase_(const std::string& filename, const SqlOpenMode mode);
 
-  protected:
-    sqlite3* db_ = nullptr;
+    void* db_ = nullptr; ///< opaque native SQLite handle (really an sqlite3*); see nativeHandle()
 
   };
-
-  namespace Internal
-  {
-    namespace SqliteHelper
-    {
-      /// Sql only stores signed 64bit ints, so we remove the highest bit, because some/most
-      /// of our sql-insert routines first convert to string, which might yield an uint64 which cannot
-      /// be represented as int64, and sqlite would attempt to store it as double(!), which will loose precision
-      template <typename T>
-      UInt64 clearSignBit(T /*value*/)
-      {
-        static_assert(std::is_same<T, std::false_type>::value, "Wrong input type to clearSignBit(). Please pass unsigned 64bit ints!");
-        return 0;
-      };
-      /// only allow UInt64 specialization
-      template <>
-      inline UInt64 clearSignBit(UInt64 value) {
-        return value & ~(1ULL << 63);
-      }
-
-
-      enum class SqlState
-      {
-        SQL_ROW,
-        SQL_DONE,
-        SQL_ERROR ///< includes SQLITE_BUSY, SQLITE_ERROR, SQLITE_MISUSE
-      };
-
-      /**
-        @brief retrieves the next row from a prepared statement
-
-        If you receive 'SqlState::SQL_DONE', do NOT query nextRow() again,
-        because you might enter an infinite loop!
-        To avoid oversights, you can pass the old return value into the function again
-        and get an Exception which will tell you that there is buggy code!
-
-        @param[in] stmt Sqlite statement object
-        @param[in] current Return value of the previous call to this function.
-        @return one of SqlState::SQL_ROW or SqlState::SQL_DONE
-        @throws Exception::SqlOperationFailed if state would be SqlState::ERROR
-      */
-      SqlState nextRow(sqlite3_stmt* stmt, SqlState current = SqlState::SQL_ROW);
-
-
-      /**
-        @brief Extracts a specific value from an SQL column
-
-        @p dst Destination (where to store the value)
-        @p stmt Sqlite statement object
-        @p pos Column position
-
-        For example, to extract a specific integer from column 5 of an SQL statement, one can use:
-
-          sqlite3_stmt* stmt;
-          sqlite3* db;
-          SqliteConnector::prepareStatement(db, &stmt, select_sql);
-          sqlite3_step(stmt);
-
-          double target;
-          while (sqlite3_column_type(stmt, 0) != SQLITE_NULL)
-          {
-            extractValue<double>(&target, stmt, 5);
-            sqlite3_step( stmt );
-          }
-          sqlite3_finalize(stmt);
-      */
-      template <typename ValueType>
-      bool extractValue(ValueType* /* dst */, sqlite3_stmt* /* stmt */, int /* pos */)
-      {
-        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-          "Not implemented");
-      }
-
-      template <> bool extractValue<double>(double* dst, sqlite3_stmt* stmt, int pos); //explicit specialization
-
-      template <> bool extractValue<int>(int* dst, sqlite3_stmt* stmt, int pos); //explicit specialization
-      template <> bool extractValue<Int64>(Int64* dst, sqlite3_stmt* stmt, int pos); //explicit specialization
-
-      template <> bool extractValue<std::string>(std::string* dst, sqlite3_stmt* stmt, int pos); //explicit specialization
-
-      template <> bool extractValue<std::string>(std::string* dst, sqlite3_stmt* stmt, int pos); //explicit specialization
-
-      /// Special case where an integer should be stored in a std::string field
-      bool extractValueIntStr(std::string* dst, sqlite3_stmt* stmt, int pos);
-
-      /** @defgroup sqlThrowingGetters Functions for getting values from sql-select statements
-
-          All these function throw Exception::SqlOperationFailed if the given position is of the wrong type.
-       @{
-       */
-      double extractDouble(sqlite3_stmt* stmt, int pos);
-      float extractFloat(sqlite3_stmt* stmt, int pos); ///< convenience function; note: in SQL there is no float, just double. So this might be narrowing.
-      int extractInt(sqlite3_stmt* stmt, int pos);
-      Int64 extractInt64(sqlite3_stmt* stmt, int pos);
-      std::string extractString(sqlite3_stmt* stmt, int pos);
-      char extractChar(sqlite3_stmt* stmt, int pos);
-      bool extractBool(sqlite3_stmt* stmt, int pos);
-      /** @} */ // end of sqlThrowingGetters
-    }
-  }
-
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/FORMAT/SqliteConnector.h
+++ b/src/openms/include/OpenMS/FORMAT/SqliteConnector.h
@@ -16,6 +16,13 @@
 
 namespace OpenMS
 {
+  namespace Internal
+  {
+    /// Grants the non-installed SqliteConnector_impl.h access to the native handle
+    /// without exposing any SQLite type in this installed header (see below).
+    struct SqliteConnectorFriend;
+  }
+
   /**
     @brief File adapter for Sqlite files
 
@@ -54,25 +61,6 @@ namespace OpenMS
 
     /// Destructor
     ~SqliteConnector();
-
-    /// @cond INTERNAL
-    /**
-      @brief Returns the raw native SQLite handle as an opaque pointer.
-
-      The returned pointer is really an @c sqlite3*; it is exposed here as a
-      @c void* so that this installed header stays free of any SQLite type.
-      To obtain the typed handle, include the non-installed
-      <OpenMS/FORMAT/SqliteConnector_impl.h> and call
-      @c Internal::SqliteHelper::getNativeHandle(*this).
-
-      @note The handle is tied to the lifetime of the SqliteConnector object;
-      do not use it after the object has gone out of scope!
-    */
-    void* nativeHandle() const
-    {
-      return db_;
-    }
-    /// @endcond
 
     /**
       @brief Checks whether the given table exists
@@ -138,8 +126,12 @@ namespace OpenMS
     */
     void openDatabase_(const std::string& filename, const SqlOpenMode mode);
 
-    void* db_ = nullptr; ///< opaque native SQLite handle (really an sqlite3*); see nativeHandle()
+    /// Opaque native SQLite handle (really an sqlite3*), stored as void* so that this
+    /// installed header names no SQLite type. The raw handle is only reachable from the
+    /// non-installed SqliteConnector_impl.h via Internal::SqliteConnectorFriend.
+    void* db_ = nullptr;
 
+    friend struct Internal::SqliteConnectorFriend;
   };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/FORMAT/SqliteConnector_impl.h
+++ b/src/openms/include/OpenMS/FORMAT/SqliteConnector_impl.h
@@ -35,12 +35,23 @@ namespace OpenMS
 {
   namespace Internal
   {
+    /// Friend of SqliteConnector: the single place allowed to turn the connector's
+    /// opaque void* handle back into a typed sqlite3*. Keeps SqliteConnector.h free
+    /// of any SQLite type while still giving the internal helpers native access.
+    struct SqliteConnectorFriend
+    {
+      static sqlite3* handle(SqliteConnector& conn)
+      {
+        return static_cast<sqlite3*>(conn.db_);
+      }
+    };
+
     namespace SqliteHelper
     {
       /// Retrieve the typed native SQLite handle behind a SqliteConnector.
       inline sqlite3* getNativeHandle(SqliteConnector& conn)
       {
-        return static_cast<sqlite3*>(conn.nativeHandle());
+        return SqliteConnectorFriend::handle(conn);
       }
 
       /**

--- a/src/openms/include/OpenMS/FORMAT/SqliteConnector_impl.h
+++ b/src/openms/include/OpenMS/FORMAT/SqliteConnector_impl.h
@@ -1,0 +1,204 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Hannes Roest $
+// $Authors: Hannes Roest $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+// -----------------------------------------------------------------------------
+// PRIVATE (non-installed) implementation header.
+//
+// This header exposes the raw SQLite C API (sqlite3 / sqlite3_stmt) that backs
+// OpenMS::SqliteConnector. It is deliberately NOT installed, NOT exported and
+// NOT part of the public API, so that SQLite can remain a fully private link
+// dependency of libOpenMS (no SQLite type ever appears in an installed header).
+//
+// It must only be included from .cpp files that live inside libOpenMS. Public
+// (installed) headers must never include it.
+// -----------------------------------------------------------------------------
+
+#include <OpenMS/FORMAT/SqliteConnector.h>
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/DATASTRUCTURES/StringUtils.h>
+
+#include <sqlite3.h>
+
+#include <sstream>
+#include <string>
+#include <type_traits> // for is_same
+#include <vector>
+
+namespace OpenMS
+{
+  namespace Internal
+  {
+    namespace SqliteHelper
+    {
+      /// Retrieve the typed native SQLite handle behind a SqliteConnector.
+      inline sqlite3* getNativeHandle(SqliteConnector& conn)
+      {
+        return static_cast<sqlite3*>(conn.nativeHandle());
+      }
+
+      /**
+        @brief Checks whether the given table exists
+
+        @p db The sqlite database (needs to be open)
+        @p tablename The name of the table to be checked
+
+        @returns Whether the table exists or not
+      */
+      bool tableExists(sqlite3* db, const std::string& tablename);
+
+      /**
+        @brief Checks whether the given table contains a certain column
+
+        @p db The sqlite database (needs to be open)
+        @p tablename The name of the table (needs to exist)
+        @p colname The name of the column to be checked
+
+        @returns Whether the column exists or not
+      */
+      bool columnExists(sqlite3* db, const std::string& tablename, const std::string& colname);
+
+      /**
+        @brief Executes a given SQL statement (insert statement)
+
+        This wraps sqlite3_exec with proper error handling.
+
+        @p db The sqlite database (needs to be open)
+        @p statement The SQL statement
+
+        @exception Exception::IllegalArgument is thrown if the SQL command fails.
+      */
+      void executeStatement(sqlite3* db, const std::string& statement);
+
+      /**
+        @brief Converts an SQL statement into a prepared statement
+
+        Internally calls sqlite3_prepare_v2.
+
+        @p db The sqlite database (needs to be open)
+        @p stmt The prepared statement (output)
+        @p prepare_statement The SQL statement to prepare (input)
+
+        @exception Exception::IllegalArgument is thrown if the SQL command fails.
+      */
+      void prepareStatement(sqlite3* db, sqlite3_stmt** stmt, const std::string& prepare_statement);
+
+      /// Convenience overload: prepare a statement directly on a SqliteConnector's native handle.
+      inline void prepareStatement(SqliteConnector& conn, sqlite3_stmt** stmt, const std::string& prepare_statement)
+      {
+        prepareStatement(getNativeHandle(conn), stmt, prepare_statement);
+      }
+
+      /**
+        @brief Executes raw data SQL statements (insert statements)
+
+        See also https://www.sqlite.org/c3ref/bind_blob.html
+
+        @p db The sqlite database (needs to be open)
+        @p prepare_statement The SQL statement
+        @p data The data to bind
+
+        @exception Exception::IllegalArgument is thrown if the SQL command fails.
+      */
+      void executeBindStatement(sqlite3* db, const std::string& prepare_statement, const std::vector<std::string>& data);
+
+      /// Sql only stores signed 64bit ints, so we remove the highest bit, because some/most
+      /// of our sql-insert routines first convert to string, which might yield an uint64 which cannot
+      /// be represented as int64, and sqlite would attempt to store it as double(!), which will loose precision
+      template <typename T>
+      UInt64 clearSignBit(T /*value*/)
+      {
+        static_assert(std::is_same<T, std::false_type>::value, "Wrong input type to clearSignBit(). Please pass unsigned 64bit ints!");
+        return 0;
+      };
+      /// only allow UInt64 specialization
+      template <>
+      inline UInt64 clearSignBit(UInt64 value) {
+        return value & ~(1ULL << 63);
+      }
+
+
+      enum class SqlState
+      {
+        SQL_ROW,
+        SQL_DONE,
+        SQL_ERROR ///< includes SQLITE_BUSY, SQLITE_ERROR, SQLITE_MISUSE
+      };
+
+      /**
+        @brief retrieves the next row from a prepared statement
+
+        If you receive 'SqlState::SQL_DONE', do NOT query nextRow() again,
+        because you might enter an infinite loop!
+        To avoid oversights, you can pass the old return value into the function again
+        and get an Exception which will tell you that there is buggy code!
+
+        @param[in] stmt Sqlite statement object
+        @param[in] current Return value of the previous call to this function.
+        @return one of SqlState::SQL_ROW or SqlState::SQL_DONE
+        @throws Exception::SqlOperationFailed if state would be SqlState::ERROR
+      */
+      SqlState nextRow(sqlite3_stmt* stmt, SqlState current = SqlState::SQL_ROW);
+
+
+      /**
+        @brief Extracts a specific value from an SQL column
+
+        @p dst Destination (where to store the value)
+        @p stmt Sqlite statement object
+        @p pos Column position
+
+        For example, to extract a specific integer from column 5 of an SQL statement, one can use:
+
+          sqlite3_stmt* stmt;
+          sqlite3* db;
+          SqliteHelper::prepareStatement(db, &stmt, select_sql);
+          sqlite3_step(stmt);
+
+          double target;
+          while (sqlite3_column_type(stmt, 0) != SQLITE_NULL)
+          {
+            extractValue<double>(&target, stmt, 5);
+            sqlite3_step( stmt );
+          }
+          sqlite3_finalize(stmt);
+      */
+      template <typename ValueType>
+      bool extractValue(ValueType* /* dst */, sqlite3_stmt* /* stmt */, int /* pos */)
+      {
+        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+          "Not implemented");
+      }
+
+      template <> bool extractValue<double>(double* dst, sqlite3_stmt* stmt, int pos); //explicit specialization
+
+      template <> bool extractValue<int>(int* dst, sqlite3_stmt* stmt, int pos); //explicit specialization
+      template <> bool extractValue<Int64>(Int64* dst, sqlite3_stmt* stmt, int pos); //explicit specialization
+
+      template <> bool extractValue<std::string>(std::string* dst, sqlite3_stmt* stmt, int pos); //explicit specialization
+
+      /// Special case where an integer should be stored in a std::string field
+      bool extractValueIntStr(std::string* dst, sqlite3_stmt* stmt, int pos);
+
+      /** @defgroup sqlThrowingGetters Functions for getting values from sql-select statements
+
+          All these function throw Exception::SqlOperationFailed if the given position is of the wrong type.
+       @{
+       */
+      double extractDouble(sqlite3_stmt* stmt, int pos);
+      float extractFloat(sqlite3_stmt* stmt, int pos); ///< convenience function; note: in SQL there is no float, just double. So this might be narrowing.
+      int extractInt(sqlite3_stmt* stmt, int pos);
+      Int64 extractInt64(sqlite3_stmt* stmt, int pos);
+      std::string extractString(sqlite3_stmt* stmt, int pos);
+      char extractChar(sqlite3_stmt* stmt, int pos);
+      bool extractBool(sqlite3_stmt* stmt, int pos);
+      /** @} */ // end of sqlThrowingGetters
+    }
+  }
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/FORMAT/sources.cmake
+++ b/src/openms/include/OpenMS/FORMAT/sources.cmake
@@ -70,8 +70,6 @@ MzTabFile.h
 MzTabMFile.h
 MzXMLFile.h
 OMSFile.h
-OMSFileLoad.h
-OMSFileStore.h
 OMSSACSVFile.h
 OMSSAXMLFile.h
 OSWFile.h
@@ -160,11 +158,19 @@ set(OpenMS_sources_h ${OpenMS_sources_h} ${sources_h})
 ### Private (non-installed) headers: the Xerces InputSource / BinInputStream
 ### adapters are internal plumbing used only by XMLFile.cpp / CompressedInputSource.cpp.
 ### Keeping them off OpenMS_sources_h is what lets Xerces be a PRIVATE link dependency.
+###
+### SqliteConnector_impl.h exposes the raw SQLite C API (sqlite3 / sqlite3_stmt)
+### and OMSFileStore.h / OMSFileLoad.h expose the SQLiteCpp C++ API (SQLite::*).
+### Keeping all three off OpenMS_sources_h is what lets SQLite (SQLiteCpp) be a
+### fully private dependency: no SQLite type appears in any installed header.
 set(private_headers_list_h
 Bzip2InputStream.h
 CompressedInputSource.h
 GzipInputStream.h
 ZipInputStream.h
+SqliteConnector_impl.h
+OMSFileLoad.h
+OMSFileStore.h
 )
 set(private_sources_h)
 foreach(i ${private_headers_list_h})

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -22,7 +22,7 @@
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
 #include <OpenMS/CHEMISTRY/ProteaseDigestion.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
-#include <OpenMS/FORMAT/SqliteConnector.h>
+#include <OpenMS/FORMAT/SqliteConnector_impl.h>
 #include <OpenMS/OPENSWATHALGO/ALGO/Scoring.h>
 
 #include <boost/range/adaptor/map.hpp>

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWParquetWriter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWParquetWriter.cpp
@@ -15,7 +15,7 @@
 #include <OpenMS/CONCEPT/VersionInfo.h>
 #include <OpenMS/FORMAT/ParquetFile.h>
 #include <OpenMS/FORMAT/ZipArchiveFile.h>
-#include <OpenMS/FORMAT/SqliteConnector.h>
+#include <OpenMS/FORMAT/SqliteConnector_impl.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/TransitionExperiment.h>
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.cpp
@@ -8,7 +8,7 @@
 
 #include <OpenMS/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.h>
 
-#include <OpenMS/FORMAT/SqliteConnector.h>
+#include <OpenMS/FORMAT/SqliteConnector_impl.h>
 #include <OpenMS/METADATA/MetaInfo.h>
 
 #include <sqlite3.h>
@@ -476,7 +476,7 @@ namespace OpenMS
       }
 
       sqlite3_stmt* stmt = nullptr;
-      SqliteConnector::prepareStatement(db, &stmt, makeInsertStatement(table, columns));
+      Internal::SqliteHelper::prepareStatement(db, &stmt, makeInsertStatement(table, columns));
       try
       {
         for (const auto& row : rows)
@@ -954,14 +954,14 @@ namespace OpenMS
     // every parameter, which stores integers as BLOB and breaks
     // "FEATURE.RUN_ID = RUN.ID" joins.
     sqlite3_stmt* stmt = nullptr;
-    SqliteConnector::prepareStatement(conn.getDB(), &stmt,
+    Internal::SqliteHelper::prepareStatement(Internal::SqliteHelper::getNativeHandle(conn), &stmt,
         "INSERT INTO RUN (ID, FILENAME) VALUES (?, ?);");
     int rc = sqlite3_bind_int64(stmt, 1, static_cast<sqlite3_int64>(rid));
     if (rc != SQLITE_OK)
     {
       sqlite3_finalize(stmt);
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-        std::string("sqlite3_bind_int64 failed: ") + sqlite3_errmsg(conn.getDB()));
+        std::string("sqlite3_bind_int64 failed: ") + sqlite3_errmsg(Internal::SqliteHelper::getNativeHandle(conn)));
     }
 
     rc = sqlite3_bind_text(stmt, 2, input_filename.c_str(),
@@ -970,7 +970,7 @@ namespace OpenMS
     {
       sqlite3_finalize(stmt);
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-        std::string("sqlite3_bind_text failed: ") + sqlite3_errmsg(conn.getDB()));
+        std::string("sqlite3_bind_text failed: ") + sqlite3_errmsg(Internal::SqliteHelper::getNativeHandle(conn)));
     }
 
     rc = sqlite3_step(stmt);
@@ -978,7 +978,7 @@ namespace OpenMS
     if (rc != SQLITE_DONE)
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-        std::string("sqlite3_step failed: ") + sqlite3_errmsg(conn.getDB()));
+        std::string("sqlite3_step failed: ") + sqlite3_errmsg(Internal::SqliteHelper::getNativeHandle(conn)));
     }
     run_id_ = rid;
   }
@@ -1462,11 +1462,11 @@ namespace OpenMS
     conn_->executeStatement("BEGIN TRANSACTION");
     try
     {
-      writeTableRows(conn_->getDB(), "FEATURE", featureColumns(), osw_output.feature_rows);
-      writeTableRows(conn_->getDB(), "FEATURE_MS1", featureMS1Columns(), osw_output.feature_ms1_rows);
-      writeTableRows(conn_->getDB(), "FEATURE_PRECURSOR", featurePrecursorColumns(), osw_output.feature_precursor_rows);
-      writeTableRows(conn_->getDB(), "FEATURE_MS2", featureMS2Columns(), osw_output.feature_ms2_rows);
-      writeTableRows(conn_->getDB(), "FEATURE_TRANSITION", featureTransitionColumns(), osw_output.feature_transition_rows);
+      writeTableRows(Internal::SqliteHelper::getNativeHandle(*conn_), "FEATURE", featureColumns(), osw_output.feature_rows);
+      writeTableRows(Internal::SqliteHelper::getNativeHandle(*conn_), "FEATURE_MS1", featureMS1Columns(), osw_output.feature_ms1_rows);
+      writeTableRows(Internal::SqliteHelper::getNativeHandle(*conn_), "FEATURE_PRECURSOR", featurePrecursorColumns(), osw_output.feature_precursor_rows);
+      writeTableRows(Internal::SqliteHelper::getNativeHandle(*conn_), "FEATURE_MS2", featureMS2Columns(), osw_output.feature_ms2_rows);
+      writeTableRows(Internal::SqliteHelper::getNativeHandle(*conn_), "FEATURE_TRANSITION", featureTransitionColumns(), osw_output.feature_transition_rows);
     }
     catch (...)
     {

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathPercolatorScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathPercolatorScoring.cpp
@@ -18,7 +18,7 @@
 #include <OpenMS/DATASTRUCTURES/Param.h>
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/FORMAT/ParquetFile.h>
-#include <OpenMS/FORMAT/SqliteConnector.h>
+#include <OpenMS/FORMAT/SqliteConnector_impl.h>
 #include <OpenMS/FORMAT/ZipArchiveFile.h>
 #include <OpenMS/SYSTEM/File.h>
 
@@ -155,7 +155,7 @@ namespace OpenMS
                                                  const String& prefix)
     {
       sqlite3_stmt* stmt = nullptr;
-      conn.prepareStatement(&stmt, "PRAGMA table_info('" + table_name + "');");
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, "PRAGMA table_info('" + table_name + "');");
       std::vector<String> columns;
       Sql::SqlState state = Sql::nextRow(stmt);
       while (state == Sql::SqlState::SQL_ROW)
@@ -496,7 +496,7 @@ namespace OpenMS
         }
         select_sql += "ORDER BY FEATURE.RUN_ID, FEATURE.PRECURSOR_ID, FEATURE.EXP_RT, FEATURE.ID;";
 
-        conn.prepareStatement(&stmt, select_sql);
+        Internal::SqliteHelper::prepareStatement(conn, &stmt, select_sql);
         Sql::SqlState state = Sql::nextRow(stmt);
         std::unordered_map<std::pair<Int64, Int64>, int, PairHash<std::pair<Int64, Int64>>> group_to_key;
         int next_group_key = 0;
@@ -573,7 +573,7 @@ namespace OpenMS
         "  AND PRECURSOR.DECOY = 0 "
         "ORDER BY FEATURE.RUN_ID, FEATURE.PRECURSOR_ID, FEATURE.EXP_RT, FEATURE_TRANSITION.TRANSITION_ID;";
 
-      conn.prepareStatement(&stmt, select_sql);
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, select_sql);
       Sql::SqlState state = Sql::nextRow(stmt);
       int next_group_key = 0;
       std::vector<ScoreRow> base_rows;
@@ -1110,7 +1110,7 @@ namespace OpenMS
           "QVALUE REAL NOT NULL, "
           "PEP REAL NOT NULL);";
       }
-      sqlite3* db = conn.getDB();
+      sqlite3* db = Internal::SqliteHelper::getNativeHandle(conn);
       sqlite3_stmt* insert_stmt = nullptr;
       bool transaction_started = false;
       conn.executeStatement("BEGIN IMMEDIATE TRANSACTION;");
@@ -1130,13 +1130,13 @@ namespace OpenMS
 
         if (transition_level)
         {
-          conn.prepareStatement(&insert_stmt,
+          Internal::SqliteHelper::prepareStatement(conn, &insert_stmt,
             "INSERT INTO SCORE_TRANSITION (FEATURE_ID, TRANSITION_ID, SCORE, RANK, PVALUE, QVALUE, PEP) "
             "VALUES (?, ?, ?, ?, ?, ?, ?);");
         }
         else
         {
-          conn.prepareStatement(&insert_stmt,
+          Internal::SqliteHelper::prepareStatement(conn, &insert_stmt,
             "INSERT INTO " + table_name + " (FEATURE_ID, SCORE, RANK, PVALUE, QVALUE, PEP) "
             "VALUES (?, ?, ?, ?, ?, ?);");
         }

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
@@ -9,7 +9,7 @@
 #include <OpenMS/ANALYSIS/OPENSWATH/TransitionPQPFile.h>
 
 #include <sqlite3.h>
-#include <OpenMS/FORMAT/SqliteConnector.h>
+#include <OpenMS/FORMAT/SqliteConnector_impl.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 
 #include <boost/range/algorithm.hpp>
@@ -44,7 +44,7 @@ namespace OpenMS
     bool tableHasRows_(sqlite3* db, const std::string& table_name)
     {
       sqlite3_stmt* stmt = nullptr;
-      SqliteConnector::prepareStatement(db, &stmt, "SELECT 1 FROM " + table_name + " LIMIT 1;");
+      Internal::SqliteHelper::prepareStatement(db, &stmt, "SELECT 1 FROM " + table_name + " LIMIT 1;");
       const bool has_rows = sqlite3_step(stmt) == SQLITE_ROW;
       sqlite3_finalize(stmt);
       return has_rows;
@@ -55,16 +55,16 @@ namespace OpenMS
       // Large PQP libraries are streamed once from a read-only connection. A bounded
       // SQLite page cache and mmap window reduce cold-cache wall time without
       // materializing the database or changing file contents.
-      SqliteConnector::executeStatement(db, "PRAGMA cache_size = -524288;");
-      SqliteConnector::executeStatement(db, "PRAGMA mmap_size = 8589934592;");
-      SqliteConnector::executeStatement(db, "PRAGMA query_only = ON;");
+      Internal::SqliteHelper::executeStatement(db, "PRAGMA cache_size = -524288;");
+      Internal::SqliteHelper::executeStatement(db, "PRAGMA mmap_size = 8589934592;");
+      Internal::SqliteHelper::executeStatement(db, "PRAGMA query_only = ON;");
 #ifdef _OPENMP
       int sqlite_threads = omp_get_max_threads();
       if (sqlite_threads < 1)
       {
         sqlite_threads = 1;
       }
-      SqliteConnector::executeStatement(db, "PRAGMA threads = " + StringUtils::toStr(sqlite_threads) + ";");
+      Internal::SqliteHelper::executeStatement(db, "PRAGMA threads = " + StringUtils::toStr(sqlite_threads) + ";");
 #endif
     }
   }
@@ -76,8 +76,9 @@ namespace OpenMS
 
   TransitionPQPFile::~TransitionPQPFile() = default;
 
-  TransitionPQPFile::PQPSqlQueryInfo TransitionPQPFile::buildPQPSelectQuery_(sqlite3* db, bool legacy_traml_id, bool stable_order) const
+  TransitionPQPFile::PQPSqlQueryInfo TransitionPQPFile::buildPQPSelectQuery_(void* db_native, bool legacy_traml_id, bool stable_order) const
   {
+    sqlite3* db = static_cast<sqlite3*>(db_native);
     PQPSqlQueryInfo info;
 
     // Use legacy TraML identifiers for precursors (transition_group_id) and transitions (transition_name)?
@@ -87,7 +88,7 @@ namespace OpenMS
 
     // Check for optional columns/tables
     std::string select_drift_time;
-    info.drift_time_exists = SqliteConnector::columnExists(db, "PRECURSOR", "LIBRARY_DRIFT_TIME");
+    info.drift_time_exists = Internal::SqliteHelper::columnExists(db, "PRECURSOR", "LIBRARY_DRIFT_TIME");
     if (info.drift_time_exists)
     {
       select_drift_time = ", PRECURSOR.LIBRARY_DRIFT_TIME AS drift_time ";
@@ -96,7 +97,7 @@ namespace OpenMS
     std::string select_gene;
     std::string select_gene_null;
     std::string join_gene;
-    info.gene_exists = SqliteConnector::tableExists(db, "GENE");
+    info.gene_exists = Internal::SqliteHelper::tableExists(db, "GENE");
     if (info.gene_exists)
     {
       // Check if the GENE table actually has any data (issue #8687).
@@ -119,17 +120,17 @@ namespace OpenMS
     }
 
     std::string select_annotation = "'' AS Annotation, ";
-    bool annotation_exists = SqliteConnector::columnExists(db, "TRANSITION", "ANNOTATION");
+    bool annotation_exists = Internal::SqliteHelper::columnExists(db, "TRANSITION", "ANNOTATION");
     if (annotation_exists) select_annotation = "TRANSITION.ANNOTATION AS Annotation, ";
 
     std::string select_adducts = "'' AS Adducts, ";
-    bool adducts_exists = SqliteConnector::columnExists(db, "COMPOUND", "ADDUCTS");
+    bool adducts_exists = Internal::SqliteHelper::columnExists(db, "COMPOUND", "ADDUCTS");
     if (adducts_exists) select_adducts = "COMPOUND.ADDUCTS AS Adducts, ";
 
-    info.compound_exists = SqliteConnector::tableExists(db, "PRECURSOR_COMPOUND_MAPPING") &&
+    info.compound_exists = Internal::SqliteHelper::tableExists(db, "PRECURSOR_COMPOUND_MAPPING") &&
                            tableHasRows_(db, "PRECURSOR_COMPOUND_MAPPING");
 
-    info.peptidoforms_exists = SqliteConnector::tableExists(db, "TRANSITION_PEPTIDE_MAPPING") &&
+    info.peptidoforms_exists = Internal::SqliteHelper::tableExists(db, "TRANSITION_PEPTIDE_MAPPING") &&
                                tableHasRows_(db, "TRANSITION_PEPTIDE_MAPPING");
 
     std::string select_peptidoforms = "NULL AS peptidoforms ";
@@ -256,11 +257,11 @@ namespace OpenMS
 
     // Open database
     SqliteConnector conn(filename, SqliteConnector::SqlOpenMode::READ_ONLY);
-    db = conn.getDB();
+    db = Internal::SqliteHelper::getNativeHandle(conn);
     configurePQPReadConnection_(db);
 
     // Count transitions
-    SqliteConnector::prepareStatement(db, &cntstmt, "SELECT COUNT(*) FROM TRANSITION;");
+    Internal::SqliteHelper::prepareStatement(db, &cntstmt, "SELECT COUNT(*) FROM TRANSITION;");
     sqlite3_step( cntstmt );
     const Size num_transitions = static_cast<Size>(sqlite3_column_int64(cntstmt, 0));
     sqlite3_finalize(cntstmt);
@@ -270,7 +271,7 @@ namespace OpenMS
     PQPSqlQueryInfo query_info = buildPQPSelectQuery_(db, legacy_traml_id, true);
 
     // Execute SQL select statement
-    SqliteConnector::prepareStatement(db, &stmt, query_info.select_sql);
+    Internal::SqliteHelper::prepareStatement(db, &stmt, query_info.select_sql);
     sqlite3_step(stmt);
     endProgress();
 
@@ -347,11 +348,11 @@ namespace OpenMS
 
     // Open database
     SqliteConnector conn(filename, SqliteConnector::SqlOpenMode::READ_ONLY);
-    db = conn.getDB();
+    db = Internal::SqliteHelper::getNativeHandle(conn);
     configurePQPReadConnection_(db);
 
     // Count transitions
-    SqliteConnector::prepareStatement(db, &cntstmt, "SELECT COUNT(*) FROM TRANSITION;");
+    Internal::SqliteHelper::prepareStatement(db, &cntstmt, "SELECT COUNT(*) FROM TRANSITION;");
     sqlite3_step( cntstmt );
     const Size num_transitions = static_cast<Size>(sqlite3_column_int64(cntstmt, 0));
     sqlite3_finalize(cntstmt);
@@ -361,12 +362,12 @@ namespace OpenMS
     // streaming query will read those tables once; reserve from the transition
     // count keeps allocation churn low without extra cold-cache I/O.
     const Size estimated_precursor_count = estimatePrecursorCountFromTransitions_(num_transitions);
-    if (SqliteConnector::tableExists(db, "PRECURSOR"))
+    if (Internal::SqliteHelper::tableExists(db, "PRECURSOR"))
     {
       exp.compounds.reserve(estimated_precursor_count);
       compound_seen.reserve(estimated_precursor_count);
     }
-    if (SqliteConnector::tableExists(db, "PROTEIN"))
+    if (Internal::SqliteHelper::tableExists(db, "PROTEIN"))
     {
       const Size estimated_protein_count = std::min(estimated_precursor_count, max_protein_reserve);
       exp.proteins.reserve(estimated_protein_count);
@@ -378,7 +379,7 @@ namespace OpenMS
     PQPSqlQueryInfo query_info = buildPQPSelectQuery_(db, legacy_traml_id, stable_order);
 
     // Execute SQL select statement
-    SqliteConnector::prepareStatement(db, &stmt, query_info.select_sql);
+    Internal::SqliteHelper::prepareStatement(db, &stmt, query_info.select_sql);
     sqlite3_step(stmt);
     endProgress();
 
@@ -1007,17 +1008,17 @@ namespace OpenMS
 
     // Open database
     SqliteConnector conn(filename);
-    db = conn.getDB();
+    db = Internal::SqliteHelper::getNativeHandle(conn);
 
     // Count Precursors 
-    SqliteConnector::prepareStatement(db, &cntstmt, "SELECT COUNT(*) FROM " + tableName + ";");
+    Internal::SqliteHelper::prepareStatement(db, &cntstmt, "SELECT COUNT(*) FROM " + tableName + ";");
     sqlite3_step( cntstmt );
     sqlite3_finalize(cntstmt);
 
     std::string query = "SELECT ID, TRAML_ID FROM " + tableName + ";"; 
 
     // Execute SQL select statement
-    SqliteConnector::prepareStatement(db, &stmt, query);
+    Internal::SqliteHelper::prepareStatement(db, &stmt, query);
     sqlite3_step(stmt);
 
     while (sqlite3_column_type(stmt, 0) != SQLITE_NULL)

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
@@ -76,9 +76,9 @@ namespace OpenMS
 
   TransitionPQPFile::~TransitionPQPFile() = default;
 
-  TransitionPQPFile::PQPSqlQueryInfo TransitionPQPFile::buildPQPSelectQuery_(void* db_native, bool legacy_traml_id, bool stable_order) const
+  TransitionPQPFile::PQPSqlQueryInfo TransitionPQPFile::buildPQPSelectQuery_(SqliteConnector& conn, bool legacy_traml_id, bool stable_order) const
   {
-    sqlite3* db = static_cast<sqlite3*>(db_native);
+    sqlite3* db = Internal::SqliteHelper::getNativeHandle(conn);
     PQPSqlQueryInfo info;
 
     // Use legacy TraML identifiers for precursors (transition_group_id) and transitions (transition_name)?
@@ -268,7 +268,7 @@ namespace OpenMS
     transition_list.reserve(num_transitions);
 
     // Build SQL query using shared helper
-    PQPSqlQueryInfo query_info = buildPQPSelectQuery_(db, legacy_traml_id, true);
+    PQPSqlQueryInfo query_info = buildPQPSelectQuery_(conn, legacy_traml_id, true);
 
     // Execute SQL select statement
     Internal::SqliteHelper::prepareStatement(db, &stmt, query_info.select_sql);
@@ -376,7 +376,7 @@ namespace OpenMS
 
     // Build SQL query using shared helper
     const bool stable_order = num_transitions <= stable_stream_order_transition_limit;
-    PQPSqlQueryInfo query_info = buildPQPSelectQuery_(db, legacy_traml_id, stable_order);
+    PQPSqlQueryInfo query_info = buildPQPSelectQuery_(conn, legacy_traml_id, stable_order);
 
     // Execute SQL select statement
     Internal::SqliteHelper::prepareStatement(db, &stmt, query_info.select_sql);

--- a/src/openms/source/FORMAT/BrukerTimsImagingFile.cpp
+++ b/src/openms/source/FORMAT/BrukerTimsImagingFile.cpp
@@ -10,7 +10,7 @@
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/FORMAT/BrukerTimsFile.h>
-#include <OpenMS/FORMAT/SqliteConnector.h>
+#include <OpenMS/FORMAT/SqliteConnector_impl.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/SYSTEM/File.h>
@@ -76,7 +76,7 @@ namespace OpenMS
     if (!conn.tableExists("GlobalMetadata")) { return ""; }
 
     sqlite3_stmt* stmt = nullptr;
-    conn.prepareStatement(&stmt, "SELECT Value FROM GlobalMetadata WHERE Key = ?1 LIMIT 1;");
+    Internal::SqliteHelper::prepareStatement(conn, &stmt, "SELECT Value FROM GlobalMetadata WHERE Key = ?1 LIMIT 1;");
     sqlite3_bind_text(stmt, 1, key.c_str(), -1, SQLITE_TRANSIENT);
 
     std::string result;
@@ -101,7 +101,7 @@ namespace OpenMS
     }
 
     sqlite3_stmt* stmt = nullptr;
-    conn.prepareStatement(&stmt, "SELECT Frame, XIndexPos, YIndexPos FROM MaldiFrameInfo ORDER BY Frame;");
+    Internal::SqliteHelper::prepareStatement(conn, &stmt, "SELECT Frame, XIndexPos, YIndexPos FROM MaldiFrameInfo ORDER BY Frame;");
 
     std::vector<MaldiPixel> rows;
     while (sqlite3_step(stmt) == SQLITE_ROW)
@@ -169,7 +169,7 @@ namespace OpenMS
       if (conn.columnExists("MaldiFrameInfo", "ZIndexPos"))
       {
         sqlite3_stmt* stmt = nullptr;
-        conn.prepareStatement(&stmt, "SELECT COUNT(DISTINCT ZIndexPos) FROM MaldiFrameInfo;");
+        Internal::SqliteHelper::prepareStatement(conn, &stmt, "SELECT COUNT(DISTINCT ZIndexPos) FROM MaldiFrameInfo;");
         int distinct_z = 0;
         if (sqlite3_step(stmt) == SQLITE_ROW) { distinct_z = sqlite3_column_int(stmt, 0); }
         sqlite3_finalize(stmt);

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
@@ -280,7 +280,6 @@ namespace OpenMS::Internal
     void MzMLSqliteHandler::readExperiment(MSExperiment& exp, bool meta_only) const
     {
       SqliteConnector conn(filename_);
-      sqlite3* db = Internal::SqliteHelper::getNativeHandle(conn);
 
       Size nr_results = 0;
       if (write_full_meta_)
@@ -345,8 +344,8 @@ namespace OpenMS::Internal
         // data (provides option to return meta-data only)
         std::vector<MSChromatogram> chromatograms;
         std::vector<MSSpectrum> spectra;
-        prepareChroms_(db, chromatograms);
-        prepareSpectra_(db, spectra);
+        prepareChroms_(conn, chromatograms);
+        prepareSpectra_(conn, spectra);
         exp.setChromatograms(chromatograms);
         exp.setSpectra(spectra);
       }
@@ -358,8 +357,8 @@ namespace OpenMS::Internal
         return;
       }
 
-      populateChromatogramsWithData_(db, exp.getChromatograms());
-      populateSpectraWithData_(db, exp.getSpectra());
+      populateChromatogramsWithData_(conn, exp.getChromatograms());
+      populateSpectraWithData_(conn, exp.getSpectra());
     }
 
     UInt64 MzMLSqliteHandler::getRunID() const
@@ -395,7 +394,7 @@ namespace OpenMS::Internal
       // creates the spectra but does not fill them with data (provides option
       // to return meta-data only)
       SqliteConnector conn(filename_);
-      prepareSpectra_(Internal::SqliteHelper::getNativeHandle(conn), exp, indices);
+      prepareSpectra_(conn, exp, indices);
       if (indices.size() != exp.size())
       {
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, 
@@ -408,7 +407,7 @@ namespace OpenMS::Internal
         return;
       }
 
-      populateSpectraWithData_(Internal::SqliteHelper::getNativeHandle(conn), exp, indices);
+      populateSpectraWithData_(conn, exp, indices);
     }
 
     void MzMLSqliteHandler::readChromatograms(std::vector<MSChromatogram> & exp,
@@ -420,7 +419,7 @@ namespace OpenMS::Internal
       // creates the chromatograms but does not fill them with data (provides
       // option to return meta-data only)
       SqliteConnector conn(filename_);
-      prepareChroms_(Internal::SqliteHelper::getNativeHandle(conn), exp, indices);
+      prepareChroms_(conn, exp, indices);
       if (indices.size() != exp.size())
       {
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, 
@@ -433,7 +432,7 @@ namespace OpenMS::Internal
         return;
       }
 
-      populateChromatogramsWithData_(Internal::SqliteHelper::getNativeHandle(conn), exp, indices);
+      populateChromatogramsWithData_(conn, exp, indices);
     }
 
     Size MzMLSqliteHandler::getNrSpectra() const
@@ -509,9 +508,9 @@ namespace OpenMS::Internal
       return (Size)ret;
     }
 
-    void MzMLSqliteHandler::populateChromatogramsWithData_(void* db_native, std::vector<MSChromatogram>& chromatograms) const
+    void MzMLSqliteHandler::populateChromatogramsWithData_(SqliteConnector& conn, std::vector<MSChromatogram>& chromatograms) const
     {
-      sqlite3* db = static_cast<sqlite3*>(db_native);
+      sqlite3* db = Internal::SqliteHelper::getNativeHandle(conn);
       std::string select_sql;
       select_sql = "SELECT " \
                     "CHROMATOGRAM.ID as chrom_id," \
@@ -531,11 +530,11 @@ namespace OpenMS::Internal
       sqlite3_finalize(stmt);
     }
 
-    void MzMLSqliteHandler::populateChromatogramsWithData_(void* db_native,
+    void MzMLSqliteHandler::populateChromatogramsWithData_(SqliteConnector& conn,
                                                            std::vector<MSChromatogram>& chromatograms,
                                                            const std::vector<int>& indices) const
     {
-      sqlite3* db = static_cast<sqlite3*>(db_native);
+      sqlite3* db = Internal::SqliteHelper::getNativeHandle(conn);
       OPENMS_PRECONDITION(!indices.empty(), "Need to select at least one index.")
       OPENMS_PRECONDITION(indices.size() == chromatograms.size(), "Chromatograms and indices need to have the same length.")
 
@@ -557,9 +556,9 @@ namespace OpenMS::Internal
       sqlite3_finalize(stmt);
     }
 
-    void MzMLSqliteHandler::populateSpectraWithData_(void* db_native, std::vector<MSSpectrum>& spectra) const
+    void MzMLSqliteHandler::populateSpectraWithData_(SqliteConnector& conn, std::vector<MSSpectrum>& spectra) const
     {
-      sqlite3* db = static_cast<sqlite3*>(db_native);
+      sqlite3* db = Internal::SqliteHelper::getNativeHandle(conn);
       std::string select_sql;
       select_sql = "SELECT " \
                     "SPECTRUM.ID as spec_id," \
@@ -578,11 +577,11 @@ namespace OpenMS::Internal
       sqlite3_finalize(stmt);
     }
 
-    void MzMLSqliteHandler::populateSpectraWithData_(void* db_native,
+    void MzMLSqliteHandler::populateSpectraWithData_(SqliteConnector& conn,
                                                      std::vector<MSSpectrum>& spectra,
                                                      const std::vector<int>& indices) const
     {
-      sqlite3* db = static_cast<sqlite3*>(db_native);
+      sqlite3* db = Internal::SqliteHelper::getNativeHandle(conn);
       OPENMS_PRECONDITION(!indices.empty(), "Need to select at least one index.")
       OPENMS_PRECONDITION(indices.size() == spectra.size(), "Spectra and indices need to have the same length.")
 
@@ -604,11 +603,11 @@ namespace OpenMS::Internal
       sqlite3_finalize(stmt);
     }
 
-    void MzMLSqliteHandler::prepareChroms_(void* db_native,
+    void MzMLSqliteHandler::prepareChroms_(SqliteConnector& conn,
                                            std::vector<MSChromatogram>& chromatograms,
                                            const std::vector<int>& indices) const
     {
-      sqlite3* db = static_cast<sqlite3*>(db_native);
+      sqlite3* db = Internal::SqliteHelper::getNativeHandle(conn);
       sqlite3_stmt* stmt;
       std::string select_sql = "SELECT " \
                     "CHROMATOGRAM.ID as chrom_id," \
@@ -723,11 +722,11 @@ namespace OpenMS::Internal
       sqlite3_finalize(stmt);
     }
 
-    void MzMLSqliteHandler::prepareSpectra_(void* db_native,
+    void MzMLSqliteHandler::prepareSpectra_(SqliteConnector& conn,
                                             std::vector<MSSpectrum>& spectra,
                                             const std::vector<int> & indices) const
     {
-      sqlite3* db = static_cast<sqlite3*>(db_native);
+      sqlite3* db = Internal::SqliteHelper::getNativeHandle(conn);
       sqlite3_stmt * stmt;
       std::string select_sql = "SELECT " \
                     "SPECTRUM.ID as spec_id," \

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
@@ -12,7 +12,7 @@
 #include <OpenMS/FORMAT/Base64.h>
 #include <OpenMS/FORMAT/MSNumpressCoder.h>
 #include <OpenMS/FORMAT/MzMLFile.h> // for writing to stringstream
-#include <OpenMS/FORMAT/SqliteConnector.h>
+#include <OpenMS/FORMAT/SqliteConnector_impl.h>
 #include <OpenMS/FORMAT/ZlibCompression.h>
 
 #include <OpenMS/SYSTEM/PathUtils.h>
@@ -280,7 +280,7 @@ namespace OpenMS::Internal
     void MzMLSqliteHandler::readExperiment(MSExperiment& exp, bool meta_only) const
     {
       SqliteConnector conn(filename_);
-      sqlite3* db = conn.getDB();
+      sqlite3* db = Internal::SqliteHelper::getNativeHandle(conn);
 
       Size nr_results = 0;
       if (write_full_meta_)
@@ -295,7 +295,7 @@ namespace OpenMS::Internal
           ";";
 
         sqlite3_stmt* stmt;
-        conn.prepareStatement(&stmt, select_sql);
+        Internal::SqliteHelper::prepareStatement(conn, &stmt, select_sql);
         sqlite3_step(stmt);
 
         // read data (throw exception if we find multiple runs)
@@ -370,7 +370,7 @@ namespace OpenMS::Internal
       std::string select_sql = "SELECT RUN.ID FROM RUN;";
 
       sqlite3_stmt* stmt;
-      conn.prepareStatement(&stmt, select_sql);
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, select_sql);
       Sql::SqlState state = Sql::SqlState::SQL_ROW;
       UInt64 id;
       while ((state = Sql::nextRow(stmt, state)) == Sql::SqlState::SQL_ROW)
@@ -395,7 +395,7 @@ namespace OpenMS::Internal
       // creates the spectra but does not fill them with data (provides option
       // to return meta-data only)
       SqliteConnector conn(filename_);
-      prepareSpectra_(conn.getDB(), exp, indices);
+      prepareSpectra_(Internal::SqliteHelper::getNativeHandle(conn), exp, indices);
       if (indices.size() != exp.size())
       {
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, 
@@ -408,7 +408,7 @@ namespace OpenMS::Internal
         return;
       }
 
-      populateSpectraWithData_(conn.getDB(), exp, indices);
+      populateSpectraWithData_(Internal::SqliteHelper::getNativeHandle(conn), exp, indices);
     }
 
     void MzMLSqliteHandler::readChromatograms(std::vector<MSChromatogram> & exp,
@@ -420,7 +420,7 @@ namespace OpenMS::Internal
       // creates the chromatograms but does not fill them with data (provides
       // option to return meta-data only)
       SqliteConnector conn(filename_);
-      prepareChroms_(conn.getDB(), exp, indices);
+      prepareChroms_(Internal::SqliteHelper::getNativeHandle(conn), exp, indices);
       if (indices.size() != exp.size())
       {
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, 
@@ -433,7 +433,7 @@ namespace OpenMS::Internal
         return;
       }
 
-      populateChromatogramsWithData_(conn.getDB(), exp, indices);
+      populateChromatogramsWithData_(Internal::SqliteHelper::getNativeHandle(conn), exp, indices);
     }
 
     Size MzMLSqliteHandler::getNrSpectra() const
@@ -442,7 +442,7 @@ namespace OpenMS::Internal
 
       int ret(0);
       sqlite3_stmt* stmt;
-      conn.prepareStatement(&stmt, "SELECT COUNT(*) FROM SPECTRUM;");
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, "SELECT COUNT(*) FROM SPECTRUM;");
       sqlite3_step(stmt);
       Sql::extractValue<int>(&ret, stmt, 0);
       sqlite3_finalize(stmt);
@@ -481,7 +481,7 @@ namespace OpenMS::Internal
 
       // Execute SQL statement
       sqlite3_stmt * stmt;
-      conn.prepareStatement(&stmt, select_sql);
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, select_sql);
       sqlite3_step(stmt);
 
       std::vector<size_t> result;
@@ -501,7 +501,7 @@ namespace OpenMS::Internal
       int ret(0);
 
       sqlite3_stmt* stmt;
-      conn.prepareStatement(&stmt, "SELECT COUNT(*) FROM CHROMATOGRAM;");
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, "SELECT COUNT(*) FROM CHROMATOGRAM;");
       sqlite3_step(stmt);
       Sql::extractValue<int>(&ret, stmt, 0);
       sqlite3_finalize(stmt);
@@ -509,8 +509,9 @@ namespace OpenMS::Internal
       return (Size)ret;
     }
 
-    void MzMLSqliteHandler::populateChromatogramsWithData_(sqlite3* db, std::vector<MSChromatogram>& chromatograms) const
+    void MzMLSqliteHandler::populateChromatogramsWithData_(void* db_native, std::vector<MSChromatogram>& chromatograms) const
     {
+      sqlite3* db = static_cast<sqlite3*>(db_native);
       std::string select_sql;
       select_sql = "SELECT " \
                     "CHROMATOGRAM.ID as chrom_id," \
@@ -525,15 +526,16 @@ namespace OpenMS::Internal
 
       // Execute SQL statement
       sqlite3_stmt* stmt;
-      SqliteConnector::prepareStatement(db, &stmt, select_sql);
+      Internal::SqliteHelper::prepareStatement(db, &stmt, select_sql);
       populateContainer_sub_<MSChromatogram>(stmt, chromatograms);
       sqlite3_finalize(stmt);
     }
 
-    void MzMLSqliteHandler::populateChromatogramsWithData_(sqlite3* db,
+    void MzMLSqliteHandler::populateChromatogramsWithData_(void* db_native,
                                                            std::vector<MSChromatogram>& chromatograms,
                                                            const std::vector<int>& indices) const
     {
+      sqlite3* db = static_cast<sqlite3*>(db_native);
       OPENMS_PRECONDITION(!indices.empty(), "Need to select at least one index.")
       OPENMS_PRECONDITION(indices.size() == chromatograms.size(), "Chromatograms and indices need to have the same length.")
 
@@ -550,13 +552,14 @@ namespace OpenMS::Internal
 
       // Execute SQL statement
       sqlite3_stmt* stmt;
-      SqliteConnector::prepareStatement(db, &stmt, select_sql);
+      Internal::SqliteHelper::prepareStatement(db, &stmt, select_sql);
       populateContainer_sub_<MSChromatogram>(stmt, chromatograms);
       sqlite3_finalize(stmt);
     }
 
-    void MzMLSqliteHandler::populateSpectraWithData_(sqlite3* db, std::vector<MSSpectrum>& spectra) const
+    void MzMLSqliteHandler::populateSpectraWithData_(void* db_native, std::vector<MSSpectrum>& spectra) const
     {
+      sqlite3* db = static_cast<sqlite3*>(db_native);
       std::string select_sql;
       select_sql = "SELECT " \
                     "SPECTRUM.ID as spec_id," \
@@ -570,15 +573,16 @@ namespace OpenMS::Internal
 
       // Execute SQL statement
       sqlite3_stmt* stmt;
-      SqliteConnector::prepareStatement(db, &stmt, select_sql);
+      Internal::SqliteHelper::prepareStatement(db, &stmt, select_sql);
       populateContainer_sub_<MSSpectrum>(stmt, spectra);
       sqlite3_finalize(stmt);
     }
 
-    void MzMLSqliteHandler::populateSpectraWithData_(sqlite3* db,
+    void MzMLSqliteHandler::populateSpectraWithData_(void* db_native,
                                                      std::vector<MSSpectrum>& spectra,
                                                      const std::vector<int>& indices) const
     {
+      sqlite3* db = static_cast<sqlite3*>(db_native);
       OPENMS_PRECONDITION(!indices.empty(), "Need to select at least one index.")
       OPENMS_PRECONDITION(indices.size() == spectra.size(), "Spectra and indices need to have the same length.")
 
@@ -595,15 +599,16 @@ namespace OpenMS::Internal
 
       // Execute SQL statement
       sqlite3_stmt* stmt;
-      SqliteConnector::prepareStatement(db, &stmt, select_sql);
+      Internal::SqliteHelper::prepareStatement(db, &stmt, select_sql);
       populateContainer_sub_<MSSpectrum>(stmt, spectra);
       sqlite3_finalize(stmt);
     }
 
-    void MzMLSqliteHandler::prepareChroms_(sqlite3* db,
+    void MzMLSqliteHandler::prepareChroms_(void* db_native,
                                            std::vector<MSChromatogram>& chromatograms,
                                            const std::vector<int>& indices) const
     {
+      sqlite3* db = static_cast<sqlite3*>(db_native);
       sqlite3_stmt* stmt;
       std::string select_sql = "SELECT " \
                     "CHROMATOGRAM.ID as chrom_id," \
@@ -638,7 +643,7 @@ namespace OpenMS::Internal
       // from sqlite3_column_blob(), sqlite3_column_text(), etc. into
       // sqlite3_free().
 
-      SqliteConnector::prepareStatement(db, &stmt, select_sql);
+      Internal::SqliteHelper::prepareStatement(db, &stmt, select_sql);
       sqlite3_step(stmt);
       std::string tmp;
       while (sqlite3_column_type( stmt, 0 ) != SQLITE_NULL)
@@ -718,10 +723,11 @@ namespace OpenMS::Internal
       sqlite3_finalize(stmt);
     }
 
-    void MzMLSqliteHandler::prepareSpectra_(sqlite3 *db,
+    void MzMLSqliteHandler::prepareSpectra_(void* db_native,
                                             std::vector<MSSpectrum>& spectra,
                                             const std::vector<int> & indices) const
     {
+      sqlite3* db = static_cast<sqlite3*>(db_native);
       sqlite3_stmt * stmt;
       std::string select_sql = "SELECT " \
                     "SPECTRUM.ID as spec_id," \
@@ -759,7 +765,7 @@ namespace OpenMS::Internal
       // from sqlite3_column_blob(), sqlite3_column_text(), etc. into
       // sqlite3_free().
 
-      SqliteConnector::prepareStatement(db, &stmt, select_sql);
+      Internal::SqliteHelper::prepareStatement(db, &stmt, select_sql);
       sqlite3_step(stmt);
       std::string tmp;
       while (sqlite3_column_type(stmt, 0) != SQLITE_NULL)

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSqliteSwathHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSqliteSwathHandler.cpp
@@ -11,7 +11,7 @@
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 
-#include <OpenMS/FORMAT/SqliteConnector.h>
+#include <OpenMS/FORMAT/SqliteConnector_impl.h>
 #include <sqlite3.h>
 
 namespace OpenMS::Internal
@@ -36,7 +36,7 @@ namespace OpenMS::Internal
                     "WHERE MSLEVEL == 2 "\
                     ";";
 
-      conn.prepareStatement(&stmt, select_sql);
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, select_sql);
       sqlite3_step( stmt );
 
       while (sqlite3_column_type( stmt, 0 ) != SQLITE_NULL)
@@ -66,7 +66,7 @@ namespace OpenMS::Internal
                    "FROM SPECTRUM " \
                    "WHERE MSLEVEL == 1;";
 
-      conn.prepareStatement(&stmt, select_sql);
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, select_sql);
       sqlite3_step(stmt);
 
       while (sqlite3_column_type(stmt, 0) != SQLITE_NULL)
@@ -95,7 +95,7 @@ namespace OpenMS::Internal
                           "WHERE ISOLATION_TARGET BETWEEN ";
 
       select_sql +=StringUtils::toStr(center - 0.01) + " AND " + StringUtils::toStr(center + 0.01) + ";";
-      conn.prepareStatement(&stmt, select_sql);
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, select_sql);
       sqlite3_step(stmt);
 
       while (sqlite3_column_type( stmt, 0 ) != SQLITE_NULL)

--- a/src/openms/source/FORMAT/OSWFile.cpp
+++ b/src/openms/source/FORMAT/OSWFile.cpp
@@ -13,6 +13,7 @@
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/SYSTEM/File.h>
 
+#include <OpenMS/FORMAT/SqliteConnector_impl.h>
 #include <sqlite3.h>
 
 #include <algorithm>
@@ -145,7 +146,7 @@ namespace OpenMS
     {
       std::vector<std::string> columns;
       sqlite3_stmt* stmt = nullptr;
-      conn.prepareStatement(&stmt, "PRAGMA table_info('" + table_name + "');");
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, "PRAGMA table_info('" + table_name + "');");
       Sql::SqlState state = Sql::nextRow(stmt);
       while (state == Sql::SqlState::SQL_ROW)
       {
@@ -350,7 +351,7 @@ namespace OpenMS
       }
 
       // Execute SQL select statement
-      conn.prepareStatement(&stmt, select_sql);
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, select_sql);
       sqlite3_step(stmt);
 
       int cols = sqlite3_column_count(stmt);
@@ -538,7 +539,7 @@ namespace OpenMS
 
       std::string select_sql = "select PROTEIN.ID as prot_id, PROTEIN_ACCESSION as prot_accession from PROTEIN order by prot_id";
       sqlite3_stmt* stmt;
-      conn_.prepareStatement(&stmt, select_sql);
+      Internal::SqliteHelper::prepareStatement(conn_, &stmt, select_sql);
       enum CBIG
       { // indices of respective columns in the query above
         I_PROTID,
@@ -823,7 +824,7 @@ namespace OpenMS
 
 
       sqlite3_stmt* stmt;
-      conn_.prepareStatement(&stmt, select_sql);
+      Internal::SqliteHelper::prepareStatement(conn_, &stmt, select_sql);
 
       Sql::SqlState rc = Sql::nextRow(stmt);
       if (sqlite3_column_count(stmt) != SIZE_OF_ColProteinSelect)
@@ -871,7 +872,7 @@ namespace OpenMS
 
       const std::string query = "SELECT ID, FILENAME FROM RUN ORDER BY ID;";
       sqlite3_stmt* stmt = nullptr;
-      conn.prepareStatement(&stmt, query);
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, query);
 
       std::map<Int64, std::string> run_names;
       Sql::SqlState state = Sql::nextRow(stmt);
@@ -903,7 +904,7 @@ namespace OpenMS
       std::string select_sql = "SELECT RUN.ID FROM RUN;";
 
       sqlite3_stmt* stmt;
-      conn.prepareStatement(&stmt, select_sql);
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, select_sql);
       Sql::SqlState state = Sql::SqlState::SQL_ROW;
       UInt64 id;
       while ((state = Sql::nextRow(stmt, state)) == Sql::SqlState::SQL_ROW)
@@ -1010,8 +1011,8 @@ namespace OpenMS
       }
 
       sqlite3_stmt* stmt = nullptr;
-      conn.prepareStatement(&stmt, query);
-      checkSqliteReturnCode_(conn.getDB(), sqlite3_bind_double(stmt, 1, config.ipf_max_peakgroup_pep),
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, query);
+      checkSqliteReturnCode_(Internal::SqliteHelper::getNativeHandle(conn), sqlite3_bind_double(stmt, 1, config.ipf_max_peakgroup_pep),
                              "Failed to bind ipf_max_peakgroup_pep for precursor query");
 
       std::vector<IPFPrecursorRow> rows;
@@ -1058,7 +1059,7 @@ namespace OpenMS
           "GROUP BY SCORE_TRANSITION.FEATURE_ID "
           "ORDER BY SCORE_TRANSITION.FEATURE_ID;";
         sqlite3_stmt* stmt = nullptr;
-        conn.prepareStatement(&stmt, num_query);
+        Internal::SqliteHelper::prepareStatement(conn, &stmt, num_query);
         Sql::SqlState state = Sql::nextRow(stmt);
         while (state == Sql::SqlState::SQL_ROW)
         {
@@ -1078,7 +1079,7 @@ namespace OpenMS
           "WHERE TRANSITION.TYPE != '' AND TRANSITION.DECOY = 0 "
           "ORDER BY TRANSITION.ID, TRANSITION_PEPTIDE_MAPPING.PEPTIDE_ID;";
         sqlite3_stmt* stmt = nullptr;
-        conn.prepareStatement(&stmt, bitmask_query);
+        Internal::SqliteHelper::prepareStatement(conn, &stmt, bitmask_query);
         Sql::SqlState state = Sql::nextRow(stmt);
         while (state == Sql::SqlState::SQL_ROW)
         {
@@ -1104,9 +1105,9 @@ namespace OpenMS
 
       sqlite3_stmt* evidence_stmt = nullptr;
       sqlite3_stmt* candidate_stmt = nullptr;
-      conn.prepareStatement(&evidence_stmt, evidence_query);
-      conn.prepareStatement(&candidate_stmt, candidate_query);
-      checkSqliteReturnCode_(conn.getDB(), sqlite3_bind_double(evidence_stmt, 1, config.ipf_max_transition_pep),
+      Internal::SqliteHelper::prepareStatement(conn, &evidence_stmt, evidence_query);
+      Internal::SqliteHelper::prepareStatement(conn, &candidate_stmt, candidate_query);
+      checkSqliteReturnCode_(Internal::SqliteHelper::getNativeHandle(conn), sqlite3_bind_double(evidence_stmt, 1, config.ipf_max_transition_pep),
                              "Failed to bind ipf_max_transition_pep for transition query");
 
       struct CompactEvidenceRow
@@ -1232,10 +1233,10 @@ namespace OpenMS
         "ORDER BY ALIGNMENT_GROUP_ID, FEATURE_LIST.FEATURE_ID;";
 
       sqlite3_stmt* stmt = nullptr;
-      conn.prepareStatement(&stmt, query);
-      checkSqliteReturnCode_(conn.getDB(), sqlite3_bind_double(stmt, 1, config.ipf_min_alignment_mapping_confidence),
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, query);
+      checkSqliteReturnCode_(Internal::SqliteHelper::getNativeHandle(conn), sqlite3_bind_double(stmt, 1, config.ipf_min_alignment_mapping_confidence),
                              "Failed to bind ipf_min_alignment_mapping_confidence for candidate alignment query");
-      checkSqliteReturnCode_(conn.getDB(), sqlite3_bind_double(stmt, 2, config.ipf_min_alignment_mapping_confidence),
+      checkSqliteReturnCode_(Internal::SqliteHelper::getNativeHandle(conn), sqlite3_bind_double(stmt, 2, config.ipf_min_alignment_mapping_confidence),
                              "Failed to bind ipf_min_alignment_mapping_confidence for candidate alignment query");
 
       std::vector<IPFAlignmentRow> rows;
@@ -1279,8 +1280,8 @@ namespace OpenMS
         "ORDER BY ALIGNMENT_GROUP_ID, FEATURE_LIST.FEATURE_ID;";
 
       sqlite3_stmt* stmt = nullptr;
-      conn.prepareStatement(&stmt, query);
-      checkSqliteReturnCode_(conn.getDB(), sqlite3_bind_double(stmt, 1, ipf_max_alignment_pep),
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, query);
+      checkSqliteReturnCode_(Internal::SqliteHelper::getNativeHandle(conn), sqlite3_bind_double(stmt, 1, ipf_max_alignment_pep),
                              "Failed to bind ipf_max_alignment_pep for historical alignment query");
 
       std::vector<IPFAlignmentRow> rows;
@@ -1300,7 +1301,7 @@ namespace OpenMS
     {
       const std::string target_filename = prepareOutputFile_(filename_, output_filename);
       SqliteConnector conn(target_filename, SqliteConnector::SqlOpenMode::READWRITE);
-      sqlite3* db = conn.getDB();
+      sqlite3* db = Internal::SqliteHelper::getNativeHandle(conn);
 
       conn.executeStatement("DROP TABLE IF EXISTS SCORE_IPF;");
       conn.executeStatement(
@@ -1313,7 +1314,7 @@ namespace OpenMS
       );
 
       sqlite3_stmt* stmt = nullptr;
-      conn.prepareStatement(&stmt,
+      Internal::SqliteHelper::prepareStatement(conn, &stmt,
         "INSERT INTO SCORE_IPF (FEATURE_ID, PEPTIDE_ID, PRECURSOR_PEAKGROUP_PEP, QVALUE, PEP) "
         "VALUES (?, ?, ?, ?, ?);");
 
@@ -1457,7 +1458,7 @@ namespace OpenMS
         "ORDER BY RUN_ID, ENTITY_ID;";
 
       sqlite3_stmt* stmt = nullptr;
-      conn.prepareStatement(&stmt, query);
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, query);
 
       std::vector<LevelContextInputRow> rows;
       Sql::SqlState state = Sql::nextRow(stmt);
@@ -1496,7 +1497,7 @@ namespace OpenMS
 
       const std::string target_filename = prepareOutputFile_(filename_, output_filename);
       SqliteConnector conn(target_filename, SqliteConnector::SqlOpenMode::READWRITE);
-      sqlite3* db = conn.getDB();
+      sqlite3* db = Internal::SqliteHelper::getNativeHandle(conn);
 
       const std::string table_name = scoreTableName_(level);
       const std::string entity_column = entityIdColumnName_(level);
@@ -1514,8 +1515,8 @@ namespace OpenMS
 
       sqlite3_stmt* delete_stmt = nullptr;
       sqlite3_stmt* insert_stmt = nullptr;
-      conn.prepareStatement(&delete_stmt, "DELETE FROM " + table_name + " WHERE CONTEXT = ?;");
-      conn.prepareStatement(&insert_stmt,
+      Internal::SqliteHelper::prepareStatement(conn, &delete_stmt, "DELETE FROM " + table_name + " WHERE CONTEXT = ?;");
+      Internal::SqliteHelper::prepareStatement(conn, &insert_stmt,
         "INSERT INTO " + table_name + " (CONTEXT, RUN_ID, " + entity_column + ", SCORE, PVALUE, QVALUE, PEP) "
         "VALUES (?, ?, ?, ?, ?, ?, ?);");
 
@@ -1599,12 +1600,12 @@ namespace OpenMS
                           const bool augmented_mode) -> std::vector<OpenSwathExportRow>
       {
         sqlite3_stmt* stmt = nullptr;
-        conn.prepareStatement(&stmt, query);
-        checkSqliteReturnCode_(conn.getDB(), sqlite3_bind_double(stmt, 1, config.max_rs_peakgroup_qvalue),
+        Internal::SqliteHelper::prepareStatement(conn, &stmt, query);
+        checkSqliteReturnCode_(Internal::SqliteHelper::getNativeHandle(conn), sqlite3_bind_double(stmt, 1, config.max_rs_peakgroup_qvalue),
                                "Failed to bind max_rs_peakgroup_qvalue for export query");
         if (peptidoform_mode)
         {
-          checkSqliteReturnCode_(conn.getDB(), sqlite3_bind_double(stmt, 2, config.ipf_max_peptidoform_pep),
+          checkSqliteReturnCode_(Internal::SqliteHelper::getNativeHandle(conn), sqlite3_bind_double(stmt, 2, config.ipf_max_peptidoform_pep),
                                  "Failed to bind ipf_max_peptidoform_pep for export query");
         }
 
@@ -1745,13 +1746,13 @@ namespace OpenMS
       if (config.ipf_mode == OpenSwathIPFExportMode::Augmented && has_score_ipf)
       {
         sqlite3_stmt* stmt = nullptr;
-        conn.prepareStatement(&stmt,
+        Internal::SqliteHelper::prepareStatement(conn, &stmt,
           "SELECT SCORE_IPF.FEATURE_ID, PEPTIDE.MODIFIED_SEQUENCE, SCORE_IPF.PRECURSOR_PEAKGROUP_PEP, SCORE_IPF.PEP, SCORE_IPF.QVALUE "
           "FROM SCORE_IPF "
           "INNER JOIN PEPTIDE ON SCORE_IPF.PEPTIDE_ID = PEPTIDE.ID "
           "WHERE SCORE_IPF.PEP < ? "
           "ORDER BY SCORE_IPF.FEATURE_ID, SCORE_IPF.PEP, PEPTIDE.MODIFIED_SEQUENCE;");
-        checkSqliteReturnCode_(conn.getDB(), sqlite3_bind_double(stmt, 1, config.ipf_max_peptidoform_pep),
+        checkSqliteReturnCode_(Internal::SqliteHelper::getNativeHandle(conn), sqlite3_bind_double(stmt, 1, config.ipf_max_peptidoform_pep),
                                "Failed to bind ipf_max_peptidoform_pep for augmented export");
         std::unordered_map<Int64, OpenSwathExportRow> ipf_best;
         Sql::SqlState state = Sql::nextRow(stmt);
@@ -1786,7 +1787,7 @@ namespace OpenMS
       auto assignStringMap = [&](const std::string& query, auto&& assign_fn)
       {
         sqlite3_stmt* stmt = nullptr;
-        conn.prepareStatement(&stmt, query);
+        Internal::SqliteHelper::prepareStatement(conn, &stmt, query);
         Sql::SqlState state = Sql::nextRow(stmt);
         while (state == Sql::SqlState::SQL_ROW)
         {
@@ -1849,10 +1850,10 @@ namespace OpenMS
           "INNER JOIN TRANSITION ON FEATURE_TRANSITION.TRANSITION_ID = TRANSITION.ID "
           "GROUP BY FEATURE_TRANSITION.FEATURE_ID;";
         sqlite3_stmt* stmt = nullptr;
-        conn.prepareStatement(&stmt, transition_query);
+        Internal::SqliteHelper::prepareStatement(conn, &stmt, transition_query);
         if (conn.tableExists("SCORE_TRANSITION"))
         {
-          checkSqliteReturnCode_(conn.getDB(), sqlite3_bind_double(stmt, 1, config.max_transition_pep),
+          checkSqliteReturnCode_(Internal::SqliteHelper::getNativeHandle(conn), sqlite3_bind_double(stmt, 1, config.max_transition_pep),
                                  "Failed to bind max_transition_pep for export transition aggregation");
         }
         Sql::SqlState state = Sql::nextRow(stmt);
@@ -2009,7 +2010,7 @@ namespace OpenMS
       if (config.use_alignment && hasLegacyExportAlignment_(conn))
       {
         sqlite3_stmt* stmt = nullptr;
-        conn.prepareStatement(&stmt,
+        Internal::SqliteHelper::prepareStatement(conn, &stmt,
           "SELECT DENSE_RANK() OVER (ORDER BY FEATURE_MS2_ALIGNMENT.PRECURSOR_ID, FEATURE_MS2_ALIGNMENT.ALIGNMENT_ID) AS ALIGNMENT_GROUP_ID, "
           "       FEATURE_MS2_ALIGNMENT.ALIGNED_FEATURE_ID, "
           "       CAST(FEATURE_MS2_ALIGNMENT.REFERENCE_FEATURE_ID AS INTEGER), "
@@ -2025,9 +2026,9 @@ namespace OpenMS
           "WHERE FEATURE_MS2_ALIGNMENT.LABEL = 1 "
           "  AND ALIGN_SCORE.PEP < ? "
           "  AND REF_SCORE_MS2.QVALUE < ?;");
-        checkSqliteReturnCode_(conn.getDB(), sqlite3_bind_double(stmt, 1, config.max_alignment_pep),
+        checkSqliteReturnCode_(Internal::SqliteHelper::getNativeHandle(conn), sqlite3_bind_double(stmt, 1, config.max_alignment_pep),
                                "Failed to bind max_alignment_pep for export alignment query");
-        checkSqliteReturnCode_(conn.getDB(), sqlite3_bind_double(stmt, 2, config.max_rs_peakgroup_qvalue),
+        checkSqliteReturnCode_(Internal::SqliteHelper::getNativeHandle(conn), sqlite3_bind_double(stmt, 2, config.max_rs_peakgroup_qvalue),
                                "Failed to bind max_rs_peakgroup_qvalue for export alignment query");
 
         struct AlignmentInfo
@@ -2342,7 +2343,7 @@ namespace OpenMS
         + "ORDER BY PRECURSOR.ID, FEATURE.ID;";
 
       sqlite3_stmt* stmt = nullptr;
-      conn.prepareStatement(&stmt, query);
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, query);
       Sql::SqlState state = Sql::nextRow(stmt);
       while (state == Sql::SqlState::SQL_ROW)
       {
@@ -2576,7 +2577,7 @@ namespace OpenMS
         "ORDER BY TRANSITION_PRECURSOR_MAPPING.PRECURSOR_ID, TRANSITION.ID, FEATURE_TRANSITION.FEATURE_ID;";
 
       sqlite3_stmt* stmt = nullptr;
-      conn.prepareStatement(&stmt, query);
+      Internal::SqliteHelper::prepareStatement(conn, &stmt, query);
       Sql::SqlState state = Sql::nextRow(stmt);
       while (state == Sql::SqlState::SQL_ROW)
       {
@@ -2658,7 +2659,7 @@ namespace OpenMS
 
       std::string select_transitions = "SELECT " + ListUtils::concatenate(colnames_tr, ",") + " FROM TRANSITION ORDER BY ID;";
       sqlite3_stmt* stmt;
-      conn_.prepareStatement(&stmt, select_transitions);
+      Internal::SqliteHelper::prepareStatement(conn_, &stmt, select_transitions);
       Sql::SqlState rc = Sql::nextRow(stmt);
       while (rc == Sql::SqlState::SQL_ROW)
       {

--- a/src/openms/source/FORMAT/SqliteConnector.cpp
+++ b/src/openms/source/FORMAT/SqliteConnector.cpp
@@ -6,11 +6,9 @@
 // $Authors: Hannes Roest $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/FORMAT/SqliteConnector.h>
+#include <OpenMS/FORMAT/SqliteConnector_impl.h>
 
 #include <OpenMS/CONCEPT/Exception.h>
-
-#include <sqlite3.h>
 
 #include <cstring> // for strcmp
 #include <iostream>
@@ -21,9 +19,10 @@ namespace OpenMS
   {
     openDatabase_(filename, mode);
   }
+
   SqliteConnector::~SqliteConnector()
   {
-    int rc = sqlite3_close_v2(db_);
+    int rc = sqlite3_close_v2(static_cast<sqlite3*>(db_));
     if (rc != SQLITE_OK)
     {
       std::cout << " Encountered error in ~SqliteConnector: " << rc << std::endl;
@@ -46,54 +45,41 @@ namespace OpenMS
         flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
         break;
     }
-    int rc = sqlite3_open_v2(filename.c_str(), &db_, flags, nullptr);
+    sqlite3* db = nullptr;
+    int rc = sqlite3_open_v2(filename.c_str(), &db, flags, nullptr);
+    db_ = db;
     if (rc)
     {
       throw Exception::SqlOperationFailed(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Could not open sqlite db '" + filename + "' in mode " + StringUtils::toStr(int(mode)));
     }
   }
 
-  bool SqliteConnector::columnExists(sqlite3 *db, const std::string& tablename, const std::string& colname)
+  bool SqliteConnector::tableExists(const std::string& tablename)
   {
-    bool found = false;
-
-    sqlite3_stmt* xcntstmt;
-    prepareStatement(db, &xcntstmt, "PRAGMA table_info(" + tablename + ")");
-
-    // Go through all columns and check whether the required column exists
-    sqlite3_step(xcntstmt);
-    while (sqlite3_column_type(xcntstmt, 0) != SQLITE_NULL)
-    {
-      if (strcmp(colname.c_str(), reinterpret_cast<const char*>(sqlite3_column_text(xcntstmt, 1))) == 0)
-      {
-        found = true;
-        break;
-      }
-      sqlite3_step(xcntstmt);
-    }
-    sqlite3_finalize(xcntstmt);
-
-    return found;
+    return Internal::SqliteHelper::tableExists(static_cast<sqlite3*>(db_), tablename);
   }
 
-  bool SqliteConnector::tableExists(sqlite3 *db, const std::string& tablename)
+  bool SqliteConnector::columnExists(const std::string& tablename, const std::string& colname)
   {
-    sqlite3_stmt* stmt;
-    prepareStatement(db, &stmt, "SELECT 1 FROM sqlite_master WHERE type='table' AND name='" + tablename + "';");
+    return Internal::SqliteHelper::columnExists(static_cast<sqlite3*>(db_), tablename, colname);
+  }
 
-    sqlite3_step(stmt);
-    // if we get a row back, the table exists:
-    bool found = (sqlite3_column_type(stmt, 0) != SQLITE_NULL);
-    sqlite3_finalize(stmt);
+  void SqliteConnector::executeStatement(const std::string& statement)
+  {
+    Internal::SqliteHelper::executeStatement(static_cast<sqlite3*>(db_), statement);
+  }
 
-    return found;
+  void SqliteConnector::executeBindStatement(const std::string& prepare_statement, const std::vector<std::string>& data)
+  {
+    Internal::SqliteHelper::executeBindStatement(static_cast<sqlite3*>(db_), prepare_statement, data);
   }
 
   Size SqliteConnector::countTableRows(const std::string& table_name)
   {
+    sqlite3* db = static_cast<sqlite3*>(db_);
     sqlite3_stmt* stmt;
     std::string select_runs = "SELECT count(*) FROM " + table_name + ";";
-    this->prepareStatement(&stmt, select_runs);
+    Internal::SqliteHelper::prepareStatement(db, &stmt, select_runs);
     sqlite3_step(stmt);
     if (sqlite3_column_type(stmt, 0) == SQLITE_NULL)
     {
@@ -104,66 +90,101 @@ namespace OpenMS
     return res;
   }
 
-  void SqliteConnector::executeStatement(sqlite3 *db, const std::string& statement)
-  {
-    char *zErrMsg = nullptr;
-    int rc = sqlite3_exec(db, statement.c_str(), nullptr /* callback */, nullptr, &zErrMsg);
-    if (rc != SQLITE_OK)
-    {
-      std::string error(zErrMsg);
-      std::cerr << "Error message after sqlite3_exec" << std::endl;
-      std::cerr << "Prepared statement " << statement << std::endl;
-      sqlite3_free(zErrMsg);
-      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, error);
-    }
-  }
-
-  void SqliteConnector::prepareStatement(sqlite3 *db, sqlite3_stmt** stmt, const std::string& prepare_statement)
-  {
-    int rc = sqlite3_prepare_v2(db, prepare_statement.c_str(), (int)prepare_statement.size(), stmt, nullptr);
-    if (rc != SQLITE_OK)
-    {
-      std::cerr << "Error message after sqlite3_prepare_v2" << std::endl;
-      std::cerr << "Prepared statement " << prepare_statement << std::endl;
-      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, sqlite3_errmsg(db));
-    }
-  }
-
-  void SqliteConnector::executeBindStatement(sqlite3 *db, const std::string& prepare_statement, const std::vector<std::string>& data)
-  {
-    int rc;
-    sqlite3_stmt *stmt = nullptr;
-    prepareStatement(db, &stmt, prepare_statement);
-    for (Size k = 0; k < data.size(); k++)
-    {
-      // Fifth argument is a destructor for the blob.
-      // SQLITE_STATIC because the statement is finalized
-      // before the buffer is freed:
-      rc = sqlite3_bind_blob(stmt, k+1, data[k].c_str(), (int)data[k].size(), SQLITE_STATIC);
-      if (rc != SQLITE_OK)
-      {
-        std::cerr << "SQL error after sqlite3_bind_blob at iteration " << k << std::endl;
-        std::cerr << "Prepared statement " << prepare_statement << std::endl;
-        // TODO this is a mem-leak (missing sqlite3_finalize())
-        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, sqlite3_errmsg(db));
-      }
-    }
-
-    rc = sqlite3_step(stmt);
-    if (rc != SQLITE_DONE)
-    {
-      std::cerr << "SQL error after sqlite3_step" << std::endl;
-      std::cerr << "Prepared statement " << prepare_statement << std::endl;
-      // TODO this is a mem-leak (missing sqlite3_finalize())
-      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, sqlite3_errmsg(db));
-    }
-
-    // free memory
-    sqlite3_finalize(stmt);
-  }
-
   namespace Internal::SqliteHelper
     {
+      bool columnExists(sqlite3 *db, const std::string& tablename, const std::string& colname)
+      {
+        bool found = false;
+
+        sqlite3_stmt* xcntstmt;
+        prepareStatement(db, &xcntstmt, "PRAGMA table_info(" + tablename + ")");
+
+        // Go through all columns and check whether the required column exists
+        sqlite3_step(xcntstmt);
+        while (sqlite3_column_type(xcntstmt, 0) != SQLITE_NULL)
+        {
+          if (strcmp(colname.c_str(), reinterpret_cast<const char*>(sqlite3_column_text(xcntstmt, 1))) == 0)
+          {
+            found = true;
+            break;
+          }
+          sqlite3_step(xcntstmt);
+        }
+        sqlite3_finalize(xcntstmt);
+
+        return found;
+      }
+
+      bool tableExists(sqlite3 *db, const std::string& tablename)
+      {
+        sqlite3_stmt* stmt;
+        prepareStatement(db, &stmt, "SELECT 1 FROM sqlite_master WHERE type='table' AND name='" + tablename + "';");
+
+        sqlite3_step(stmt);
+        // if we get a row back, the table exists:
+        bool found = (sqlite3_column_type(stmt, 0) != SQLITE_NULL);
+        sqlite3_finalize(stmt);
+
+        return found;
+      }
+
+      void executeStatement(sqlite3 *db, const std::string& statement)
+      {
+        char *zErrMsg = nullptr;
+        int rc = sqlite3_exec(db, statement.c_str(), nullptr /* callback */, nullptr, &zErrMsg);
+        if (rc != SQLITE_OK)
+        {
+          std::string error(zErrMsg);
+          std::cerr << "Error message after sqlite3_exec" << std::endl;
+          std::cerr << "Prepared statement " << statement << std::endl;
+          sqlite3_free(zErrMsg);
+          throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, error);
+        }
+      }
+
+      void prepareStatement(sqlite3 *db, sqlite3_stmt** stmt, const std::string& prepare_statement)
+      {
+        int rc = sqlite3_prepare_v2(db, prepare_statement.c_str(), (int)prepare_statement.size(), stmt, nullptr);
+        if (rc != SQLITE_OK)
+        {
+          std::cerr << "Error message after sqlite3_prepare_v2" << std::endl;
+          std::cerr << "Prepared statement " << prepare_statement << std::endl;
+          throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, sqlite3_errmsg(db));
+        }
+      }
+
+      void executeBindStatement(sqlite3 *db, const std::string& prepare_statement, const std::vector<std::string>& data)
+      {
+        int rc;
+        sqlite3_stmt *stmt = nullptr;
+        prepareStatement(db, &stmt, prepare_statement);
+        for (Size k = 0; k < data.size(); k++)
+        {
+          // Fifth argument is a destructor for the blob.
+          // SQLITE_STATIC because the statement is finalized
+          // before the buffer is freed:
+          rc = sqlite3_bind_blob(stmt, k+1, data[k].c_str(), (int)data[k].size(), SQLITE_STATIC);
+          if (rc != SQLITE_OK)
+          {
+            std::cerr << "SQL error after sqlite3_bind_blob at iteration " << k << std::endl;
+            std::cerr << "Prepared statement " << prepare_statement << std::endl;
+            // TODO this is a mem-leak (missing sqlite3_finalize())
+            throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, sqlite3_errmsg(db));
+          }
+        }
+
+        rc = sqlite3_step(stmt);
+        if (rc != SQLITE_DONE)
+        {
+          std::cerr << "SQL error after sqlite3_step" << std::endl;
+          std::cerr << "Prepared statement " << prepare_statement << std::endl;
+          // TODO this is a mem-leak (missing sqlite3_finalize())
+          throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, sqlite3_errmsg(db));
+        }
+
+        // free memory
+        sqlite3_finalize(stmt);
+      }
 
       template <> bool extractValue<double>(double* dst, sqlite3_stmt* stmt, int pos) //explicit specialization
       {
@@ -250,7 +271,7 @@ namespace OpenMS
       double extractDouble(sqlite3_stmt* stmt, int pos)
       {
         double res;
-        if (!extractValue<double>(&res, stmt, pos)) 
+        if (!extractValue<double>(&res, stmt, pos))
         {
           throw Exception::SqlOperationFailed(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Conversion of column " + StringUtils::toStr(pos) + " to double failed");
         }
@@ -310,4 +331,3 @@ namespace OpenMS
     }
 
 }
-

--- a/src/tests/class_tests/openms/source/SqliteConnector_test.cpp
+++ b/src/tests/class_tests/openms/source/SqliteConnector_test.cpp
@@ -11,6 +11,12 @@
 
 ///////////////////////////
 
+// NOTE: this test deliberately includes only the public, SQLite-free header.
+// SQLite is a private dependency of OpenMS, so downstream consumers (like this
+// test) do not have <sqlite3.h> on their include path. The raw SQLite C API
+// (Internal::SqliteHelper, sqlite3*/sqlite3_stmt*) lives in the non-installed
+// <OpenMS/FORMAT/SqliteConnector_impl.h> and is exercised transitively by the
+// OSWFile / MzMLSqlite / TransitionPQP tests. Here we cover the public API only.
 #include <OpenMS/FORMAT/SqliteConnector.h>
 
 #include <vector>
@@ -40,7 +46,7 @@ START_SECTION((SqliteConnector(const std::string& filename, const SqlOpenMode mo
   // READWRITE_OR_CREATE creates the database if it does not exist
   ptr = new SqliteConnector(tmp_db, Mode::READWRITE_OR_CREATE);
   TEST_NOT_EQUAL(ptr, null_ptr)
-  TEST_NOT_EQUAL(ptr->getDB(), nullptr)
+  TEST_NOT_EQUAL(ptr->nativeHandle(), nullptr)
 }
 END_SECTION
 
@@ -50,10 +56,12 @@ START_SECTION((~SqliteConnector()))
 }
 END_SECTION
 
-START_SECTION((sqlite3* getDB()))
+START_SECTION((void* nativeHandle() const))
 {
+  // The public accessor returns an opaque (void*) native handle without exposing
+  // any SQLite type; it must be non-null for an opened connection.
   SqliteConnector conn(tmp_db, Mode::READWRITE_OR_CREATE);
-  TEST_NOT_EQUAL(conn.getDB(), nullptr)
+  TEST_NOT_EQUAL(conn.nativeHandle(), nullptr)
 }
 END_SECTION
 
@@ -65,7 +73,7 @@ START_SECTION((void executeStatement(const std::string& statement)))
   conn.executeStatement("INSERT INTO T (ID, NAME) VALUES (1, 'a')");
   TEST_EQUAL(conn.tableExists("T"), true)
 
-  // malformed SQL -> IllegalArgument
+  // malformed SQL -> IllegalArgument (exercises the internal prepare/exec error path)
   TEST_EXCEPTION(Exception::IllegalArgument, conn.executeStatement("THIS IS NOT SQL"))
 }
 END_SECTION
@@ -101,7 +109,7 @@ START_SECTION((Size countTableRows(const std::string& table_name)))
   conn.executeStatement("INSERT INTO T (ID, NAME) VALUES (2, 'b')");
   TEST_EQUAL(conn.countTableRows("T"), 2)
 
-  // unknown table cannot be prepared -> IllegalArgument
+  // unknown table cannot be prepared -> IllegalArgument (exercises the internal prepare error path)
   TEST_EXCEPTION(Exception::IllegalArgument, conn.countTableRows("UNKNOWN"))
 }
 END_SECTION
@@ -113,41 +121,6 @@ START_SECTION((void executeBindStatement(const std::string& prepare_statement, c
   conn.executeStatement("CREATE TABLE T (ID INT, NAME TEXT)");
   conn.executeBindStatement("INSERT INTO T (ID, NAME) VALUES (1, ?1)", std::vector<std::string>{"bound_value"});
   TEST_EQUAL(conn.countTableRows("T"), 1)
-}
-END_SECTION
-
-START_SECTION((void prepareStatement(sqlite3_stmt** stmt, const std::string& prepare_statement)))
-{
-  // The happy path is exercised transitively by tableExists/columnExists/countTableRows
-  // above. Here we cover the error path without depending on the raw sqlite3 C API
-  // (sqlite3_stmt is only forward-declared in the public header).
-  SqliteConnector conn(tmp_db, Mode::READWRITE_OR_CREATE);
-  conn.executeStatement("DROP TABLE IF EXISTS T");
-  conn.executeStatement("CREATE TABLE T (ID INT, NAME TEXT)");
-
-  // invalid statement -> IllegalArgument (no statement is allocated on failure)
-  sqlite3_stmt* bad = nullptr;
-  TEST_EXCEPTION(Exception::IllegalArgument, conn.prepareStatement(&bad, "SELECT FROM NOPE NONSENSE"))
-}
-END_SECTION
-
-START_SECTION((static bool tableExists(sqlite3* db, const std::string& tablename)))
-{
-  SqliteConnector conn(tmp_db, Mode::READWRITE_OR_CREATE);
-  conn.executeStatement("DROP TABLE IF EXISTS T");
-  conn.executeStatement("CREATE TABLE T (ID INT, NAME TEXT)");
-  TEST_EQUAL(SqliteConnector::tableExists(conn.getDB(), "T"), true)
-  TEST_EQUAL(SqliteConnector::tableExists(conn.getDB(), "NOPE"), false)
-}
-END_SECTION
-
-START_SECTION((static bool columnExists(sqlite3* db, const std::string& tablename, const std::string& colname)))
-{
-  SqliteConnector conn(tmp_db, Mode::READWRITE_OR_CREATE);
-  conn.executeStatement("DROP TABLE IF EXISTS T");
-  conn.executeStatement("CREATE TABLE T (ID INT, NAME TEXT)");
-  TEST_EQUAL(SqliteConnector::columnExists(conn.getDB(), "T", "NAME"), true)
-  TEST_EQUAL(SqliteConnector::columnExists(conn.getDB(), "T", "MISSING"), false)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/SqliteConnector_test.cpp
+++ b/src/tests/class_tests/openms/source/SqliteConnector_test.cpp
@@ -46,22 +46,15 @@ START_SECTION((SqliteConnector(const std::string& filename, const SqlOpenMode mo
   // READWRITE_OR_CREATE creates the database if it does not exist
   ptr = new SqliteConnector(tmp_db, Mode::READWRITE_OR_CREATE);
   TEST_NOT_EQUAL(ptr, null_ptr)
-  TEST_NOT_EQUAL(ptr->nativeHandle(), nullptr)
+  // a successfully opened connection is usable (the native handle is fully private)
+  ptr->executeStatement("CREATE TABLE IF NOT EXISTS liveness_check (ID INT)");
+  TEST_EQUAL(ptr->tableExists("liveness_check"), true)
 }
 END_SECTION
 
 START_SECTION((~SqliteConnector()))
 {
   delete ptr;
-}
-END_SECTION
-
-START_SECTION((void* nativeHandle() const))
-{
-  // The public accessor returns an opaque (void*) native handle without exposing
-  // any SQLite type; it must be non-null for an opened connection.
-  SqliteConnector conn(tmp_db, Mode::READWRITE_OR_CREATE);
-  TEST_NOT_EQUAL(conn.nativeHandle(), nullptr)
 }
 END_SECTION
 

--- a/src/topp/FeatureFinderMetaboIdent.cpp
+++ b/src/topp/FeatureFinderMetaboIdent.cpp
@@ -24,7 +24,6 @@
 
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
-#include <OpenMS/FORMAT/OMSFileLoad.h>
 
 #include <cmath>
 


### PR DESCRIPTION
## Summary

SQLite (via the vendored SQLiteCpp) was already a PRIVATE **link** dependency, but SQLite types still leaked into installed public headers. This removes every `sqlite3` / `sqlite3_stmt` / `SQLite::*` reference from the **installed header set**, so downstream consumers can build and link against libOpenMS without any SQLite headers on their include path. This mirrors the Xerces private-dependency work in #9712 and reuses the same `OpenMS_private_headers` (non-installed header) mechanism.

## What changed

**C API — `SqliteConnector` + `Internal::SqliteHelper` (the root leak)**
- Pimpl the native handle: `sqlite3* db_` → `void* db_`, exposed via a doc-hidden `void* nativeHandle()`.
- Move `getDB()`, the `sqlite3*`-based static helpers, and the whole `Internal::SqliteHelper` namespace into a **new non-installed** `include/OpenMS/FORMAT/SqliteConnector_impl.h`. Added `SqliteHelper::getNativeHandle(SqliteConnector&)` and a `prepareStatement(SqliteConnector&, …)` convenience overload.

**SQLiteCpp C++ API — `SQLite::Database/Statement`**
- `OMSFileStore.h` / `OMSFileLoad.h` are `Internal::` helpers → **de-installed** (moved to `OpenMS_private_headers`). Removed the unused `OMSFileLoad.h` include from `FeatureFinderMetaboIdent.cpp` (its only external includer).

**pyOpenMS-wrapped classes (must stay installed)**
- `MzMLSqliteHandler.h` / `TransitionPQPFile.h` exposed `sqlite3*` only in **private** methods → parameter changed to `void*`, cast inside the `.cpp`.
- `MzMLSqliteSwathHandler.h`: dropped a stale, unused `struct sqlite3;`.

Internal call sites now obtain the raw handle via `SqliteHelper::getNativeHandle()` and include the private impl header. `SqliteConnector_test` now covers the public, SQLite-free API only — a consumer test has no `<sqlite3.h>` on its include path, which is exactly the guarantee this PR enforces.

## Verification
- libOpenMS + pyOpenMS build clean (WITH_OPENTIMS + WITH_THERMO_RAW on, so every changed file compiled).
- 14 SQLite-related class tests pass: `SqliteConnector`, `OSWFile`(+`Inference`), `OpenSwath{Export,OSWWriter,PercolatorScoring}`, `TransitionPQPFile`, `BrukerTimsImagingFile`, `MzMLSqlite{Handler,SwathHandler}`, `OMSFile`, `SqMassFile`, `SpectrumAccessSqMass`, `CachedMzML`.
- Confirmed no actual SQLite type remains in any installed header (only doc-comment mentions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the SQLite connector so SQLite implementation details and native SQLite types are no longer exposed in installed/public headers.
  * Internal SQLite logic was consolidated behind a SQLite-free connector surface, while keeping existing file read/write, querying, and metadata workflows working as before.
  * Added internal-only support headers to separate adapter internals from the public API.

* **Tests**
  * Adjusted connector tests to focus on the public, SQLite-free interface and removed checks that depended on direct exposure of native SQLite types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->