### PR TITLE
fixes failing pyopenms tests on Windows when -DNO_DEPENDENCIES=ON, 

### DIFF
--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -245,9 +245,15 @@ else()
       ${OPENSWATHALGO_TARGET}
       Eigen3::Eigen
     )
+    # The trailing "$<0:>" is an (empty) generator expression: it makes CMake use
+    # this path verbatim instead of appending a per-configuration subdirectory on
+    # multi-config generators (Visual Studio, Xcode). Without it the modules land
+    # in pyopenms/Release/, where pyopenms/__init__.py (pkgutil.iter_modules, which
+    # does not recurse) cannot find them, and `import pyopenms` fails with
+    # "Failed to import any pyOpenMS bindings".
     set_target_properties(${target_name} PROPERTIES
-      LIBRARY_OUTPUT_DIRECTORY "${PYOPENMS_BUILD_DIR}/pyopenms"
-      RUNTIME_OUTPUT_DIRECTORY "${PYOPENMS_BUILD_DIR}/pyopenms"
+      LIBRARY_OUTPUT_DIRECTORY "${PYOPENMS_BUILD_DIR}/pyopenms/$<0:>"
+      RUNTIME_OUTPUT_DIRECTORY "${PYOPENMS_BUILD_DIR}/pyopenms/$<0:>"
     )
     if(NOT PYOPENMS_PREPARE_WHEEL_REPAIR)
       set_target_properties(${target_name} PROPERTIES
@@ -516,9 +522,33 @@ if((DEFINED OPENMS_TARGET AND TARGET ${OPENMS_TARGET}) OR TARGET OpenMS)
   # Override pyproject.toml's addopts which uses -v (verbose).
   set(_PYTEST_ARGS -m pytest -o addopts=-q\ --tb=short)
 
+  # On Windows, when NO_DEPENDENCIES=ON the OpenMS runtime libraries are not
+  # copied next to the compiled extension modules. Python >= 3.8 does not search
+  # PATH for an extension module's dependent DLLs, and Windows has no RPATH, so
+  # pyopenms/__init__.py registers the directories holding OpenMS.dll and its
+  # transitive dependencies via os.add_dll_directory(), reading them from the
+  # PYOPENMS_DLL_PATH environment variable. We set that variable for the test
+  # process with `cmake -E env` so the TARGET_FILE_DIR generator expression (the
+  # per-configuration OpenMS bin folder) is resolved; being an environment
+  # variable it also reaches child processes that some tests spawn to
+  # `import pyopenms`. Harmless no-op when the dependencies are already bundled
+  # (NO_DEPENDENCIES=OFF) and on non-Windows.
+  set(_pyopenms_test_cmd_prefix "")
+  if(WIN32)
+    set(_pyopenms_dll_dirs "$<TARGET_FILE_DIR:${OPENMS_TARGET}>")
+    string(APPEND _pyopenms_dll_dirs "$<SEMICOLON>$<TARGET_FILE_DIR:${OPENSWATHALGO_TARGET}>")
+    if(OPENMS_CONTRIB_LIBS)
+      string(APPEND _pyopenms_dll_dirs "$<SEMICOLON>${OPENMS_CONTRIB_LIBS}/lib")
+    endif()
+    if(QT_INSTALL_BINS)
+      string(APPEND _pyopenms_dll_dirs "$<SEMICOLON>${QT_INSTALL_BINS}")
+    endif()
+    set(_pyopenms_test_cmd_prefix ${CMAKE_COMMAND} -E env "PYOPENMS_DLL_PATH=${_pyopenms_dll_dirs}")
+  endif()
+
   add_test(
     NAME pyopenms_unittests
-    COMMAND ${Python_EXECUTABLE} ${_PYTEST_ARGS}
+    COMMAND ${_pyopenms_test_cmd_prefix} ${Python_EXECUTABLE} ${_PYTEST_ARGS}
       --ignore=tests/unittests/test_docstrings.py
       --ignore=tests/unittests/test_docstring_format.py
       tests/unittests
@@ -543,7 +573,7 @@ if((DEFINED OPENMS_TARGET AND TARGET ${OPENMS_TARGET}) OR TARGET OpenMS)
 
   add_test(
     NAME pyopenms_docstring_tests
-    COMMAND ${Python_EXECUTABLE} ${_PYTEST_ARGS}
+    COMMAND ${_pyopenms_test_cmd_prefix} ${Python_EXECUTABLE} ${_PYTEST_ARGS}
       tests/unittests/test_docstrings.py
       tests/unittests/test_docstring_format.py
     WORKING_DIRECTORY ${PYOPENMS_BUILD_DIR}
@@ -551,7 +581,7 @@ if((DEFINED OPENMS_TARGET AND TARGET ${OPENMS_TARGET}) OR TARGET OpenMS)
 
   add_test(
     NAME pyopenms_integration_tests
-    COMMAND ${Python_EXECUTABLE} ${_PYTEST_ARGS} tests/integration_tests
+    COMMAND ${_pyopenms_test_cmd_prefix} ${Python_EXECUTABLE} ${_PYTEST_ARGS} tests/integration_tests
     WORKING_DIRECTORY ${PYOPENMS_BUILD_DIR}
   )
 
@@ -560,7 +590,7 @@ if((DEFINED OPENMS_TARGET AND TARGET ${OPENMS_TARGET}) OR TARGET OpenMS)
   if(_pyopenms_toplevel_tests)
     add_test(
       NAME pyopenms_feature_tests
-      COMMAND ${Python_EXECUTABLE} ${_PYTEST_ARGS} ${_pyopenms_toplevel_tests}
+      COMMAND ${_pyopenms_test_cmd_prefix} ${Python_EXECUTABLE} ${_PYTEST_ARGS} ${_pyopenms_toplevel_tests}
       WORKING_DIRECTORY ${PYOPENMS_BUILD_DIR}
     )
   endif()

--- a/src/pyOpenMS/pyopenms/__init__.py
+++ b/src/pyOpenMS/pyopenms/__init__.py
@@ -171,6 +171,26 @@ if sys.platform.startswith("linux") and os.path.exists(os.path.join(here, "libOp
     ctypes.cdll.LoadLibrary(os.path.join(here, "libOpenMS.so"))
 
 
+# On Windows, Python >= 3.8 no longer uses PATH to resolve an extension module's
+# dependent DLLs; only the module's own directory, System32 and directories
+# registered via os.add_dll_directory() are searched. A wheel ships OpenMS.dll and
+# its dependencies next to the modules (found automatically), but an in-tree build
+# with NO_DEPENDENCIES=ON keeps them elsewhere (the OpenMS bin and contrib lib
+# folders). PYOPENMS_DLL_PATH (os.pathsep-separated) lets the caller point pyOpenMS
+# at those directories. Because it is an environment variable it also propagates to
+# child processes that `import pyopenms` (e.g. the subprocess probes in the test
+# suite), which os.add_dll_directory() alone cannot do. Inert when unset.
+_dll_directory_handles = []  # keep handles alive for the process lifetime
+if sys.platform == "win32" and hasattr(os, "add_dll_directory"):
+    for _dll_dir in os.environ.get("PYOPENMS_DLL_PATH", "").split(os.pathsep):
+        if _dll_dir and os.path.isdir(_dll_dir):
+            try:
+                _dll_directory_handles.append(os.add_dll_directory(_dll_dir))
+            except OSError:
+                pass
+    del _dll_dir
+
+
 def _import_submodules():
     """Import all nanobind submodules and merge into this namespace."""
     import importlib


### PR DESCRIPTION
fixes #9732

The easy fix would be to always use NO_DEPENDENCIES=OFF when building (except when creating the pyopenms wheel).
But I wanted the pyopenms tests to always work, no matter the state of NO_DEPENDENCIES.
This does it.
There is a ton of code around NO_DEPENDENCIES, which fixes/undoes stuff, and this could be cleaned up or unified, maybe, with MacOS etc?! Not sure...


History:
`NO_DEPENDENCIES` originally introduced in OpenMS/OpenMS#5780, and switched to 'OFF' by default in #8530 (thanks Claude)

CI Matrix only uses 'OFF' for Ubuntu: https://github.com/OpenMS/OpenMS/blob/develop/.github/workflows/openms_ci_matrix_full.yml#L285

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows support by ensuring required dynamic libraries are located automatically when importing pyOpenMS.
  - Resolved issues that could prevent pyOpenMS modules and tests from running when dependencies are installed in separate directories.

- **Improvements**
  - Standardized the placement of generated pyOpenMS modules across different build configurations.
  - Increased reliability for unit, integration, documentation, and feature tests on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->