### PR TITLE
Fixes stale and missing documentation in ImzMLFile

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/ImzMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ImzMLFile.h
@@ -43,10 +43,11 @@ namespace OpenMS
     decodes IMS-specific terms and reads peak data from the @c .ibd file.
 
     @b Loading modes
-    - In-memory: @p load(filename, MSImagingExperiment&) decodes the spectra and
-      builds @p MSImagingGeometry for random access by (x, y) in RAM (zero-based
-      coordinates; imzML file coordinates are 1-based). Use
-      @p MSImagingExperiment::getMSExperiment() for the flat spectra.
+    - In-memory: @p load(filename, MSImagingExperiment&) decodes the spectra,
+      derives @p MSImagingGeometry directly from the parsed per-spectrum coordinate
+      index, and provides zero-based (x, y) random access in RAM (imzML file
+      coordinates are 1-based). Use @p MSImagingExperiment::getMSExperiment()
+      for the flat spectra.
     - Streaming: @p load(filename, IMSDataConsumer&) forwards decoded spectra to
       the consumer without retaining them in @p ImzMLFile. Delivery is batched
       after the @c spectrumList XML section is parsed (same as @p MzMLHandler),
@@ -61,6 +62,13 @@ namespace OpenMS
     data types when present in the file.
     Per-spectrum pixel coordinates use @p imzml:x, @p imzml:y, @p imzml:z.
 
+    @b IBD integrity check
+    Every load path verifies that the first 16 bytes of the companion @c .ibd match
+    the UUID declared via @c IMS:1000080 in the @c .imzML XML.  A mismatch (or a missing
+    / unparsable UUID in the XML) is reported as a @b warning rather than a hard error,
+    so that legacy and non-conformant datasets still load.  Callers that require strict
+    conformance should inspect the warning log.
+
     @ingroup FileIO
 
     @see MzMLFile, OnDiscImzMLExperiment, MSImagingExperiment, ImzMLMeta, ImzMLSpectrumIndex
@@ -73,14 +81,19 @@ namespace OpenMS
 
     /** @name Constructors and destructor */
     //@{
+    /// Default constructor
     ImzMLFile();
+    /// Destructor
     ~ImzMLFile() override = default;
     //@}
 
     /** @name Options */
     //@{
+    /// Mutable access to the options for loading/storing
     PeakFileOptions& getOptions();
+    /// Non-mutable access to the options for loading/storing
     const PeakFileOptions& getOptions() const;
+    /// Set options for loading/storing
     void setOptions(const PeakFileOptions& options);
     //@}
 
@@ -89,10 +102,12 @@ namespace OpenMS
     /**
       @brief Load an imzML file into an MSImagingExperiment for in-memory random access.
 
-      Performs a full load, then builds @p MSImagingGeometry from @p imzml:x/y
-      MetaValues on each spectrum (imzML 1-based coordinates are mapped to
-      zero-based pixel indices). Only spectra with @p imzml:z = 1 are indexed
-      (2-D datasets).
+      Performs a full load and derives @p MSImagingGeometry directly from the
+      parsed per-spectrum coordinate index — the same path used by
+      @p loadSpectraIndex and @p OnDiscImzMLExperiment. Coordinates are converted
+      from imzML's 1-based convention to zero-based pixel indices; only spectra
+      with z = 1 are indexed (2-D datasets). Out-of-grid or &lt; 1 coordinates
+      are skipped with a warning; duplicates raise Exception::InvalidValue.
 
       Use @p MSImagingExperiment::getSpectrum(x, y) to fetch spectra by pixel
       without re-reading the @c .ibd file.
@@ -102,7 +117,7 @@ namespace OpenMS
 
       @throws Exception::FileNotFound if the @c .imzML or @c .ibd cannot be opened.
       @throws Exception::ParseError   if the XML is malformed.
-      @throws Exception::InvalidValue if pixel coordinates are invalid or duplicate.
+      @throws Exception::InvalidValue if pixel coordinates are duplicate.
     */
     void load(const std::string& filename, MSImagingExperiment& exp);
 
@@ -112,12 +127,17 @@ namespace OpenMS
       Reads dataset dimensions from @p imzml:max_count_x/y MetaValues when
       present and registers each spectrum that carries @p imzml:x/y (and
       @p imzml:z = 1). Coordinates are converted from imzML's 1-based convention
-      to zero-based geometry indices.
+      to zero-based geometry indices. Out-of-grid or &lt; 1 coordinates are
+      warned and skipped; duplicates raise Exception::InvalidValue.
+
+      Prefer the index-based overload when a spectrum index is available (used
+      by the loaders). This MetaValue-based path is for experiments already
+      loaded into an @p MSExperiment (e.g. via @p FileHandler).
 
       @param[in] exp  Experiment previously loaded from imzML (e.g. via @p load or @p FileHandler).
       @param[out] geom Geometry to populate (cleared first).
 
-      @throws Exception::InvalidValue on invalid or duplicate pixel coordinates.
+      @throws Exception::InvalidValue on duplicate pixel coordinates.
     */
     static void buildImagingGeometry(const MSExperiment& exp, MSImagingGeometry& geom);
 


### PR DESCRIPTION
## Summary

Fixes stale and missing documentation in `ImzMLFile` to accurately reflect current implementation behaviour.

## Changes

**`ImzMLFile` class-level description**
- Corrected the "In-memory" loading mode bullet: geometry is derived from the parsed per-spectrum coordinate index, not from `imzml:x/y` MetaValues.
- Added a new **IBD integrity check** section documenting that every load path verifies the first 16 bytes of the `.ibd` against the `IMS:1000080` UUID in the `.imzML` XML, and that mismatches are advisory warnings (not hard errors) so legacy/non-conformant datasets still load.

**`load(filename, MSImagingExperiment&)`**
- Rewrote method description to clearly state geometry comes from the parsed coordinate index (same path as `loadSpectraIndex` / `OnDiscImzMLExperiment`).
- `@throws Exception::InvalidValue` narrowed to duplicate pixel coordinates only (out-of-grid and `< 1` coordinates are warned and skipped, not thrown).

**`buildImagingGeometry(const MSExperiment&, MSImagingGeometry&)`**
- Documented that out-of-grid and `< 1` coordinates emit a warning and are skipped.
- `@throws Exception::InvalidValue` narrowed to duplicate pixel coordinates only.
- Added note recommending the index-based overload when a parsed index is available.

## Scope

Documentation only — no functional code changes.

## Files changed

- `src/openms/include/OpenMS/FORMAT/ImzMLFile.h`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how imzML loading constructs imaging geometry and handles random access.
  * Documented validation of the companion IBD file against the XML UUID, including warning behavior for mismatches or missing UUIDs.
  * Clarified handling of duplicate, invalid, and out-of-grid coordinates, including when entries are skipped or errors are raised.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->