### PR TITLE
[FEATURE] pyOpenMS: Wrap Quality Control (QC) classes in Python

### DIFF
--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -31,7 +31,7 @@ option(PYOPENMS_GENERATE_STUBS "Generate .pyi stub files" ON)
 option(PYOPENMS_PREPARE_WHEEL_REPAIR "Set RPATH for wheel repair tools (auditwheel/delocate)" OFF)
 
 set(PYOPENMS_DOMAINS
-    kernel metadata chemistry analysis featurefinder
+    kernel metadata chemistry analysis featurefinder qc
     format processing datastructures ml misc
     spectrum chromatogram experiment
 )

--- a/src/pyOpenMS/bindings/bind_qc.cpp
+++ b/src/pyOpenMS/bindings/bind_qc.cpp
@@ -1,0 +1,323 @@
+// pyOpenMS nanobind bindings
+// Domain: qc
+
+#include "all_casters.h"
+#include <OpenMS/QC/QCBase.h>
+#include <OpenMS/QC/Contaminants.h>
+#include <OpenMS/QC/DBSuitability.h>
+#include <OpenMS/QC/FWHM.h>
+#include <OpenMS/QC/FeatureSummary.h>
+#include <OpenMS/QC/FragmentMassError.h>
+#include <OpenMS/QC/IdentificationSummary.h>
+#include <OpenMS/QC/MissedCleavages.h>
+#include <OpenMS/QC/Ms2IdentificationRate.h>
+#include <OpenMS/QC/Ms2SpectrumStats.h>
+#include <OpenMS/QC/MzCalibration.h>
+#include <OpenMS/QC/PSMExplainedIonCurrent.h>
+#include <OpenMS/QC/PeptideMass.h>
+#include <OpenMS/QC/RTAlignment.h>
+#include <OpenMS/QC/SpectrumCount.h>
+#include <OpenMS/QC/TIC.h>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/operators.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/map.h>
+#include <nanobind/stl/pair.h>
+#include <nanobind/stl/shared_ptr.h>
+#include "binding_utils.h"
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+NB_MODULE(_pyopenms_qc, m) {
+    m.doc() = "pyOpenMS Quality Control (QC) bindings";
+
+    // -------------------------------------------------------------------------
+    // QCBase Enums & Internal Classes
+    // -------------------------------------------------------------------------
+    nb::enum_<OpenMS::QCBase::Requires>(m, "QCBaseRequires")
+        .value("NOTHING", OpenMS::QCBase::Requires::NOTHING)
+        .value("RAWMZML", OpenMS::QCBase::Requires::RAWMZML)
+        .value("POSTFDRFEAT", OpenMS::QCBase::Requires::POSTFDRFEAT)
+        .value("PREFDRFEAT", OpenMS::QCBase::Requires::PREFDRFEAT)
+        .value("CONTAMINANTS", OpenMS::QCBase::Requires::CONTAMINANTS)
+        .value("TRAFOALIGN", OpenMS::QCBase::Requires::TRAFOALIGN)
+        .value("ID", OpenMS::QCBase::Requires::ID)
+        ;
+
+    nb::enum_<OpenMS::QCBase::ToleranceUnit>(m, "QCBaseToleranceUnit")
+        .value("AUTO", OpenMS::QCBase::ToleranceUnit::AUTO)
+        .value("PPM", OpenMS::QCBase::ToleranceUnit::PPM)
+        .value("DA", OpenMS::QCBase::ToleranceUnit::DA)
+        ;
+
+    // FlagSet<Requires> / Status
+    nb::class_<OpenMS::FlagSet<OpenMS::QCBase::Requires>>(m, "QCBaseStatus")
+        .def(nb::init<>())
+        .def(nb::init<OpenMS::QCBase::Requires>())
+        .def(nb::self == nb::self)
+        .def(nb::self & OpenMS::QCBase::Requires())
+        .def(nb::self & nb::self)
+        .def(nb::self | OpenMS::QCBase::Requires())
+        .def(nb::self | nb::self)
+        .def(nb::self - OpenMS::QCBase::Requires())
+        .def(nb::self - nb::self)
+        .def("__ior__", [](OpenMS::FlagSet<OpenMS::QCBase::Requires>& self, const OpenMS::QCBase::Requires& rhs) { self |= rhs; return self; })
+        .def("__ior__", [](OpenMS::FlagSet<OpenMS::QCBase::Requires>& self, const OpenMS::FlagSet<OpenMS::QCBase::Requires>& rhs) { self |= rhs; return self; })
+        .def("__iand__", [](OpenMS::FlagSet<OpenMS::QCBase::Requires>& self, const OpenMS::QCBase::Requires& rhs) { self &= rhs; return self; })
+        .def("__iand__", [](OpenMS::FlagSet<OpenMS::QCBase::Requires>& self, const OpenMS::FlagSet<OpenMS::QCBase::Requires>& rhs) { self &= rhs; return self; })
+        .def("isSuperSetOf", [](const OpenMS::FlagSet<OpenMS::QCBase::Requires>& self, const OpenMS::FlagSet<OpenMS::QCBase::Requires>& required) { return self.isSuperSetOf(required); })
+        .def("isSuperSetOf", [](const OpenMS::FlagSet<OpenMS::QCBase::Requires>& self, const OpenMS::QCBase::Requires& required) { return self.isSuperSetOf(required); })
+        .def("empty", &OpenMS::FlagSet<OpenMS::QCBase::Requires>::empty)
+        .def("value", &OpenMS::FlagSet<OpenMS::QCBase::Requires>::value)
+        ;
+
+    nb::class_<OpenMS::QCBase::SpectraMap>(m, "QCSpectraMap")
+        .def(nb::init<>())
+        .def(nb::init<const OpenMS::MSExperiment&>())
+        .def("calculateMap", &OpenMS::QCBase::SpectraMap::calculateMap)
+        .def("at", &OpenMS::QCBase::SpectraMap::at)
+        .def("clear", &OpenMS::QCBase::SpectraMap::clear)
+        .def("empty", &OpenMS::QCBase::SpectraMap::empty)
+        .def("size", &OpenMS::QCBase::SpectraMap::size)
+        ;
+
+    // QCBase
+    nb::class_<OpenMS::QCBase>(m, "QCBase")
+        .def("getName", &OpenMS::QCBase::getName, nb::rv_policy::reference_internal)
+        .def("requirements", &OpenMS::QCBase::requirements)
+        .def("isRunnable", &OpenMS::QCBase::isRunnable)
+        .def_static("isLabeledExperiment", &OpenMS::QCBase::isLabeledExperiment)
+        ;
+
+    // -------------------------------------------------------------------------
+    // FWHM
+    // -------------------------------------------------------------------------
+    nb::class_<OpenMS::FWHM, OpenMS::QCBase>(m, "FWHM")
+        .def(nb::init<>())
+        .def("compute", &OpenMS::FWHM::compute, "features"_a)
+        ;
+
+    // -------------------------------------------------------------------------
+    // TIC
+    // -------------------------------------------------------------------------
+    nb::class_<OpenMS::TIC::Result>(m, "TICResult")
+        .def(nb::init<>())
+        .def_rw("intensities", &OpenMS::TIC::Result::intensities)
+        .def_rw("relative_intensities", &OpenMS::TIC::Result::relative_intensities)
+        .def_rw("retention_times", &OpenMS::TIC::Result::retention_times)
+        .def_rw("area", &OpenMS::TIC::Result::area)
+        .def_rw("fall", &OpenMS::TIC::Result::fall)
+        .def_rw("jump", &OpenMS::TIC::Result::jump)
+        .def(nb::self == nb::self)
+        ;
+
+    nb::class_<OpenMS::TIC, OpenMS::QCBase>(m, "TIC")
+        .def(nb::init<>())
+        .def("compute", &OpenMS::TIC::compute, "exp"_a, "bin_size"_a = 0.0f, "ms_level"_a = 1)
+        .def("getResults", &OpenMS::TIC::getResults, nb::rv_policy::reference_internal)
+        .def("addMetaDataMetricsToMzTab", &OpenMS::TIC::addMetaDataMetricsToMzTab, "meta"_a, "tics"_a)
+        ;
+
+    // -------------------------------------------------------------------------
+    // MissedCleavages
+    // -------------------------------------------------------------------------
+    nb::class_<OpenMS::MissedCleavages, OpenMS::QCBase>(m, "MissedCleavages")
+        .def(nb::init<>())
+        .def("compute", nb::overload_cast<OpenMS::FeatureMap&>(&OpenMS::MissedCleavages::compute), "fmap"_a)
+        .def("compute", nb::overload_cast<std::vector<OpenMS::ProteinIdentification>&, OpenMS::PeptideIdentificationList&>(&OpenMS::MissedCleavages::compute), "prot_ids"_a, "pep_ids"_a)
+        .def("getResults", &OpenMS::MissedCleavages::getResults, nb::rv_policy::reference_internal)
+        ;
+
+    // -------------------------------------------------------------------------
+    // FragmentMassError
+    // -------------------------------------------------------------------------
+    nb::class_<OpenMS::FragmentMassError::Statistics>(m, "FragmentMassErrorStatistics")
+        .def(nb::init<>())
+        .def_rw("average_ppm", &OpenMS::FragmentMassError::Statistics::average_ppm)
+        .def_rw("variance_ppm", &OpenMS::FragmentMassError::Statistics::variance_ppm)
+        ;
+
+    nb::class_<OpenMS::FragmentMassError, OpenMS::QCBase>(m, "FragmentMassError")
+        .def(nb::init<>())
+        .def("compute", nb::overload_cast<OpenMS::FeatureMap&, const OpenMS::MSExperiment&, const OpenMS::QCBase::SpectraMap&, OpenMS::QCBase::ToleranceUnit, double>(&OpenMS::FragmentMassError::compute),
+             "fmap"_a, "exp"_a, "map_to_spectrum"_a, "tolerance_unit"_a = OpenMS::QCBase::ToleranceUnit::AUTO, "tolerance"_a = 20.0)
+        .def("compute", nb::overload_cast<OpenMS::PeptideIdentificationList&, const OpenMS::ProteinIdentification::SearchParameters&, const OpenMS::MSExperiment&, const OpenMS::QCBase::SpectraMap&, OpenMS::QCBase::ToleranceUnit, double>(&OpenMS::FragmentMassError::compute),
+             "pep_ids"_a, "search_params"_a, "exp"_a, "map_to_spectrum"_a, "tolerance_unit"_a = OpenMS::QCBase::ToleranceUnit::AUTO, "tolerance"_a = 20.0)
+        .def("getResults", &OpenMS::FragmentMassError::getResults, nb::rv_policy::reference_internal)
+        ;
+
+    // -------------------------------------------------------------------------
+    // SpectrumCount
+    // -------------------------------------------------------------------------
+    nb::class_<OpenMS::SpectrumCount, OpenMS::QCBase>(m, "SpectrumCount")
+        .def(nb::init<>())
+        .def("compute", &OpenMS::SpectrumCount::compute, "exp"_a)
+        ;
+
+    // -------------------------------------------------------------------------
+    // PeptideMass
+    // -------------------------------------------------------------------------
+    nb::class_<OpenMS::PeptideMass, OpenMS::QCBase>(m, "PeptideMass")
+        .def(nb::init<>())
+        .def("compute", &OpenMS::PeptideMass::compute, "features"_a)
+        ;
+
+    // -------------------------------------------------------------------------
+    // RTAlignment
+    // -------------------------------------------------------------------------
+    nb::class_<OpenMS::RTAlignment, OpenMS::QCBase>(m, "RTAlignment")
+        .def(nb::init<>())
+        .def("compute", nb::overload_cast<OpenMS::FeatureMap&, const OpenMS::TransformationDescription&>(&OpenMS::RTAlignment::compute, nb::const_), "fm"_a, "trafo"_a)
+        .def("compute", nb::overload_cast<OpenMS::PeptideIdentificationList&, const OpenMS::TransformationDescription&>(&OpenMS::RTAlignment::compute, nb::const_), "ids"_a, "trafo"_a)
+        ;
+
+    // -------------------------------------------------------------------------
+    // MzCalibration
+    // -------------------------------------------------------------------------
+    nb::class_<OpenMS::MzCalibration, OpenMS::QCBase>(m, "MzCalibration")
+        .def(nb::init<>())
+        .def("compute", &OpenMS::MzCalibration::compute, "features"_a, "exp"_a, "map_to_spectrum"_a)
+        ;
+
+    // -------------------------------------------------------------------------
+    // Contaminants
+    // -------------------------------------------------------------------------
+    nb::class_<OpenMS::Contaminants::ContaminantsSummary>(m, "ContaminantsSummary")
+        .def(nb::init<>())
+        .def_rw("assigned_contaminants_ratio", &OpenMS::Contaminants::ContaminantsSummary::assigned_contaminants_ratio)
+        .def_rw("unassigned_contaminants_ratio", &OpenMS::Contaminants::ContaminantsSummary::unassigned_contaminants_ratio)
+        .def_rw("all_contaminants_ratio", &OpenMS::Contaminants::ContaminantsSummary::all_contaminants_ratio)
+        .def_rw("assigned_contaminants_intensity_ratio", &OpenMS::Contaminants::ContaminantsSummary::assigned_contaminants_intensity_ratio)
+        .def_rw("empty_features", &OpenMS::Contaminants::ContaminantsSummary::empty_features)
+        ;
+
+    nb::class_<OpenMS::Contaminants, OpenMS::QCBase>(m, "Contaminants")
+        .def(nb::init<>())
+        .def("compute", &OpenMS::Contaminants::compute, "features"_a, "contaminants"_a)
+        .def("getResults", &OpenMS::Contaminants::getResults, nb::rv_policy::reference_internal)
+        ;
+
+    // -------------------------------------------------------------------------
+    // DBSuitability
+    // -------------------------------------------------------------------------
+    nb::class_<OpenMS::DBSuitability::SuitabilityData>(m, "DBSuitabilityData")
+        .def(nb::init<>())
+        .def_rw("num_top_novo", &OpenMS::DBSuitability::SuitabilityData::num_top_novo)
+        .def_rw("num_top_db", &OpenMS::DBSuitability::SuitabilityData::num_top_db)
+        .def_rw("num_interest", &OpenMS::DBSuitability::SuitabilityData::num_interest)
+        .def_rw("num_re_ranked", &OpenMS::DBSuitability::SuitabilityData::num_re_ranked)
+        .def_rw("cut_off", &OpenMS::DBSuitability::SuitabilityData::cut_off)
+        .def_rw("suitability", &OpenMS::DBSuitability::SuitabilityData::suitability)
+        .def_rw("suitability_no_rerank", &OpenMS::DBSuitability::SuitabilityData::suitability_no_rerank)
+        .def_rw("suitability_corr_no_rerank", &OpenMS::DBSuitability::SuitabilityData::suitability_corr_no_rerank)
+        .def("clear", &OpenMS::DBSuitability::SuitabilityData::clear)
+        .def("setCorrectionFactor", &OpenMS::DBSuitability::SuitabilityData::setCorrectionFactor, "factor"_a)
+        .def("getCorrectionFactor", &OpenMS::DBSuitability::SuitabilityData::getCorrectionFactor)
+        .def("getCorrectedNovoHits", &OpenMS::DBSuitability::SuitabilityData::getCorrectedNovoHits)
+        .def("getCorrectedSuitability", &OpenMS::DBSuitability::SuitabilityData::getCorrectedSuitability)
+        .def("simulateNoReRanking", &OpenMS::DBSuitability::SuitabilityData::simulateNoReRanking)
+        ;
+
+    auto dbsuitability_class = nb::class_<OpenMS::DBSuitability>(m, "DBSuitability")
+        .def(nb::init<>())
+        .def("compute", [](OpenMS::DBSuitability& self, const OpenMS::PeptideIdentificationList& pep_ids, const OpenMS::MSExperiment& exp, const std::vector<OpenMS::FASTAFile::FASTAEntry>& original_fasta, const std::vector<OpenMS::FASTAFile::FASTAEntry>& novo_fasta, const OpenMS::ProteinIdentification::SearchParameters& search_params) {
+            OpenMS::PeptideIdentificationList p = pep_ids;
+            self.compute(std::move(p), exp, original_fasta, novo_fasta, search_params);
+        }, "pep_ids"_a, "exp"_a, "original_fasta"_a, "novo_fasta"_a, "search_params"_a)
+        .def("getResults", &OpenMS::DBSuitability::getResults, nb::rv_policy::reference_internal)
+        ;
+    def_DefaultParamHandler<OpenMS::DBSuitability>(dbsuitability_class);
+
+    // -------------------------------------------------------------------------
+    // FeatureSummary
+    // -------------------------------------------------------------------------
+    nb::class_<OpenMS::FeatureSummary::Result>(m, "FeatureSummaryResult")
+        .def(nb::init<>())
+        .def_rw("feature_count", &OpenMS::FeatureSummary::Result::feature_count)
+        .def_rw("rt_shift_mean", &OpenMS::FeatureSummary::Result::rt_shift_mean)
+        .def(nb::self == nb::self)
+        ;
+
+    nb::class_<OpenMS::FeatureSummary, OpenMS::QCBase>(m, "FeatureSummary")
+        .def(nb::init<>())
+        .def("compute", &OpenMS::FeatureSummary::compute, "feature_map"_a)
+        ;
+
+    // -------------------------------------------------------------------------
+    // IdentificationSummary
+    // -------------------------------------------------------------------------
+    nb::class_<OpenMS::IdentificationSummary::UniqueID>(m, "UniqueID")
+        .def(nb::init<>())
+        .def_rw("count", &OpenMS::IdentificationSummary::UniqueID::count)
+        .def_rw("fdr_threshold", &OpenMS::IdentificationSummary::UniqueID::fdr_threshold)
+        ;
+
+    nb::class_<OpenMS::IdentificationSummary::Result>(m, "IdentificationSummaryResult")
+        .def(nb::init<>())
+        .def_rw("peptide_spectrum_matches", &OpenMS::IdentificationSummary::Result::peptide_spectrum_matches)
+        .def_rw("unique_peptides", &OpenMS::IdentificationSummary::Result::unique_peptides)
+        .def_rw("unique_proteins", &OpenMS::IdentificationSummary::Result::unique_proteins)
+        .def_rw("missed_cleavages_mean", &OpenMS::IdentificationSummary::Result::missed_cleavages_mean)
+        .def_rw("protein_hit_scores_mean", &OpenMS::IdentificationSummary::Result::protein_hit_scores_mean)
+        .def_rw("peptide_length_mean", &OpenMS::IdentificationSummary::Result::peptide_length_mean)
+        .def(nb::self == nb::self)
+        ;
+
+    nb::class_<OpenMS::IdentificationSummary, OpenMS::QCBase>(m, "IdentificationSummary")
+        .def(nb::init<>())
+        .def("compute", &OpenMS::IdentificationSummary::compute, "prot_ids"_a, "pep_ids"_a)
+        ;
+
+    // -------------------------------------------------------------------------
+    // Ms2IdentificationRate
+    // -------------------------------------------------------------------------
+    nb::class_<OpenMS::Ms2IdentificationRate::IdentificationRateData>(m, "IdentificationRateData")
+        .def(nb::init<>())
+        .def_rw("num_peptide_identification", &OpenMS::Ms2IdentificationRate::IdentificationRateData::num_peptide_identification)
+        .def_rw("num_ms2_spectra", &OpenMS::Ms2IdentificationRate::IdentificationRateData::num_ms2_spectra)
+        .def_rw("identification_rate", &OpenMS::Ms2IdentificationRate::IdentificationRateData::identification_rate)
+        ;
+
+    nb::class_<OpenMS::Ms2IdentificationRate, OpenMS::QCBase>(m, "Ms2IdentificationRate")
+        .def(nb::init<>())
+        .def("compute", nb::overload_cast<const OpenMS::FeatureMap&, const OpenMS::MSExperiment&, bool>(&OpenMS::Ms2IdentificationRate::compute), "feature_map"_a, "exp"_a, "assume_all_target"_a = false)
+        .def("compute", nb::overload_cast<const OpenMS::PeptideIdentificationList&, const OpenMS::MSExperiment&, bool>(&OpenMS::Ms2IdentificationRate::compute), "pep_ids"_a, "exp"_a, "assume_all_target"_a = false)
+        .def("getResults", &OpenMS::Ms2IdentificationRate::getResults, nb::rv_policy::reference_internal)
+        .def("addMetaDataMetricsToMzTab", &OpenMS::Ms2IdentificationRate::addMetaDataMetricsToMzTab, "meta"_a)
+        ;
+
+    // -------------------------------------------------------------------------
+    // Ms2SpectrumStats
+    // -------------------------------------------------------------------------
+    nb::class_<OpenMS::Ms2SpectrumStats::ScanEvent>(m, "Ms2SpectrumStatsScanEvent")
+        .def(nb::init<UInt32, bool>())
+        .def_rw("scan_event_number", &OpenMS::Ms2SpectrumStats::ScanEvent::scan_event_number)
+        .def_rw("ms2_presence", &OpenMS::Ms2SpectrumStats::ScanEvent::ms2_presence)
+        ;
+
+    nb::class_<OpenMS::Ms2SpectrumStats, OpenMS::QCBase>(m, "Ms2SpectrumStats")
+        .def(nb::init<>())
+        .def("compute", &OpenMS::Ms2SpectrumStats::compute, "exp"_a, "features"_a, "map_to_spectrum"_a)
+        ;
+
+    // -------------------------------------------------------------------------
+    // PSMExplainedIonCurrent
+    // -------------------------------------------------------------------------
+    nb::class_<OpenMS::PSMExplainedIonCurrent::Statistics>(m, "PSMExplainedIonCurrentStatistics")
+        .def(nb::init<>())
+        .def_rw("average_correctness", &OpenMS::PSMExplainedIonCurrent::Statistics::average_correctness)
+        .def_rw("variance_correctness", &OpenMS::PSMExplainedIonCurrent::Statistics::variance_correctness)
+        ;
+
+    nb::class_<OpenMS::PSMExplainedIonCurrent, OpenMS::QCBase>(m, "PSMExplainedIonCurrent")
+        .def(nb::init<>())
+        .def("compute", nb::overload_cast<OpenMS::FeatureMap&, const OpenMS::MSExperiment&, const OpenMS::QCBase::SpectraMap&, OpenMS::QCBase::ToleranceUnit, double>(&OpenMS::PSMExplainedIonCurrent::compute),
+             "fmap"_a, "exp"_a, "map_to_spectrum"_a, "tolerance_unit"_a = OpenMS::QCBase::ToleranceUnit::AUTO, "tolerance"_a = 20.0)
+        .def("compute", nb::overload_cast<OpenMS::PeptideIdentificationList&, const OpenMS::ProteinIdentification::SearchParameters&, const OpenMS::MSExperiment&, const OpenMS::QCBase::SpectraMap&, OpenMS::QCBase::ToleranceUnit, double>(&OpenMS::PSMExplainedIonCurrent::compute),
+             "pep_ids"_a, "search_params"_a, "exp"_a, "map_to_spectrum"_a, "tolerance_unit"_a = OpenMS::QCBase::ToleranceUnit::AUTO, "tolerance"_a = 20.0)
+        .def("getResults", &OpenMS::PSMExplainedIonCurrent::getResults, nb::rv_policy::reference_internal)
+        ;
+}

--- a/src/pyOpenMS/bindings/bind_qc.cpp
+++ b/src/pyOpenMS/bindings/bind_qc.cpp
@@ -156,7 +156,6 @@ NB_MODULE(_pyopenms_qc, m) {
         .def("__copy__",     [](const OpenMS::TIC& self) { return self; })
         .def("__deepcopy__", [](const OpenMS::TIC& self, nb::dict&) { return self; }, "memo"_a)
         .def("compute",    &OpenMS::TIC::compute, "exp"_a, "bin_size"_a = 0.0f, "ms_level"_a = 1)
-        .def("getResults", &OpenMS::TIC::getResults, nb::rv_policy::reference_internal)
         .def("addMetaDataMetricsToMzTab", &OpenMS::TIC::addMetaDataMetricsToMzTab, "meta"_a, "tics"_a)
         ;
 
@@ -304,6 +303,9 @@ NB_MODULE(_pyopenms_qc, m) {
 
     auto dbs_cls = nb::class_<OpenMS::DBSuitability>(m, "DBSuitability")
         .def(nb::init<>())
+        .def(nb::init<const OpenMS::DBSuitability&>())
+        .def("__copy__",     [](const OpenMS::DBSuitability& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::DBSuitability& self, nb::dict&) { return self; }, "memo"_a)
         // compute takes PeptideIdentificationList&&; copy in Python, move in C++
         .def("compute",
              [](OpenMS::DBSuitability& self,

--- a/src/pyOpenMS/bindings/bind_qc.cpp
+++ b/src/pyOpenMS/bindings/bind_qc.cpp
@@ -1,7 +1,17 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Krrish Verma $
+// $Authors: Krrish Verma $
+// --------------------------------------------------------------------------
+
 // pyOpenMS nanobind bindings
 // Domain: qc
 
 #include "all_casters.h"
+
+// QC headers (forward-declare many types; pull in full definitions below)
 #include <OpenMS/QC/QCBase.h>
 #include <OpenMS/QC/Contaminants.h>
 #include <OpenMS/QC/DBSuitability.h>
@@ -19,23 +29,25 @@
 #include <OpenMS/QC/SpectrumCount.h>
 #include <OpenMS/QC/TIC.h>
 
-#include <nanobind/nanobind.h>
+// Full definitions required by nanobind for forward-declared types in QC headers
+#include <OpenMS/KERNEL/ConsensusMap.h>
+#include <OpenMS/KERNEL/FeatureMap.h>
+#include <OpenMS/KERNEL/MSChromatogram.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/FORMAT/MzTab.h>
+#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationDescription.h>
+
 #include <nanobind/operators.h>
-#include <nanobind/stl/vector.h>
-#include <nanobind/stl/string.h>
-#include <nanobind/stl/map.h>
-#include <nanobind/stl/pair.h>
-#include <nanobind/stl/shared_ptr.h>
+
 #include "binding_utils.h"
 
-namespace nb = nanobind;
 using namespace nb::literals;
 
 NB_MODULE(_pyopenms_qc, m) {
     m.doc() = "pyOpenMS Quality Control (QC) bindings";
 
     // -------------------------------------------------------------------------
-    // QCBase Enums & Internal Classes
+    // QCBase Enums
     // -------------------------------------------------------------------------
     nb::enum_<OpenMS::QCBase::Requires>(m, "QCBaseRequires")
         .value("NOTHING", OpenMS::QCBase::Requires::NOTHING)
@@ -53,43 +65,61 @@ NB_MODULE(_pyopenms_qc, m) {
         .value("DA", OpenMS::QCBase::ToleranceUnit::DA)
         ;
 
-    // FlagSet<Requires> / Status
+    // -------------------------------------------------------------------------
+    // FlagSet<QCBase::Requires> a.k.a. QCBase::Status
+    // Use explicit lambdas instead of nb::self for non-const operators
+    // -------------------------------------------------------------------------
     nb::class_<OpenMS::FlagSet<OpenMS::QCBase::Requires>>(m, "QCBaseStatus")
         .def(nb::init<>())
         .def(nb::init<OpenMS::QCBase::Requires>())
-        .def(nb::self == nb::self)
-        .def(nb::self & OpenMS::QCBase::Requires())
-        .def(nb::self & nb::self)
-        .def(nb::self | OpenMS::QCBase::Requires())
-        .def(nb::self | nb::self)
-        .def(nb::self - OpenMS::QCBase::Requires())
-        .def(nb::self - nb::self)
-        .def("__ior__", [](OpenMS::FlagSet<OpenMS::QCBase::Requires>& self, const OpenMS::QCBase::Requires& rhs) { self |= rhs; return self; })
-        .def("__ior__", [](OpenMS::FlagSet<OpenMS::QCBase::Requires>& self, const OpenMS::FlagSet<OpenMS::QCBase::Requires>& rhs) { self |= rhs; return self; })
-        .def("__iand__", [](OpenMS::FlagSet<OpenMS::QCBase::Requires>& self, const OpenMS::QCBase::Requires& rhs) { self &= rhs; return self; })
-        .def("__iand__", [](OpenMS::FlagSet<OpenMS::QCBase::Requires>& self, const OpenMS::FlagSet<OpenMS::QCBase::Requires>& rhs) { self &= rhs; return self; })
+        .def(nb::init<const OpenMS::FlagSet<OpenMS::QCBase::Requires>&>())
+        .def("__copy__",  [](const OpenMS::FlagSet<OpenMS::QCBase::Requires>& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::FlagSet<OpenMS::QCBase::Requires>& self, nb::dict&) { return self; }, "memo"_a)
+        .def("__eq__",  [](const OpenMS::FlagSet<OpenMS::QCBase::Requires>& a, const OpenMS::FlagSet<OpenMS::QCBase::Requires>& b) { return a == b; })
+        // bitwise OR (returns new object)
+        .def("__or__",  [](const OpenMS::FlagSet<OpenMS::QCBase::Requires>& a, const OpenMS::QCBase::Requires& b) { return a | b; })
+        .def("__or__",  [](const OpenMS::FlagSet<OpenMS::QCBase::Requires>& a, const OpenMS::FlagSet<OpenMS::QCBase::Requires>& b) { return a | b; })
+        // bitwise AND (returns new object)
+        .def("__and__", [](const OpenMS::FlagSet<OpenMS::QCBase::Requires>& a, const OpenMS::QCBase::Requires& b) { return a & b; })
+        .def("__and__", [](const OpenMS::FlagSet<OpenMS::QCBase::Requires>& a, const OpenMS::FlagSet<OpenMS::QCBase::Requires>& b) { return a & b; })
+        // subtraction (returns new object; note: operator- is non-const in FlagSet)
+        .def("__sub__", [](OpenMS::FlagSet<OpenMS::QCBase::Requires> a, const OpenMS::QCBase::Requires& b) { return a - b; })
+        .def("__sub__", [](OpenMS::FlagSet<OpenMS::QCBase::Requires> a, const OpenMS::FlagSet<OpenMS::QCBase::Requires>& b) { return a - b; })
+        // in-place operators
+        .def("__ior__",  [](OpenMS::FlagSet<OpenMS::QCBase::Requires>& a, const OpenMS::QCBase::Requires& b) -> OpenMS::FlagSet<OpenMS::QCBase::Requires>& { a |= b; return a; })
+        .def("__ior__",  [](OpenMS::FlagSet<OpenMS::QCBase::Requires>& a, const OpenMS::FlagSet<OpenMS::QCBase::Requires>& b) -> OpenMS::FlagSet<OpenMS::QCBase::Requires>& { a |= b; return a; })
+        .def("__iand__", [](OpenMS::FlagSet<OpenMS::QCBase::Requires>& a, const OpenMS::QCBase::Requires& b) -> OpenMS::FlagSet<OpenMS::QCBase::Requires>& { a &= b; return a; })
+        .def("__iand__", [](OpenMS::FlagSet<OpenMS::QCBase::Requires>& a, const OpenMS::FlagSet<OpenMS::QCBase::Requires>& b) -> OpenMS::FlagSet<OpenMS::QCBase::Requires>& { a &= b; return a; })
         .def("isSuperSetOf", [](const OpenMS::FlagSet<OpenMS::QCBase::Requires>& self, const OpenMS::FlagSet<OpenMS::QCBase::Requires>& required) { return self.isSuperSetOf(required); })
         .def("isSuperSetOf", [](const OpenMS::FlagSet<OpenMS::QCBase::Requires>& self, const OpenMS::QCBase::Requires& required) { return self.isSuperSetOf(required); })
         .def("empty", &OpenMS::FlagSet<OpenMS::QCBase::Requires>::empty)
         .def("value", &OpenMS::FlagSet<OpenMS::QCBase::Requires>::value)
         ;
 
+    // -------------------------------------------------------------------------
+    // QCBase::SpectraMap
+    // -------------------------------------------------------------------------
     nb::class_<OpenMS::QCBase::SpectraMap>(m, "QCSpectraMap")
         .def(nb::init<>())
         .def(nb::init<const OpenMS::MSExperiment&>())
-        .def("calculateMap", &OpenMS::QCBase::SpectraMap::calculateMap)
-        .def("at", &OpenMS::QCBase::SpectraMap::at)
-        .def("clear", &OpenMS::QCBase::SpectraMap::clear)
-        .def("empty", &OpenMS::QCBase::SpectraMap::empty)
+        .def(nb::init<const OpenMS::QCBase::SpectraMap&>())
+        .def("__copy__",  [](const OpenMS::QCBase::SpectraMap& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::QCBase::SpectraMap& self, nb::dict&) { return self; }, "memo"_a)
+        .def("calculateMap", &OpenMS::QCBase::SpectraMap::calculateMap, "exp"_a)
+        .def("at",   &OpenMS::QCBase::SpectraMap::at,   "identifier"_a)
+        .def("clear",&OpenMS::QCBase::SpectraMap::clear)
+        .def("empty",&OpenMS::QCBase::SpectraMap::empty)
         .def("size", &OpenMS::QCBase::SpectraMap::size)
         ;
 
-    // QCBase
+    // -------------------------------------------------------------------------
+    // QCBase (abstract base)
+    // -------------------------------------------------------------------------
     nb::class_<OpenMS::QCBase>(m, "QCBase")
-        .def("getName", &OpenMS::QCBase::getName, nb::rv_policy::reference_internal)
-        .def("requirements", &OpenMS::QCBase::requirements)
-        .def("isRunnable", &OpenMS::QCBase::isRunnable)
-        .def_static("isLabeledExperiment", &OpenMS::QCBase::isLabeledExperiment)
+        .def("getName",        &OpenMS::QCBase::getName, nb::rv_policy::reference_internal)
+        .def("requirements",   &OpenMS::QCBase::requirements)
+        .def("isRunnable",     &OpenMS::QCBase::isRunnable, "s"_a)
+        .def_static("isLabeledExperiment", &OpenMS::QCBase::isLabeledExperiment, "cm"_a)
         ;
 
     // -------------------------------------------------------------------------
@@ -97,26 +127,35 @@ NB_MODULE(_pyopenms_qc, m) {
     // -------------------------------------------------------------------------
     nb::class_<OpenMS::FWHM, OpenMS::QCBase>(m, "FWHM")
         .def(nb::init<>())
-        .def("compute", &OpenMS::FWHM::compute, "features"_a)
+        .def(nb::init<const OpenMS::FWHM&>())
+        .def("__copy__",     [](const OpenMS::FWHM& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::FWHM& self, nb::dict&) { return self; }, "memo"_a)
+        .def("compute",    &OpenMS::FWHM::compute, "features"_a)
         ;
 
     // -------------------------------------------------------------------------
-    // TIC
+    // TIC::Result and TIC
     // -------------------------------------------------------------------------
     nb::class_<OpenMS::TIC::Result>(m, "TICResult")
         .def(nb::init<>())
-        .def_rw("intensities", &OpenMS::TIC::Result::intensities)
+        .def(nb::init<const OpenMS::TIC::Result&>())
+        .def("__copy__",     [](const OpenMS::TIC::Result& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::TIC::Result& self, nb::dict&) { return self; }, "memo"_a)
+        .def_rw("intensities",          &OpenMS::TIC::Result::intensities)
         .def_rw("relative_intensities", &OpenMS::TIC::Result::relative_intensities)
-        .def_rw("retention_times", &OpenMS::TIC::Result::retention_times)
-        .def_rw("area", &OpenMS::TIC::Result::area)
-        .def_rw("fall", &OpenMS::TIC::Result::fall)
-        .def_rw("jump", &OpenMS::TIC::Result::jump)
-        .def(nb::self == nb::self)
+        .def_rw("retention_times",      &OpenMS::TIC::Result::retention_times)
+        .def_rw("area",  &OpenMS::TIC::Result::area)
+        .def_rw("fall",  &OpenMS::TIC::Result::fall)
+        .def_rw("jump",  &OpenMS::TIC::Result::jump)
+        .def("__eq__",   [](const OpenMS::TIC::Result& a, const OpenMS::TIC::Result& b) { return a == b; })
         ;
 
     nb::class_<OpenMS::TIC, OpenMS::QCBase>(m, "TIC")
         .def(nb::init<>())
-        .def("compute", &OpenMS::TIC::compute, "exp"_a, "bin_size"_a = 0.0f, "ms_level"_a = 1)
+        .def(nb::init<const OpenMS::TIC&>())
+        .def("__copy__",     [](const OpenMS::TIC& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::TIC& self, nb::dict&) { return self; }, "memo"_a)
+        .def("compute",    &OpenMS::TIC::compute, "exp"_a, "bin_size"_a = 0.0f, "ms_level"_a = 1)
         .def("getResults", &OpenMS::TIC::getResults, nb::rv_policy::reference_internal)
         .def("addMetaDataMetricsToMzTab", &OpenMS::TIC::addMetaDataMetricsToMzTab, "meta"_a, "tics"_a)
         ;
@@ -126,26 +165,39 @@ NB_MODULE(_pyopenms_qc, m) {
     // -------------------------------------------------------------------------
     nb::class_<OpenMS::MissedCleavages, OpenMS::QCBase>(m, "MissedCleavages")
         .def(nb::init<>())
+        .def(nb::init<const OpenMS::MissedCleavages&>())
+        .def("__copy__",     [](const OpenMS::MissedCleavages& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::MissedCleavages& self, nb::dict&) { return self; }, "memo"_a)
         .def("compute", nb::overload_cast<OpenMS::FeatureMap&>(&OpenMS::MissedCleavages::compute), "fmap"_a)
         .def("compute", nb::overload_cast<std::vector<OpenMS::ProteinIdentification>&, OpenMS::PeptideIdentificationList&>(&OpenMS::MissedCleavages::compute), "prot_ids"_a, "pep_ids"_a)
         .def("getResults", &OpenMS::MissedCleavages::getResults, nb::rv_policy::reference_internal)
         ;
 
     // -------------------------------------------------------------------------
-    // FragmentMassError
+    // FragmentMassError::Statistics and FragmentMassError
     // -------------------------------------------------------------------------
     nb::class_<OpenMS::FragmentMassError::Statistics>(m, "FragmentMassErrorStatistics")
         .def(nb::init<>())
-        .def_rw("average_ppm", &OpenMS::FragmentMassError::Statistics::average_ppm)
+        .def(nb::init<const OpenMS::FragmentMassError::Statistics&>())
+        .def("__copy__",     [](const OpenMS::FragmentMassError::Statistics& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::FragmentMassError::Statistics& self, nb::dict&) { return self; }, "memo"_a)
+        .def_rw("average_ppm",  &OpenMS::FragmentMassError::Statistics::average_ppm)
         .def_rw("variance_ppm", &OpenMS::FragmentMassError::Statistics::variance_ppm)
         ;
 
     nb::class_<OpenMS::FragmentMassError, OpenMS::QCBase>(m, "FragmentMassError")
         .def(nb::init<>())
-        .def("compute", nb::overload_cast<OpenMS::FeatureMap&, const OpenMS::MSExperiment&, const OpenMS::QCBase::SpectraMap&, OpenMS::QCBase::ToleranceUnit, double>(&OpenMS::FragmentMassError::compute),
-             "fmap"_a, "exp"_a, "map_to_spectrum"_a, "tolerance_unit"_a = OpenMS::QCBase::ToleranceUnit::AUTO, "tolerance"_a = 20.0)
-        .def("compute", nb::overload_cast<OpenMS::PeptideIdentificationList&, const OpenMS::ProteinIdentification::SearchParameters&, const OpenMS::MSExperiment&, const OpenMS::QCBase::SpectraMap&, OpenMS::QCBase::ToleranceUnit, double>(&OpenMS::FragmentMassError::compute),
-             "pep_ids"_a, "search_params"_a, "exp"_a, "map_to_spectrum"_a, "tolerance_unit"_a = OpenMS::QCBase::ToleranceUnit::AUTO, "tolerance"_a = 20.0)
+        .def(nb::init<const OpenMS::FragmentMassError&>())
+        .def("__copy__",     [](const OpenMS::FragmentMassError& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::FragmentMassError& self, nb::dict&) { return self; }, "memo"_a)
+        .def("compute",
+             nb::overload_cast<OpenMS::FeatureMap&, const OpenMS::MSExperiment&, const OpenMS::QCBase::SpectraMap&, OpenMS::QCBase::ToleranceUnit, double>(&OpenMS::FragmentMassError::compute),
+             "fmap"_a, "exp"_a, "map_to_spectrum"_a,
+             "tolerance_unit"_a = OpenMS::QCBase::ToleranceUnit::AUTO, "tolerance"_a = 20.0)
+        .def("compute",
+             nb::overload_cast<OpenMS::PeptideIdentificationList&, const OpenMS::ProteinIdentification::SearchParameters&, const OpenMS::MSExperiment&, const OpenMS::QCBase::SpectraMap&, OpenMS::QCBase::ToleranceUnit, double>(&OpenMS::FragmentMassError::compute),
+             "pep_ids"_a, "search_params"_a, "exp"_a, "map_to_spectrum"_a,
+             "tolerance_unit"_a = OpenMS::QCBase::ToleranceUnit::AUTO, "tolerance"_a = 20.0)
         .def("getResults", &OpenMS::FragmentMassError::getResults, nb::rv_policy::reference_internal)
         ;
 
@@ -154,6 +206,9 @@ NB_MODULE(_pyopenms_qc, m) {
     // -------------------------------------------------------------------------
     nb::class_<OpenMS::SpectrumCount, OpenMS::QCBase>(m, "SpectrumCount")
         .def(nb::init<>())
+        .def(nb::init<const OpenMS::SpectrumCount&>())
+        .def("__copy__",     [](const OpenMS::SpectrumCount& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::SpectrumCount& self, nb::dict&) { return self; }, "memo"_a)
         .def("compute", &OpenMS::SpectrumCount::compute, "exp"_a)
         ;
 
@@ -162,16 +217,29 @@ NB_MODULE(_pyopenms_qc, m) {
     // -------------------------------------------------------------------------
     nb::class_<OpenMS::PeptideMass, OpenMS::QCBase>(m, "PeptideMass")
         .def(nb::init<>())
+        .def(nb::init<const OpenMS::PeptideMass&>())
+        .def("__copy__",     [](const OpenMS::PeptideMass& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::PeptideMass& self, nb::dict&) { return self; }, "memo"_a)
         .def("compute", &OpenMS::PeptideMass::compute, "features"_a)
         ;
 
     // -------------------------------------------------------------------------
     // RTAlignment
+    // RTAlignment::compute is const-overloaded; use explicit const pointer cast
     // -------------------------------------------------------------------------
     nb::class_<OpenMS::RTAlignment, OpenMS::QCBase>(m, "RTAlignment")
         .def(nb::init<>())
-        .def("compute", nb::overload_cast<OpenMS::FeatureMap&, const OpenMS::TransformationDescription&>(&OpenMS::RTAlignment::compute, nb::const_), "fm"_a, "trafo"_a)
-        .def("compute", nb::overload_cast<OpenMS::PeptideIdentificationList&, const OpenMS::TransformationDescription&>(&OpenMS::RTAlignment::compute, nb::const_), "ids"_a, "trafo"_a)
+        .def(nb::init<const OpenMS::RTAlignment&>())
+        .def("__copy__",     [](const OpenMS::RTAlignment& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::RTAlignment& self, nb::dict&) { return self; }, "memo"_a)
+        .def("compute",
+             [](const OpenMS::RTAlignment& self, OpenMS::FeatureMap& fm, const OpenMS::TransformationDescription& trafo) {
+                 self.compute(fm, trafo);
+             }, "fm"_a, "trafo"_a)
+        .def("compute",
+             [](const OpenMS::RTAlignment& self, OpenMS::PeptideIdentificationList& ids, const OpenMS::TransformationDescription& trafo) {
+                 self.compute(ids, trafo);
+             }, "ids"_a, "trafo"_a)
         ;
 
     // -------------------------------------------------------------------------
@@ -179,145 +247,205 @@ NB_MODULE(_pyopenms_qc, m) {
     // -------------------------------------------------------------------------
     nb::class_<OpenMS::MzCalibration, OpenMS::QCBase>(m, "MzCalibration")
         .def(nb::init<>())
+        .def(nb::init<const OpenMS::MzCalibration&>())
+        .def("__copy__",     [](const OpenMS::MzCalibration& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::MzCalibration& self, nb::dict&) { return self; }, "memo"_a)
         .def("compute", &OpenMS::MzCalibration::compute, "features"_a, "exp"_a, "map_to_spectrum"_a)
         ;
 
     // -------------------------------------------------------------------------
-    // Contaminants
+    // Contaminants::ContaminantsSummary and Contaminants
     // -------------------------------------------------------------------------
     nb::class_<OpenMS::Contaminants::ContaminantsSummary>(m, "ContaminantsSummary")
         .def(nb::init<>())
-        .def_rw("assigned_contaminants_ratio", &OpenMS::Contaminants::ContaminantsSummary::assigned_contaminants_ratio)
-        .def_rw("unassigned_contaminants_ratio", &OpenMS::Contaminants::ContaminantsSummary::unassigned_contaminants_ratio)
-        .def_rw("all_contaminants_ratio", &OpenMS::Contaminants::ContaminantsSummary::all_contaminants_ratio)
+        .def(nb::init<const OpenMS::Contaminants::ContaminantsSummary&>())
+        .def("__copy__",     [](const OpenMS::Contaminants::ContaminantsSummary& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::Contaminants::ContaminantsSummary& self, nb::dict&) { return self; }, "memo"_a)
+        .def_rw("assigned_contaminants_ratio",           &OpenMS::Contaminants::ContaminantsSummary::assigned_contaminants_ratio)
+        .def_rw("unassigned_contaminants_ratio",         &OpenMS::Contaminants::ContaminantsSummary::unassigned_contaminants_ratio)
+        .def_rw("all_contaminants_ratio",                &OpenMS::Contaminants::ContaminantsSummary::all_contaminants_ratio)
         .def_rw("assigned_contaminants_intensity_ratio", &OpenMS::Contaminants::ContaminantsSummary::assigned_contaminants_intensity_ratio)
-        .def_rw("empty_features", &OpenMS::Contaminants::ContaminantsSummary::empty_features)
+        .def_rw("empty_features",                        &OpenMS::Contaminants::ContaminantsSummary::empty_features)
         ;
 
     nb::class_<OpenMS::Contaminants, OpenMS::QCBase>(m, "Contaminants")
         .def(nb::init<>())
-        .def("compute", &OpenMS::Contaminants::compute, "features"_a, "contaminants"_a)
+        .def(nb::init<const OpenMS::Contaminants&>())
+        .def("__copy__",     [](const OpenMS::Contaminants& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::Contaminants& self, nb::dict&) { return self; }, "memo"_a)
+        .def("compute",    &OpenMS::Contaminants::compute, "features"_a, "contaminants"_a)
         .def("getResults", &OpenMS::Contaminants::getResults, nb::rv_policy::reference_internal)
         ;
 
     // -------------------------------------------------------------------------
-    // DBSuitability
+    // DBSuitability::SuitabilityData and DBSuitability
+    // Note: DBSuitability inherits from DefaultParamHandler, NOT QCBase
     // -------------------------------------------------------------------------
     nb::class_<OpenMS::DBSuitability::SuitabilityData>(m, "DBSuitabilityData")
         .def(nb::init<>())
-        .def_rw("num_top_novo", &OpenMS::DBSuitability::SuitabilityData::num_top_novo)
-        .def_rw("num_top_db", &OpenMS::DBSuitability::SuitabilityData::num_top_db)
-        .def_rw("num_interest", &OpenMS::DBSuitability::SuitabilityData::num_interest)
-        .def_rw("num_re_ranked", &OpenMS::DBSuitability::SuitabilityData::num_re_ranked)
-        .def_rw("cut_off", &OpenMS::DBSuitability::SuitabilityData::cut_off)
-        .def_rw("suitability", &OpenMS::DBSuitability::SuitabilityData::suitability)
-        .def_rw("suitability_no_rerank", &OpenMS::DBSuitability::SuitabilityData::suitability_no_rerank)
-        .def_rw("suitability_corr_no_rerank", &OpenMS::DBSuitability::SuitabilityData::suitability_corr_no_rerank)
-        .def("clear", &OpenMS::DBSuitability::SuitabilityData::clear)
-        .def("setCorrectionFactor", &OpenMS::DBSuitability::SuitabilityData::setCorrectionFactor, "factor"_a)
-        .def("getCorrectionFactor", &OpenMS::DBSuitability::SuitabilityData::getCorrectionFactor)
-        .def("getCorrectedNovoHits", &OpenMS::DBSuitability::SuitabilityData::getCorrectedNovoHits)
-        .def("getCorrectedSuitability", &OpenMS::DBSuitability::SuitabilityData::getCorrectedSuitability)
-        .def("simulateNoReRanking", &OpenMS::DBSuitability::SuitabilityData::simulateNoReRanking)
+        .def(nb::init<const OpenMS::DBSuitability::SuitabilityData&>())
+        .def("__copy__",     [](const OpenMS::DBSuitability::SuitabilityData& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::DBSuitability::SuitabilityData& self, nb::dict&) { return self; }, "memo"_a)
+        .def_rw("num_top_novo",              &OpenMS::DBSuitability::SuitabilityData::num_top_novo)
+        .def_rw("num_top_db",                &OpenMS::DBSuitability::SuitabilityData::num_top_db)
+        .def_rw("num_interest",              &OpenMS::DBSuitability::SuitabilityData::num_interest)
+        .def_rw("num_re_ranked",             &OpenMS::DBSuitability::SuitabilityData::num_re_ranked)
+        .def_rw("cut_off",                   &OpenMS::DBSuitability::SuitabilityData::cut_off)
+        .def_rw("suitability",               &OpenMS::DBSuitability::SuitabilityData::suitability)
+        .def_rw("suitability_no_rerank",     &OpenMS::DBSuitability::SuitabilityData::suitability_no_rerank)
+        .def_rw("suitability_corr_no_rerank",&OpenMS::DBSuitability::SuitabilityData::suitability_corr_no_rerank)
+        .def("clear",                 &OpenMS::DBSuitability::SuitabilityData::clear)
+        .def("setCorrectionFactor",   &OpenMS::DBSuitability::SuitabilityData::setCorrectionFactor,   "factor"_a)
+        .def("getCorrectionFactor",   &OpenMS::DBSuitability::SuitabilityData::getCorrectionFactor)
+        .def("getCorrectedNovoHits",  &OpenMS::DBSuitability::SuitabilityData::getCorrectedNovoHits)
+        .def("getCorrectedSuitability",&OpenMS::DBSuitability::SuitabilityData::getCorrectedSuitability)
+        .def("simulateNoReRanking",   &OpenMS::DBSuitability::SuitabilityData::simulateNoReRanking)
         ;
 
-    auto dbsuitability_class = nb::class_<OpenMS::DBSuitability>(m, "DBSuitability")
+    auto dbs_cls = nb::class_<OpenMS::DBSuitability>(m, "DBSuitability")
         .def(nb::init<>())
-        .def("compute", [](OpenMS::DBSuitability& self, const OpenMS::PeptideIdentificationList& pep_ids, const OpenMS::MSExperiment& exp, const std::vector<OpenMS::FASTAFile::FASTAEntry>& original_fasta, const std::vector<OpenMS::FASTAFile::FASTAEntry>& novo_fasta, const OpenMS::ProteinIdentification::SearchParameters& search_params) {
-            OpenMS::PeptideIdentificationList p = pep_ids;
-            self.compute(std::move(p), exp, original_fasta, novo_fasta, search_params);
-        }, "pep_ids"_a, "exp"_a, "original_fasta"_a, "novo_fasta"_a, "search_params"_a)
+        // compute takes PeptideIdentificationList&&; copy in Python, move in C++
+        .def("compute",
+             [](OpenMS::DBSuitability& self,
+                OpenMS::PeptideIdentificationList pep_ids,
+                const OpenMS::MSExperiment& exp,
+                const std::vector<OpenMS::FASTAFile::FASTAEntry>& original_fasta,
+                const std::vector<OpenMS::FASTAFile::FASTAEntry>& novo_fasta,
+                const OpenMS::ProteinIdentification::SearchParameters& search_params) {
+                 self.compute(std::move(pep_ids), exp, original_fasta, novo_fasta, search_params);
+             }, "pep_ids"_a, "exp"_a, "original_fasta"_a, "novo_fasta"_a, "search_params"_a)
         .def("getResults", &OpenMS::DBSuitability::getResults, nb::rv_policy::reference_internal)
         ;
-    def_DefaultParamHandler<OpenMS::DBSuitability>(dbsuitability_class);
+    def_DefaultParamHandler<OpenMS::DBSuitability>(dbs_cls);
 
     // -------------------------------------------------------------------------
-    // FeatureSummary
+    // FeatureSummary::Result and FeatureSummary
     // -------------------------------------------------------------------------
     nb::class_<OpenMS::FeatureSummary::Result>(m, "FeatureSummaryResult")
         .def(nb::init<>())
+        .def(nb::init<const OpenMS::FeatureSummary::Result&>())
+        .def("__copy__",     [](const OpenMS::FeatureSummary::Result& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::FeatureSummary::Result& self, nb::dict&) { return self; }, "memo"_a)
         .def_rw("feature_count", &OpenMS::FeatureSummary::Result::feature_count)
         .def_rw("rt_shift_mean", &OpenMS::FeatureSummary::Result::rt_shift_mean)
-        .def(nb::self == nb::self)
+        .def("__eq__", [](const OpenMS::FeatureSummary::Result& a, const OpenMS::FeatureSummary::Result& b) { return a == b; })
         ;
 
     nb::class_<OpenMS::FeatureSummary, OpenMS::QCBase>(m, "FeatureSummary")
         .def(nb::init<>())
+        .def(nb::init<const OpenMS::FeatureSummary&>())
+        .def("__copy__",     [](const OpenMS::FeatureSummary& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::FeatureSummary& self, nb::dict&) { return self; }, "memo"_a)
         .def("compute", &OpenMS::FeatureSummary::compute, "feature_map"_a)
         ;
 
     // -------------------------------------------------------------------------
-    // IdentificationSummary
+    // IdentificationSummary::UniqueID, ::Result, and IdentificationSummary
     // -------------------------------------------------------------------------
     nb::class_<OpenMS::IdentificationSummary::UniqueID>(m, "UniqueID")
         .def(nb::init<>())
-        .def_rw("count", &OpenMS::IdentificationSummary::UniqueID::count)
+        .def(nb::init<const OpenMS::IdentificationSummary::UniqueID&>())
+        .def("__copy__",     [](const OpenMS::IdentificationSummary::UniqueID& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::IdentificationSummary::UniqueID& self, nb::dict&) { return self; }, "memo"_a)
+        .def_rw("count",         &OpenMS::IdentificationSummary::UniqueID::count)
         .def_rw("fdr_threshold", &OpenMS::IdentificationSummary::UniqueID::fdr_threshold)
         ;
 
     nb::class_<OpenMS::IdentificationSummary::Result>(m, "IdentificationSummaryResult")
         .def(nb::init<>())
+        .def(nb::init<const OpenMS::IdentificationSummary::Result&>())
+        .def("__copy__",     [](const OpenMS::IdentificationSummary::Result& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::IdentificationSummary::Result& self, nb::dict&) { return self; }, "memo"_a)
         .def_rw("peptide_spectrum_matches", &OpenMS::IdentificationSummary::Result::peptide_spectrum_matches)
-        .def_rw("unique_peptides", &OpenMS::IdentificationSummary::Result::unique_peptides)
-        .def_rw("unique_proteins", &OpenMS::IdentificationSummary::Result::unique_proteins)
-        .def_rw("missed_cleavages_mean", &OpenMS::IdentificationSummary::Result::missed_cleavages_mean)
-        .def_rw("protein_hit_scores_mean", &OpenMS::IdentificationSummary::Result::protein_hit_scores_mean)
-        .def_rw("peptide_length_mean", &OpenMS::IdentificationSummary::Result::peptide_length_mean)
-        .def(nb::self == nb::self)
+        .def_rw("unique_peptides",          &OpenMS::IdentificationSummary::Result::unique_peptides)
+        .def_rw("unique_proteins",          &OpenMS::IdentificationSummary::Result::unique_proteins)
+        .def_rw("missed_cleavages_mean",    &OpenMS::IdentificationSummary::Result::missed_cleavages_mean)
+        .def_rw("protein_hit_scores_mean",  &OpenMS::IdentificationSummary::Result::protein_hit_scores_mean)
+        .def_rw("peptide_length_mean",      &OpenMS::IdentificationSummary::Result::peptide_length_mean)
+        .def("__eq__", [](const OpenMS::IdentificationSummary::Result& a, const OpenMS::IdentificationSummary::Result& b) { return a == b; })
         ;
 
     nb::class_<OpenMS::IdentificationSummary, OpenMS::QCBase>(m, "IdentificationSummary")
         .def(nb::init<>())
+        .def(nb::init<const OpenMS::IdentificationSummary&>())
+        .def("__copy__",     [](const OpenMS::IdentificationSummary& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::IdentificationSummary& self, nb::dict&) { return self; }, "memo"_a)
         .def("compute", &OpenMS::IdentificationSummary::compute, "prot_ids"_a, "pep_ids"_a)
         ;
 
     // -------------------------------------------------------------------------
-    // Ms2IdentificationRate
+    // Ms2IdentificationRate::IdentificationRateData and Ms2IdentificationRate
     // -------------------------------------------------------------------------
     nb::class_<OpenMS::Ms2IdentificationRate::IdentificationRateData>(m, "IdentificationRateData")
         .def(nb::init<>())
+        .def(nb::init<const OpenMS::Ms2IdentificationRate::IdentificationRateData&>())
+        .def("__copy__",     [](const OpenMS::Ms2IdentificationRate::IdentificationRateData& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::Ms2IdentificationRate::IdentificationRateData& self, nb::dict&) { return self; }, "memo"_a)
         .def_rw("num_peptide_identification", &OpenMS::Ms2IdentificationRate::IdentificationRateData::num_peptide_identification)
-        .def_rw("num_ms2_spectra", &OpenMS::Ms2IdentificationRate::IdentificationRateData::num_ms2_spectra)
-        .def_rw("identification_rate", &OpenMS::Ms2IdentificationRate::IdentificationRateData::identification_rate)
+        .def_rw("num_ms2_spectra",            &OpenMS::Ms2IdentificationRate::IdentificationRateData::num_ms2_spectra)
+        .def_rw("identification_rate",        &OpenMS::Ms2IdentificationRate::IdentificationRateData::identification_rate)
         ;
 
     nb::class_<OpenMS::Ms2IdentificationRate, OpenMS::QCBase>(m, "Ms2IdentificationRate")
         .def(nb::init<>())
-        .def("compute", nb::overload_cast<const OpenMS::FeatureMap&, const OpenMS::MSExperiment&, bool>(&OpenMS::Ms2IdentificationRate::compute), "feature_map"_a, "exp"_a, "assume_all_target"_a = false)
-        .def("compute", nb::overload_cast<const OpenMS::PeptideIdentificationList&, const OpenMS::MSExperiment&, bool>(&OpenMS::Ms2IdentificationRate::compute), "pep_ids"_a, "exp"_a, "assume_all_target"_a = false)
-        .def("getResults", &OpenMS::Ms2IdentificationRate::getResults, nb::rv_policy::reference_internal)
-        .def("addMetaDataMetricsToMzTab", &OpenMS::Ms2IdentificationRate::addMetaDataMetricsToMzTab, "meta"_a)
+        .def(nb::init<const OpenMS::Ms2IdentificationRate&>())
+        .def("__copy__",     [](const OpenMS::Ms2IdentificationRate& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::Ms2IdentificationRate& self, nb::dict&) { return self; }, "memo"_a)
+        .def("compute",
+             nb::overload_cast<const OpenMS::FeatureMap&, const OpenMS::MSExperiment&, bool>(&OpenMS::Ms2IdentificationRate::compute),
+             "feature_map"_a, "exp"_a, "assume_all_target"_a = false)
+        .def("compute",
+             nb::overload_cast<const OpenMS::PeptideIdentificationList&, const OpenMS::MSExperiment&, bool>(&OpenMS::Ms2IdentificationRate::compute),
+             "pep_ids"_a, "exp"_a, "assume_all_target"_a = false)
+        .def("getResults",               &OpenMS::Ms2IdentificationRate::getResults, nb::rv_policy::reference_internal)
+        .def("addMetaDataMetricsToMzTab",&OpenMS::Ms2IdentificationRate::addMetaDataMetricsToMzTab, "meta"_a)
         ;
 
     // -------------------------------------------------------------------------
-    // Ms2SpectrumStats
+    // Ms2SpectrumStats::ScanEvent and Ms2SpectrumStats
     // -------------------------------------------------------------------------
     nb::class_<OpenMS::Ms2SpectrumStats::ScanEvent>(m, "Ms2SpectrumStatsScanEvent")
-        .def(nb::init<UInt32, bool>())
+        .def(nb::init<OpenMS::UInt32, bool>())
+        .def(nb::init<const OpenMS::Ms2SpectrumStats::ScanEvent&>())
+        .def("__copy__",     [](const OpenMS::Ms2SpectrumStats::ScanEvent& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::Ms2SpectrumStats::ScanEvent& self, nb::dict&) { return self; }, "memo"_a)
         .def_rw("scan_event_number", &OpenMS::Ms2SpectrumStats::ScanEvent::scan_event_number)
-        .def_rw("ms2_presence", &OpenMS::Ms2SpectrumStats::ScanEvent::ms2_presence)
+        .def_rw("ms2_presence",      &OpenMS::Ms2SpectrumStats::ScanEvent::ms2_presence)
         ;
 
     nb::class_<OpenMS::Ms2SpectrumStats, OpenMS::QCBase>(m, "Ms2SpectrumStats")
         .def(nb::init<>())
+        .def(nb::init<const OpenMS::Ms2SpectrumStats&>())
+        .def("__copy__",     [](const OpenMS::Ms2SpectrumStats& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::Ms2SpectrumStats& self, nb::dict&) { return self; }, "memo"_a)
         .def("compute", &OpenMS::Ms2SpectrumStats::compute, "exp"_a, "features"_a, "map_to_spectrum"_a)
         ;
 
     // -------------------------------------------------------------------------
-    // PSMExplainedIonCurrent
+    // PSMExplainedIonCurrent::Statistics and PSMExplainedIonCurrent
     // -------------------------------------------------------------------------
     nb::class_<OpenMS::PSMExplainedIonCurrent::Statistics>(m, "PSMExplainedIonCurrentStatistics")
         .def(nb::init<>())
-        .def_rw("average_correctness", &OpenMS::PSMExplainedIonCurrent::Statistics::average_correctness)
+        .def(nb::init<const OpenMS::PSMExplainedIonCurrent::Statistics&>())
+        .def("__copy__",     [](const OpenMS::PSMExplainedIonCurrent::Statistics& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::PSMExplainedIonCurrent::Statistics& self, nb::dict&) { return self; }, "memo"_a)
+        .def_rw("average_correctness",  &OpenMS::PSMExplainedIonCurrent::Statistics::average_correctness)
         .def_rw("variance_correctness", &OpenMS::PSMExplainedIonCurrent::Statistics::variance_correctness)
         ;
 
     nb::class_<OpenMS::PSMExplainedIonCurrent, OpenMS::QCBase>(m, "PSMExplainedIonCurrent")
         .def(nb::init<>())
-        .def("compute", nb::overload_cast<OpenMS::FeatureMap&, const OpenMS::MSExperiment&, const OpenMS::QCBase::SpectraMap&, OpenMS::QCBase::ToleranceUnit, double>(&OpenMS::PSMExplainedIonCurrent::compute),
-             "fmap"_a, "exp"_a, "map_to_spectrum"_a, "tolerance_unit"_a = OpenMS::QCBase::ToleranceUnit::AUTO, "tolerance"_a = 20.0)
-        .def("compute", nb::overload_cast<OpenMS::PeptideIdentificationList&, const OpenMS::ProteinIdentification::SearchParameters&, const OpenMS::MSExperiment&, const OpenMS::QCBase::SpectraMap&, OpenMS::QCBase::ToleranceUnit, double>(&OpenMS::PSMExplainedIonCurrent::compute),
-             "pep_ids"_a, "search_params"_a, "exp"_a, "map_to_spectrum"_a, "tolerance_unit"_a = OpenMS::QCBase::ToleranceUnit::AUTO, "tolerance"_a = 20.0)
+        .def(nb::init<const OpenMS::PSMExplainedIonCurrent&>())
+        .def("__copy__",     [](const OpenMS::PSMExplainedIonCurrent& self) { return self; })
+        .def("__deepcopy__", [](const OpenMS::PSMExplainedIonCurrent& self, nb::dict&) { return self; }, "memo"_a)
+        .def("compute",
+             nb::overload_cast<OpenMS::FeatureMap&, const OpenMS::MSExperiment&, const OpenMS::QCBase::SpectraMap&, OpenMS::QCBase::ToleranceUnit, double>(&OpenMS::PSMExplainedIonCurrent::compute),
+             "fmap"_a, "exp"_a, "map_to_spectrum"_a,
+             "tolerance_unit"_a = OpenMS::QCBase::ToleranceUnit::AUTO, "tolerance"_a = 20.0)
+        .def("compute",
+             nb::overload_cast<OpenMS::PeptideIdentificationList&, const OpenMS::ProteinIdentification::SearchParameters&, const OpenMS::MSExperiment&, const OpenMS::QCBase::SpectraMap&, OpenMS::QCBase::ToleranceUnit, double>(&OpenMS::PSMExplainedIonCurrent::compute),
+             "pep_ids"_a, "search_params"_a, "exp"_a, "map_to_spectrum"_a,
+             "tolerance_unit"_a = OpenMS::QCBase::ToleranceUnit::AUTO, "tolerance"_a = 20.0)
         .def("getResults", &OpenMS::PSMExplainedIonCurrent::getResults, nb::rv_policy::reference_internal)
         ;
 }

--- a/src/pyOpenMS/tests/unittests/test_QC.py
+++ b/src/pyOpenMS/tests/unittests/test_QC.py
@@ -1,20 +1,22 @@
-"""Smoke tests for OpenMS Quality Control (QC) bindings.
+"""Smoke tests for OpenMS Quality Control (QC) Python bindings.
 
-Run directly:
-    PYTHONPATH=OpenMS-build/pyOpenMS python3 src/pyOpenMS/tests/unittests/test_QC.py
+Run directly (from OUTSIDE the source tree to avoid shadowing):
+    PYTHONPATH=/path/to/OpenMS-build/pyOpenMS python3 src/pyOpenMS/tests/unittests/test_QC.py
 """
 
+import copy
 import pyopenms as oms
 
 
 def test_import_qc():
-    # Enums & Status
+    """Verify all expected symbols are exported from the qc module."""
+    # Enums
     assert hasattr(oms, "QCBaseRequires")
     assert hasattr(oms, "QCBaseToleranceUnit")
+    # Flag set / status
     assert hasattr(oms, "QCBaseStatus")
     assert hasattr(oms, "QCSpectraMap")
     assert hasattr(oms, "QCBase")
-
     # Metrics
     assert hasattr(oms, "FWHM")
     assert hasattr(oms, "TIC")
@@ -43,97 +45,249 @@ def test_import_qc():
     assert hasattr(oms, "PSMExplainedIonCurrentStatistics")
 
 
-def test_qcbase_status():
-    # Default CTor
-    status = oms.QCBaseStatus()
-    assert status.empty()
-
-    # Enum CTor
-    status_raw = oms.QCBaseStatus(oms.QCBaseRequires.RAWMZML)
-    assert not status_raw.empty()
-    assert status_raw.value() > 0
-
-    # Bitwise operations
-    status_both = status_raw | oms.QCBaseRequires.ID
-    assert status_both.isSuperSetOf(oms.QCBaseRequires.RAWMZML)
-    assert status_both.isSuperSetOf(oms.QCBaseRequires.ID)
-
-    status_both &= oms.QCBaseRequires.ID
-    assert not status_both.isSuperSetOf(oms.QCBaseRequires.RAWMZML)
-    assert status_both.isSuperSetOf(oms.QCBaseRequires.ID)
+def test_qcbase_status_default():
+    """QCBaseStatus should start empty."""
+    s = oms.QCBaseStatus()
+    assert s.empty()
+    assert s.value() == 0
 
 
-def test_spectra_map():
-    map = oms.QCSpectraMap()
-    assert map.empty()
-    assert map.size() == 0
+def test_qcbase_status_from_enum():
+    """Constructing from enum should set the corresponding bit."""
+    s = oms.QCBaseStatus(oms.QCBaseRequires.RAWMZML)
+    assert not s.empty()
+    assert s.value() > 0
+    assert s.isSuperSetOf(oms.QCBaseRequires.RAWMZML)
 
 
-def test_tic():
+def test_qcbase_status_bitwise_or():
+    """Bitwise OR should combine two flags."""
+    s_raw = oms.QCBaseStatus(oms.QCBaseRequires.RAWMZML)
+    s_id  = oms.QCBaseStatus(oms.QCBaseRequires.ID)
+    s_both = s_raw | s_id
+    assert s_both.isSuperSetOf(oms.QCBaseRequires.RAWMZML)
+    assert s_both.isSuperSetOf(oms.QCBaseRequires.ID)
+
+
+def test_qcbase_status_bitwise_and():
+    """Bitwise AND should mask flags."""
+    s_both = (oms.QCBaseStatus(oms.QCBaseRequires.RAWMZML)
+              | oms.QCBaseRequires.ID)
+    s_masked = s_both & oms.QCBaseRequires.ID
+    assert s_masked.isSuperSetOf(oms.QCBaseRequires.ID)
+    assert not s_masked.isSuperSetOf(oms.QCBaseRequires.RAWMZML)
+
+
+def test_qcbase_status_inplace_or():
+    """In-place |= should mutate the object."""
+    s = oms.QCBaseStatus()
+    s |= oms.QCBaseRequires.RAWMZML
+    assert not s.empty()
+    assert s.isSuperSetOf(oms.QCBaseRequires.RAWMZML)
+
+
+def test_qcbase_status_copy():
+    """QCBaseStatus should support copy.copy and copy.deepcopy."""
+    s = oms.QCBaseStatus(oms.QCBaseRequires.RAWMZML)
+    s2 = copy.copy(s)
+    s3 = copy.deepcopy(s)
+    assert s2.isSuperSetOf(oms.QCBaseRequires.RAWMZML)
+    assert s3.isSuperSetOf(oms.QCBaseRequires.RAWMZML)
+
+
+def test_spectra_map_empty():
+    """Freshly created SpectraMap should be empty."""
+    m = oms.QCSpectraMap()
+    assert m.empty()
+    assert m.size() == 0
+
+
+def test_spectra_map_copy():
+    """QCSpectraMap should support copy.copy."""
+    m = oms.QCSpectraMap()
+    m2 = copy.copy(m)
+    assert m2.empty()
+
+
+def test_tic_name_and_requirements():
+    """TIC should advertise its name and require a raw mzML."""
     tic = oms.TIC()
     assert tic.getName() == "TIC"
     req = tic.requirements()
     assert req.isSuperSetOf(oms.QCBaseRequires.RAWMZML)
 
-    exp = oms.MSExperiment()
-    result = tic.compute(exp, 0.0, 1)
-    assert result.area == 0
+
+def test_tic_compute_empty():
+    """TIC.compute on an empty MSExperiment should return an empty result."""
+    tic = oms.TIC()
+    result = tic.compute(oms.MSExperiment(), 0.0, 1)
+    assert result.area == 0.0
     assert len(result.intensities) == 0
+    assert len(result.retention_times) == 0
 
 
-def test_spectrum_count():
+def test_tic_copy():
+    """TICResult and TIC should support copy."""
+    result = oms.TICResult()
+    result2 = copy.copy(result)
+    assert result == result2
+
+    tic = oms.TIC()
+    tic2 = copy.copy(tic)
+    assert tic2.getName() == "TIC"
+
+
+def test_spectrum_count_name():
+    """SpectrumCount should report the correct name."""
     sc = oms.SpectrumCount()
     assert sc.getName() == "SpectrumCount"
-    exp = oms.MSExperiment()
-    counts = sc.compute(exp)
-    assert len(counts) == 0
 
 
-def test_missed_cleavages():
+def test_spectrum_count_empty():
+    """SpectrumCount.compute on empty experiment should return empty map."""
+    sc = oms.SpectrumCount()
+    result = sc.compute(oms.MSExperiment())
+    assert len(result) == 0
+
+
+def test_missed_cleavages_empty_results():
+    """MissedCleavages.getResults() should be empty initially."""
     mc = oms.MissedCleavages()
     assert mc.getName() == "MissedCleavages"
-    res = mc.getResults()
-    assert len(res) == 0
+    assert len(mc.getResults()) == 0
 
 
-def test_contaminants():
+def test_missed_cleavages_copy():
+    """MissedCleavages should support copy."""
+    mc = oms.MissedCleavages()
+    mc2 = copy.copy(mc)
+    assert mc2.getName() == "MissedCleavages"
+
+
+def test_fragment_mass_error_statistics_defaults():
+    """FragmentMassErrorStatistics should have zero defaults."""
+    stats = oms.FragmentMassErrorStatistics()
+    assert stats.average_ppm == 0.0
+    assert stats.variance_ppm == 0.0
+
+
+def test_contaminants_empty_results():
+    """Contaminants.getResults() should be empty initially."""
     cont = oms.Contaminants()
     assert cont.getName() == "Contaminants"
-    res = cont.getResults()
-    assert len(res) == 0
+    assert len(cont.getResults()) == 0
 
 
-def test_dbsuitability():
+def test_db_suitability_empty_results():
+    """DBSuitability.getResults() should be empty initially."""
     db = oms.DBSuitability()
-    assert db.getName() == "DBSuitability"
-    res = db.getResults()
-    assert len(res) == 0
+    # DBSuitability inherits DefaultParamHandler, not QCBase
+    assert hasattr(db, "getResults")
+    assert len(db.getResults()) == 0
 
 
-def test_feature_summary():
+def test_db_suitability_data_defaults():
+    """DBSuitabilityData fields should have correct defaults."""
+    data = oms.DBSuitabilityData()
+    assert data.num_top_novo == 0
+    assert data.num_top_db == 0
+    assert data.suitability == 0.0
+
+
+def test_feature_summary_requirements():
+    """FeatureSummary should require POSTFDRFEAT."""
     fs = oms.FeatureSummary()
-    assert fs.getName() == "Summary of features from featureXML file"
     req = fs.requirements()
     assert req.isSuperSetOf(oms.QCBaseRequires.POSTFDRFEAT)
 
 
+def test_feature_summary_result_defaults():
+    """FeatureSummaryResult should have zero defaults and support equality."""
+    r = oms.FeatureSummaryResult()
+    assert r.feature_count == 0
+    r2 = copy.copy(r)
+    assert r == r2
+
+
+def test_identification_summary_unique_id_defaults():
+    """UniqueID should have zero defaults."""
+    uid = oms.UniqueID()
+    assert uid.count == 0
+    assert uid.fdr_threshold == -1.0
+
+
+def test_ms2_identification_rate_empty_results():
+    """Ms2IdentificationRate.getResults() should be empty initially."""
+    rate = oms.Ms2IdentificationRate()
+    assert rate.getName() == "Ms2IdentificationRate"
+    assert len(rate.getResults()) == 0
+
+
+def test_identification_rate_data_defaults():
+    """IdentificationRateData should default to zeros."""
+    d = oms.IdentificationRateData()
+    assert d.num_peptide_identification == 0
+    assert d.num_ms2_spectra == 0
+    assert d.identification_rate == 0.0
+
+
+def test_ms2_spectrum_stats_scan_event():
+    """Ms2SpectrumStatsScanEvent should store fields."""
+    se = oms.Ms2SpectrumStatsScanEvent(3, True)
+    assert se.scan_event_number == 3
+    assert se.ms2_presence is True
+    se2 = copy.copy(se)
+    assert se2.scan_event_number == 3
+
+
+def test_psm_explained_ion_current_statistics_defaults():
+    """PSMExplainedIonCurrentStatistics should default to zeros."""
+    stats = oms.PSMExplainedIonCurrentStatistics()
+    assert stats.average_correctness == 0.0
+    assert stats.variance_correctness == 0.0
+    stats2 = copy.copy(stats)
+    assert stats2.average_correctness == 0.0
+
+
+def test_psm_explained_ion_current_empty_results():
+    """PSMExplainedIonCurrent.getResults() should be empty initially."""
+    psm = oms.PSMExplainedIonCurrent()
+    assert psm.getName() == "PSMExplainedIonCurrent"
+    assert len(psm.getResults()) == 0
+
+
 if __name__ == "__main__":
-    test_import_qc()
-    print("test_import_qc: passed")
-    test_qcbase_status()
-    print("test_qcbase_status: passed")
-    test_spectra_map()
-    print("test_spectra_map: passed")
-    test_tic()
-    print("test_tic: passed")
-    test_spectrum_count()
-    print("test_spectrum_count: passed")
-    test_missed_cleavages()
-    print("test_missed_cleavages: passed")
-    test_contaminants()
-    print("test_contaminants: passed")
-    test_dbsuitability()
-    print("test_dbsuitability: passed")
-    test_feature_summary()
-    print("test_feature_summary: passed")
+    tests = [
+        test_import_qc,
+        test_qcbase_status_default,
+        test_qcbase_status_from_enum,
+        test_qcbase_status_bitwise_or,
+        test_qcbase_status_bitwise_and,
+        test_qcbase_status_inplace_or,
+        test_qcbase_status_copy,
+        test_spectra_map_empty,
+        test_spectra_map_copy,
+        test_tic_name_and_requirements,
+        test_tic_compute_empty,
+        test_tic_copy,
+        test_spectrum_count_name,
+        test_spectrum_count_empty,
+        test_missed_cleavages_empty_results,
+        test_missed_cleavages_copy,
+        test_fragment_mass_error_statistics_defaults,
+        test_contaminants_empty_results,
+        test_db_suitability_empty_results,
+        test_db_suitability_data_defaults,
+        test_feature_summary_requirements,
+        test_feature_summary_result_defaults,
+        test_identification_summary_unique_id_defaults,
+        test_ms2_identification_rate_empty_results,
+        test_identification_rate_data_defaults,
+        test_ms2_spectrum_stats_scan_event,
+        test_psm_explained_ion_current_statistics_defaults,
+        test_psm_explained_ion_current_empty_results,
+    ]
+    for t in tests:
+        t()
+        print(f"{t.__name__}: passed")
     print("\nAll QC pyOpenMS tests passed.")

--- a/src/pyOpenMS/tests/unittests/test_QC.py
+++ b/src/pyOpenMS/tests/unittests/test_QC.py
@@ -1,7 +1,7 @@
 """Smoke tests for OpenMS Quality Control (QC) Python bindings.
 
-Run directly (from OUTSIDE the source tree to avoid shadowing):
-    PYTHONPATH=/path/to/OpenMS-build/pyOpenMS python3 src/pyOpenMS/tests/unittests/test_QC.py
+Run directly (from /tmp to avoid shadowing):
+    cd /tmp && PYTHONPATH=/path/to/OpenMS-build/pyOpenMS python3 /path/to/OpenMS/src/pyOpenMS/tests/unittests/test_QC.py
 """
 
 import copy
@@ -186,6 +186,15 @@ def test_db_suitability_empty_results():
     assert len(db.getResults()) == 0
 
 
+def test_db_suitability_copy():
+    """DBSuitability should support copy and deepcopy."""
+    db = oms.DBSuitability()
+    db2 = copy.copy(db)
+    db3 = copy.deepcopy(db)
+    assert len(db2.getResults()) == 0
+    assert len(db3.getResults()) == 0
+
+
 def test_db_suitability_data_defaults():
     """DBSuitabilityData fields should have correct defaults."""
     data = oms.DBSuitabilityData()
@@ -194,11 +203,12 @@ def test_db_suitability_data_defaults():
     assert data.suitability == 0.0
 
 
+
 def test_feature_summary_requirements():
-    """FeatureSummary should require POSTFDRFEAT."""
+    """FeatureSummary should require PREFDRFEAT."""
     fs = oms.FeatureSummary()
     req = fs.requirements()
-    assert req.isSuperSetOf(oms.QCBaseRequires.POSTFDRFEAT)
+    assert req.isSuperSetOf(oms.QCBaseRequires.PREFDRFEAT)
 
 
 def test_feature_summary_result_defaults():
@@ -277,6 +287,7 @@ if __name__ == "__main__":
         test_fragment_mass_error_statistics_defaults,
         test_contaminants_empty_results,
         test_db_suitability_empty_results,
+        test_db_suitability_copy,
         test_db_suitability_data_defaults,
         test_feature_summary_requirements,
         test_feature_summary_result_defaults,

--- a/src/pyOpenMS/tests/unittests/test_QC.py
+++ b/src/pyOpenMS/tests/unittests/test_QC.py
@@ -1,0 +1,139 @@
+"""Smoke tests for OpenMS Quality Control (QC) bindings.
+
+Run directly:
+    PYTHONPATH=OpenMS-build/pyOpenMS python3 src/pyOpenMS/tests/unittests/test_QC.py
+"""
+
+import pyopenms as oms
+
+
+def test_import_qc():
+    # Enums & Status
+    assert hasattr(oms, "QCBaseRequires")
+    assert hasattr(oms, "QCBaseToleranceUnit")
+    assert hasattr(oms, "QCBaseStatus")
+    assert hasattr(oms, "QCSpectraMap")
+    assert hasattr(oms, "QCBase")
+
+    # Metrics
+    assert hasattr(oms, "FWHM")
+    assert hasattr(oms, "TIC")
+    assert hasattr(oms, "TICResult")
+    assert hasattr(oms, "MissedCleavages")
+    assert hasattr(oms, "FragmentMassError")
+    assert hasattr(oms, "FragmentMassErrorStatistics")
+    assert hasattr(oms, "SpectrumCount")
+    assert hasattr(oms, "PeptideMass")
+    assert hasattr(oms, "RTAlignment")
+    assert hasattr(oms, "MzCalibration")
+    assert hasattr(oms, "Contaminants")
+    assert hasattr(oms, "ContaminantsSummary")
+    assert hasattr(oms, "DBSuitability")
+    assert hasattr(oms, "DBSuitabilityData")
+    assert hasattr(oms, "FeatureSummary")
+    assert hasattr(oms, "FeatureSummaryResult")
+    assert hasattr(oms, "IdentificationSummary")
+    assert hasattr(oms, "IdentificationSummaryResult")
+    assert hasattr(oms, "UniqueID")
+    assert hasattr(oms, "Ms2IdentificationRate")
+    assert hasattr(oms, "IdentificationRateData")
+    assert hasattr(oms, "Ms2SpectrumStats")
+    assert hasattr(oms, "Ms2SpectrumStatsScanEvent")
+    assert hasattr(oms, "PSMExplainedIonCurrent")
+    assert hasattr(oms, "PSMExplainedIonCurrentStatistics")
+
+
+def test_qcbase_status():
+    # Default CTor
+    status = oms.QCBaseStatus()
+    assert status.empty()
+
+    # Enum CTor
+    status_raw = oms.QCBaseStatus(oms.QCBaseRequires.RAWMZML)
+    assert not status_raw.empty()
+    assert status_raw.value() > 0
+
+    # Bitwise operations
+    status_both = status_raw | oms.QCBaseRequires.ID
+    assert status_both.isSuperSetOf(oms.QCBaseRequires.RAWMZML)
+    assert status_both.isSuperSetOf(oms.QCBaseRequires.ID)
+
+    status_both &= oms.QCBaseRequires.ID
+    assert not status_both.isSuperSetOf(oms.QCBaseRequires.RAWMZML)
+    assert status_both.isSuperSetOf(oms.QCBaseRequires.ID)
+
+
+def test_spectra_map():
+    map = oms.QCSpectraMap()
+    assert map.empty()
+    assert map.size() == 0
+
+
+def test_tic():
+    tic = oms.TIC()
+    assert tic.getName() == "TIC"
+    req = tic.requirements()
+    assert req.isSuperSetOf(oms.QCBaseRequires.RAWMZML)
+
+    exp = oms.MSExperiment()
+    result = tic.compute(exp, 0.0, 1)
+    assert result.area == 0
+    assert len(result.intensities) == 0
+
+
+def test_spectrum_count():
+    sc = oms.SpectrumCount()
+    assert sc.getName() == "SpectrumCount"
+    exp = oms.MSExperiment()
+    counts = sc.compute(exp)
+    assert len(counts) == 0
+
+
+def test_missed_cleavages():
+    mc = oms.MissedCleavages()
+    assert mc.getName() == "MissedCleavages"
+    res = mc.getResults()
+    assert len(res) == 0
+
+
+def test_contaminants():
+    cont = oms.Contaminants()
+    assert cont.getName() == "Contaminants"
+    res = cont.getResults()
+    assert len(res) == 0
+
+
+def test_dbsuitability():
+    db = oms.DBSuitability()
+    assert db.getName() == "DBSuitability"
+    res = db.getResults()
+    assert len(res) == 0
+
+
+def test_feature_summary():
+    fs = oms.FeatureSummary()
+    assert fs.getName() == "Summary of features from featureXML file"
+    req = fs.requirements()
+    assert req.isSuperSetOf(oms.QCBaseRequires.POSTFDRFEAT)
+
+
+if __name__ == "__main__":
+    test_import_qc()
+    print("test_import_qc: passed")
+    test_qcbase_status()
+    print("test_qcbase_status: passed")
+    test_spectra_map()
+    print("test_spectra_map: passed")
+    test_tic()
+    print("test_tic: passed")
+    test_spectrum_count()
+    print("test_spectrum_count: passed")
+    test_missed_cleavages()
+    print("test_missed_cleavages: passed")
+    test_contaminants()
+    print("test_contaminants: passed")
+    test_dbsuitability()
+    print("test_dbsuitability: passed")
+    test_feature_summary()
+    print("test_feature_summary: passed")
+    print("\nAll QC pyOpenMS tests passed.")


### PR DESCRIPTION
### Description
Addresses #6102. Exposes the core C++ QC classes in `src/openms/include/OpenMS/QC/` to Python using the nanobind wrapping layer. 

This enables Python-based workflows to directly compute and inspect mass spectrometry QC metrics like TIC, FWHM, missed cleavages, contaminants, and database suitability.

### Changes
1. **Registered QC Domain**: Added `qc` to `PYOPENMS_DOMAINS` in `src/pyOpenMS/CMakeLists.txt`.
2. **Created QC Bindings**: Implemented `src/pyOpenMS/bindings/bind_qc.cpp` to expose:
   - Base definitions (`QCBase`, `QCBaseRequires`, `QCBaseToleranceUnit`, `QCBaseStatus`, `QCSpectraMap`).
   - All standard QC metric classes (`FWHM`, `TIC`, `MissedCleavages`, `FragmentMassError`, `SpectrumCount`, `PeptideMass`, `RTAlignment`, `MzCalibration`, `Contaminants`, `DBSuitability`, `FeatureSummary`, `IdentificationSummary`, `Ms2IdentificationRate`, `Ms2SpectrumStats`, `PSMExplainedIonCurrent`).
   - Multi-module type compatibility by registering the classes within the shared `"pyopenms"` domain.
3. **Added Python Unit Tests**: Created `src/pyOpenMS/tests/unittests/test_QC.py` to cover instantiation, status flag bitwise arithmetic, and callability of getName/requirements/compute.

### Verification
Local pyOpenMS compilation and tests can be executed via:
```bash
cmake --build OpenMS-build --target pyopenms -j$(nproc)
cd OpenMS-build && PYTHONPATH=./pyOpenMS python3 -m pytest ../src/pyOpenMS/tests/unittests/test_QC.py -v
```

Closes #6102


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OpenMS Quality Control (QC) support to the Python build with a dedicated QC extension module.
  - Exposed QC enums, QC status/flag handling, core QC interfaces, and QC algorithm bindings with result/metrics types.

- **Tests**
  - Added a QC smoke-test suite covering successful import, default behaviors, bitwise flag operations, shallow/deep copy semantics, and empty-input computation outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->