### PR TITLE
Fix nightly update workflow: retry and decouple downstream dispatches

### DIFF
--- a/.github/workflows/scripts/dispatch_with_retry.sh
+++ b/.github/workflows/scripts/dispatch_with_retry.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Dispatches a workflow_dispatch event via `gh workflow run`, retrying on
+# transient failures (e.g. intermittent 5xx errors from the GitHub API).
+set -uo pipefail
+
+workflow="$1"
+ref="$2"
+max_attempts=3
+delay=10
+
+for attempt in $(seq 1 "$max_attempts"); do
+  if gh workflow run "$workflow" --ref "$ref"; then
+    exit 0
+  fi
+  if [ "$attempt" -lt "$max_attempts" ]; then
+    echo "Attempt $attempt/$max_attempts to dispatch '$workflow' (ref: $ref) failed, retrying in ${delay}s..."
+    sleep "$delay"
+    delay=$((delay * 2))
+  fi
+done
+
+echo "All $max_attempts attempts to dispatch '$workflow' (ref: $ref) failed."
+exit 1

--- a/.github/workflows/update_nightly.yml
+++ b/.github/workflows/update_nightly.yml
@@ -57,36 +57,58 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.OPENMS_GITHUB_APP_PRIVATE_KEY }}
 
     - name: Call CI
+      id: call_ci
       if: steps.compare_branches.outputs.behind == 'true' || inputs.force
-      run: |
-        gh workflow run openms-ci-full --ref nightly
+      continue-on-error: true
+      run: .github/workflows/scripts/dispatch_with_retry.sh openms-ci-full nightly
       env:
         GH_TOKEN: ${{ github.token }}
 
     - name: Build Develop for cache
+      id: build_cache
       if: steps.compare_branches.outputs.behind == 'true' || inputs.force
-      run: |
-        gh workflow run openms-ci-full --ref develop
+      continue-on-error: true
+      run: .github/workflows/scripts/dispatch_with_retry.sh openms-ci-full develop
       env:
         GH_TOKEN: ${{ github.token }}
-        
+
     - name: Build wheels
+      id: build_wheels
       if: steps.compare_branches.outputs.behind == 'true' || inputs.force
-      run: |
-        gh workflow run pyopenms-wheels-cibuildwheel --ref nightly
+      continue-on-error: true
+      run: .github/workflows/scripts/dispatch_with_retry.sh pyopenms-wheels-cibuildwheel nightly
       env:
         GH_TOKEN: ${{ github.token }}
 
     - name: Deploy to Bioconda
+      id: deploy_bioconda
       if: steps.compare_branches.outputs.behind == 'true' || inputs.force
-      run: |
-        gh workflow run "Deploy to Bioconda" --ref nightly
+      continue-on-error: true
+      run: .github/workflows/scripts/dispatch_with_retry.sh "Deploy to Bioconda" nightly
       env:
         GH_TOKEN: ${{ github.token }}
 
     - name: Deploy container images
+      id: deploy_containers
       if: steps.compare_branches.outputs.behind == 'true' || inputs.force
-      run: |
-        gh workflow run containerdeploy.yml --ref nightly
+      continue-on-error: true
+      run: .github/workflows/scripts/dispatch_with_retry.sh containerdeploy.yml nightly
       env:
         GH_TOKEN: ${{ github.token }}
+
+    - name: Verify all downstream workflow dispatches succeeded
+      if: steps.compare_branches.outputs.behind == 'true' || inputs.force
+      run: |
+        status=0
+        check() {
+          if [ "$2" != "success" ]; then
+            echo "::error::Failed to trigger '$1' after retries"
+            status=1
+          fi
+        }
+        check "openms-ci-full (nightly)"                "${{ steps.call_ci.outcome }}"
+        check "openms-ci-full (develop)"                "${{ steps.build_cache.outcome }}"
+        check "pyopenms-wheels-cibuildwheel (nightly)"   "${{ steps.build_wheels.outcome }}"
+        check "Deploy to Bioconda (nightly)"             "${{ steps.deploy_bioconda.outcome }}"
+        check "Deploy container images (nightly)"        "${{ steps.deploy_containers.outcome }}"
+        exit $status


### PR DESCRIPTION
## Description

The scheduled "Update nightly from develop" run on 2026-07-18 ([run 29625727900](https://github.com/OpenMS/OpenMS/actions/runs/29625727900)) failed at the "Deploy container images" step:

```
could not create workflow dispatch event: HTTP 500: Failed to run workflow dispatch (https://api.github.com/repos/OpenMS/OpenMS/actions/workflows/44484323/dispatches)
##[error]Process completed with exit code 1.
```

Root cause: this step calls `gh workflow run containerdeploy.yml --ref nightly` to trigger the container deploy workflow. This explicit dispatch is actually necessary (not redundant) — `containerdeploy.yml` also has a `push: branches: [nightly]` trigger, but GitHub suppresses new workflow runs triggered by pushes made with the workflow's own token, so the `git push origin nightly` earlier in the job does *not* fire it. That day, GitHub's Actions API returned a transient `HTTP 500` on the dispatch call, and since the step had no retry logic, the whole job aborted — no container images were built for `nightly` that day. Checking the last 30 days of `Deploy container images` runs confirms there is normally exactly one run per day; 2026-07-18 has none.

A second, related problem: each of the five downstream `gh workflow run` steps (`Call CI`, `Build Develop for cache`, `Build wheels`, `Deploy to Bioconda`, `Deploy container images`) ran sequentially with no `continue-on-error`. A transient failure on *any* one of them (not just the last) would have aborted the job and skipped triggering the remaining downstream workflows too, even though they are logically independent of each other.

## Fix

- Added `.github/workflows/scripts/dispatch_with_retry.sh`, a small helper that retries a `gh workflow run` dispatch up to 3 times with exponential backoff, to absorb transient GitHub API errors like the 500 seen above.
- Each downstream dispatch step now uses this helper and sets `continue-on-error: true`, so a failure on one dispatch no longer prevents the others from being attempted.
- Added a final "Verify all downstream workflow dispatches succeeded" step that checks the outcome of every dispatch step and fails the job if any of them did not ultimately succeed after retries — so persistent/real failures are still surfaced and not silently swallowed.

This is not a workaround to force CI green: the job will still fail (with a clear `::error::` per workflow) if a dispatch genuinely cannot be triggered after retries. It only adds resilience against transient upstream API errors and removes an unnecessary coupling between independent dispatch steps.

## Checklist
- [x] New script passes `bash -n` syntax check; workflow YAML validated with `yaml.safe_load`
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes (workflow-only change; no unit tests apply)
- [x] Updated or added python bindings for changed or new classes (not applicable — CI workflow change only)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AqEsB5mUpnWg8Uzd3vzKQW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of nightly workflow triggers with automatic retries.
  * Added verification to detect failed downstream workflow dispatches.
  * Ensured nightly updates report failures clearly when required workflows do not start successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->