### PR TITLE
Retry gh workflow dispatches in nightly-sync job on transient API errors

### DIFF
--- a/.github/scripts/gh_dispatch_retry.sh
+++ b/.github/scripts/gh_dispatch_retry.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Dispatch a workflow_dispatch event via `gh workflow run`, retrying on
+# transient GitHub API errors (e.g. intermittent HTTP 5xx responses).
+set -u
+
+workflow="$1"
+ref="$2"
+max_attempts=5
+
+for attempt in $(seq 1 "$max_attempts"); do
+  if gh workflow run "$workflow" --ref "$ref"; then
+    exit 0
+  fi
+  if [ "$attempt" -eq "$max_attempts" ]; then
+    echo "::error::Failed to dispatch workflow '$workflow' on ref '$ref' after $max_attempts attempts"
+    exit 1
+  fi
+  delay=$((5 * attempt))
+  echo "Attempt $attempt/$max_attempts to dispatch '$workflow' on ref '$ref' failed, retrying in ${delay}s..."
+  sleep "$delay"
+done

--- a/.github/workflows/update_nightly.yml
+++ b/.github/workflows/update_nightly.yml
@@ -59,34 +59,34 @@ jobs:
     - name: Call CI
       if: steps.compare_branches.outputs.behind == 'true' || inputs.force
       run: |
-        gh workflow run openms-ci-full --ref nightly
+        .github/scripts/gh_dispatch_retry.sh openms-ci-full nightly
       env:
         GH_TOKEN: ${{ github.token }}
 
     - name: Build Develop for cache
       if: steps.compare_branches.outputs.behind == 'true' || inputs.force
       run: |
-        gh workflow run openms-ci-full --ref develop
+        .github/scripts/gh_dispatch_retry.sh openms-ci-full develop
       env:
         GH_TOKEN: ${{ github.token }}
-        
+
     - name: Build wheels
       if: steps.compare_branches.outputs.behind == 'true' || inputs.force
       run: |
-        gh workflow run pyopenms-wheels-cibuildwheel --ref nightly
+        .github/scripts/gh_dispatch_retry.sh pyopenms-wheels-cibuildwheel nightly
       env:
         GH_TOKEN: ${{ github.token }}
 
     - name: Deploy to Bioconda
       if: steps.compare_branches.outputs.behind == 'true' || inputs.force
       run: |
-        gh workflow run "Deploy to Bioconda" --ref nightly
+        .github/scripts/gh_dispatch_retry.sh "Deploy to Bioconda" nightly
       env:
         GH_TOKEN: ${{ github.token }}
 
     - name: Deploy container images
       if: steps.compare_branches.outputs.behind == 'true' || inputs.force
       run: |
-        gh workflow run containerdeploy.yml --ref nightly
+        .github/scripts/gh_dispatch_retry.sh containerdeploy.yml nightly
       env:
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Investigated the "nightly build CI" and found the **actual nightly build matrix (`openms-ci-full` on the `nightly` branch) has been green every night** — all build/test/package/deploy jobs (Linux, macOS, Windows, ARM, docs, KNIME, installer) passed on 2026-07-18.

The failure was in the orchestrator, `Update nightly from develop` (`.github/workflows/update_nightly.yml`), which fast-forwards `nightly` to `develop` and then dispatches the downstream workflows (CI, wheels, Bioconda, container images). On 2026-07-18 its last step failed:

```
could not create workflow dispatch event: HTTP 500: Failed to run workflow dispatch
  (.../actions/workflows/44484323/dispatches)
##[error]Process completed with exit code 1.
```

This is a transient GitHub API error on the `gh workflow run containerdeploy.yml --ref nightly` call, not a code/test defect — everything before it (the nightly branch fast-forward, and dispatching `openms-ci-full`, `pyopenms-wheels-cibuildwheel`, and `Deploy to Bioconda`) had already succeeded that run. But because GitHub Actions steps stop the job on the first failing step, a single flaky dispatch call aborts the whole job and (had it happened earlier in the sequence) would have silently skipped the remaining dispatches too.

## Fix

Added `.github/scripts/gh_dispatch_retry.sh`, a small retry-with-backoff wrapper around `gh workflow run <workflow> --ref <ref>` (5 attempts, linear backoff), and updated each of the five dispatch steps in `update_nightly.yml` to use it. A dispatch call now only fails the job after 5 unsuccessful attempts, which tolerates one-off API hiccups like the one observed while still surfacing a genuine, persistent failure (no error suppression — the job still fails loudly if the API stays down).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/update_nightly.yml'))"` — YAML parses
- [x] `bash -n .github/scripts/gh_dispatch_retry.sh` — script syntax check
- [ ] Next scheduled/triggered run of "Update nightly from develop" exercises the new retry path in production

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bg6MhKkxUPexR4NwYcVJUX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of nightly update automation by automatically retrying workflow dispatches after transient failures.
  - Added clearer failure reporting when all retry attempts are unsuccessful.
  - Preserved existing conditions and targets for nightly CI, cache, wheel, package, and container update jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->