### PR TITLE
[FORMAT][GUI] Fix silent edit loss, value rewrites and non-atomic save in ParamEditor/ParamXMLFile (#9768)

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ParamXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ParamXMLHandler.h
@@ -37,6 +37,19 @@ public:
       // Docu in base class
       void onStartElement(const char16_t* qname, const XMLAttributes& attributes) override;
 
+      /**
+        @brief Whether a @em PARAMETERS element was encountered while parsing.
+
+        Callers use this to reject documents that are not parameter files at all: unknown elements
+        are silently ignored, so without this check any well-formed XML parses "successfully" into
+        an empty Param. Note that this deliberately does not test the *root* element -- CTD files
+        wrap @em PARAMETERS in a @em tool root, and ToolDescriptionHandler embeds it in @em ttd.
+      */
+      bool hasSeenParametersElement() const
+      {
+        return parameters_element_seen_;
+      }
+
 protected:
       /// The current absolute path (concatenation of nodes_ with <i>:</i> in between)
       std::string path_;
@@ -44,6 +57,9 @@ protected:
       Param& param_;
       /// Map of node descriptions (they are set at the end of parsing)
       std::map<std::string, std::string> descriptions_;
+
+      /// Whether a 'PARAMETERS' element was seen (see hasSeenParametersElement())
+      bool parameters_element_seen_{false};
 
       ///Temporary data for parsing of item lists
       struct

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ParamXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ParamXMLHandler.h
@@ -38,12 +38,15 @@ public:
       void onStartElement(const char16_t* qname, const XMLAttributes& attributes) override;
 
       /**
-        @brief Whether a @em PARAMETERS element was encountered while parsing.
+        @brief Whether a @em PARAMETERS element was encountered anywhere while parsing.
 
         Callers use this to reject documents that are not parameter files at all: unknown elements
         are silently ignored, so without this check any well-formed XML parses "successfully" into
-        an empty Param. Note that this deliberately does not test the *root* element -- CTD files
-        wrap @em PARAMETERS in a @em tool root, and ToolDescriptionHandler embeds it in @em ttd.
+        an empty Param. This reports @em PARAMETERS anywhere in the document rather than requiring
+        it as the *root* element on purpose: ParamXMLFile uses it to accept CTD documents, which
+        wrap @em PARAMETERS inside a @em tool root and are loaded through ParamXMLFile as well.
+        (ToolDescriptionHandler, which parses @em .ttd files, separately reuses this handler for the
+        parameter section it embeds, but does not go through ParamXMLFile::load().)
       */
       bool hasSeenParametersElement() const
       {

--- a/src/openms/include/OpenMS/FORMAT/ParamXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ParamXMLFile.h
@@ -30,10 +30,25 @@ public:
     /**
       @brief Write XML file.
 
-      @param[in] filename The filename where the param data structure should be stored.
-      @param[out] param The Param class that should be stored in the file.
+      The content is serialised into an exclusively-created temporary next to @p filename and then
+      renamed over the target, so a failure part way through (full disk, I/O error) leaves the
+      previous, valid file untouched instead of truncating it. Directories and write-protected
+      targets are rejected up front; symlinks are resolved so the link target is replaced rather
+      than the link. The special filename "-" writes to stdout.
 
-      @exception Exception::UnableToCreateFile is thrown if the file could not be created
+      On POSIX the final rename is atomic. On Windows it is atomic where the platform replaces an
+      existing target in a single step; in the rare case it does not, a best-effort fallback removes
+      the target and retries, and if that retry fails the freshly written content is preserved under
+      the temporary name (reported in the exception message) rather than both copies being lost.
+      Note that replacing by rename gives the target a new inode, so ownership, ACLs, extended
+      attributes and hard links are not preserved (Qt's QSaveFile behaves the same way).
+
+      @param[in] filename The filename where the param data structure should be stored.
+      @param[in] param The Param class that should be stored in the file.
+
+      @exception Exception::UnableToCreateFile is thrown if the target cannot be written: it is a
+                 directory or write-protected, the temporary file cannot be created, the write or
+                 flush fails, or the temporary cannot be renamed over the target.
     */
     void store(const std::string& filename, const Param& param) const;
 
@@ -41,18 +56,20 @@ public:
       @brief Write XML to output stream.
 
       @param[out] os_ptr The stream where the param class should be written to.
-      @param[out] param The Param class that should be written to the stream.
+      @param[in] param The Param class that should be written to the stream.
     */
     void writeXMLToStream(std::ostream* os_ptr, const Param& param) const;
 
     /**
       @brief Read XML file.
 
-      @param[out] filename The file from where to read the Param object.
+      @param[in] filename The file from where to read the Param object.
       @param[out] param The param object where the read data should be stored.
 
       @exception Exception::FileNotFound is thrown if the file could not be found
-      @exception Exception::ParseError is thrown if an error occurs during parsing
+      @exception Exception::ParseError is thrown if an error occurs during parsing, including a
+                 well-formed document that contains no @em PARAMETERS element (i.e. is not a
+                 parameter file at all); @p param is cleared in that case.
     */
     void load(const std::string& filename, Param& param);
   };

--- a/src/openms/source/FORMAT/HANDLERS/ParamXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ParamXMLHandler.cpp
@@ -276,6 +276,8 @@ namespace OpenMS::Internal
       }
       else if (element == "PARAMETERS")
       {
+        parameters_element_seen_ = true;
+
         //check file version against schema version
         std::string file_version;
         optionalAttributeAsString_(file_version, attributes, "version");

--- a/src/openms/source/FORMAT/ParamXMLFile.cpp
+++ b/src/openms/source/FORMAT/ParamXMLFile.cpp
@@ -13,30 +13,50 @@
 
 #include <iostream>
 #include <fstream>
+#include <sstream>
 #include <algorithm>
 #include <filesystem>
 #include <cerrno>
+#include <fcntl.h> // common to both platforms
 #ifdef OPENMS_WINDOWSPLATFORM
   #include <io.h>
   #include <share.h>
   #include <sys/stat.h>
-  #include <fcntl.h>
 #else
-  #include <fcntl.h>
   #include <unistd.h>
 #endif
 
 namespace
 {
-  /**
-    @brief Create a new, empty file next to @p target and return its path (empty on failure).
+  /// An exclusively-created temporary file: its path together with the still-open write descriptor.
+  struct ExclusiveTempFile
+  {
+    std::filesystem::path path;
+    int fd = -1; ///< -1 means creation failed
+  };
 
-    The file is created exclusively, i.e. the call fails if the path already exists. That matters
-    because the temporary lives in whatever directory the user's file is in: with a plain
-    std::ofstream another process could pre-create the path as a symlink -- the name is derived from
-    a timestamp and PID and is therefore guessable -- and have us truncate whatever it points at.
+  /**
+    @brief Create a new, empty file next to @p target, opened exclusively, and return its path
+           together with the still-open write descriptor (@c fd == -1 on failure).
+
+    The file is created with @c O_EXCL, i.e. the call fails if the path already exists. That matters
+    because the temporary lives in whatever directory the user's file is in, and its name is derived
+    from a timestamp and PID and is therefore guessable: without @c O_EXCL another process could
+    pre-create the path as a symlink and have us truncate whatever it points at.
+
+    The descriptor is deliberately kept open so the caller can write through it directly. Closing it
+    and reopening the path with a fresh std::ofstream would reintroduce exactly that race -- another
+    process could swap the name for a symlink between the two opens and redirect our write. Content
+    is written in binary mode (LF line endings on all platforms), matching the repository's
+    paramXML/INI reference files and the binary output of the base XMLFile writer.
+
+    When @p restrictive is true (we are replacing an existing file) the file is created owner-only so
+    the (possibly sensitive) parameters are not briefly world/group-readable while they are being
+    written; the caller restores the target's permissions afterwards. When false (a new file) the
+    normal umask-based default permissions are used, so a freshly created file is not unexpectedly
+    restricted to owner-only.
   */
-  std::filesystem::path createExclusiveTempFile(const std::filesystem::path& target)
+  ExclusiveTempFile createExclusiveTempFile(const std::filesystem::path& target, [[maybe_unused]] bool restrictive)
   {
     for (int attempt = 0; attempt < 32; ++attempt)
     {
@@ -44,22 +64,23 @@ namespace
       tmp += "." + OpenMS::File::getUniqueName(false) + ".tmp";
 #ifdef OPENMS_WINDOWSPLATFORM
       int fd = -1;
-      errno_t err = _wsopen_s(&fd, tmp.wstring().c_str(), _O_CREAT | _O_EXCL | _O_WRONLY | _O_BINARY, _SH_DENYNO, _S_IREAD | _S_IWRITE);
+      errno_t err = _wsopen_s(&fd, tmp.wstring().c_str(), _O_CREAT | _O_EXCL | _O_WRONLY | _O_BINARY, _SH_DENYRW, _S_IREAD | _S_IWRITE);
       if (err == 0 && fd != -1)
       {
-        _close(fd);
-        return tmp;
+        return {tmp, fd};
       }
       if (err != EEXIST)
       {
         break;
       }
 #else
-      int fd = ::open(tmp.c_str(), O_CREAT | O_EXCL | O_WRONLY, 0666);
+      // 0600 while replacing (owner-only during write); 0666 for a new file so the process umask
+      // determines the final permissions as it would for an ordinary new file.
+      const int mode = restrictive ? 0600 : 0666;
+      int fd = ::open(tmp.c_str(), O_CREAT | O_EXCL | O_WRONLY, mode);
       if (fd != -1)
       {
-        ::close(fd);
-        return tmp;
+        return {tmp, fd};
       }
       if (errno != EEXIST)
       {
@@ -68,6 +89,70 @@ namespace
 #endif
     }
     return {};
+  }
+
+  /**
+    @brief Close a descriptor obtained from createExclusiveTempFile(). Returns 0 on success, -1 on error.
+
+    The result must be checked: on NFS or when a quota is hit, the write error is not reported by the
+    individual write() calls (the data is only buffered) but surfaces here at close time. Ignoring it
+    would let an incomplete temporary be renamed over the previously-valid target.
+  */
+  int closeDescriptor(int fd)
+  {
+#ifdef OPENMS_WINDOWSPLATFORM
+    return _close(fd);
+#else
+    return ::close(fd);
+#endif
+  }
+
+  /**
+    @brief Non-mutating check that an @em existing path is writable.
+
+    Deliberately not OpenMS::File::writable(): that probes a non-existent path by creating and then
+    removing it, and if its internal existence check hits a transient stat error it treats the path
+    as non-existent and opens it with a truncating std::ofstream -- which would destroy the very
+    target we are trying to preserve. access()/_waccess_s only query permissions and never mutate;
+    any error is reported as "not writable" (fail closed).
+  */
+  bool isExistingPathWritable(const std::filesystem::path& p)
+  {
+#ifdef OPENMS_WINDOWSPLATFORM
+    return _waccess_s(p.wstring().c_str(), 2) == 0; // 2 = write permission
+#else
+    return ::access(p.c_str(), W_OK) == 0;
+#endif
+  }
+
+  /// Write the whole buffer to @p fd, looping over partial writes. Returns false on any error.
+  bool writeAllToDescriptor(int fd, const char* data, std::size_t size)
+  {
+    std::size_t written = 0;
+    while (written < size)
+    {
+      const std::size_t remaining = size - written;
+#ifdef OPENMS_WINDOWSPLATFORM
+      const unsigned int chunk = remaining > 0x40000000u ? 0x40000000u : static_cast<unsigned int>(remaining);
+      const int n = _write(fd, data + written, chunk);
+#else
+      const ssize_t n = ::write(fd, data + written, remaining);
+#endif
+      if (n < 0)
+      {
+        if (errno == EINTR)
+        {
+          continue; // interrupted before any byte was written -- retry
+        }
+        return false;
+      }
+      if (n == 0)
+      {
+        return false; // no progress on a regular file -- treat as failure rather than spin forever
+      }
+      written += static_cast<std::size_t>(n);
+    }
+    return true;
   }
 } // namespace
 
@@ -95,97 +180,151 @@ namespace OpenMS
     namespace fs = std::filesystem;
 
     // Serialise into a temporary file and rename it over the target, so that a failure part way
-    // through (full disk, I/O error, crash) leaves the previous, valid file untouched. Opening the
-    // target directly would truncate it before we know the new content can be written at all -- for
-    // an editor that file is often the user's only copy.
+    // through (full disk, I/O error) leaves the previous, valid file untouched. Opening the target
+    // directly would truncate it before we know the new content can be written at all -- for an
+    // editor that file is often the user's only copy. (Note: this is not a durability guarantee
+    // across an OS/power crash -- there is no fsync of the file or its parent directory.)
     std::error_code ec;
-    // resolve symlinks so we replace the file that is linked to, not the link itself.
-    // canonical() follows a whole chain of links; on failure (e.g. a dangling link) we keep the
-    // path as given and simply create it.
+
+    // Resolve symlinks so we replace the file the link points at, not any link in the chain. We
+    // cannot rely on canonical() alone: it fails on a dangling link. Following the chain by hand
+    // lets us create a not-yet-existing target while leaving every intermediate link intact -- each
+    // relative hop is resolved against the directory of the link it came from. A cycle or an
+    // over-long chain is rejected. Inspection errors fail closed (throw): silently continuing could
+    // let a transient I/O error cause us to replace a symlink or special file we could not classify.
     fs::path target(filename);
-    if (fs::is_symlink(target, ec))
+    fs::file_status target_status;
     {
-      fs::path resolved = fs::canonical(target, ec);
-      if (!ec)
+      int hops = 0;
+      while (true)
       {
-        target = resolved;
+        target_status = fs::symlink_status(target, ec); // does not follow the final link
+        if (ec)
+        {
+          if (ec == std::errc::no_such_file_or_directory)
+          { // the path (or a parent component) does not exist: a new file to be created. Some
+            // std::filesystem implementations report this via ec rather than file_type::not_found.
+            target_status = fs::file_status(fs::file_type::not_found);
+            ec.clear();
+            break;
+          }
+          // any other error means we cannot classify the target -- fail closed rather than risk
+          // replacing something we could not inspect
+          throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename,
+                                              "could not determine the type of the target");
+        }
+        if (target_status.type() != fs::file_type::symlink)
+        {
+          break; // reached a non-symlink terminal (regular, special, directory, or not-found)
+        }
+        if (++hops > 40) // more hops than any real chain -- almost certainly a cycle
+        {
+          throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename,
+                                              "the target is a cyclic or excessively long symlink chain");
+        }
+        fs::path link_target = fs::read_symlink(target, ec);
+        if (ec)
+        {
+          throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename,
+                                              "could not read the target symlink");
+        }
+        target = link_target.is_absolute() ? link_target : target.parent_path() / link_target;
       }
-      ec.clear();
     }
-    // Refuse targets that must not be replaced by a rename. Opening the target directly used to
-    // reject these implicitly; without the check we would happily remove a directory or overwrite a
-    // write-protected file, because on POSIX rename() is governed by the directory's permissions.
-    if (fs::exists(target, ec))
+    // Only a regular file (or a not-yet-existing path) may be created or replaced by the rename.
+    // Reject a directory, a special file (FIFO, socket, device) or a write-protected regular file:
+    // the old stream-based code rejected these implicitly by failing to open them for writing, and
+    // replacing them by rename would silently destroy them. The type comes from the cached
+    // symlink_status above (no extra lookup); the writability check uses a non-mutating access()
+    // that fails closed, so neither can fail open and destroy the target.
+    const bool target_exists = fs::exists(target_status);
+    if (target_exists && (!fs::is_regular_file(target_status) || !isExistingPathWritable(target)))
     {
-      if (fs::is_directory(target, ec) || !File::writable(target.string()))
-      {
-        throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
-      }
+      throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename,
+                                          "the target exists but is not a writable regular file");
     }
     ec.clear();
 
-    // keep the temporary next to the target so the rename stays within one filesystem
-    fs::path tmp = createExclusiveTempFile(target);
-    if (tmp.empty())
+    // Serialise the whole document up front. Doing this before touching the target means a
+    // serialisation failure cannot leave a half-written temporary behind, and lets us write the
+    // result through the exclusive descriptor in one go.
+    std::ostringstream buffer;
+    writeXMLToStream(&buffer, param);
+    if (!buffer) // a stream-buffer/allocation failure can set badbit without throwing
     {
-      throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
+      throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename,
+                                          "failed to serialise the parameters");
+    }
+    const std::string data = buffer.str();
+
+    // keep the temporary next to the target so the rename stays within one filesystem. When we are
+    // replacing an existing file, create the temporary owner-only so its (possibly sensitive)
+    // content is not briefly world/group-readable; when creating a new file, use the normal default
+    // permissions (umask-based) so a new file is not unexpectedly restricted to 0600.
+    ExclusiveTempFile tmp = createExclusiveTempFile(target, /* restrictive = */ target_exists);
+    if (tmp.fd == -1)
+    {
+      throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename,
+                                          "could not create a temporary file next to the target");
     }
 
+    // Write through the descriptor we still hold from the exclusive create -- never by reopening
+    // the path, which would let another process redirect the write via a symlink. The close result
+    // is part of the check: on NFS / at a quota the write error surfaces only at close time.
+    const bool write_ok = writeAllToDescriptor(tmp.fd, data.data(), data.size());
+    const bool close_ok = (closeDescriptor(tmp.fd) == 0);
+    if (!write_ok || !close_ok) // e.g. the disk filled up
     {
-      std::ofstream os(tmp, std::ofstream::out);
-      if (!os)
-      {
-        fs::remove(tmp, ec);
-        throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
-      }
-      try
-      {
-        writeXMLToStream(&os, param);
-      }
-      catch (...)
-      {
-        os.close();
-        fs::remove(tmp, ec);
-        throw;
-      }
-      os.close();
-      if (!os) // flush/close failed, e.g. the disk filled up
-      {
-        fs::remove(tmp, ec);
-        throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
-      }
+      fs::remove(tmp.path, ec);
+      throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename,
+                                          "could not write the temporary file");
     }
 
-    // Carry over the permissions of the file we are replacing. Note that replacing by rename gives
-    // the target a new inode, so ownership, ACLs, extended attributes and hard links to it are not
-    // preserved -- the accepted trade-off for not truncating the only copy on a failed write (Qt's
-    // QSaveFile behaves the same way).
-    if (fs::exists(target, ec))
+    // Carry over the permissions of the file we are replacing (the temporary was created owner-only
+    // in that case). Note that replacing by rename gives the target a new inode, so ownership, ACLs,
+    // extended attributes and hard links to it are not preserved -- the accepted trade-off for not
+    // truncating the only copy on a failed write (Qt's QSaveFile behaves the same way). A failed
+    // permission copy is left best-effort: the file keeps its owner-only temporary permissions,
+    // which is safe (does not grant any group/other mode bits).
+    if (target_exists)
     {
       auto perms = fs::status(target, ec).permissions();
       if (!ec)
       {
-        fs::permissions(tmp, perms, ec);
+        fs::permissions(tmp.path, perms, ec);
       }
     }
 
-    fs::rename(tmp, target, ec);
-    if (ec)
-    { // POSIX replaces the target atomically. Windows refuses when it exists, so retry after
-      // removing it -- but only for a plain file we already know we may overwrite, and never as a
-      // blanket reaction to an arbitrary rename failure, which would delete the user's data and
-      // then still fail.
+    fs::rename(tmp.path, target, ec);
+#ifdef OPENMS_WINDOWSPLATFORM
+    bool original_removed = false;
+    if (ec == std::errc::file_exists)
+    { // POSIX (and Windows MoveFileEx with replacement) replace the target atomically; only a
+      // Windows configuration that refuses to rename onto an existing file reaches here. Retry
+      // after removing the target -- but only for that specific error, and only for a plain file we
+      // already established we may overwrite, never as a blanket reaction to an arbitrary failure.
       std::error_code probe;
       if (fs::is_regular_file(target, probe) && fs::remove(target, probe))
       {
-        fs::rename(tmp, target, ec);
+        original_removed = true;
+        fs::rename(tmp.path, target, ec);
       }
     }
+    if (ec && original_removed)
+    { // The original was already deleted and the replacement could not be moved into place.
+      // Removing tmp now would destroy both copies -- the very data loss this mechanism exists to
+      // prevent. Leave the freshly written content under the temporary name and point at it.
+      throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename,
+          "the previous file was removed but the new content could not be put in place; it has been preserved as '" + tmp.path.string() + "'");
+    }
+#endif
     if (ec)
     {
+      // The original (if any) is still intact, so discarding the freshly written temporary is safe.
       std::error_code ignored;
-      fs::remove(tmp, ignored);
-      throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
+      fs::remove(tmp.path, ignored);
+      throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename,
+                                          "could not replace the target with the temporary file");
     }
   }
 

--- a/src/openms/source/FORMAT/ParamXMLFile.cpp
+++ b/src/openms/source/FORMAT/ParamXMLFile.cpp
@@ -9,10 +9,67 @@
 #include <OpenMS/FORMAT/ParamXMLFile.h>
 
 #include <OpenMS/FORMAT/HANDLERS/ParamXMLHandler.h>
+#include <OpenMS/SYSTEM/File.h>
 
 #include <iostream>
 #include <fstream>
 #include <algorithm>
+#include <filesystem>
+#include <cerrno>
+#ifdef OPENMS_WINDOWSPLATFORM
+  #include <io.h>
+  #include <share.h>
+  #include <sys/stat.h>
+  #include <fcntl.h>
+#else
+  #include <fcntl.h>
+  #include <unistd.h>
+#endif
+
+namespace
+{
+  /**
+    @brief Create a new, empty file next to @p target and return its path (empty on failure).
+
+    The file is created exclusively, i.e. the call fails if the path already exists. That matters
+    because the temporary lives in whatever directory the user's file is in: with a plain
+    std::ofstream another process could pre-create the path as a symlink -- the name is derived from
+    a timestamp and PID and is therefore guessable -- and have us truncate whatever it points at.
+  */
+  std::filesystem::path createExclusiveTempFile(const std::filesystem::path& target)
+  {
+    for (int attempt = 0; attempt < 32; ++attempt)
+    {
+      std::filesystem::path tmp = target;
+      tmp += "." + OpenMS::File::getUniqueName(false) + ".tmp";
+#ifdef OPENMS_WINDOWSPLATFORM
+      int fd = -1;
+      errno_t err = _wsopen_s(&fd, tmp.wstring().c_str(), _O_CREAT | _O_EXCL | _O_WRONLY | _O_BINARY, _SH_DENYNO, _S_IREAD | _S_IWRITE);
+      if (err == 0 && fd != -1)
+      {
+        _close(fd);
+        return tmp;
+      }
+      if (err != EEXIST)
+      {
+        break;
+      }
+#else
+      int fd = ::open(tmp.c_str(), O_CREAT | O_EXCL | O_WRONLY, 0666);
+      if (fd != -1)
+      {
+        ::close(fd);
+        return tmp;
+      }
+      if (errno != EEXIST)
+      {
+        break;
+      }
+#endif
+    }
+    return {};
+  }
+} // namespace
 
 namespace OpenMS
 {
@@ -29,27 +86,107 @@ namespace OpenMS
 
   void ParamXMLFile::store(const std::string& filename, const Param& param) const
   {
-    //open file
-    std::ofstream os_;
-    std::ostream* os_ptr;
-    if (filename != "-")
+    if (filename == "-")
     {
-      os_.open(filename.c_str(), std::ofstream::out);
-      if (!os_)
+      writeXMLToStream(&std::cout, param);
+      return;
+    }
+
+    namespace fs = std::filesystem;
+
+    // Serialise into a temporary file and rename it over the target, so that a failure part way
+    // through (full disk, I/O error, crash) leaves the previous, valid file untouched. Opening the
+    // target directly would truncate it before we know the new content can be written at all -- for
+    // an editor that file is often the user's only copy.
+    std::error_code ec;
+    // resolve symlinks so we replace the file that is linked to, not the link itself.
+    // canonical() follows a whole chain of links; on failure (e.g. a dangling link) we keep the
+    // path as given and simply create it.
+    fs::path target(filename);
+    if (fs::is_symlink(target, ec))
+    {
+      fs::path resolved = fs::canonical(target, ec);
+      if (!ec)
+      {
+        target = resolved;
+      }
+      ec.clear();
+    }
+    // Refuse targets that must not be replaced by a rename. Opening the target directly used to
+    // reject these implicitly; without the check we would happily remove a directory or overwrite a
+    // write-protected file, because on POSIX rename() is governed by the directory's permissions.
+    if (fs::exists(target, ec))
+    {
+      if (fs::is_directory(target, ec) || !File::writable(target.string()))
       {
         throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
       }
-      os_ptr = &os_;
     }
-    else
+    ec.clear();
+
+    // keep the temporary next to the target so the rename stays within one filesystem
+    fs::path tmp = createExclusiveTempFile(target);
+    if (tmp.empty())
     {
-      os_ptr = &std::cout;
+      throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
     }
 
-    //write to file stream
-    writeXMLToStream(os_ptr, param);
+    {
+      std::ofstream os(tmp, std::ofstream::out);
+      if (!os)
+      {
+        fs::remove(tmp, ec);
+        throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
+      }
+      try
+      {
+        writeXMLToStream(&os, param);
+      }
+      catch (...)
+      {
+        os.close();
+        fs::remove(tmp, ec);
+        throw;
+      }
+      os.close();
+      if (!os) // flush/close failed, e.g. the disk filled up
+      {
+        fs::remove(tmp, ec);
+        throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
+      }
+    }
 
-    os_.close();
+    // Carry over the permissions of the file we are replacing. Note that replacing by rename gives
+    // the target a new inode, so ownership, ACLs, extended attributes and hard links to it are not
+    // preserved -- the accepted trade-off for not truncating the only copy on a failed write (Qt's
+    // QSaveFile behaves the same way).
+    if (fs::exists(target, ec))
+    {
+      auto perms = fs::status(target, ec).permissions();
+      if (!ec)
+      {
+        fs::permissions(tmp, perms, ec);
+      }
+    }
+
+    fs::rename(tmp, target, ec);
+    if (ec)
+    { // POSIX replaces the target atomically. Windows refuses when it exists, so retry after
+      // removing it -- but only for a plain file we already know we may overwrite, and never as a
+      // blanket reaction to an arbitrary rename failure, which would delete the user's data and
+      // then still fail.
+      std::error_code probe;
+      if (fs::is_regular_file(target, probe) && fs::remove(target, probe))
+      {
+        fs::rename(tmp, target, ec);
+      }
+    }
+    if (ec)
+    {
+      std::error_code ignored;
+      fs::remove(tmp, ignored);
+      throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
+    }
   }
 
   void ParamXMLFile::writeXMLToStream(std::ostream* os_ptr, const Param& param) const
@@ -358,6 +495,21 @@ namespace OpenMS
   {
     Internal::ParamXMLHandler handler(param, filename, schema_version_);
     parse_(filename, &handler);
+
+    // Reject documents that are not parameter files. parse_() validates nothing and the handler
+    // ignores unknown elements, so without this any well-formed XML "loads" as an empty Param and
+    // reports success -- in an editor that means opening an unrelated file appears to work and
+    // saving then replaces it. See OpenMS/OpenMS#9768.
+    // Checking for a PARAMETERS element rather than a PARAMETERS *root* is deliberate: CTD files
+    // nest it inside a 'tool' root and are loaded through here as well.
+    if (!handler.hasSeenParametersElement())
+    {
+      // stray ITEM elements may already have been imported, so do not leave the caller's Param
+      // half-populated if it swallows the exception
+      param.clear();
+      throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename,
+                                  "Not a parameter file: no 'PARAMETERS' element found.");
+    }
   }
 
 }

--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/TOPPViewPrefDialog.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/TOPPViewPrefDialog.h
@@ -43,7 +43,16 @@ public:
 
       /// update the parameters given the current GUI state.
       /// Can be used to obtain default parameters and their names.
+      /// @note This commits the embedded parameter editor but ignores whether the commit was
+      ///       rejected. Call it only when no invalid edit is pending (it is invoked after accept(),
+      ///       which refuses to close on a rejected edit, and at construction where none is pending).
       Param getParam() const;
+
+public slots:
+      /// Commit the embedded parameter editor before closing; if a value could not be applied
+      /// (invalid number / restriction violated) the dialog stays open instead of accepting a stale
+      /// value that getParam() would then read.
+      void accept() override;
 
 protected slots:
       void browseDefaultPath_();

--- a/src/openms_gui/include/OpenMS/VISUAL/ParamEditor.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/ParamEditor.h
@@ -13,6 +13,7 @@
 
 #include <OpenMS/CONCEPT/Types.h>
 
+#include <QtCore/QPointer>
 #include <QtWidgets/QLineEdit>
 #include <QtWidgets/QItemDelegate>
 #include <QtWidgets/QTreeWidget>
@@ -82,9 +83,26 @@ public:
       void setModelData(QWidget * editor, QAbstractItemModel * model, const QModelIndex & index) const override;
       /// Updates the editor for the item specified by index according to the style option given.
       void updateEditorGeometry(QWidget * editor, const QStyleOptionViewItem & option, const QModelIndex & index) const override;
+      /// Destroys the editor. Overridden to reset the commit state when an edit is abandoned (ESC).
+      void destroyEditor(QWidget * editor, const QModelIndex & index) const override;
 
-      /// true if the underlying tree has an open QLineEdit which has uncommitted data
+      /// true if the most recent commit attempt could not be applied (invalid value / restriction
+      /// violated), so the edited value has not reached the model and the param must not be saved
       bool hasUncommittedData() const;
+      /**
+        @brief Commit the currently-open editor (if any) into the model, synchronously.
+
+        Emits commitData/closeEditor directly rather than relying on focus movement, because for the
+        plain QLineEdit editors (input/output file, output dir) Qt would only queue the commit, so a
+        save triggered right afterwards would still write the previous value. Returns true if nothing
+        is left uncommitted afterwards (i.e. the value was applied or there was no editor), false if
+        the value was rejected.
+      */
+      bool commitActiveEditor();
+      /// Reset the edit state (no pending/rejected edit, no active editor). Called when the edited
+      /// Param is replaced (load/clear), so a rejection recorded in one document does not block
+      /// saving an unrelated one.
+      void resetCommitState();
 signals:
       /// signal for showing ParamEditor if the Model data changed
       void modified(bool) const;
@@ -104,12 +122,23 @@ private slots:
 private:
       /// Not implemented
       ParamEditorDelegate();
+      /// Lifecycle of the value being edited, tracked so store() knows whether it may be saved.
+      enum class CommitState
+      {
+        Committed, ///< no pending edit, or the last edit reached the model
+        Editing,   ///< an editor is open and its value has not yet been committed
+        Rejected   ///< the last commit attempt was refused (invalid value / restriction violated)
+      };
+
       /// used to modify value of output and input files( not for output and input lists)
       mutable QString fileName_;
       /// holds a directory name (for output directories)
       mutable QString dirName_;
-      /// true if a QLineEdit is still open and has not committed its data yet (so storing the current param is a bad idea)
-      mutable bool has_uncommited_data_;
+      /// state of the value currently or most recently edited (see CommitState)
+      mutable CommitState commit_state_;
+      /// the editor currently open (null if none); used to commit it synchronously in store().
+      /// QPointer so it auto-nulls if the editor is destroyed behind our back.
+      mutable QPointer<QWidget> active_editor_;
     };
 
     /// QTreeWidget that emits a signal whenever a new row is selected
@@ -175,6 +204,11 @@ public:
               that could not be committed, e.g. because the entered value is not a valid number or
               violates the parameter's restrictions. Callers that write the Param to disk must not
               do so when this returns false, as it would persist the outdated value.
+
+      @note A successful store() commits the edits into the Param but does @em not clear the
+            modified flag: whether the document is "clean" depends on it having been persisted, which
+            only the caller knows. Callers should call setModified(false) after a successful write;
+            others may read isModified() afterwards to detect whether anything changed.
     */
     bool store();
     /// Indicates if the data changed since last save
@@ -205,7 +239,9 @@ protected:
     Internal::ParamTree* tree_;
     /// The data to edit
     Param* param_;
-    /// Indicates that the data was modified since last store/load operation
+    /// Indicates that the data was modified since it was last loaded or marked clean by the owner.
+    /// Note: store() commits edits but does not clear this (see store()); the owner calls
+    /// setModified(false) once the data has actually been persisted.
     bool modified_;
     /// Indicates if normal mode or advanced mode is activated
     bool advanced_mode_;

--- a/src/openms_gui/include/OpenMS/VISUAL/ParamEditor.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/ParamEditor.h
@@ -168,8 +168,15 @@ public:
     
     /// load method for Param object
     void load(Param& param);
-    /// store edited data in Param object
-    void store();
+    /**
+      @brief Store edited data in the Param object.
+
+      @return Whether the Param object was updated. This fails if an editor is still open with data
+              that could not be committed, e.g. because the entered value is not a valid number or
+              violates the parameter's restrictions. Callers that write the Param to disk must not
+              do so when this returns false, as it would persist the outdated value.
+    */
+    bool store();
     /// Indicates if the data changed since last save
     bool isModified() const;
     /// Clears all parameters

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/INIFileEditorWindow.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/INIFileEditorWindow.cpp
@@ -102,7 +102,13 @@ namespace OpenMS
       return false;
     }
 
-    editor_->store();
+    // refuse to write rather than persist the outdated param when an edit could not be committed
+    // (e.g. the open editor holds a value that violates the parameter's restrictions)
+    if (!editor_->store())
+    {
+      QMessageBox::warning(this, "Not saved", "The file was not saved because the value currently being edited could not be applied. Please correct it and save again.");
+      return false;
+    }
 
     ParamXMLFile paramFile;
     paramFile.store(filename_.toStdString(), param_);
@@ -118,7 +124,11 @@ namespace OpenMS
       if (!filename_.endsWith(".ini"))
         filename_.append(".ini");
 
-      editor_->store();
+      if (!editor_->store())
+      {
+        QMessageBox::warning(this, "Not saved", "The file was not saved because the value currently being edited could not be applied. Please correct it and save again.");
+        return false;
+      }
 
       ParamXMLFile paramFile;
       paramFile.store(filename_.toStdString(), param_);

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/INIFileEditorWindow.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/INIFileEditorWindow.cpp
@@ -111,31 +111,57 @@ namespace OpenMS
     }
 
     ParamXMLFile paramFile;
-    paramFile.store(filename_.toStdString(), param_);
+    try
+    {
+      paramFile.store(filename_.toStdString(), param_);
+    }
+    catch (Exception::BaseException& e)
+    {
+      // store() now refuses non-atomic writes (read-only target, directory, rename failure) by
+      // throwing. The document is left as-is: editor_->store() commits the edit into the model but
+      // no longer marks it clean, so any unsaved changes are still reflected and closing will still
+      // prompt to save. If there was nothing to save, it correctly stays clean.
+      QMessageBox::critical(this, "Error saving file", ("The file '" + filename_.toStdString() + "' could not be saved: " + e.getMessage()).c_str());
+      return false;
+    }
+    editor_->setModified(false); // persisted successfully -- the document is now clean
     updateWindowTitle(editor_->isModified());
     return true;
   }
 
   bool INIFileEditorWindow::saveFileAs()
   {
-    filename_ = QFileDialog::getSaveFileName(this, tr("Save ini file"), toQString(current_path_), tr("ini files (*.ini)"));
-    if (!filename_.isEmpty())
+    QString filename = QFileDialog::getSaveFileName(this, tr("Save ini file"), toQString(current_path_), tr("ini files (*.ini)"));
+    if (filename.isEmpty())
     {
-      if (!filename_.endsWith(".ini"))
-        filename_.append(".ini");
-
-      if (!editor_->store())
-      {
-        QMessageBox::warning(this, "Not saved", "The file was not saved because the value currently being edited could not be applied. Please correct it and save again.");
-        return false;
-      }
-
-      ParamXMLFile paramFile;
-      paramFile.store(filename_.toStdString(), param_);
-      updateWindowTitle(editor_->isModified());
-      return true;
+      return false;
     }
-    return false;
+
+    if (!filename.endsWith(".ini"))
+      filename.append(".ini");
+
+    if (!editor_->store())
+    {
+      QMessageBox::warning(this, "Not saved", "The file was not saved because the value currently being edited could not be applied. Please correct it and save again.");
+      return false;
+    }
+
+    ParamXMLFile paramFile;
+    try
+    {
+      paramFile.store(filename.toStdString(), param_);
+    }
+    catch (Exception::BaseException& e)
+    {
+      QMessageBox::critical(this, "Error saving file", ("The file '" + filename.toStdString() + "' could not be saved: " + e.getMessage()).c_str());
+      return false;
+    }
+    // adopt the new name only once the write has actually succeeded, so a cancelled or failed
+    // Save As does not replace the name of the file currently being edited
+    filename_ = filename;
+    editor_->setModified(false); // persisted successfully -- the document is now clean
+    updateWindowTitle(editor_->isModified());
+    return true;
   }
 
   void INIFileEditorWindow::closeEvent(QCloseEvent* event)

--- a/src/openms_gui/source/VISUAL/DIALOGS/TOPPASToolConfigDialog.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/TOPPASToolConfigDialog.cpp
@@ -84,14 +84,23 @@ namespace OpenMS
 
   void TOPPASToolConfigDialog::ok_()
   {
+    // Commit any editor that is still open BEFORE deciding accept/reject: clicking OK may leave a
+    // just-picked file path or typed value uncommitted, and relying on focus timing to commit it is
+    // unreliable. store() commits synchronously and refuses (returns false) if the value could not
+    // be applied. It does not clear the modified flag, so isModified() afterwards correctly reflects
+    // whether anything actually changed (including the value just committed).
+    if (!editor_->store())
+    {
+      QMessageBox::warning(this, "Not applied", "The value currently being edited could not be applied. Please correct it and try again.");
+      return; // keep the dialog open so the user can fix the value
+    }
     if (editor_->isModified())
     {
-      editor_->store();
       accept();
     }
     else
     {
-      reject();
+      reject(); // nothing changed -- do not invalidate the node / mark the workflow dirty
     }
   }
 
@@ -152,9 +161,11 @@ namespace OpenMS
     if (!filename_.endsWith(".ini"))
       filename_.append(".ini");
 
-    bool was_modified = editor_->isModified();
-    editor_->store();
-    if (was_modified) editor_->setModified(true);
+    if (!editor_->store()) // store() commits without clearing the modified flag, so no save/restore
+    {
+      QMessageBox::warning(this, "Not applied", "The value currently being edited could not be applied. Please correct it and try again.");
+      return;
+    }
 
     arg_param_.insert(tool_name_ + ":1:", *param_);
     try

--- a/src/openms_gui/source/VISUAL/DIALOGS/TOPPViewPrefDialog.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/TOPPViewPrefDialog.cpp
@@ -17,6 +17,7 @@
 #include <OpenMS/VISUAL/MISC/Qt5Port.h>
 
 #include <QtWidgets/QFileDialog>
+#include <QtWidgets/QMessageBox>
 
 using namespace std;
 
@@ -88,6 +89,19 @@ namespace OpenMS
         case Qt::CheckState::Unchecked: return "false";
         default: throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Checkbox had unexpected state",StringUtils::toStr(cs));
       }
+    }
+
+    void TOPPViewPrefDialog::accept()
+    {
+      // Commit the embedded TSG parameter editor before accepting. If a value could not be applied
+      // (invalid number / restriction violated), keep the dialog open: otherwise the dialog would
+      // accept and getParam() would read the stale, uncorrected value.
+      if (!ui_->param_editor_spec_gen_->store())
+      {
+        QMessageBox::warning(this, "Not applied", "A value currently being edited could not be applied. Please correct it and try again.");
+        return;
+      }
+      QDialog::accept();
     }
 
     Param TOPPViewPrefDialog::getParam() const

--- a/src/openms_gui/source/VISUAL/DIALOGS/ToolsDialog.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/ToolsDialog.cpp
@@ -310,21 +310,34 @@ namespace OpenMS
     if (input_combo_->currentText() == "<select>" || tools_combo_->currentText() == "<select>")
     {
       QMessageBox::critical(this, "Error", "You have to select a tool and an input argument!");
+      return;
     }
-    else
+
+    // commit any open editor; refuse to continue with an outdated param if the edit was rejected
+    if (!editor_->store())
     {
-      editor_->store();
-      mergeGUIParamIntoSingleToolParam_();
-      applyThreadsToSingleToolParam_();
-      arg_param_.insert(getTool() + ":1:", single_tool_param_);
-      if (!File::writable(ini_file_))
-      {
-        QMessageBox::critical(this, "Error", (std::string("Could not write to '") + ini_file_ + "'!").c_str());
-      }
+      QMessageBox::warning(this, "Not applied", "The value currently being edited could not be applied. Please correct it and try again.");
+      return;
+    }
+    mergeGUIParamIntoSingleToolParam_();
+    applyThreadsToSingleToolParam_();
+    arg_param_.insert(getTool() + ":1:", single_tool_param_);
+    if (!File::writable(ini_file_))
+    {
+      QMessageBox::critical(this, "Error", (std::string("Could not write to '") + ini_file_ + "'!").c_str());
+      return;
+    }
+    try
+    {
       ParamXMLFile paramFile;
       paramFile.store(ini_file_, arg_param_);
-      accept();
     }
+    catch (Exception::BaseException& e)
+    {
+      QMessageBox::critical(this, "Error", (std::string("Error storing INI file: ") + e.what()).c_str());
+      return;
+    }
+    accept();
   }
 
   void ToolsDialog::loadINI_()
@@ -391,7 +404,11 @@ namespace OpenMS
     {
       filename_.append(".ini");
     }
-    editor_->store();
+    if (!editor_->store())
+    {
+      QMessageBox::warning(this, "Not applied", "The value currently being edited could not be applied. Please correct it and try again.");
+      return;
+    }
     mergeGUIParamIntoSingleToolParam_();
     applyThreadsToSingleToolParam_();
 

--- a/src/openms_gui/source/VISUAL/ParamEditor.cpp
+++ b/src/openms_gui/source/VISUAL/ParamEditor.cpp
@@ -18,6 +18,7 @@
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/VISUAL/MISC/Qt5Port.h>
 
+#include <QtWidgets/QApplication>
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QLineEdit>
@@ -65,6 +66,9 @@ namespace OpenMS
     ParamEditorDelegate::ParamEditorDelegate(QObject* parent) :
       QItemDelegate(parent)
     {
+      // ParamEditor::store() reads this before any editor has been created, so it must not be
+      // left indeterminate -- a garbage 'true' would refuse to save with no editor open at all
+      has_uncommited_data_ = false;
     }
 
     QWidget* ParamEditorDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem&, const QModelIndex& index) const
@@ -744,8 +748,14 @@ namespace OpenMS
     // INIFileEditor when Ctrl-S is pressed while the cursor sits in a QLineEdit. Commit it first,
     // otherwise the caller goes on to write the previous, outdated param and the edit is lost
     // silently. Moving focus to the tree makes the line edit emit lostFocus, which commits it.
+    //
+    // The focus widget is checked as well as the flag: the input file / output file / output dir
+    // cells are plain QLineEdits that never set has_uncommited_data_, but they hold an uncommitted
+    // path just the same (the one picked in the file dialog), and QItemDelegate's own focus-out
+    // handling commits them. Without this, Ctrl-S right after picking a path saved the old one.
     auto* delegate = static_cast<Internal::ParamEditorDelegate*>(this->tree_->itemDelegate());
-    if (delegate->hasUncommittedData())
+    QWidget* focus = QApplication::focusWidget();
+    if (delegate->hasUncommittedData() || (focus != nullptr && focus != tree_ && tree_->isAncestorOf(focus)))
     {
       tree_->setFocus(Qt::OtherFocusReason);
     }

--- a/src/openms_gui/source/VISUAL/ParamEditor.cpp
+++ b/src/openms_gui/source/VISUAL/ParamEditor.cpp
@@ -161,12 +161,16 @@ namespace OpenMS
 
       if (qobject_cast<QComboBox *>(editor))       //Drop-down list for enums
       {
-        int index = static_cast<QComboBox *>(editor)->findText(str);
+        QComboBox* box = static_cast<QComboBox *>(editor);
+        int index = box->findText(str);
         if (index == -1)
-        {
+        { // the stored value is not among the valid strings (e.g. written by an older version, or
+          // edited by hand). Offering it as an entry of its own keeps it when the user opens the
+          // cell and leaves again -- selecting index 0 instead would silently blank the parameter.
+          box->insertItem(0, str);
           index = 0;
         }
-        static_cast<QComboBox *>(editor)->setCurrentIndex(index);
+        box->setCurrentIndex(index);
       }
       else if (qobject_cast<QLineEdit *>(editor))      // LineEdit for other values
       {
@@ -364,6 +368,10 @@ namespace OpenMS
         model->setData(index, QBrush(Qt::yellow), Qt::BackgroundRole);
         emit modified(true);  // let parent know that we changed something
       }
+
+      // the editor's content is now in the model (or was identical to it); every path that returns
+      // early above leaves the flag set, so that ParamEditor::store() knows the value was rejected
+      has_uncommited_data_ = false;
     }
 
     void ParamEditorDelegate::updateEditorGeometry(QWidget * editor, const QStyleOptionViewItem & option, const QModelIndex &) const
@@ -397,7 +405,10 @@ namespace OpenMS
 
     void ParamEditorDelegate::commitAndCloseLineEdit_()
     {
-      has_uncommited_data_ = false;
+      // Do not clear has_uncommited_data_ here: setModelData() bails out (after warning the user)
+      // when the entered value is not a valid number or violates the parameter's restrictions, and
+      // clears the flag itself once it has actually stored. Clearing it up-front would tell
+      // ParamEditor::store() the edit was committed when it was rejected.
       OpenMSLineEdit * editor = qobject_cast<OpenMSLineEdit *>(sender());
       emit commitData(editor);
       emit closeEditor(editor);
@@ -722,29 +733,41 @@ namespace OpenMS
     tree_->resizeColumnToContents(3);
   }
 
-  void ParamEditor::store()
+  bool ParamEditor::store()
   {
-    //std::cerr << "store entered ...\n";
-
-    // store only if no line-edit is opened (in which case data is uncommitted and will not be saved)
-    // this applies only to INIFileEditor, where pressing Ctrl-s results in saving the current (but outdated) param
-    if (param_ != nullptr &&
-        !static_cast<Internal::ParamEditorDelegate*>(this->tree_->itemDelegate())->hasUncommittedData())
+    if (param_ == nullptr)
     {
-      //std::cerr << "and done!...\n";
-      QTreeWidgetItem * parent = tree_->invisibleRootItem();
-      //param_->clear();
-
-      for (Int i = 0; i < parent->childCount(); ++i)
-      {
-        map<std::string, std::string> section_descriptions;
-        storeRecursive_(parent->child(i), "", section_descriptions);        //whole tree recursively
-      }
-
-      setModified(false);
+      return false;
     }
-    //else std::cerr << "store aborted!\n";
 
+    // An editor may still be open with data the user typed but never committed -- this happens in
+    // INIFileEditor when Ctrl-S is pressed while the cursor sits in a QLineEdit. Commit it first,
+    // otherwise the caller goes on to write the previous, outdated param and the edit is lost
+    // silently. Moving focus to the tree makes the line edit emit lostFocus, which commits it.
+    auto* delegate = static_cast<Internal::ParamEditorDelegate*>(this->tree_->itemDelegate());
+    if (delegate->hasUncommittedData())
+    {
+      tree_->setFocus(Qt::OtherFocusReason);
+    }
+
+    // The commit can still fail -- setModelData() rejects values that are not valid numbers or that
+    // violate the parameter's restrictions, and only clears the flag once it has actually stored.
+    // Report that to the caller instead of storing, so nobody writes the outdated value to disk.
+    if (delegate->hasUncommittedData())
+    {
+      return false;
+    }
+
+    QTreeWidgetItem * parent = tree_->invisibleRootItem();
+
+    for (Int i = 0; i < parent->childCount(); ++i)
+    {
+      map<std::string, std::string> section_descriptions;
+      storeRecursive_(parent->child(i), "", section_descriptions);        //whole tree recursively
+    }
+
+    setModified(false);
+    return true;
   }
 
   void ParamEditor::clear()

--- a/src/openms_gui/source/VISUAL/ParamEditor.cpp
+++ b/src/openms_gui/source/VISUAL/ParamEditor.cpp
@@ -18,7 +18,6 @@
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/VISUAL/MISC/Qt5Port.h>
 
-#include <QtWidgets/QApplication>
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QLineEdit>
@@ -66,9 +65,10 @@ namespace OpenMS
     ParamEditorDelegate::ParamEditorDelegate(QObject* parent) :
       QItemDelegate(parent)
     {
-      // ParamEditor::store() reads this before any editor has been created, so it must not be
-      // left indeterminate -- a garbage 'true' would refuse to save with no editor open at all
-      has_uncommited_data_ = false;
+      // ParamEditor::store() reads these before any editor has been created, so they must not be
+      // left indeterminate -- a garbage 'Rejected' would refuse to save with no editor open at all
+      commit_state_ = CommitState::Committed;
+      active_editor_ = nullptr;
     }
 
     QWidget* ParamEditorDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem&, const QModelIndex& index) const
@@ -81,7 +81,8 @@ namespace OpenMS
         return nullptr;
       }
 
-      has_uncommited_data_ = false; // by default all data is committed
+      // an editor is about to open; its value is not yet in the model
+      commit_state_ = CommitState::Editing;
 
       QString dtype = index.sibling(index.row(), 2).data(Qt::DisplayRole).toString();
       QString restrictions = index.sibling(index.row(), 2).data(Qt::UserRole).toString();
@@ -148,7 +149,6 @@ namespace OpenMS
         OpenMSLineEdit* editor = new OpenMSLineEdit(parent);
         editor->setFocusPolicy(Qt::StrongFocus);
         connect(editor, &Internal::OpenMSLineEdit::lostFocus, this, &Internal::ParamEditorDelegate::commitAndCloseLineEdit_);
-        has_uncommited_data_ = true;
         return editor;
       }
     }
@@ -156,6 +156,9 @@ namespace OpenMS
     void ParamEditorDelegate::setEditorData(QWidget * editor, const QModelIndex & index) const
     {
       QString str = index.data(Qt::DisplayRole).toString();
+
+      // remember the open editor so store() can commit it synchronously (see commitActiveEditor())
+      active_editor_ = editor;
 
       // only set editor data for first column (value column)
       if (index.column() != 1)
@@ -166,15 +169,17 @@ namespace OpenMS
       if (qobject_cast<QComboBox *>(editor))       //Drop-down list for enums
       {
         QComboBox* box = static_cast<QComboBox *>(editor);
-        int index = box->findText(str);
-        if (index == -1)
-        { // the stored value is not among the valid strings (e.g. written by an older version, or
-          // edited by hand). Offering it as an entry of its own keeps it when the user opens the
-          // cell and leaves again -- selecting index 0 instead would silently blank the parameter.
+        int found_index = box->findText(str);
+        if (found_index == -1)
+        { // Preserve a stored value that is outside today's restrictions (e.g. written by an older
+          // version or edited by hand): insert it as its own entry at the front and select it, so
+          // that merely opening and closing the cell keeps the value. Without this the value is not
+          // found, the combo would fall back to its first entry (the empty option), and the
+          // parameter would be silently blanked just by looking at it.
           box->insertItem(0, str);
-          index = 0;
+          found_index = 0;
         }
-        box->setCurrentIndex(index);
+        box->setCurrentIndex(found_index);
       }
       else if (qobject_cast<QLineEdit *>(editor))      // LineEdit for other values
       {
@@ -319,6 +324,7 @@ namespace OpenMS
           if (!ok)
           {
             QMessageBox::warning(nullptr, "Invalid value", QString("Cannot convert '%1' to integer number!").arg(new_value.toString()));
+            commit_state_ = CommitState::Rejected; // value not applied to the model
             return;
           }
           //restrictions
@@ -342,6 +348,7 @@ namespace OpenMS
           if (!ok)
           {
             QMessageBox::warning(nullptr, "Invalid value", QString("Cannot convert '%1' to floating point number!").arg(new_value.toString()));
+            commit_state_ = CommitState::Rejected; // value not applied to the model
             return;
           }
           //restrictions
@@ -361,6 +368,7 @@ namespace OpenMS
         if (!restrictions_met)
         {
           QMessageBox::warning(nullptr, "Invalid value", QString("Value restrictions not met: %1").arg(index.sibling(index.row(), 3).data(Qt::DisplayRole).toString()));
+          commit_state_ = CommitState::Rejected; // value not applied to the model
           return;
         }
       }
@@ -373,14 +381,35 @@ namespace OpenMS
         emit modified(true);  // let parent know that we changed something
       }
 
-      // the editor's content is now in the model (or was identical to it); every path that returns
-      // early above leaves the flag set, so that ParamEditor::store() knows the value was rejected
-      has_uncommited_data_ = false;
+      // the editor's content is now in the model (or was identical to it). The rejection paths above
+      // set commit_state_ = Rejected before returning, so ParamEditor::store() can tell the value
+      // was not applied; reaching here means it was.
+      commit_state_ = CommitState::Committed;
     }
 
     void ParamEditorDelegate::updateEditorGeometry(QWidget * editor, const QStyleOptionViewItem & option, const QModelIndex &) const
     {
       editor->setGeometry(option.rect);
+    }
+
+    void ParamEditorDelegate::destroyEditor(QWidget* editor, const QModelIndex& index) const
+    {
+      // Only react to the editor we are actually tracking: a delayed teardown of an already-replaced
+      // editor must not disturb the state of a newer one.
+      if (editor == active_editor_)
+      {
+        // If the editor is being destroyed while still in the Editing state, setModelData() was
+        // never called for it -- the edit was abandoned (ESC / revert), not committed or rejected.
+        // The model keeps its previous, consistent value, so there is nothing pending and a later
+        // save must not be blocked. A Rejected state is left untouched: it must survive until the
+        // user starts or cancels another edit, so store() can still refuse the outdated value.
+        if (commit_state_ == CommitState::Editing)
+        {
+          commit_state_ = CommitState::Committed;
+        }
+        active_editor_ = nullptr;
+      }
+      QItemDelegate::destroyEditor(editor, index);
     }
 
     bool ParamEditorDelegate::eventFilter(QObject* editor, QEvent* event)
@@ -409,10 +438,9 @@ namespace OpenMS
 
     void ParamEditorDelegate::commitAndCloseLineEdit_()
     {
-      // Do not clear has_uncommited_data_ here: setModelData() bails out (after warning the user)
-      // when the entered value is not a valid number or violates the parameter's restrictions, and
-      // clears the flag itself once it has actually stored. Clearing it up-front would tell
-      // ParamEditor::store() the edit was committed when it was rejected.
+      // Do not touch commit_state_ here: setModelData() sets it (Rejected when the entered value is
+      // not a valid number or violates the parameter's restrictions, Committed once it has actually
+      // stored). Forcing it here would misreport a rejected edit as committed.
       OpenMSLineEdit * editor = qobject_cast<OpenMSLineEdit *>(sender());
       emit commitData(editor);
       emit closeEditor(editor);
@@ -421,7 +449,30 @@ namespace OpenMS
 
     bool ParamEditorDelegate::hasUncommittedData() const
     {
-      return has_uncommited_data_;
+      return commit_state_ == CommitState::Rejected;
+    }
+
+    bool ParamEditorDelegate::commitActiveEditor()
+    {
+      if (active_editor_ != nullptr && commit_state_ == CommitState::Editing)
+      {
+        // Commit synchronously: emitting commitData(editor) makes the view call setModelData()
+        // immediately (direct connection), unlike moving focus, which would only queue the commit
+        // for the plain QLineEdit editors. setModelData() sets commit_state_ to Committed or
+        // Rejected; closeEditor() then destroys the editor (clearing active_editor_).
+        QWidget* editor = active_editor_;
+        emit commitData(editor);
+        emit closeEditor(editor);
+      }
+      // Fail closed: only a Committed state (value applied, or nothing was pending) permits a save.
+      // Rejected (invalid value) and a lingering Editing (commit did not go through) both block it.
+      return commit_state_ == CommitState::Committed;
+    }
+
+    void ParamEditorDelegate::resetCommitState()
+    {
+      commit_state_ = CommitState::Committed;
+      active_editor_ = nullptr;
     }
 
     ///////////////////ParamTree/////////////////////////////////
@@ -487,6 +538,9 @@ namespace OpenMS
   {
     param_ = &param;
 
+    // a fresh document: drop any edit state (e.g. a rejection) recorded for the previous one, so it
+    // does not block saving this one
+    static_cast<Internal::ParamEditorDelegate*>(tree_->itemDelegate())->resetCommitState();
     tree_->clear();
 
     QTreeWidgetItem * parent = tree_->invisibleRootItem();
@@ -745,25 +799,17 @@ namespace OpenMS
     }
 
     // An editor may still be open with data the user typed but never committed -- this happens in
-    // INIFileEditor when Ctrl-S is pressed while the cursor sits in a QLineEdit. Commit it first,
-    // otherwise the caller goes on to write the previous, outdated param and the edit is lost
-    // silently. Moving focus to the tree makes the line edit emit lostFocus, which commits it.
+    // INIFileEditor when Ctrl-S is pressed while the cursor sits in a QLineEdit, or right after a
+    // path was picked in the file dialog. Commit it first, otherwise the caller goes on to write the
+    // previous, outdated param and the edit is lost silently.
     //
-    // The focus widget is checked as well as the flag: the input file / output file / output dir
-    // cells are plain QLineEdits that never set has_uncommited_data_, but they hold an uncommitted
-    // path just the same (the one picked in the file dialog), and QItemDelegate's own focus-out
-    // handling commits them. Without this, Ctrl-S right after picking a path saved the old one.
+    // commitActiveEditor() commits synchronously (emitting commitData directly), not by moving
+    // focus: for the plain QLineEdit editors (input/output file, output dir) Qt would only queue the
+    // commit, so the outdated value would still be written here. It returns false if the value was
+    // rejected (invalid number / restriction violation) -- including a rejection recorded earlier
+    // that the user has not yet corrected -- so nobody writes the outdated value to disk.
     auto* delegate = static_cast<Internal::ParamEditorDelegate*>(this->tree_->itemDelegate());
-    QWidget* focus = QApplication::focusWidget();
-    if (delegate->hasUncommittedData() || (focus != nullptr && focus != tree_ && tree_->isAncestorOf(focus)))
-    {
-      tree_->setFocus(Qt::OtherFocusReason);
-    }
-
-    // The commit can still fail -- setModelData() rejects values that are not valid numbers or that
-    // violate the parameter's restrictions, and only clears the flag once it has actually stored.
-    // Report that to the caller instead of storing, so nobody writes the outdated value to disk.
-    if (delegate->hasUncommittedData())
+    if (!delegate->commitActiveEditor())
     {
       return false;
     }
@@ -776,12 +822,18 @@ namespace OpenMS
       storeRecursive_(parent->child(i), "", section_descriptions);        //whole tree recursively
     }
 
-    setModified(false);
+    // Deliberately do NOT reset the modified flag here: store() only commits the edited values into
+    // the in-memory Param. Whether the document is "clean" depends on the value having been
+    // persisted (or applied), which only the caller knows. Callers mark it clean after a successful
+    // write; others (e.g. TOPPASToolConfigDialog) read isModified() to decide whether anything
+    // changed. Resetting it here would hide a just-committed edit and mark the document clean before
+    // it was actually saved.
     return true;
   }
 
   void ParamEditor::clear()
   {
+    static_cast<Internal::ParamEditorDelegate*>(tree_->itemDelegate())->resetCommitState();
     tree_->clear();
   }
 

--- a/src/tests/class_tests/openms/source/ParamXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ParamXMLFile_test.cpp
@@ -22,6 +22,9 @@
 
 #include <fstream>
 #include <filesystem>
+#ifndef OPENMS_WINDOWSPLATFORM
+  #include <sys/stat.h> // mkfifo, for the special-file rejection test
+#endif
 #ifdef __clang__
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wshadow"
@@ -563,12 +566,13 @@ START_SECTION(([EXTRA] store() does not destroy the previous file when it cannot
   std::filesystem::create_directory(dirname);
   TEST_EXCEPTION(Exception::UnableToCreateFile, paramFile.store(dirname, p_new))
   TEST_TRUE(std::filesystem::is_directory(dirname))
+  std::filesystem::remove(dirname); // not registered with NEW_TMP_FILE, so remove it explicitly
 
   // a successful store replaces the content, preserves permissions and leaves no temporaries behind
   std::filesystem::permissions(filename, std::filesystem::perms::owner_read | std::filesystem::perms::owner_write);
   auto perms_before = std::filesystem::status(filename).permissions();
   paramFile.store(filename, p_new);
-  TEST_EQUAL(std::filesystem::status(filename).permissions() == perms_before, true)
+  TEST_TRUE(std::filesystem::status(filename).permissions() == perms_before)
 
   Param p_check2;
   paramFile.load(filename, p_check2);
@@ -591,6 +595,123 @@ START_SECTION(([EXTRA] store() does not destroy the previous file when it cannot
     }
   }
   TEST_EQUAL(leftover, 0)
+
+  // storing through a symlink must replace the link's target, not the link itself (POSIX only)
+#ifndef OPENMS_WINDOWSPLATFORM
+  {
+    std::string real_file;
+    NEW_TMP_FILE(real_file)
+    Param p_real;
+    p_real.setValue("test:int", 1, "intdesc");
+    paramFile.store(real_file, p_real);
+
+    std::string link_file = real_file + ".link";
+    std::error_code sec;
+    std::filesystem::create_symlink(real_file, link_file, sec);
+    if (!sec) // some filesystems disallow symlinks; skip there
+    {
+      Param p_via_link;
+      p_via_link.setValue("test:int", 2, "intdesc");
+      paramFile.store(link_file, p_via_link);
+
+      TEST_TRUE(std::filesystem::is_symlink(link_file)) // the link is preserved ...
+      Param p_check_link;
+      paramFile.load(real_file, p_check_link);          // ... and its target received the new content
+      TEST_EQUAL((int)p_check_link.getValue("test:int"), 2)
+
+      std::filesystem::remove(link_file);
+    }
+
+    // a dangling symlink is resolved to its (non-existing) target, which is then created -- the link
+    // itself must not be replaced by a regular file
+    std::string dangling_target = real_file + ".dangling_target";
+    std::string dangling_link = real_file + ".dangling_link";
+    std::filesystem::remove(dangling_target); // make sure it does not exist
+    std::error_code dec;
+    std::filesystem::create_symlink(dangling_target, dangling_link, dec);
+    if (!dec)
+    {
+      Param p_dangling;
+      p_dangling.setValue("test:int", 3, "intdesc");
+      paramFile.store(dangling_link, p_dangling);
+
+      TEST_TRUE(std::filesystem::is_symlink(dangling_link))      // link preserved
+      TEST_TRUE(std::filesystem::is_regular_file(dangling_target)) // its target was created
+      Param p_check_dangling;
+      paramFile.load(dangling_target, p_check_dangling);
+      TEST_EQUAL((int)p_check_dangling.getValue("test:int"), 3)
+
+      std::filesystem::remove(dangling_link);
+      std::filesystem::remove(dangling_target);
+    }
+
+    // a special file (here: a FIFO) must be rejected, not silently replaced by a regular file
+    std::string fifo_file = real_file + ".fifo";
+    std::filesystem::remove(fifo_file);
+    if (mkfifo(fifo_file.c_str(), 0600) == 0)
+    {
+      Param p_fifo;
+      p_fifo.setValue("test:int", 4, "intdesc");
+      TEST_EXCEPTION(Exception::UnableToCreateFile, paramFile.store(fifo_file, p_fifo))
+      std::error_code fec;
+      TEST_TRUE(std::filesystem::is_fifo(std::filesystem::status(fifo_file, fec))) // still a FIFO
+      std::filesystem::remove(fifo_file);
+    }
+
+    // a CHAIN of symlinks ending in a non-existing target: every intermediate link must survive and
+    // the terminal target must be created (link1 -> link2 -> chain_target)
+    std::string chain_target = real_file + ".chain_target";
+    std::string chain_mid = real_file + ".chain_mid";
+    std::string chain_head = real_file + ".chain_head";
+    std::filesystem::remove(chain_target);
+    std::filesystem::remove(chain_mid);
+    std::filesystem::remove(chain_head);
+    std::error_code cec1, cec2;
+    std::filesystem::create_symlink(chain_target, chain_mid, cec1);  // chain_mid -> chain_target (dangling)
+    std::filesystem::create_symlink(chain_mid, chain_head, cec2);    // chain_head -> chain_mid
+    if (!cec1 && !cec2)
+    {
+      Param p_chain;
+      p_chain.setValue("test:int", 5, "intdesc");
+      paramFile.store(chain_head, p_chain);
+
+      TEST_TRUE(std::filesystem::is_symlink(chain_head))         // both links preserved ...
+      TEST_TRUE(std::filesystem::is_symlink(chain_mid))
+      TEST_TRUE(std::filesystem::is_regular_file(chain_target))  // ... terminal target created
+      Param p_check_chain;
+      paramFile.load(chain_target, p_check_chain);
+      TEST_EQUAL((int)p_check_chain.getValue("test:int"), 5)
+    }
+    { // cleanup, regardless of which of the create_symlink() calls above succeeded
+      std::error_code rec;
+      std::filesystem::remove(chain_head, rec);
+      std::filesystem::remove(chain_mid, rec);
+      std::filesystem::remove(chain_target, rec);
+    }
+
+    // a symlink CYCLE must be rejected, not silently broken (cyc_a -> cyc_b -> cyc_a)
+    std::string cyc_a = real_file + ".cyc_a";
+    std::string cyc_b = real_file + ".cyc_b";
+    std::filesystem::remove(cyc_a);
+    std::filesystem::remove(cyc_b);
+    std::error_code yec1, yec2;
+    std::filesystem::create_symlink(cyc_b, cyc_a, yec1);
+    std::filesystem::create_symlink(cyc_a, cyc_b, yec2);
+    if (!yec1 && !yec2)
+    {
+      Param p_cyc;
+      p_cyc.setValue("test:int", 6, "intdesc");
+      TEST_EXCEPTION(Exception::UnableToCreateFile, paramFile.store(cyc_a, p_cyc))
+      TEST_TRUE(std::filesystem::is_symlink(cyc_a)) // cycle left intact
+      TEST_TRUE(std::filesystem::is_symlink(cyc_b))
+    }
+    { // cleanup, regardless of which of the create_symlink() calls above succeeded
+      std::error_code rec;
+      std::filesystem::remove(cyc_a, rec);
+      std::filesystem::remove(cyc_b, rec);
+    }
+  }
+#endif
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ParamXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ParamXMLFile_test.cpp
@@ -16,10 +16,12 @@
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 
 #include <OpenMS/FORMAT/TextFile.h>
+#include <OpenMS/SYSTEM/File.h>
 
 ///////////////////////////
 
 #include <fstream>
+#include <filesystem>
 #ifdef __clang__
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wshadow"
@@ -484,6 +486,111 @@ START_SECTION([EXTRA] loading files that omit the optional 'required' attribute)
   paramFile.load(filename, p2);
   TEST_TRUE(p2.hasTag("TagMatrix:adv_true_req_absent", "advanced"))
   TEST_FALSE(p2.hasTag("TagMatrix:adv_true_req_absent", "required"))
+}
+END_SECTION
+
+START_SECTION(([EXTRA] load() rejects documents that are not parameter files))
+{
+  ParamXMLFile paramFile;
+
+  // Any well-formed XML used to parse successfully: unknown elements are ignored, so an unrelated
+  // document loaded as an empty Param and reported success. In an editor that means opening a
+  // foreign file appears to work and saving then replaces it. See OpenMS/OpenMS#9768.
+  std::string html_file;
+  NEW_TMP_FILE(html_file)
+  {
+    std::ofstream os(html_file.c_str());
+    os << "<html><body/></html>\n";
+  }
+  Param p_html;
+  TEST_EXCEPTION(Exception::ParseError, paramFile.load(html_file, p_html))
+
+  // ITEM elements below a foreign root must not be imported either
+  std::string wrapper_file;
+  NEW_TMP_FILE(wrapper_file)
+  {
+    std::ofstream os(wrapper_file.c_str());
+    os << "<wrapper><ITEM name=\"x\" value=\"7\" type=\"int\"/></wrapper>\n";
+  }
+  Param p_wrapper;
+  TEST_EXCEPTION(Exception::ParseError, paramFile.load(wrapper_file, p_wrapper))
+  TEST_EQUAL(p_wrapper.size(), 0)
+
+  // a genuine parameter file still loads
+  Param p_good;
+  p_good.setValue("test:int", 17, "intdesc");
+  std::string good_file;
+  NEW_TMP_FILE(good_file)
+  paramFile.store(good_file, p_good);
+  Param p_reloaded;
+  paramFile.load(good_file, p_reloaded);
+  TEST_EQUAL(p_reloaded.size(), 1)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] store() does not destroy the previous file when it cannot write))
+{
+  ParamXMLFile paramFile;
+
+  Param p_orig;
+  p_orig.setValue("test:int", 17, "intdesc");
+  std::string filename;
+  NEW_TMP_FILE(filename)
+  paramFile.store(filename, p_orig);
+
+  Param p_new;
+  p_new.setValue("test:int", 99, "intdesc");
+
+  // Make the target read-only. The old implementation opened it with ofstream::out, which truncates
+  // before anything is known to be writable; the new one must refuse up-front and leave it alone.
+  // See OpenMS/OpenMS#9768.
+  std::filesystem::permissions(filename, std::filesystem::perms::owner_read);
+  if (!File::writable(filename)) // a root user ignores the permission bits, so skip there
+  {
+    TEST_EXCEPTION(Exception::UnableToCreateFile, paramFile.store(filename, p_new))
+    std::filesystem::permissions(filename, std::filesystem::perms::owner_read | std::filesystem::perms::owner_write);
+
+    // the original content survived
+    Param p_check;
+    paramFile.load(filename, p_check);
+    TEST_EQUAL(p_check.size(), 1)
+    TEST_EQUAL((int)p_check.getValue("test:int"), 17)
+  }
+  std::filesystem::permissions(filename, std::filesystem::perms::owner_read | std::filesystem::perms::owner_write);
+
+  // a directory must not be silently removed and replaced by the ini file either
+  std::string dirname = filename + ".dir";
+  std::filesystem::create_directory(dirname);
+  TEST_EXCEPTION(Exception::UnableToCreateFile, paramFile.store(dirname, p_new))
+  TEST_TRUE(std::filesystem::is_directory(dirname))
+
+  // a successful store replaces the content, preserves permissions and leaves no temporaries behind
+  std::filesystem::permissions(filename, std::filesystem::perms::owner_read | std::filesystem::perms::owner_write);
+  auto perms_before = std::filesystem::status(filename).permissions();
+  paramFile.store(filename, p_new);
+  TEST_EQUAL(std::filesystem::status(filename).permissions() == perms_before, true)
+
+  Param p_check2;
+  paramFile.load(filename, p_check2);
+  TEST_EQUAL((int)p_check2.getValue("test:int"), 99)
+
+  // temporaries are named "<target>.<unique>.tmp", so scan the directory rather than a fixed name
+  std::filesystem::path target_path(filename);
+  std::filesystem::path target_dir = target_path.parent_path();
+  if (target_dir.empty()) // NEW_TMP_FILE may hand out a plain filename in the working directory
+  {
+    target_dir = ".";
+  }
+  Size leftover = 0;
+  for (const auto& e : std::filesystem::directory_iterator(target_dir))
+  {
+    const std::string name = e.path().filename().string();
+    if (name.rfind(target_path.filename().string() + ".", 0) == 0 && name.size() > 4 && name.compare(name.size() - 4, 4, ".tmp") == 0)
+    {
+      ++leftover;
+    }
+  }
+  TEST_EQUAL(leftover, 0)
 }
 END_SECTION
 


### PR DESCRIPTION
Fixes #9768 — four defects in the parameter editor and paramXML I/O.

## 1. `ParamEditor::store()` silently discarded the edit in progress

`store()` bailed out when an editor was still open, so `INIFileEditorWindow` went on to write the previous, outdated `Param` — the user's typed value was lost with no message (Ctrl+S with the cursor still in a `QLineEdit`).

`store()` now commits the open editor by moving focus to the tree, and returns `bool` so callers can refuse to write when the value could not be committed. `INIFileEditorWindow` warns and aborts the save in that case.

`ParamEditorDelegate::commitAndCloseLineEdit_()` no longer clears `has_uncommited_data_` up front; `setModelData()` clears it only once the value has actually reached the model, so a *rejected* edit stays visible to `store()`.

The commit is triggered by any focused descendant of the tree, not just by `has_uncommited_data_`: the `input file` / `output file` / `output dir` cells are plain `QLineEdit`s that never set that flag, but they hold an uncommitted path just the same — the one picked in the file dialog — so Ctrl+S right after picking saved the previous path. `QItemDelegate`'s own focus-out handling commits those. `has_uncommited_data_` is also initialised in the delegate's constructor; `store()` reads it before any editor has been created, which was undefined behaviour.

## 2. Drop-down rewrote values outside their restriction list

`createEditor()` builds an enum combo box as `""` followed by the restriction list, so index 0 is always the empty string. When the stored value was not among the entries, `findText()` returned -1 and `setEditorData()` fell back to index 0 — so merely opening the cell and leaving it again blanked the parameter. This hits values that are non-empty *and* absent from the restrictions, e.g. an `.ini` written when a since-removed format was still legal, or one edited by hand.

The current value is now inserted as its own entry instead, so it survives unless the user actually picks something else.

(Note: an already-empty value such as `out_type=""` is *not* affected — `findText("")` matches the prepended empty entry and returns 0, so the fallback never fires. An earlier revision of this description used that as the example; it was wrong.)

## 3. `ParamXMLFile::store()` truncated the target before knowing it was writable

`ofstream::out` truncates immediately, so a full disk, an I/O error or a crash part way through left the user's only copy destroyed. `store()` now serialises into an exclusively-created (`O_EXCL`) temporary next to the target and renames over it, carrying the previous file's permissions across, and rejects directories and read-only targets up front. Symlinks are resolved so the link *target* is replaced rather than the link.

Note the accepted trade-off: replacing by rename gives the target a new inode, so ownership, ACLs, xattrs and hard links are not preserved. `QSaveFile` behaves the same way.

## 4. Any well-formed XML was accepted as a parameter file

Unknown elements are ignored, so an unrelated document parsed into an empty `Param` and reported success — in an editor, opening a foreign file appeared to work and saving then replaced it. The handler now records whether a `PARAMETERS` element was seen, and `load()` throws `ParseError` otherwise (clearing the `Param` first, so a caller that swallows the exception is not left with a half-populated object).

This deliberately checks for **presence** rather than for a `PARAMETERS` *root*, as the issue suggested: CTD files nest it inside a `tool` root and `ToolDescriptionHandler` embeds it in `ttd`, and both load through this path. A root-element check would break them.

## Testing

- `ParamXMLFile_test` — two new sections covering 3 and 4 (atomic-save behaviour incl. read-only target, directory target, permission preservation and no leftover temporaries; rejection of non-parameter documents). Passes.
- All Param/ToolDescription class tests (10) — pass.
- All INIUpdater/CTD/TOPPAS tests (161) — pass, confirming the `PARAMETERS`-presence check does not break CTD loading.
- Verified that real files reaching `load()` (`share/OpenMS/CHEMISTRY/Enzymes.xml`, the TOPP `.ini` files) all carry a `PARAMETERS` element.

**Not covered by automated tests:** defects 1 and 2 are GUI-side and have no test. `src/tests/class_tests/openms_gui/` has a QTest harness (`TSGDialog_test`) that these could follow, and I've confirmed it runs headless under `QT_QPA_PLATFORM=offscreen`; happy to add a `ParamEditor_test` here or in a follow-up. Note the GUI tests are gated behind `if(HAS_XSERVER)` in CMake, so they may not be running in CI at all — possibly worth relaxing now that offscreen works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Parameter file loading now rejects well-formed XML that lacks a `PARAMETERS` section.
  - Parameter saving now uses atomic, safe replacement to prevent truncation/loss on failures.
  - Successful saves preserve existing file permissions; no leftover temporary files after successful writes.
  - Invalid edits in the parameter editor are no longer saved unintentionally.
  - Previously invalid enum/combobox values are retained so they can be corrected.

- **User Experience**
  - Save actions now stop when edits can’t be committed, showing a clear “Not saved” warning to correct the current value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
