### PR TITLE
Fix installation of TOPPBase public headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ OpenMS/
 
 - **CMake minimum**: 3.21; **C++ standard**: C++23
 - Out-of-tree build expected in `OpenMS-build/`; build in place for development (install prefixes are for system installs).
+- When adding or removing a public header under `src/openms/include/OpenMS/`, update the matching directory's `sources.cmake` header list. These lists control the `OpenMS_headers` install component, and missing entries break consumers of the installed package.
 - Use `CMAKE_BUILD_TYPE=Debug` for development to keep assertions/pre/post-conditions.
 - Dependencies via distro packages or the contrib tree; set `OPENMS_CONTRIB_LIBS` and `CMAKE_PREFIX_PATH` as needed (Qt, contrib).
 - **contrib is a git submodule**: run `git submodule update --init contrib` (or clone with `--recurse-submodules`) before building if you need the vendored third-party libraries.

--- a/src/openms/include/OpenMS/APPLICATIONS/sources.cmake
+++ b/src/openms/include/OpenMS/APPLICATIONS/sources.cmake
@@ -11,6 +11,8 @@ ParameterInformation.h
 SearchEngineBase.h
 ToolHandler.h
 TOPPBase.h
+TOPPBase_defs.h
+TOPPExternalToolBase.h
 )
 
 ### add path to the filenames


### PR DESCRIPTION
## Summary

- register `TOPPBase_defs.h` as an OpenMS public header
- register `TOPPExternalToolBase.h` as an OpenMS public header
- include both files in the `OpenMS_headers` install component

## Root cause

The TOPPBase refactor added these public headers but did not add them to `src/openms/include/OpenMS/APPLICATIONS/sources.cmake`. `TOPPBase.h` is installed and includes `TOPPBase_defs.h`, so consumers of an installed OpenMS package fail to compile with a missing-header error.

## Impact

Standalone consumers can build against a normal `cmake --install` OpenMS prefix again. This was found while building the extracted OpenMS Legacy GUI against a core-only OpenMS installation.

## Validation

- configured current `develop` from an isolated worktree
- verified generated install rules place both headers in `include/OpenMS/APPLICATIONS`
- ran `cmake --install --component OpenMS_headers` successfully
- compared both installed headers byte-for-byte with their source files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build and Packaging**
  * Added missing application headers to the build’s header list so they’re included in generated project files and source groupings.
* **Documentation**
  * Updated contributor guidance to ensure that changes to public headers under `src/openms/include/OpenMS/` are mirrored in the CMake header list used for installation, preventing downstream breakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->