### PR TITLE
Fix Check ToolHandler.cpp / Check AUTHORS File failing on every fork PR

### DIFF
--- a/.github/workflows/check-authors-file-comment.yml
+++ b/.github/workflows/check-authors-file-comment.yml
@@ -1,0 +1,32 @@
+name: Post AUTHORS file check comment
+on:
+  workflow_run:
+    workflows: [ "Check AUTHORS File" ]
+    types: [ "completed" ]
+
+# Runs in the base repository's context (never checks out the fork's code), so it can
+# safely hold a privileged token to comment on the PR. The PR number and comment body
+# are handed over via the artifact uploaded by the "Check AUTHORS File" run, since
+# github.event.workflow_run.pull_requests is empty for PRs from forks.
+jobs:
+  comment:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Download PR comment artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: authors-pr-comment
+          path: pr-comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Post comment on the PR
+        if: hashFiles('pr-comment/body') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "$(cat pr-comment/pr-number)" --repo "${{ github.repository }}" --body-file pr-comment/body

--- a/.github/workflows/check-authors-file-comment.yml
+++ b/.github/workflows/check-authors-file-comment.yml
@@ -5,9 +5,13 @@ on:
     types: [ "completed" ]
 
 # Runs in the base repository's context (never checks out the fork's code), so it can
-# safely hold a privileged token to comment on the PR. The PR number and comment body
-# are handed over via the artifact uploaded by the "Check AUTHORS File" run, since
-# github.event.workflow_run.pull_requests is empty for PRs from forks.
+# safely hold a privileged token to comment on the PR. The comment body is handed over
+# via the artifact uploaded by the "Check AUTHORS File" run, but the target PR number
+# is deliberately NOT taken from that artifact: `pull_request` (unlike `_target`) runs
+# using the workflow file from the fork's own branch, so a malicious fork could rewrite
+# that step to fabricate an arbitrary PR number and trick this privileged job into
+# posting on an unrelated PR. Instead, the PR is resolved from workflow_run.head_sha,
+# which GitHub itself sets and the fork cannot influence, via the "commit -> PRs" API.
 jobs:
   comment:
     if: github.event.workflow_run.conclusion == 'success'
@@ -24,9 +28,17 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Post comment on the PR
-        if: hashFiles('pr-comment/body') != ''
+      - name: Resolve the PR for this run's head commit
+        id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr comment "$(cat pr-comment/pr-number)" --repo "${{ github.repository }}" --body-file pr-comment/body
+          pr_number=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" --jq '.[0].number // empty')
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Post comment on the PR
+        if: steps.resolve.outputs.pr_number != '' && hashFiles('pr-comment/body') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ steps.resolve.outputs.pr_number }}" --repo "${{ github.repository }}" --body-file pr-comment/body

--- a/.github/workflows/check-authors-file-comment.yml
+++ b/.github/workflows/check-authors-file-comment.yml
@@ -37,8 +37,14 @@ jobs:
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
 
       - name: Post comment on the PR
-        if: steps.resolve.outputs.pr_number != '' && hashFiles('pr-comment/body') != ''
+        # hashFiles() only checks that the artifact contained a "body" file, not that
+        # it has content (the check step always creates it via shell redirection, even
+        # when there's nothing to say) — so the actual "is there anything to post?"
+        # check has to happen with a real, in-shell `-s` (exists-and-non-empty) test.
+        if: steps.resolve.outputs.pr_number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr comment "${{ steps.resolve.outputs.pr_number }}" --repo "${{ github.repository }}" --body-file pr-comment/body
+          if [ -s pr-comment/body ]; then
+            gh pr comment "${{ steps.resolve.outputs.pr_number }}" --repo "${{ github.repository }}" --body-file pr-comment/body
+          fi

--- a/.github/workflows/check-authors-file-comment.yml
+++ b/.github/workflows/check-authors-file-comment.yml
@@ -32,9 +32,21 @@ jobs:
         id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          pr_number=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" --jq '.[0].number // empty')
-          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          # The commit -> PRs API doesn't document a response order and can list more
+          # than one PR for a commit, so only proceed when exactly one open PR matches
+          # this run's actual head commit; otherwise fail closed (skip commenting).
+          prs=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
+            --jq '[.[] | select(.state == "open" and .head.sha == env.HEAD_SHA)]')
+          count=$(jq 'length' <<< "$prs")
+          if [ "$count" -eq 1 ]; then
+            echo "pr_number=$(jq '.[0].number' <<< "$prs")" >> "$GITHUB_OUTPUT"
+          else
+            echo "Found $count matching open PR(s) for $HEAD_SHA; skipping comment." >&2
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Post comment on the PR
         # hashFiles() only checks that the artifact contained a "body" file, not that
@@ -44,7 +56,9 @@ jobs:
         if: steps.resolve.outputs.pr_number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
         run: |
           if [ -s pr-comment/body ]; then
-            gh pr comment "${{ steps.resolve.outputs.pr_number }}" --repo "${{ github.repository }}" --body-file pr-comment/body
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file pr-comment/body
           fi

--- a/.github/workflows/check-authors-file.yml
+++ b/.github/workflows/check-authors-file.yml
@@ -1,7 +1,7 @@
 name: Check AUTHORS File
 run-name: Checking if ${{ github.actor }} is in the AUTHORS file
 on:
-  pull_request_target:
+  pull_request:
     types: [ "opened" ]
     branches: [ "develop" ]
 jobs:
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Clone PR Repository
         uses: actions/checkout@v6
@@ -23,16 +22,33 @@ jobs:
           path: ci-tools
       - name: Check the AUTHORS File
         run: |
+          mkdir -p pr-comment
+          echo "${{ github.event.pull_request.number }}" > pr-comment/pr-number
           exit_code=0
           ci-tools/scripts/authors.sh "$GITHUB_BASE_REF" "HEAD" || exit_code=$?
 
           if [ "$exit_code" -eq 100 ]; then
-            ci-tools/scripts/authors.sh -p "$ACTOR" "$GITHUB_BASE_REF" "HEAD" |
-              gh pr comment "$PR" --body-file -
+            ci-tools/scripts/authors.sh -p "$ACTOR" "$GITHUB_BASE_REF" "HEAD" > pr-comment/body
           elif [ "$exit_code" -ne 0 ]; then
             exit "$exit_code"
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.pull_request.html_url }}
           ACTOR: ${{ github.actor }}
+      # Uploading the comment body as an artifact (instead of posting it directly with
+      # `gh pr comment` here) lets this job run under the unprivileged, read-only
+      # GITHUB_TOKEN that GitHub issues for `pull_request` runs triggered from forks.
+      # A separate `workflow_run`-triggered job (check-authors-file-comment.yml) picks
+      # the artifact up and posts the comment with a privileged token, without ever
+      # having to check out the fork's code itself. See check-authors-file-comment.yml
+      # for why: `actions/checkout` refuses to check out a fork's PR head in a
+      # `pull_request_target` job (https://gh.io/securely-using-pull_request_target),
+      # which is what this workflow used before and why it started failing for every
+      # external contributor's PR.
+      - name: Upload PR comment
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: authors-pr-comment
+          path: pr-comment/
+          if-no-files-found: ignore
+          retention-days: 1

--- a/.github/workflows/check-authors-file.yml
+++ b/.github/workflows/check-authors-file.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Check the AUTHORS File
         run: |
           mkdir -p pr-comment
+          touch pr-comment/body
           exit_code=0
           ci-tools/scripts/authors.sh "$GITHUB_BASE_REF" "HEAD" || exit_code=$?
 

--- a/.github/workflows/check-authors-file.yml
+++ b/.github/workflows/check-authors-file.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Check the AUTHORS File
         run: |
           mkdir -p pr-comment
-          echo "${{ github.event.pull_request.number }}" > pr-comment/pr-number
           exit_code=0
           ci-tools/scripts/authors.sh "$GITHUB_BASE_REF" "HEAD" || exit_code=$?
 

--- a/.github/workflows/check-tool-handler-comment.yml
+++ b/.github/workflows/check-tool-handler-comment.yml
@@ -37,8 +37,14 @@ jobs:
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
 
       - name: Post comment on the PR
-        if: steps.resolve.outputs.pr_number != '' && hashFiles('pr-comment/body') != ''
+        # hashFiles() only checks that the artifact contained a "body" file, not that
+        # it has content (the check step always creates it via shell redirection, even
+        # when there's nothing to say) — so the actual "is there anything to post?"
+        # check has to happen with a real, in-shell `-s` (exists-and-non-empty) test.
+        if: steps.resolve.outputs.pr_number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr comment "${{ steps.resolve.outputs.pr_number }}" --repo "${{ github.repository }}" --body-file pr-comment/body
+          if [ -s pr-comment/body ]; then
+            gh pr comment "${{ steps.resolve.outputs.pr_number }}" --repo "${{ github.repository }}" --body-file pr-comment/body
+          fi

--- a/.github/workflows/check-tool-handler-comment.yml
+++ b/.github/workflows/check-tool-handler-comment.yml
@@ -1,0 +1,32 @@
+name: Post ToolHandler.cpp check comment
+on:
+  workflow_run:
+    workflows: [ "Check ToolHandler.cpp" ]
+    types: [ "completed" ]
+
+# Runs in the base repository's context (never checks out the fork's code), so it can
+# safely hold a privileged token to comment on the PR. The PR number and comment body
+# are handed over via the artifact uploaded by the "Check ToolHandler.cpp" run, since
+# github.event.workflow_run.pull_requests is empty for PRs from forks.
+jobs:
+  comment:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Download PR comment artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tool-handler-pr-comment
+          path: pr-comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Post comment on the PR
+        if: hashFiles('pr-comment/body') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "$(cat pr-comment/pr-number)" --repo "${{ github.repository }}" --body-file pr-comment/body

--- a/.github/workflows/check-tool-handler-comment.yml
+++ b/.github/workflows/check-tool-handler-comment.yml
@@ -32,9 +32,21 @@ jobs:
         id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          pr_number=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" --jq '.[0].number // empty')
-          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          # The commit -> PRs API doesn't document a response order and can list more
+          # than one PR for a commit, so only proceed when exactly one open PR matches
+          # this run's actual head commit; otherwise fail closed (skip commenting).
+          prs=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
+            --jq '[.[] | select(.state == "open" and .head.sha == env.HEAD_SHA)]')
+          count=$(jq 'length' <<< "$prs")
+          if [ "$count" -eq 1 ]; then
+            echo "pr_number=$(jq '.[0].number' <<< "$prs")" >> "$GITHUB_OUTPUT"
+          else
+            echo "Found $count matching open PR(s) for $HEAD_SHA; skipping comment." >&2
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Post comment on the PR
         # hashFiles() only checks that the artifact contained a "body" file, not that
@@ -44,7 +56,9 @@ jobs:
         if: steps.resolve.outputs.pr_number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
         run: |
           if [ -s pr-comment/body ]; then
-            gh pr comment "${{ steps.resolve.outputs.pr_number }}" --repo "${{ github.repository }}" --body-file pr-comment/body
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file pr-comment/body
           fi

--- a/.github/workflows/check-tool-handler-comment.yml
+++ b/.github/workflows/check-tool-handler-comment.yml
@@ -5,9 +5,13 @@ on:
     types: [ "completed" ]
 
 # Runs in the base repository's context (never checks out the fork's code), so it can
-# safely hold a privileged token to comment on the PR. The PR number and comment body
-# are handed over via the artifact uploaded by the "Check ToolHandler.cpp" run, since
-# github.event.workflow_run.pull_requests is empty for PRs from forks.
+# safely hold a privileged token to comment on the PR. The comment body is handed over
+# via the artifact uploaded by the "Check ToolHandler.cpp" run, but the target PR number
+# is deliberately NOT taken from that artifact: `pull_request` (unlike `_target`) runs
+# using the workflow file from the fork's own branch, so a malicious fork could rewrite
+# that step to fabricate an arbitrary PR number and trick this privileged job into
+# posting on an unrelated PR. Instead, the PR is resolved from workflow_run.head_sha,
+# which GitHub itself sets and the fork cannot influence, via the "commit -> PRs" API.
 jobs:
   comment:
     if: github.event.workflow_run.conclusion == 'success'
@@ -24,9 +28,17 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Post comment on the PR
-        if: hashFiles('pr-comment/body') != ''
+      - name: Resolve the PR for this run's head commit
+        id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr comment "$(cat pr-comment/pr-number)" --repo "${{ github.repository }}" --body-file pr-comment/body
+          pr_number=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" --jq '.[0].number // empty')
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Post comment on the PR
+        if: steps.resolve.outputs.pr_number != '' && hashFiles('pr-comment/body') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ steps.resolve.outputs.pr_number }}" --repo "${{ github.repository }}" --body-file pr-comment/body

--- a/.github/workflows/check-tool-handler.yml
+++ b/.github/workflows/check-tool-handler.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Check the ToolHandler.cpp file
         run: |
           mkdir -p pr-comment
-          echo "${{ github.event.pull_request.number }}" > pr-comment/pr-number
           exit_code=0
           ci-tools/scripts/check-tool-handler.sh "$GITHUB_BASE_REF" "HEAD" || exit_code=$?
 

--- a/.github/workflows/check-tool-handler.yml
+++ b/.github/workflows/check-tool-handler.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Check the ToolHandler.cpp file
         run: |
           mkdir -p pr-comment
+          touch pr-comment/body
           exit_code=0
           ci-tools/scripts/check-tool-handler.sh "$GITHUB_BASE_REF" "HEAD" || exit_code=$?
 

--- a/.github/workflows/check-tool-handler.yml
+++ b/.github/workflows/check-tool-handler.yml
@@ -1,6 +1,6 @@
 name: Check ToolHandler.cpp
 on:
-  pull_request_target:
+  pull_request:
     types: [ "opened" ]
     branches: [ "develop" ]
 jobs:
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Clone PR Repository
         uses: actions/checkout@v6
@@ -22,16 +21,33 @@ jobs:
           path: ci-tools
       - name: Check the ToolHandler.cpp file
         run: |
+          mkdir -p pr-comment
+          echo "${{ github.event.pull_request.number }}" > pr-comment/pr-number
           exit_code=0
           ci-tools/scripts/check-tool-handler.sh "$GITHUB_BASE_REF" "HEAD" || exit_code=$?
 
           if [ "$exit_code" -eq 100 ]; then
-            ci-tools/scripts/check-tool-handler.sh -p "$ACTOR" "$GITHUB_BASE_REF" "HEAD" |
-              gh pr comment "$PR" --body-file -
+            ci-tools/scripts/check-tool-handler.sh -p "$ACTOR" "$GITHUB_BASE_REF" "HEAD" > pr-comment/body
           elif [ "$exit_code" -ne 0 ]; then
             exit "$exit_code"
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.pull_request.html_url }}
           ACTOR: ${{ github.actor }}
+      # Uploading the comment body as an artifact (instead of posting it directly with
+      # `gh pr comment` here) lets this job run under the unprivileged, read-only
+      # GITHUB_TOKEN that GitHub issues for `pull_request` runs triggered from forks.
+      # A separate `workflow_run`-triggered job (check-tool-handler-comment.yml) picks
+      # the artifact up and posts the comment with a privileged token, without ever
+      # having to check out the fork's code itself. See check-tool-handler-comment.yml
+      # for why: `actions/checkout` refuses to check out a fork's PR head in a
+      # `pull_request_target` job (https://gh.io/securely-using-pull_request_target),
+      # which is what this workflow used before and why it started failing for every
+      # external contributor's PR.
+      - name: Upload PR comment
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tool-handler-pr-comment
+          path: pr-comment/
+          if-no-files-found: ignore
+          retention-days: 1


### PR DESCRIPTION
## Summary

- `actions/checkout@v6` now refuses to check out a fork's PR head SHA from a `pull_request_target` job (the "pwn request" guard: https://gh.io/securely-using-pull_request_target). Both `Check ToolHandler.cpp` and `Check AUTHORS File` do exactly that, so they've been failing unconditionally for **every PR opened from an actual fork** since ~2026-07-16, instead of running their intended diff check. PRs from branches within `OpenMS/OpenMS` itself are unaffected, which is why this went unnoticed.
- Fixes #9785, which has full evidence (affected run IDs, timeline, confirmation that same-repo branches are unaffected).

## What changed

Split each workflow into two:
1. **`check-tool-handler.yml` / `check-authors-file.yml`** — now triggered on plain `pull_request` (not `_target`), so checking out the fork's head is safe and unrestricted. Runs the existing `ci-tools` check script and, instead of posting the PR comment directly (this job only gets a read-only token when triggered from a fork), uploads the PR number + comment body as an artifact.
2. **`check-tool-handler-comment.yml` / `check-authors-file-comment.yml`** (new) — triggered on `workflow_run` once the corresponding check completes. This job runs in the base repo's context (never checks out fork code) and can safely hold a `pull-requests: write` token. It downloads the artifact and posts the comment.

Note: `github.event.workflow_run.pull_requests` is empty for fork-originated PRs, so the PR number is carried through the artifact rather than read off the `workflow_run` event.

This mirrors GitHub's documented secure replacement pattern for `pull_request_target` combined with fork-code checkout.

## Test plan

- [x] YAML syntax validated for all 4 files (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Since this only triggers under real fork-PR conditions, please verify end-to-end against an actual external-fork PR after merge (e.g. re-run on a currently-failing fork PR, or open a throwaway fork PR) — I could not simulate a `workflow_run`-triggered cross-run artifact download locally.
- [ ] Confirm the comment still posts correctly for the "found an issue" case (exit code 100 path) and stays silent for the clean case.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01ELBxffE1E3xZ9ar5Fvs7xZ


---
_Generated by [Claude Code](https://claude.ai/code/session_01ELBxffE1E3xZ9ar5Fvs7xZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated pull request comments for AUTHORS and ToolHandler validations after each check finishes.
- **Bug Fixes**
  - Improved comment reliability by preparing comment content during validation and only publishing when valid output is available.
  - Strengthened safety by running workflows with read-only permissions and avoiding direct commenting from less-trusted contexts.
- **Chores**
  - Updated workflow triggers and refined execution flow to post comments in a more controlled, consistent manner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->