### PR TITLE
[CI] Fix recurring Bioconda nightly deploy failure: rebase → merge

### DIFF
--- a/.github/workflows/bioconda_deploy.yaml
+++ b/.github/workflows/bioconda_deploy.yaml
@@ -55,7 +55,16 @@ jobs:
           git checkout -b nightly origin/nightly
           git remote add bioconda https://github.com/bioconda/bioconda-recipes.git
           git fetch bioconda master
-          git rebase bioconda/master
+          # Use a merge, not a rebase, to integrate upstream bioconda/master.
+          # Rebase replays our nightly branch's commits one at a time, in their
+          # original historical order, onto today's master. Since our nightly
+          # branch already periodically merges upstream (so its tip is already
+          # reconciled with a past state of master), replaying an older nightly
+          # commit in isolation reintroduces conflicts upstream and nightly
+          # resolved together long ago -- even though the two tips merge
+          # cleanly. A merge diffs tip-vs-tip once instead of replaying stale
+          # history, so it only conflicts on genuinely unresolved changes.
+          git merge --no-edit bioconda/master
 
       - name: Lint and build OpenMS Bioconda packages
         run: |


### PR DESCRIPTION
## Description

The nightly build CI (triggered by `.github/workflows/update_nightly.yml` every night at 01:4x UTC) is green for the main `openms-ci-full` build/test/package matrix, but the **"Deploy to Bioconda"** workflow it also triggers has failed **every single night for 16 consecutive days** (2026-07-10 through 2026-07-26), always at the same step:

```
error: could not apply 3968e92688... Re-sync nightly recipes onto bioconda/master (pyopenms+openms 3.6.0dev)
CONFLICT (content): Merge conflict in recipes/pyopenms/meta.yaml
##[error]Process completed with exit code 1.
```

### Root cause

The "Clone Bioconda recipes repository and add our changes" step integrates the `OpenMS/bioconda-recipes` fork's `nightly` branch (which carries OpenMS-specific customizations: dev version pins, Arrow/Parquet pins, a nanobind-wheel build fix, etc.) with upstream `bioconda/master` via:

```sh
git rebase bioconda/master
```

`git rebase` replays the `nightly` branch's commits **one at a time, in their original historical order**, onto whatever `bioconda/master` looks like *today*. The `nightly` branch already periodically merges upstream on its own (its tip is already reconciled with a past state of `bioconda/master`), so replaying an old individual commit (e.g. the June 16 "Re-sync nightly recipes..." commit) in isolation reintroduces a conflict that upstream and `nightly` already resolved together long ago — **even though the current tips of both branches merge together with zero conflicts.**

I verified this locally:
- `git clone` the fork's `nightly` branch, add the `bioconda` remote, `git rebase bioconda/master` → same conflict reproduced in `recipes/pyopenms/meta.yaml`.
- `git merge --no-edit bioconda/master` from the same starting point → **merges cleanly, no conflicts**, and every OpenMS-owned recipe file (`recipes/pyopenms/meta.yaml`, `recipes/pyopenms/build.sh`, `recipes/openms-meta/*`) comes out **byte-identical** to before the merge — only unrelated upstream recipes elsewhere in the tree change.

### Fix

Replace `git rebase bioconda/master` with `git merge --no-edit bioconda/master`. This diffs tip-vs-tip once instead of replaying stale per-commit history, which is what actually matches how this branch is used here (the merge result is only used locally within the CI job to build packages; nothing is pushed back, so there's no need for a linear rebased history). It will still fail loudly if a **genuine**, currently-unresolved content conflict arises between our nightly customizations and upstream — this is not a suppression of the check, just the correct git operation for combining two independently-evolving branches.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file (CI-only fix, not user-facing)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes (CI workflow change; validated by reproducing the failure and the fix locally against the real `OpenMS/bioconda-recipes` and `bioconda/bioconda-recipes` repos — not covered by the local `ctest` suite)
- [x] Updated or added python bindings for changed or new classes (N/A, no code changes)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XeR6LJZjRVwAeUd53i2uqL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the nightly deployment workflow for incorporating upstream Bioconda updates.
  * Reduced the likelihood of recurring merge conflicts during automated deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->