### PR TITLE
[FIX] MSExperiment::extractXICs: set both precursor and product m/z

### DIFF
--- a/src/openms/include/OpenMS/KERNEL/MSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/MSExperiment.h
@@ -682,6 +682,8 @@ std::vector<std::vector<MSExperiment::CoordinateType>> aggregate(
  * @param[in] func_mz_reduction The MzReductionFunctionType used to reduce the m/z values.
  *
  * @return A vector of MSChromatogram objects representing the extracted XICs.
+ *         Both the product and the precursor m/z of each chromatogram are set to the
+ *         centre of the corresponding m/z range.
  */
 template<class MzReductionFunctionType>
 std::vector<MSChromatogram> extractXICs(
@@ -752,8 +754,12 @@ std::vector<MSChromatogram> extractXICs(
     {        
         const auto& [start, stop] = rt_ranges_idcs[i];
         result[i].resize(stop - start);
-        result[i].getProduct().setMZ(
-          (mz_rt_ranges[i].first.getMinMZ() + mz_rt_ranges[i].first.getMaxMZ()) / 2.0);
+        // Consumers are split on where they read a chromatogram's m/z from:
+        // MSChromatogram::getMZ() reads the product, DimMapper reads the precursor.
+        // Set both so the XIC is positioned correctly either way.
+        const double mz_center = (mz_rt_ranges[i].first.getMinMZ() + mz_rt_ranges[i].first.getMaxMZ()) / 2.0;
+        result[i].getProduct().setMZ(mz_center);
+        result[i].getPrecursor().setMZ(mz_center);
         for (size_t j = start; j < stop; ++j) 
         {
           spec_idx_to_range_idx[j].push_back(i);

--- a/src/openms/include/OpenMS/KERNEL/MSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/MSExperiment.h
@@ -757,7 +757,7 @@ std::vector<MSChromatogram> extractXICs(
         // Consumers are split on where they read a chromatogram's m/z from:
         // MSChromatogram::getMZ() reads the product, DimMapper reads the precursor.
         // Set both so the XIC is positioned correctly either way.
-        const double mz_center = (mz_rt_ranges[i].first.getMinMZ() + mz_rt_ranges[i].first.getMaxMZ()) / 2.0;
+        const double mz_center = mz_rt_ranges[i].first.center();
         result[i].getProduct().setMZ(mz_center);
         result[i].getPrecursor().setMZ(mz_center);
         for (size_t j = start; j < stop; ++j) 

--- a/src/tests/class_tests/openms/source/MSExperiment_test.cpp
+++ b/src/tests/class_tests/openms/source/MSExperiment_test.cpp
@@ -2384,6 +2384,15 @@ START_SECTION((std::vector<MSChromatogram> extractXICsFromMatrix(const Matrix<do
         TEST_REAL_SIMILAR(result[1][0].getIntensity(), 2000.0);  // First spectrum intensity
         TEST_REAL_SIMILAR(result[1][1].getIntensity(), 2100.0);  // Third spectrum intensity
         TEST_REAL_SIMILAR(result[1][2].getIntensity(), 2200.0);  // Fourth spectrum intensity
+
+        // Both product and precursor m/z are set to the centre of the m/z range,
+        // so consumers reading either field position the XIC correctly
+        TEST_REAL_SIMILAR(result[0].getProduct().getMZ(), (90.0 + 110.0) / 2.0);
+        TEST_REAL_SIMILAR(result[0].getPrecursor().getMZ(), (90.0 + 110.0) / 2.0);
+        TEST_REAL_SIMILAR(result[0].getMZ(), (90.0 + 110.0) / 2.0);
+        TEST_REAL_SIMILAR(result[1].getProduct().getMZ(), (190.0 + 210.0) / 2.0);
+        TEST_REAL_SIMILAR(result[1].getPrecursor().getMZ(), (190.0 + 210.0) / 2.0);
+        TEST_REAL_SIMILAR(result[1].getMZ(), (190.0 + 210.0) / 2.0);
     }
 
 }
@@ -2570,8 +2579,9 @@ START_SECTION((template<class MzReductionFunctionType> std::vector<MSChromatogra
         TEST_REAL_SIMILAR(chromatograms[0][2].getRT(), 4.0);
         TEST_REAL_SIMILAR(chromatograms[0][2].getIntensity(), 1200.0);
 
-        // Check m/z value of the chromatogram
+        // Check m/z value of the chromatogram (product and precursor are both set)
         TEST_REAL_SIMILAR(chromatograms[0].getProduct().getMZ(), (90.0 + 110.0) / 2.0);
+        TEST_REAL_SIMILAR(chromatograms[0].getPrecursor().getMZ(), (90.0 + 110.0) / 2.0);
 
         // Check Range 2 chromatogram
         TEST_EQUAL(chromatograms[1].size(), 3); // Should cover 3 spectra
@@ -2584,8 +2594,9 @@ START_SECTION((template<class MzReductionFunctionType> std::vector<MSChromatogra
         TEST_REAL_SIMILAR(chromatograms[1][2].getRT(), 4.0);
         TEST_REAL_SIMILAR(chromatograms[1][2].getIntensity(), 2200.0);
 
-        // Check m/z value of the chromatogram
+        // Check m/z value of the chromatogram (product and precursor are both set)
         TEST_REAL_SIMILAR(chromatograms[1].getProduct().getMZ(), (190.0 + 210.0) / 2.0);
+        TEST_REAL_SIMILAR(chromatograms[1].getPrecursor().getMZ(), (190.0 + 210.0) / 2.0);
     }
 
     // Test 2: MS2 spectra
@@ -2603,8 +2614,9 @@ START_SECTION((template<class MzReductionFunctionType> std::vector<MSChromatogra
         TEST_REAL_SIMILAR(chromatograms[0][0].getRT(), 2.0);
         TEST_REAL_SIMILAR(chromatograms[0][0].getIntensity(), 1500.0);
 
-        // Check m/z value of the chromatogram
+        // Check m/z value of the chromatogram (product and precursor are both set)
         TEST_REAL_SIMILAR(chromatograms[0].getProduct().getMZ(), (140.0 + 160.0) / 2.0);
+        TEST_REAL_SIMILAR(chromatograms[0].getPrecursor().getMZ(), (140.0 + 160.0) / 2.0);
     }
 
     // Test 3: Custom reduction function (average intensity)
@@ -2638,8 +2650,9 @@ START_SECTION((template<class MzReductionFunctionType> std::vector<MSChromatogra
         TEST_REAL_SIMILAR(chromatograms[0][2].getRT(), 4.0);
         TEST_REAL_SIMILAR(chromatograms[0][2].getIntensity(), 2200.0); // Average of [1200, 2200, 3200]
 
-        // Check m/z value of the chromatogram
+        // Check m/z value of the chromatogram (product and precursor are both set)
         TEST_REAL_SIMILAR(chromatograms[0].getProduct().getMZ(), (90.0 + 310.0) / 2.0);
+        TEST_REAL_SIMILAR(chromatograms[0].getPrecursor().getMZ(), (90.0 + 310.0) / 2.0);
     }
 }
 END_SECTION


### PR DESCRIPTION
## Problem

`MSExperiment::extractXICs` set only the **product** m/z of each extracted chromatogram (to the centre of the requested m/z window), leaving the precursor at its default of 0.

OpenMS is split on which field a chromatogram's m/z is read from:

| Reads **product** | Reads **precursor** |
|---|---|
| `MSChromatogram::getMZ()` (`MSChromatogram.cpp:80`) | `DimMapper` m/z mapping (`DimMapper.h:324`) |
| `MSExperiment::updateRanges` (`MSExperiment.cpp:714`) | `ChromatogramTools` XIC path (`ChromatogramTools.h:152`) |
| TOPPView chromatogram tree m/z column, `Plot2DCanvas`, `LayerDataChrom` | `FeatureFindingMetabo` mass traces (`FeatureFindingMetabo.cpp:126`) |

For genuine SRM/MRM transitions both fields are always set, so the ambiguity only bites MS1 single-mass chromatograms — exactly what `extractXICs` produces.

The practical consequence: an XIC from `extractXICs` reported its m/z correctly via `getMZ()`, but came out at **0** when positioned by m/z in a 2D view, since all of `openms_gui` plotting goes through `DimMapper`. The other producers of MS1 chromatograms (`ChromatogramTools`' force-conversion path, `FeatureFindingMetabo`) chose the precursor and have the mirror-image problem — notably `ChromatogramTools.h:153` has a commented-out `setProduct` with `// probably no product`.

## Change

Set **both** precursor and product m/z to the centre of the m/z range, so the chromatogram is positioned correctly regardless of which accessor a consumer uses. This is the only choice that satisfies both families of consumer.

The centre is taken from the existing `RangeBase::center()` API (`RangeManager.h:255`) rather than computed by hand. Besides reusing the API — already used at `DIAHelper.cpp:241` and `IMDataConverter.cpp:217` — this fixes the empty-range case: an empty `RangeMZ` carries `min_ = double::max()` and `max_ = double::lowest()`, so a manual `(min + max) / 2.0` silently yields **0.0**, which is exactly the sentinel the codebase uses for "never set" (cf. the `fabs(mz) > 1e-8` set-checks in `MRMChromHandler.cpp:241-242` and `MRMMapping.cpp:63-64`). `center()` returns `nan` instead, which is an honest signal. It also computes `min + (max - min) / 2`, which cannot overflow for large bounds and is guaranteed to land inside `[min, max]`.

Also documents the behaviour in the `extractXICs` doxygen block.

## Notes

- The kernel `extractXICs` / `extractXICsFromMatrix` have **no C++ production callers** — they are reached from tests and from the pyOpenMS binding (`MSExperiment.extractXICsFromMatrix`), so the blast radius is small. (The identically-named `MetaProSIPXICExtraction::extractXICs` in `src/topp/MetaProSIP.cpp` is an unrelated local helper.)
- Writing an mzML with these chromatograms will now emit a `<precursor>` block for what is an MS1 chromatogram. That is the trade-off for making them plot correctly; it is consistent with what `ChromatogramTools` already does for force-converted MS1 XICs.
- Passing an empty or inverted m/z range now produces a chromatogram with `nan` precursor/product m/z instead of `0.0`. This is the intended contract of `RangeBase::center()`, and `nan` is the more honest value, but it is a behaviour change for any caller that was relying on the old `0.0`.

## Testing

Extended `MSExperiment_test` to assert precursor, product and `getMZ()` in both the `extractXICs` and `extractXICsFromMatrix` sections.

`ctest -R "MRMMapping|ChromatogramTools|MSChromatogram|MRMChromHandler|ChromatogramExtractor|DimMapper|MSExperiment"` — 28/28 pass locally.

Full CI green: 31 passed, 8 skipped (release/deploy jobs), 0 failed — including `build-and-test` on Ubuntu g++ 13 / clang++ 18 / Ubuntu-arm / macOS 15 / Windows MSVC, and the `build-wheels` + `test-wheels` matrix across Python 3.10–3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed extracted ion chromatograms so both precursor and product m/z metadata are set consistently using the center of the selected m/z range.
  * Improved m/z metadata consistency checks across supported chromatogram extraction scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
