### PR TITLE
docs(pyOpenMS): fix stale/missing MSChromatogram and Mobilogram docstrings

### DIFF
--- a/src/pyOpenMS/bindings/bind_chromatogram.cpp
+++ b/src/pyOpenMS/bindings/bind_chromatogram.cpp
@@ -90,7 +90,11 @@ rt, intensities = chromatogram.get_peaks()
         .def("getName", [](const OpenMS::MSChromatogram& self) { return self.getName(); }, "Returns the name")
         .def("setName", [](OpenMS::MSChromatogram& self, const std::string& name) { return self.setName(name); }, "name"_a, "Sets the name")
         .def("getMZ", [](const OpenMS::MSChromatogram& self) { return self.getMZ(); }, "Returns the mz of the product entry, makes sense especially for MRM scans")
-        .def("sortByIntensity", [](OpenMS::MSChromatogram& self, bool reverse) { return self.sortByIntensity(reverse); }, "reverse"_a = false)
+        .def("sortByIntensity", [](OpenMS::MSChromatogram& self, bool reverse) { return self.sortByIntensity(reverse); }, "reverse"_a = false,
+            R"doc(
+Lexicographically sorts the peaks by their intensity.
+Sorts the peaks according to ascending intensity. Meta data arrays will be sorted accordingly
+)doc")
         .def("sortByPosition", [](OpenMS::MSChromatogram& self) { return self.sortByPosition(); },
             R"doc(
 Lexicographically sorts the peaks by their position (RT).
@@ -99,10 +103,17 @@ Sorts the peaks according to ascending RT. Meta data arrays will be sorted accor
         .def("isSorted", [](const OpenMS::MSChromatogram& self) { return self.isSorted(); }, "Checks if all peaks are sorted with respect to ascending RT")
         .def("findNearest", [](const OpenMS::MSChromatogram& self, double rt) { return self.findNearest(rt); }, "rt"_a,
             R"doc(
-Lexicographically sorts the peaks by their position
-The chromatogram is sorted with respect to position. Meta data arrays will be sorted accordingly
+Binary search for the peak nearest to a specific RT.
+Returns the index of the peak. The chromatogram must be sorted with respect to RT, otherwise
+the result is undefined. Raises an exception if the chromatogram is empty.
 )doc")
-        .def("clear", [](OpenMS::MSChromatogram& self, bool clear_meta_data) { return self.clear(clear_meta_data); }, "clear_meta_data"_a)
+        .def("clear", [](OpenMS::MSChromatogram& self, bool clear_meta_data) { return self.clear(clear_meta_data); }, "clear_meta_data"_a,
+            R"doc(
+Clears all data and meta data.
+Deletes all peaks as well as any associated data arrays (float, integer, string) and the
+ranges. If clear_meta_data is True, the descriptive meta data (ChromatogramSettings, name)
+is deleted as well.
+)doc")
         .def("getNativeID", [](const OpenMS::MSChromatogram& self) { return self.getNativeID(); }, "Returns the native identifier for the spectrum, used by the acquisition software.")
         .def("setNativeID", [](OpenMS::MSChromatogram& self, const std::string& native_id) { return self.setNativeID(native_id); }, "native_id"_a, "Sets the native identifier for the spectrum, used by the acquisition software.")
         .def("getComment", [](const OpenMS::MSChromatogram& self) { return self.getComment(); }, "Returns the free-text comment")

--- a/src/pyOpenMS/bindings/bind_chromatogram.cpp
+++ b/src/pyOpenMS/bindings/bind_chromatogram.cpp
@@ -93,7 +93,9 @@ rt, intensities = chromatogram.get_peaks()
         .def("sortByIntensity", [](OpenMS::MSChromatogram& self, bool reverse) { return self.sortByIntensity(reverse); }, "reverse"_a = false,
             R"doc(
 Lexicographically sorts the peaks by their intensity.
-Sorts the peaks according to ascending intensity. Meta data arrays will be sorted accordingly
+Sorts the peaks according to ascending intensity (lowest to highest) when reverse is False.
+When reverse is True, sorts by descending intensity (highest to lowest).
+Meta data arrays will be sorted accordingly
 )doc")
         .def("sortByPosition", [](OpenMS::MSChromatogram& self) { return self.sortByPosition(); },
             R"doc(
@@ -110,9 +112,8 @@ the result is undefined. Raises an exception if the chromatogram is empty.
         .def("clear", [](OpenMS::MSChromatogram& self, bool clear_meta_data) { return self.clear(clear_meta_data); }, "clear_meta_data"_a,
             R"doc(
 Clears all data and meta data.
-Deletes all peaks as well as any associated data arrays (float, integer, string) and the
-ranges. If clear_meta_data is True, the descriptive meta data (ChromatogramSettings, name)
-is deleted as well.
+Always deletes all peaks, associated data arrays (float, integer, string), and ranges.
+If clear_meta_data is True, also deletes the descriptive meta data (ChromatogramSettings, name).
 )doc")
         .def("getNativeID", [](const OpenMS::MSChromatogram& self) { return self.getNativeID(); }, "Returns the native identifier for the spectrum, used by the acquisition software.")
         .def("setNativeID", [](OpenMS::MSChromatogram& self, const std::string& native_id) { return self.setNativeID(native_id); }, "native_id"_a, "Sets the native identifier for the spectrum, used by the acquisition software.")

--- a/src/pyOpenMS/bindings/bind_kernel.cpp
+++ b/src/pyOpenMS/bindings/bind_kernel.cpp
@@ -1603,11 +1603,15 @@ mobility, intensities = mobilogram.get_peaks()
         .def("getDriftTimeUnit", [](const OpenMS::Mobilogram& self) { return self.getDriftTimeUnit(); }, "Returns the ion mobility drift time unit")
         .def("getDriftTimeUnitAsString", [](const OpenMS::Mobilogram& self) { return self.getDriftTimeUnitAsString(); }, "Returns the ion mobility drift time unit as string")
         .def("setDriftTimeUnit", [](OpenMS::Mobilogram& self, OpenMS::DriftTimeUnit dt) { return self.setDriftTimeUnit(dt); }, "dt"_a, "Sets the ion mobility drift time unit")
-        .def("sortByIntensity", [](OpenMS::Mobilogram& self, bool reverse) { return self.sortByIntensity(reverse); }, "reverse"_a = false)
-        .def("sortByPosition", [](OpenMS::Mobilogram& self) { return self.sortByPosition(); }, 
+        .def("sortByIntensity", [](OpenMS::Mobilogram& self, bool reverse) { return self.sortByIntensity(reverse); }, "reverse"_a = false,
             R"doc(
 Lexicographically sorts the peaks by their intensity
 Sorts the peaks according to ascending intensity. Meta data arrays will be sorted accordingly
+)doc")
+        .def("sortByPosition", [](OpenMS::Mobilogram& self) { return self.sortByPosition(); },
+            R"doc(
+Lexicographically sorts the peaks by their position (mobility)
+The mobilogram is sorted with respect to position (mobility). Meta data arrays will be sorted accordingly
 )doc")
         .def("isSorted", [](const OpenMS::Mobilogram& self) { return self.isSorted(); }, "Checks if all peaks are sorted with respect to ascending mobility")
         .def("calculateTIC", [](const OpenMS::Mobilogram& self) { return self.calculateTIC(); }, "Compute the total ion count (sum of all peak intensities)")
@@ -1639,7 +1643,7 @@ Sorts the peaks according to ascending intensity. Meta data arrays will be sorte
 
         .def("clear", [](OpenMS::Mobilogram& self) {
             self.clear();
-        }, "Clear all peaks")
+        }, "Clears all data: deletes all peaks as well as any associated data arrays (float, integer, string), since those arrays are parallel to the peaks")
 
         .def("get_peaks", [](const OpenMS::Mobilogram& self) {
             // Single allocation + single capsule to reduce overhead for small arrays

--- a/src/pyOpenMS/bindings/bind_kernel.cpp
+++ b/src/pyOpenMS/bindings/bind_kernel.cpp
@@ -1606,7 +1606,9 @@ mobility, intensities = mobilogram.get_peaks()
         .def("sortByIntensity", [](OpenMS::Mobilogram& self, bool reverse) { return self.sortByIntensity(reverse); }, "reverse"_a = false,
             R"doc(
 Lexicographically sorts the peaks by their intensity
-Sorts the peaks according to ascending intensity. Meta data arrays will be sorted accordingly
+Sorts the peaks according to ascending intensity (lowest to highest) when reverse is False.
+When reverse is True, sorts by descending intensity (highest to lowest).
+Meta data arrays will be sorted accordingly
 )doc")
         .def("sortByPosition", [](OpenMS::Mobilogram& self) { return self.sortByPosition(); },
             R"doc(
@@ -1643,7 +1645,7 @@ The mobilogram is sorted with respect to position (mobility). Meta data arrays w
 
         .def("clear", [](OpenMS::Mobilogram& self) {
             self.clear();
-        }, "Clears all data: deletes all peaks as well as any associated data arrays (float, integer, string), since those arrays are parallel to the peaks")
+        }, "Clears all data: deletes all peaks, associated data arrays (float, integer, string), and resets the mobility and intensity ranges")
 
         .def("get_peaks", [](const OpenMS::Mobilogram& self) {
             // Single allocation + single capsule to reduce overhead for small arrays


### PR DESCRIPTION
MSChromatogram.findNearest() carried a copy-pasted sortByPosition()
docstring instead of describing its own binary-search-nearest-RT
behavior. MSChromatogram.clear()/sortByIntensity() and
Mobilogram.sortByPosition()/sortByIntensity() had no docstring at all,
and Mobilogram.clear() still said "Clear all peaks" even though #9795
made it also clear the parallel data arrays. Bring all of these in
line with the corresponding Doxygen comments in MSChromatogram.h /
Mobilogram.h.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Python API documentation for chromatogram and mobilogram sorting methods, including sort order and metadata handling.
  * Clarified that nearest-peak searches require retention-time-sorted data and describe behavior for empty chromatograms.
  * Documented the data and metadata removed when clearing chromatograms or mobilograms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->