### PR TITLE
[DOC] Correct the qpx converter survey in the pg run_file_name TODO (#9817)

### DIFF
--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -673,8 +673,13 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
       // TODO(#9817): provisional, not a settled contract. The QPX spec makes
       // (pg_accessions, run_file_name) the pg primary key and requires both to be non-null, and
       // quantms silently DROPS rows whose run_file_name is empty - so these groups would vanish
-      // downstream rather than being flagged. qpx's own converters emit a stable non-empty token
-      // ("unknown" / the mzid basename / "combined") instead. Honest-but-dropped vs. lossy-but-
+      // downstream rather than being flagged. qpx has no cross-run encoding at all: pg.md mandates
+      // one row per group PER RUN, and its four quantitative converters melt wide->long on per-run
+      // intensity columns. Only its identification-only converter (mzIdentML) does the opposite,
+      // emitting one global row per group labelled with the source file's basename - so upstream is
+      // self-inconsistent on exactly the shape we produce here. Melting is available to us too: the
+      // peptide loop below already matches peptides to this run, and each one's origin file is
+      // recoverable via Constants::UserParam::ID_MERGE_INDEX. Honest-but-dropped vs. lossy-but-
       // visible is unresolved upstream (bigbio/qpx#51) and is to be decided in #9817. Unreachable
       // from any TOPP tool today (ProSE, the only caller, always passes a single-path run).
       OPENMS_LOG_WARN << "ProteinGroupArrowExport (id-only): identification run '" << prot_id.getIdentifier()


### PR DESCRIPTION
Comment-only follow-up to #9818. No behaviour change.

The `TODO(#9817)` added in eafaa82eb5 states that qpx's own converters "emit a stable non-empty token (`"unknown"` / the mzid basename / `"combined"`)" for a protein group with no single origin run. Checking the converters directly, that is wrong in two ways.

**No converter emits the literal `combined`.** The string appears in `docs/spec/tool-mappings.md`'s MaxQuant column and in FragPipe's `combined_protein.tsv` filename and its `Combined Total Peptides` columns, but never as a `run_file_name` value. MaxQuant's `"unknown"` is a fallback for input carrying no per-sample intensity columns at all, not a cross-run encoding.

**More importantly, the framing is misleading — qpx has no cross-run encoding to copy.** `pg.md` mandates one row per protein group *per run* and requires converters to melt wide-format columns into separate rows keyed by `run_file_name`. Its four quantitative converters (MaxQuant, FragPipe, DIA-NN, quantms) all do that, taking run identity from per-run intensity columns. Only mzIdentML — the one identification-only converter, i.e. exactly the shape this branch produces — emits a single global row per group, labelled with the source file basename. Upstream answers the question two incompatible ways.

The comment now says that, and additionally records that melting is available to us without quantification: the peptide loop directly below already matches peptides to this run, and each one's origin file is recoverable via `Constants::UserParam::ID_MERGE_INDEX`. That turns "unresolved upstream" into a concrete starting point for whoever implements the decision.

Raised upstream in bigbio/qpx#51 (https://github.com/bigbio/qpx/issues/51#issuecomment-5115165643); tracked in #9817 and #9820.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DF2YUewPQTC5tJWqn23pUm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how protein groups spanning multiple MS runs are represented in exported data.
  * Added context explaining when the originating run filename is intentionally left empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->