### PR TITLE
[FIX] QPX export: make the psm, feature and pg views spec-conformant and joinable

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/ArrowIOHelpers.h
+++ b/src/openms/include/OpenMS/FORMAT/ArrowIOHelpers.h
@@ -127,6 +127,19 @@ namespace ArrowIOHelpers
   */
   OPENMS_DLLAPI std::string qpxScanFormat(const std::vector<std::string>& native_ids);
 
+  /**
+    @brief Reduce an MS run path to the QPX @c run_file_name form
+
+    QPX defines @c run_file_name as the raw data file name *without* extension, and uses it
+    as a primary-key component in the psm, feature and pg views (and to join them against
+    @c run.parquet). The full name with extension belongs in @c run.file_name.
+
+    @param[in] ms_run_path Source path, e.g. <tt>/data/proj/S1_Frontal_1.mzML</tt>
+    @return The stem, e.g. <tt>S1_Frontal_1</tt>; empty input yields an empty result.
+  */
+  OPENMS_DLLAPI std::string qpxRunFileName(const std::string& ms_run_path);
+
+
   // ---------------------------------------------------------------------------
   // Read helpers
   // ---------------------------------------------------------------------------

--- a/src/openms/include/OpenMS/FORMAT/ArrowIOHelpers.h
+++ b/src/openms/include/OpenMS/FORMAT/ArrowIOHelpers.h
@@ -143,6 +143,23 @@ namespace ArrowIOHelpers
   */
   OPENMS_DLLAPI std::string qpxRunFileName(const std::string& ms_run_path);
 
+  /**
+    @brief Warn once per export about source files that collapse onto one @c run_file_name
+
+    QPX defines the column as the file name without path or extension, so two distinct paths
+    sharing a stem (@c /a/run1.mzML and @c /b/run1.mzML) become indistinguishable as a join
+    and partition key. Same-named files in different directories are a legitimate layout and
+    the origin is known -- only the spec's representation cannot express it -- so this warns
+    rather than failing, matching the policy the PSM exporter already applies.
+
+    @param[in] context Caller name for the log line
+    @param[in] ms_run_paths Source paths participating in one QPX collection
+    @return true if every distinct path yields a distinct run name
+  */
+  OPENMS_DLLAPI bool qpxWarnOnRunNameCollisions(
+    const std::string& context,
+    const std::vector<std::string>& ms_run_paths);
+
 
   /**
     @brief QPX @c intensities[].label for a ConsensusMap column header

--- a/src/openms/include/OpenMS/FORMAT/ArrowIOHelpers.h
+++ b/src/openms/include/OpenMS/FORMAT/ArrowIOHelpers.h
@@ -13,7 +13,9 @@
 #include <OpenMS/FORMAT/MSExperimentArrowExport.h>  // for ParquetWriteConfig
 
 #include <cstdint>
+#include <map>
 #include <memory>
+#include <string>
 #include <unordered_set>
 #include <vector>
 
@@ -21,6 +23,7 @@
 namespace arrow
 {
   class Array;
+  class KeyValueMetadata;
   class Table;
 }
 
@@ -75,7 +78,54 @@ namespace ArrowIOHelpers
   OPENMS_DLLAPI bool concatenateAndWriteToParquet(
     const std::vector<std::shared_ptr<arrow::Table>>& tables,
     const std::string& filename,
-    const ParquetWriteConfig& config = ParquetWriteConfig{});
+    const ParquetWriteConfig& config = ParquetWriteConfig{},
+    const std::shared_ptr<const arrow::KeyValueMetadata>& metadata = nullptr);
+
+  // ---------------------------------------------------------------------------
+  // QPX file metadata
+  // ---------------------------------------------------------------------------
+
+  /**
+    @brief Build the canonical QPX file-level key-value metadata
+
+    Writes the keys defined by the QPX serialization spec: @c qpx_version,
+    @c file_type, @c creator, @c software_provider, @c creation_date (ISO 8601),
+    @c compression_format and @c uuid, plus any @p extra keys.
+
+    Build this <b>once per output file</b> and reuse the returned object for both the
+    writer schema and every batch — each call mints a fresh @c uuid and
+    @c creation_date, so calling it per batch would produce mismatched schemas.
+
+    @param[in] file_type QPX view token: @c "psm_file", @c "feature_file" or @c "pg_file"
+    @param[in] config Write configuration; supplies @c compression_format
+    @param[in] extra Additional keys, e.g. <tt>{{"scan_format", "scan"}}</tt>
+    @return The metadata, or @c nullptr if @p config selects a compression QPX does not
+            define (LZ4). Callers must treat @c nullptr as a write failure.
+  */
+  OPENMS_DLLAPI std::shared_ptr<const arrow::KeyValueMetadata> qpxFileMetadata(
+    const std::string& file_type,
+    const ParquetWriteConfig& config = ParquetWriteConfig{},
+    const std::map<std::string, std::string>& extra = {});
+
+  /**
+    @brief Classify a spectrum native ID into a QPX @c scan_format token
+
+    @param[in] native_id A spectrum native ID (e.g. <tt>controllerType=0 ... scan=1234</tt>)
+    @return @c "index" for @c index= IDs, @c "scan" for other recognized native IDs,
+            or @c "" when the convention cannot be determined.
+
+    @see qpxScanFormat(const std::vector<std::string>&)
+  */
+  OPENMS_DLLAPI std::string qpxScanFormat(const std::string& native_id);
+
+  /**
+    @brief Derive a single QPX @c scan_format token for a set of native IDs
+
+    Unrecognized IDs are ignored. Returns @c "" when no ID is recognized, or when the
+    inputs disagree — mixed conventions are reported once via the log rather than
+    guessed at, so an ambiguous export omits @c scan_format instead of mislabeling it.
+  */
+  OPENMS_DLLAPI std::string qpxScanFormat(const std::vector<std::string>& native_ids);
 
   // ---------------------------------------------------------------------------
   // Read helpers

--- a/src/openms/include/OpenMS/FORMAT/ArrowIOHelpers.h
+++ b/src/openms/include/OpenMS/FORMAT/ArrowIOHelpers.h
@@ -140,6 +140,30 @@ namespace ArrowIOHelpers
   OPENMS_DLLAPI std::string qpxRunFileName(const std::string& ms_run_path);
 
 
+  /**
+    @brief QPX @c intensities[].label for a ConsensusMap column header
+
+    The label is a join key: QPX matches @c intensities[].label against the unnested
+    @c run.samples[].label of @c run.parquet (docs/spec/views.md), so it must be a
+    canonical channel token, not a channel index or a file name.
+
+    Isobaric channels resolve to the reporter name prefixed by the method family, using
+    OpenMS' own channel names — @c "TMT126", @c "TMT131" (TMT10-plex channel 10),
+    @c "ITRAQ114". Label-free maps resolve to @c "LFQ".
+
+    @param[in] column_label ConsensusMap::ColumnHeader::label. IsobaricChannelExtractor
+               writes @c "&lt;methodname&gt;_&lt;channelname&gt;" (e.g. @c "tmt10plex_126");
+               ProteomicsLFQ writes @c "label-free".
+    @param[in] channel_name The header's @c channel_name meta value (e.g. @c "126"); empty
+               when the map is not isobaric.
+    @return The label, or @c "" when @p channel_name names a channel whose quantitation
+            method cannot be identified — writing a guessed token into a join key is worse
+            than writing none, so callers must handle the empty result.
+  */
+  OPENMS_DLLAPI std::string qpxIntensityLabel(
+    const std::string& column_label,
+    const std::string& channel_name);
+
   // ---------------------------------------------------------------------------
   // Read helpers
   // ---------------------------------------------------------------------------

--- a/src/openms/include/OpenMS/FORMAT/ArrowIOHelpers.h
+++ b/src/openms/include/OpenMS/FORMAT/ArrowIOHelpers.h
@@ -73,6 +73,10 @@ namespace ArrowIOHelpers
     @param[in] tables Vector of Arrow tables to concatenate (must share schema)
     @param[in] filename Output file path
     @param[in] config Parquet writer configuration
+    @param[in] metadata Schema key-value metadata for the merged file. Concatenation
+               otherwise inherits the first input's metadata, i.e. that table's identity;
+               pass a fresh one (see qpxFileMetadata()) so the merged file is its own.
+               @c nullptr keeps whatever the concatenation produced.
     @return true on success (or if @p tables is empty), false on error
   */
   OPENMS_DLLAPI bool concatenateAndWriteToParquet(

--- a/src/openms/include/OpenMS/FORMAT/ConsensusMapArrowExport.h
+++ b/src/openms/include/OpenMS/FORMAT/ConsensusMapArrowExport.h
@@ -50,6 +50,31 @@ public:
     @param[in] cmap The ConsensusMap to export
     @return Shared pointer to Arrow Table, or nullptr on error
   */
+  /**
+    @brief Verify that every feature can be attributed to a single peptide
+
+    The QPX feature and pg views have singular @c sequence / @c peptidoform / @c charge and
+    no ConsensusFeature identifier, so a feature whose identifications disagree on the top
+    peptide cannot be represented: exporting one would publish a chosen interpretation while
+    silently discarding the alternatives, and the pg view would count evidence contributed by
+    one peptide under another's identity. The ambiguity-preserving representation is the
+    OpenMS-native @c consensusparquet (ConsensusMapArrowIO), which keeps every hit and the
+    consensus feature association, and which @ref TOPP_IDConflictResolver accepts as input.
+
+    Several identifications agreeing on the same modified sequence
+    (@c FEATURE_ID_MULTIPLE_SAME) are unambiguous and accepted -- that is the deliberate
+    output of IDConflictResolverAlgorithm::resolve() with @p keep_matching.
+
+    @note Must be called as a preflight, before any OpenMP region and before the output file
+          is opened. An exception escaping the parallel batch build would be flattened into a
+          boolean by the worker's catch-all, and one escaping the region at all is
+          std::terminate.
+
+    @param[in] cmap The map about to be exported
+    @throw Exception::IllegalArgument if any feature has divergent peptide annotations
+  */
+  static void requireUnambiguousIdentities(const ConsensusMap& cmap);
+
   static std::shared_ptr<arrow::Table> exportToArrow(const ConsensusMap& cmap);
 
   /**

--- a/src/openms/include/OpenMS/FORMAT/ConsensusMapArrowExport.h
+++ b/src/openms/include/OpenMS/FORMAT/ConsensusMapArrowExport.h
@@ -50,6 +50,8 @@ public:
     @param[in] cmap The ConsensusMap to export
     @return Shared pointer to Arrow Table, or nullptr on error
   */
+  static std::shared_ptr<arrow::Table> exportToArrow(const ConsensusMap& cmap);
+
   /**
     @brief Verify that every feature can be attributed to a single peptide
 
@@ -74,8 +76,6 @@ public:
     @throw Exception::IllegalArgument if any feature has divergent peptide annotations
   */
   static void requireUnambiguousIdentities(const ConsensusMap& cmap);
-
-  static std::shared_ptr<arrow::Table> exportToArrow(const ConsensusMap& cmap);
 
   /**
     @brief Export ConsensusMap to Parquet file

--- a/src/openms/include/OpenMS/FORMAT/QPXFile.h
+++ b/src/openms/include/OpenMS/FORMAT/QPXFile.h
@@ -92,19 +92,24 @@ public:
     @brief Write a pre-built QPX PSM Arrow table to a Parquet file
 
     The table is expected to follow QPXPSMSchema (e.g., from exportPSMsToQPXArrow).
-    Attaches QPX file metadata (qpx_version, file_type="psm", UUID, creation_date)
-    before writing. Use this overload when the caller already has the table built
-    (e.g., for merged output) to avoid rebuilding it.
+    Attaches QPX file metadata (qpx_version, file_type="psm_file", UUID, creation_date,
+    compression_format) before writing. Use this overload when the caller already has the
+    table built (e.g., for merged output) to avoid rebuilding it.
 
     @param[in] table QPX PSM Arrow table (must not be null)
     @param[in] filename Output file path
     @param[in] config Parquet writing options
+    @param[in] scan_format QPX scan_format token for the source native IDs, from
+               ArrowIOHelpers::qpxScanFormat(). A pre-built table no longer carries the
+               native IDs, so the caller must supply it; when empty the key is omitted
+               rather than guessed.
     @return true on success, false on error
   */
   static bool exportToParquet(
     const std::shared_ptr<arrow::Table>& table,
     const std::string& filename,
-    const ParquetWriteConfig& config = ParquetWriteConfig{});
+    const ParquetWriteConfig& config = ParquetWriteConfig{},
+    const std::string& scan_format = "");
 
   /**
     @brief Stream PSMs to a QPX Parquet file in row-batches to cap peak memory.

--- a/src/openms/include/OpenMS/PROCESSING/ID/IDFilter.h
+++ b/src/openms/include/OpenMS/PROCESSING/ID/IDFilter.h
@@ -678,39 +678,11 @@ namespace OpenMS
     template<class IdentificationType>
     static bool getBestHit(const std::vector<IdentificationType>& identifications, bool assume_sorted, typename IdentificationType::HitType& best_hit)
     {
-      Size unused_index = 0;
-      return getBestHit(identifications, assume_sorted, best_hit, unused_index);
-    }
-
-    /**
-       @brief Finds the best-scoring hit, and reports which identification it came from.
-
-       Same semantics as the three-argument getBestHit(); the extra output identifies the
-       owning identification, which callers need when the identifications in @p
-       identifications differ in provenance (e.g. one per MS run, so that only the winner's
-       parent names the run the best hit was seen in).
-
-       @param[in] identifications Vector of peptide or protein IDs, each containing one or more (peptide/protein) hits
-       @param[in] assume_sorted Are hits sorted by score (best score first) already? This allows for faster query, since only the first hit needs to be looked at
-       @param[out] best_hit Contains the best hit if successful
-       @param[out] best_id_index Index into @p identifications of the identification holding @p best_hit
-
-       @throws Exception::InvalidValue if the IDs have different score types (i.e. scores cannot be compared)
-
-       @return true if a hit was present, false otherwise
-    */
-    template<class IdentificationType>
-    static bool getBestHit(const std::vector<IdentificationType>& identifications, bool assume_sorted, typename IdentificationType::HitType& best_hit, Size& best_id_index)
-    {
       if (identifications.empty())
         return false;
 
-      // NOTE: best_id_it is the *reference* identification -- it fixes the score type and
-      // orientation used for comparison, and stays at the first non-empty entry. It is NOT
-      // the owner of the winning hit, which is tracked separately in winner_index.
       typename std::vector<IdentificationType>::const_iterator best_id_it = identifications.end();
       typename std::vector<typename IdentificationType::HitType>::const_iterator best_hit_it;
-      Size winner_index = 0;
 
       for (typename std::vector<IdentificationType>::const_iterator id_it = identifications.begin(); id_it != identifications.end(); ++id_it)
       {
@@ -721,7 +693,6 @@ namespace OpenMS
         {
           best_id_it = id_it;
           best_hit_it = id_it->getHits().begin();
-          winner_index = static_cast<Size>(std::distance(identifications.begin(), id_it));
         }
         else if (best_id_it->getScoreType() != id_it->getScoreType())
         {
@@ -734,7 +705,6 @@ namespace OpenMS
           if ((higher_better && (hit_it->getScore() > best_hit_it->getScore())) || (!higher_better && (hit_it->getScore() < best_hit_it->getScore())))
           {
             best_hit_it = hit_it;
-            winner_index = static_cast<Size>(std::distance(identifications.begin(), id_it));
           }
           if (assume_sorted)
             break; // only consider the first hit
@@ -747,7 +717,6 @@ namespace OpenMS
       }
 
       best_hit = *best_hit_it;
-      best_id_index = winner_index;
       return true;
     }
 

--- a/src/openms/include/OpenMS/PROCESSING/ID/IDFilter.h
+++ b/src/openms/include/OpenMS/PROCESSING/ID/IDFilter.h
@@ -678,11 +678,39 @@ namespace OpenMS
     template<class IdentificationType>
     static bool getBestHit(const std::vector<IdentificationType>& identifications, bool assume_sorted, typename IdentificationType::HitType& best_hit)
     {
+      Size unused_index = 0;
+      return getBestHit(identifications, assume_sorted, best_hit, unused_index);
+    }
+
+    /**
+       @brief Finds the best-scoring hit, and reports which identification it came from.
+
+       Same semantics as the three-argument getBestHit(); the extra output identifies the
+       owning identification, which callers need when the identifications in @p
+       identifications differ in provenance (e.g. one per MS run, so that only the winner's
+       parent names the run the best hit was seen in).
+
+       @param[in] identifications Vector of peptide or protein IDs, each containing one or more (peptide/protein) hits
+       @param[in] assume_sorted Are hits sorted by score (best score first) already? This allows for faster query, since only the first hit needs to be looked at
+       @param[out] best_hit Contains the best hit if successful
+       @param[out] best_id_index Index into @p identifications of the identification holding @p best_hit
+
+       @throws Exception::InvalidValue if the IDs have different score types (i.e. scores cannot be compared)
+
+       @return true if a hit was present, false otherwise
+    */
+    template<class IdentificationType>
+    static bool getBestHit(const std::vector<IdentificationType>& identifications, bool assume_sorted, typename IdentificationType::HitType& best_hit, Size& best_id_index)
+    {
       if (identifications.empty())
         return false;
 
+      // NOTE: best_id_it is the *reference* identification -- it fixes the score type and
+      // orientation used for comparison, and stays at the first non-empty entry. It is NOT
+      // the owner of the winning hit, which is tracked separately in winner_index.
       typename std::vector<IdentificationType>::const_iterator best_id_it = identifications.end();
       typename std::vector<typename IdentificationType::HitType>::const_iterator best_hit_it;
+      Size winner_index = 0;
 
       for (typename std::vector<IdentificationType>::const_iterator id_it = identifications.begin(); id_it != identifications.end(); ++id_it)
       {
@@ -693,6 +721,7 @@ namespace OpenMS
         {
           best_id_it = id_it;
           best_hit_it = id_it->getHits().begin();
+          winner_index = static_cast<Size>(std::distance(identifications.begin(), id_it));
         }
         else if (best_id_it->getScoreType() != id_it->getScoreType())
         {
@@ -705,6 +734,7 @@ namespace OpenMS
           if ((higher_better && (hit_it->getScore() > best_hit_it->getScore())) || (!higher_better && (hit_it->getScore() < best_hit_it->getScore())))
           {
             best_hit_it = hit_it;
+            winner_index = static_cast<Size>(std::distance(identifications.begin(), id_it));
           }
           if (assume_sorted)
             break; // only consider the first hit
@@ -717,6 +747,7 @@ namespace OpenMS
       }
 
       best_hit = *best_hit_it;
+      best_id_index = winner_index;
       return true;
     }
 

--- a/src/openms/source/FORMAT/ArrowIOHelpers.cpp
+++ b/src/openms/source/FORMAT/ArrowIOHelpers.cpp
@@ -10,8 +10,11 @@
 
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/UniqueIdGenerator.h>
+#include <OpenMS/CONCEPT/VersionInfo.h>
+#include <OpenMS/DATASTRUCTURES/DateTime.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/METADATA/MetaInfoInterface.h>
+#include <OpenMS/METADATA/SpectrumNativeIDParser.h>
 
 #include <arrow/api.h>
 #include <arrow/io/file.h>
@@ -45,6 +48,82 @@ namespace
     }
     return arrow::Compression::ZSTD;
   }
+
+  /// QPX `compression_format` token for @p c, or "" if QPX does not define one.
+  /// The spec's vocabulary is zstd|snappy|gzip|lzo|none — LZ4 has no token.
+  std::string qpxCompressionName(ParquetWriteConfig::Compression c)
+  {
+    switch (c)
+    {
+      case ParquetWriteConfig::Compression::NONE:   return "none";
+      case ParquetWriteConfig::Compression::SNAPPY: return "snappy";
+      case ParquetWriteConfig::Compression::GZIP:   return "gzip";
+      case ParquetWriteConfig::Compression::ZSTD:   return "zstd";
+      case ParquetWriteConfig::Compression::LZ4:    return "";
+    }
+    return "";
+  }
+}
+
+std::shared_ptr<const arrow::KeyValueMetadata> qpxFileMetadata(
+  const std::string& file_type,
+  const ParquetWriteConfig& config,
+  const std::map<std::string, std::string>& extra)
+{
+  const std::string compression = qpxCompressionName(config.compression);
+  if (compression.empty())
+  {
+    OPENMS_LOG_ERROR << "ArrowIOHelpers: QPX does not define a compression_format token for LZ4; "
+                        "use ZSTD (default), SNAPPY, GZIP or NONE for QPX output." << std::endl;
+    return nullptr;
+  }
+
+  std::vector<std::string> keys{
+    "qpx_version", "file_type", "creator", "software_provider", "creation_date",
+    "compression_format", "uuid"};
+  std::vector<std::string> values{
+    "1.0",
+    file_type,
+    "OpenMS",
+    "OpenMS " + VersionInfo::getVersion(),
+    DateTime::nowUTC().toString("yyyy-MM-ddThh:mm:ssZ"),
+    compression,
+    generateUuidV4()};
+
+  for (const auto& [k, v] : extra)
+  {
+    keys.push_back(k);
+    values.push_back(v);
+  }
+
+  return std::make_shared<arrow::KeyValueMetadata>(std::move(keys), std::move(values));
+}
+
+std::string qpxScanFormat(const std::string& native_id)
+{
+  if (StringUtils::hasPrefix(native_id, "index=")) { return "index"; }
+  if (SpectrumNativeIDParser::isNativeID(native_id)) { return "scan"; }
+  return "";
+}
+
+std::string qpxScanFormat(const std::vector<std::string>& native_ids)
+{
+  std::string resolved;
+  for (const auto& id : native_ids)
+  {
+    const std::string fmt = qpxScanFormat(id);
+    if (fmt.empty()) { continue; } // unrecognized IDs carry no evidence either way
+    if (resolved.empty()) { resolved = fmt; }
+    else if (resolved != fmt)
+    {
+      // Two conventions in one export: neither token would describe the whole file, so
+      // omit scan_format rather than assert a wrong one.
+      OPENMS_LOG_WARN << "ArrowIOHelpers: spectrum native IDs mix '" << resolved << "' and '"
+                      << fmt << "' conventions; omitting QPX scan_format." << std::endl;
+      return "";
+    }
+  }
+  return resolved;
 }
 
 bool writeTableToParquet(
@@ -110,7 +189,8 @@ bool writeTableToParquet(
 bool concatenateAndWriteToParquet(
   const std::vector<std::shared_ptr<arrow::Table>>& tables,
   const std::string& filename,
-  const ParquetWriteConfig& config)
+  const ParquetWriteConfig& config,
+  const std::shared_ptr<const arrow::KeyValueMetadata>& metadata)
 {
   if (tables.empty()) { return true; }
 
@@ -122,7 +202,11 @@ bool concatenateAndWriteToParquet(
     return false;
   }
 
-  return writeTableToParquet(concat_result.ValueOrDie(), filename, config);
+  auto table = concat_result.ValueOrDie();
+  // The concatenated table inherits the first input's schema metadata, which carries that
+  // input's uuid/creation_date. Stamp one identity for the merged file instead.
+  if (metadata) { table = table->ReplaceSchemaMetadata(metadata); }
+  return writeTableToParquet(table, filename, config);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/openms/source/FORMAT/ArrowIOHelpers.cpp
+++ b/src/openms/source/FORMAT/ArrowIOHelpers.cpp
@@ -16,7 +16,10 @@
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/METADATA/MetaInfoInterface.h>
 #include <OpenMS/METADATA/SpectrumNativeIDParser.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/SYSTEM/File.h>
+
+#include <set>
 
 #include <arrow/api.h>
 #include <arrow/io/file.h>
@@ -148,6 +151,29 @@ std::string qpxRunFileName(const std::string& ms_run_path)
 {
   // File::stemName() already maps "" -> "".
   return File::stemName(ms_run_path);
+}
+
+bool qpxWarnOnRunNameCollisions(const std::string& context,
+                                const std::vector<std::string>& ms_run_paths)
+{
+  std::map<std::string, std::set<std::string>> stem_to_paths;
+  for (const auto& path : ms_run_paths)
+  {
+    if (path.empty()) { continue; }
+    stem_to_paths[qpxRunFileName(path)].insert(path);
+  }
+
+  bool unique = true;
+  for (const auto& [stem, paths] : stem_to_paths)
+  {
+    if (paths.size() < 2) { continue; }
+    unique = false;
+    OPENMS_LOG_WARN << context << ": several MS runs share the run_file_name '" << stem
+                    << "' after stripping path and extension: "
+                    << ListUtils::concatenate(StringList(paths.begin(), paths.end()), ", ")
+                    << ". They cannot be told apart in the exported QPX tables." << std::endl;
+  }
+  return unique;
 }
 
 std::string qpxScanFormat(const std::vector<std::string>& native_ids)

--- a/src/openms/source/FORMAT/ArrowIOHelpers.cpp
+++ b/src/openms/source/FORMAT/ArrowIOHelpers.cpp
@@ -15,6 +15,7 @@
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/METADATA/MetaInfoInterface.h>
 #include <OpenMS/METADATA/SpectrumNativeIDParser.h>
+#include <OpenMS/SYSTEM/File.h>
 
 #include <arrow/api.h>
 #include <arrow/io/file.h>
@@ -104,6 +105,12 @@ std::string qpxScanFormat(const std::string& native_id)
   if (StringUtils::hasPrefix(native_id, "index=")) { return "index"; }
   if (SpectrumNativeIDParser::isNativeID(native_id)) { return "scan"; }
   return "";
+}
+
+std::string qpxRunFileName(const std::string& ms_run_path)
+{
+  if (ms_run_path.empty()) { return ""; }
+  return File::stemName(ms_run_path);
 }
 
 std::string qpxScanFormat(const std::vector<std::string>& native_ids)

--- a/src/openms/source/FORMAT/ArrowIOHelpers.cpp
+++ b/src/openms/source/FORMAT/ArrowIOHelpers.cpp
@@ -126,28 +126,16 @@ std::string qpxIntensityLabel(const std::string& column_label, const std::string
   const std::string method_name = (sep == std::string::npos) ? "" : column_label.substr(0, sep);
   const auto method = IsobaricQuantitationMethod::methodTypeFromName(method_name);
 
-  // Family prefix + OpenMS' own reporter name. OpenMS names are authoritative, so
-  // TMT10-plex channel 10 is "TMT131" (not the 11-plex-indexed "TMT131N").
-  using MT = IsobaricQuantitationMethod::MethodType;
-  switch (method)
+  // Family prefix + OpenMS' own reporter name, so TMT10-plex channel 10 is "TMT131"
+  // (qpx's own converter map is 11-plex-indexed and says "TMT131N"; sdrf-pipelines agrees
+  // with OpenMS). methodTypeFromName() has already validated the method against
+  // METHOD_REGISTRY, so the family follows from its canonical identifier ("tmt6plex",
+  // "itraq4plex", ...) rather than from a switch that would silently drop a join key for
+  // any method added later.
+  if (method != IsobaricQuantitationMethod::MethodType::UNKNOWN)
   {
-    case MT::TMT_6PLEX:
-    case MT::TMT_10PLEX:
-    case MT::TMT_11PLEX:
-    case MT::TMT_16PLEX:
-    case MT::TMT_18PLEX:
-    case MT::TMT_32PLEX:
-    case MT::TMT_35PLEX:
-      return "TMT" + channel_name;
-    case MT::ITRAQ_4PLEX:
-    case MT::ITRAQ_8PLEX:
-      // Uppercase, consistent with the TMT prefix. Note qpx's intensities.md example spells
-      // it "iTRAQ114", but no qpx converter actually emits an iTRAQ channel label (its
-      // channel map is TMT-only and the iTRAQ path passes the raw tool value through), so
-      // there is no implementation to match -- only a doc example.
-      return "ITRAQ" + channel_name;
-    default:
-      break;
+    if (StringUtils::hasPrefix(method_name, "tmt"))   { return "TMT" + channel_name; }
+    if (StringUtils::hasPrefix(method_name, "itraq")) { return "ITRAQ" + channel_name; }
   }
 
   OPENMS_LOG_ERROR << "ArrowIOHelpers: cannot derive a QPX intensity label for channel '"
@@ -158,7 +146,7 @@ std::string qpxIntensityLabel(const std::string& column_label, const std::string
 
 std::string qpxRunFileName(const std::string& ms_run_path)
 {
-  if (ms_run_path.empty()) { return ""; }
+  // File::stemName() already maps "" -> "".
   return File::stemName(ms_run_path);
 }
 

--- a/src/openms/source/FORMAT/ArrowIOHelpers.cpp
+++ b/src/openms/source/FORMAT/ArrowIOHelpers.cpp
@@ -8,6 +8,7 @@
 
 #include <OpenMS/FORMAT/ArrowIOHelpers.h>
 
+#include <OpenMS/ANALYSIS/QUANTITATION/IsobaricQuantitationMethod.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/UniqueIdGenerator.h>
 #include <OpenMS/CONCEPT/VersionInfo.h>
@@ -104,6 +105,54 @@ std::string qpxScanFormat(const std::string& native_id)
 {
   if (StringUtils::hasPrefix(native_id, "index=")) { return "index"; }
   if (SpectrumNativeIDParser::isNativeID(native_id)) { return "scan"; }
+  return "";
+}
+
+std::string qpxIntensityLabel(const std::string& column_label, const std::string& channel_name)
+{
+  // No channel => not an isobaric map.
+  if (channel_name.empty())
+  {
+    // ProteomicsLFQ stamps "label-free" on every header; an unset label means the same.
+    if (column_label.empty() || column_label == "label-free") { return "LFQ"; }
+    // Multiplex/SILAC headers carry the modification in `label` and annotate no channel
+    // (see ConsensusMap::ColumnHeader::getLabelAsUInt). QPX defines no token for those, so
+    // pass the tool's own label through rather than mislabel it as LFQ.
+    return column_label;
+  }
+
+  // Isobaric: IsobaricChannelExtractor builds the label as "<methodname>_<channelname>".
+  const auto sep = column_label.rfind('_');
+  const std::string method_name = (sep == std::string::npos) ? "" : column_label.substr(0, sep);
+  const auto method = IsobaricQuantitationMethod::methodTypeFromName(method_name);
+
+  // Family prefix + OpenMS' own reporter name. OpenMS names are authoritative, so
+  // TMT10-plex channel 10 is "TMT131" (not the 11-plex-indexed "TMT131N").
+  using MT = IsobaricQuantitationMethod::MethodType;
+  switch (method)
+  {
+    case MT::TMT_6PLEX:
+    case MT::TMT_10PLEX:
+    case MT::TMT_11PLEX:
+    case MT::TMT_16PLEX:
+    case MT::TMT_18PLEX:
+    case MT::TMT_32PLEX:
+    case MT::TMT_35PLEX:
+      return "TMT" + channel_name;
+    case MT::ITRAQ_4PLEX:
+    case MT::ITRAQ_8PLEX:
+      // Uppercase, consistent with the TMT prefix. Note qpx's intensities.md example spells
+      // it "iTRAQ114", but no qpx converter actually emits an iTRAQ channel label (its
+      // channel map is TMT-only and the iTRAQ path passes the raw tool value through), so
+      // there is no implementation to match -- only a doc example.
+      return "ITRAQ" + channel_name;
+    default:
+      break;
+  }
+
+  OPENMS_LOG_ERROR << "ArrowIOHelpers: cannot derive a QPX intensity label for channel '"
+                   << channel_name << "' — column header label '" << column_label
+                   << "' does not name a known isobaric quantitation method." << std::endl;
   return "";
 }
 

--- a/src/openms/source/FORMAT/ArrowSchemaRegistry.cpp
+++ b/src/openms/source/FORMAT/ArrowSchemaRegistry.cpp
@@ -656,7 +656,9 @@ namespace OpenMS
       arrow::field(INTENSITIES, intensitiesType()),
       arrow::field(ADDITIONAL_INTENSITIES, additionalIntensitiesType()),
       arrow::field(PG_ACCESSIONS, pgAccessionsType()),
-      arrow::field(ANCHOR_PROTEIN, arrow::utf8(), /*nullable=*/false),
+      // nullable since bigbio/qpx#212 (de novo workflows): "Representative protein; null when
+      // no protein mapping was performed". Still `required: true` -- the column must exist.
+      arrow::field(ANCHOR_PROTEIN, arrow::utf8()),
       arrow::field(UNIQUE, arrow::boolean()),
       arrow::field(PG_GLOBAL_QVALUE, arrow::float64()),
       arrow::field(PG_POSITIONS, pgPositionsType()),

--- a/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
@@ -138,6 +138,17 @@ FeatureIdLookups buildFeatureIdLookups(const ConsensusMap& cmap)
   // accept either. (The sibling pg exporter reaches the same conclusion via
   // ColumnHeader::getLabelAsUInt(getExperimentType()).)
   lut.is_isobaric = (cmap.getExperimentType() != "label-free");
+
+  // Same policy as the PSM exporter: two source paths sharing a stem are indistinguishable
+  // as a join key, but same-named files in different directories are a legitimate layout, so
+  // warn rather than fail. Rows stay separate -- grouping keys on the source path, not the
+  // stem -- so this reports an ambiguous key, never a merged one.
+  {
+    std::vector<std::string> header_paths;
+    header_paths.reserve(cmap.getColumnHeaders().size());
+    for (const auto& [map_index, header] : cmap.getColumnHeaders()) { header_paths.push_back(header.filename); }
+    (void)ArrowIOHelpers::qpxWarnOnRunNameCollisions("ConsensusMapArrowExport", header_paths);
+  }
   for (const auto& [map_index, header] : cmap.getColumnHeaders())
   {
     const std::string channel_name = header.metaValueExists("channel_name")

--- a/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
@@ -8,6 +8,7 @@
 
 #include <OpenMS/FORMAT/ConsensusMapArrowExport.h>
 
+#include <OpenMS/FORMAT/ArrowIOHelpers.h>
 #include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h>
@@ -975,6 +976,35 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
   return table;
 }
 
+/// Build the canonical QPX "feature" file metadata for @p cmap. Each call mints a fresh
+/// uuid/creation_date, so build it once per output file and reuse it for the writer schema
+/// and every batch. Returns nullptr when QPX defines no token for the configured compression.
+std::shared_ptr<const arrow::KeyValueMetadata> qpxFeatureMetadata(
+  const ConsensusMap& cmap,
+  const ParquetWriteConfig& config)
+{
+  // scan_format describes the `scan` column, which is extracted from the spectrum native
+  // IDs of the features' peptide identifications (and the unassigned ones, which share the
+  // same source runs).
+  std::vector<std::string> refs;
+  for (const auto& cf : cmap)
+  {
+    for (const auto& pid : cf.getPeptideIdentifications())
+    {
+      if (!pid.getSpectrumReference().empty()) { refs.push_back(pid.getSpectrumReference()); }
+    }
+  }
+  for (const auto& pid : cmap.getUnassignedPeptideIdentifications())
+  {
+    if (!pid.getSpectrumReference().empty()) { refs.push_back(pid.getSpectrumReference()); }
+  }
+
+  std::map<std::string, std::string> extra;
+  const std::string scan_format = ArrowIOHelpers::qpxScanFormat(refs);
+  if (!scan_format.empty()) { extra["scan_format"] = scan_format; }
+  return ArrowIOHelpers::qpxFileMetadata("feature_file", config, extra);
+}
+
 } // anonymous namespace (feature range builder + shared per-map lookups)
 
 
@@ -995,6 +1025,10 @@ bool ConsensusMapArrowExport::exportToParquet(
     OPENMS_LOG_ERROR << "ConsensusMapArrowExport: Failed to create Arrow table" << std::endl;
     return false;
   }
+
+  auto meta = qpxFeatureMetadata(cmap, config);
+  if (!meta) { return false; } // unsupported compression for QPX; already logged
+  table = table->ReplaceSchemaMetadata(meta);
 
   // Open output file
   auto result = arrow::io::FileOutputStream::Open(filename);
@@ -1053,9 +1087,15 @@ bool ConsensusMapArrowExport::exportToParquetStreaming(
   (void)Scores::isKnownScoreType("q-value");
   (void)AASequence::fromString("PEPTIDEK").getMZ(2); // inits AASequence static residue path
 
+  // One metadata identity (uuid/creation_date) for the whole file, reused for the writer
+  // schema and every batch so their schemas are identical.
+  auto meta = qpxFeatureMetadata(cmap, config);
+  if (!meta) { return false; } // unsupported compression for QPX; already logged
+
   // The writer's schema must match each batch table's schema exactly. buildFeatureTableRange()
-  // stamps QPXFeatureSchema::schema() on every batch, so open the writer with the same schema.
-  const auto schema = QPXFeatureSchema::schema();
+  // stamps QPXFeatureSchema::schema() on every batch, so open the writer with the same schema
+  // plus the shared metadata (re-stamped per batch below).
+  const auto schema = QPXFeatureSchema::schema()->WithMetadata(meta);
 
   auto file_result = arrow::io::FileOutputStream::Open(filename);
   if (!file_result.ok())
@@ -1129,7 +1169,7 @@ bool ConsensusMapArrowExport::exportToParquetStreaming(
         OPENMS_LOG_ERROR << "ConsensusMapArrowExport: Failed to build feature batch partition " << t << std::endl;
         return false;
       }
-      auto st = writer->WriteTable(*parts[t], rg);
+      auto st = writer->WriteTable(*parts[t]->ReplaceSchemaMetadata(meta), rg);
       if (!st.ok())
       {
         OPENMS_LOG_ERROR << "ConsensusMapArrowExport: Failed to write feature batch to " << filename << ": "

--- a/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
@@ -12,7 +12,6 @@
 #include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h>
-#include <OpenMS/PROCESSING/ID/IDFilter.h>
 #include <OpenMS/ANALYSIS/ID/Scores.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
@@ -91,6 +90,25 @@ struct FeatureIdLookups
   /// id_run_file_name. Read-only after construction, so it is safe to share across the
   /// streaming path's OpenMP workers.
   IdentifierMSRunMapper run_mapper;
+
+  /// Per column header (map index): the QPX run name and intensity label.
+  /// Both are expensive to derive and depend only on the header, of which there are at most
+  /// a few dozen -- while the export loop touches them once per FeatureHandle per row.
+  /// File::stemName() scans the 73-entry file-type table, and reading the header's
+  /// channel_name by string takes the MetaInfoRegistry omp-critical lock, which would
+  /// serialize the parallel batch build (see the note on pre-resolved metavalue indices).
+  struct RunColumnInfo
+  {
+    std::string run_name;   ///< stemmed run_file_name
+    std::string label;      ///< QPX intensities[].label
+  };
+  std::unordered_map<UInt64, RunColumnInfo> run_columns;
+
+  /// Whether the map is isobaric, deciding where a row's coordinates come from.
+  bool is_isobaric = false;
+  /// Set when a column header names a channel QPX cannot label; the export must not proceed,
+  /// since the label is a join key.
+  bool has_unlabelable_channel = false;
 };
 
 /// Build the per-map protein-group q-value and gene-info lookups from the
@@ -112,6 +130,34 @@ FeatureIdLookups buildFeatureIdLookups(const ConsensusMap& cmap)
                        "runs (" << e.getMessage() << "); id_run_file_name resolution continues "
                        "on the identifier -> path mapping." << std::endl;
   }
+  // A map is isobaric if it says so OR if its headers carry channel annotations. Neither
+  // signal alone is reliable: IsobaricWorkflow annotates channels without ever calling
+  // setExperimentType, while other producers declare a labelled experiment type without
+  // writing channel_name. Getting this wrong writes reporter-ion m/z into observed_mz, so
+  // accept either. (The sibling pg exporter reaches the same conclusion via
+  // ColumnHeader::getLabelAsUInt(getExperimentType()).)
+  lut.is_isobaric = (cmap.getExperimentType() != "label-free");
+  for (const auto& [map_index, header] : cmap.getColumnHeaders())
+  {
+    const std::string channel_name = header.metaValueExists("channel_name")
+                                   ? header.getMetaValue("channel_name").toString() : "";
+    if (!channel_name.empty()) { lut.is_isobaric = true; }
+
+    std::string label = ArrowIOHelpers::qpxIntensityLabel(header.label, channel_name);
+    if (label.empty())
+    {
+      // qpxIntensityLabel() documents that callers must handle this: the channel's method
+      // could not be identified, so any token written here would be a guessed join key.
+      lut.has_unlabelable_channel = true;
+      OPENMS_LOG_ERROR << "ConsensusMapArrowExport: column header '" << header.label
+                       << "' names channel '" << channel_name << "' whose quantitation method "
+                          "cannot be identified, so no QPX intensity label can be derived for it."
+                       << std::endl;
+    }
+    lut.run_columns[map_index] = FeatureIdLookups::RunColumnInfo{
+      ArrowIOHelpers::qpxRunFileName(header.filename), std::move(label)};
+  }
+
   for (const auto& prot_id : cmap.getProteinIdentifications())
   {
     // Gene info from ProteinHit metavalues
@@ -147,6 +193,65 @@ FeatureIdLookups buildFeatureIdLookups(const ConsensusMap& cmap)
     }
   }
   return lut;
+}
+
+/// Select the identity of a consensus feature: the best-scoring hit across ALL of its
+/// peptide identifications, together with the index of the identification holding it.
+///
+/// Deliberately local rather than an IDFilter addition. IDFilter::getBestHit() reports only
+/// the hit, and its internal "best" iterator is the score-type *reference* (pinned to the
+/// first non-empty identification), not the winner -- while the QPX feature view needs the
+/// winner's parent to resolve id_run_file_name. Exposing that would mean new public API in a
+/// widely-included header for a single caller, and it could not replace the existing
+/// per-identification helpers (MapAlignmentAlgorithmIdentification::getBestScoringHit works
+/// within one identification and returns a pointer; MzTab aggregates scores with different
+/// tie-breaking). Score comparison itself is not duplicated -- it delegates to
+/// PeptideIdentification::getScoreComparator, the same primitive those helpers use.
+///
+/// Scores from identifications with different score types are not comparable. Rather than
+/// compare them anyway, fall back to the first identification that has a hit and report it
+/// through @p mixed_score_types so the caller can warn once per export.
+///
+/// @param[in] pep_ids The feature's peptide identifications
+/// @param[out] best_id_index Index into @p pep_ids of the identification holding the winner
+/// @param[out] mixed_score_types Set when the identifications disagree on score type
+/// @return Pointer to the winning hit, or nullptr when no identification has one
+const PeptideHit* selectFeatureIdentity(
+  const PeptideIdentificationList& pep_ids,
+  Size& best_id_index,
+  bool& mixed_score_types)
+{
+  const PeptideHit* best_hit = nullptr;
+  const PeptideIdentification* ref_id = nullptr;   // fixes the score type and orientation
+  best_id_index = 0;
+  mixed_score_types = false;
+
+  for (Size i = 0; i < pep_ids.size(); ++i)
+  {
+    const auto& pid = pep_ids[i];
+    if (pid.getHits().empty()) { continue; }       // hitless ids must not veto later ones
+
+    if (ref_id == nullptr)
+    {
+      ref_id = &pid;
+    }
+    else if (ref_id->getScoreType() != pid.getScoreType())
+    {
+      mixed_score_types = true;
+      break;                                        // keep the first hit found; see below
+    }
+
+    const auto better = PeptideIdentification::getScoreComparator(pid.isHigherScoreBetter());
+    for (const auto& hit : pid.getHits())
+    {
+      if (best_hit == nullptr || better(hit, *best_hit))
+      {
+        best_hit = &hit;
+        best_id_index = i;
+      }
+    }
+  }
+  return best_hit;
 }
 
 /// Build Parquet WriterProperties from the OpenMS config (shared by the one-shot
@@ -349,10 +454,7 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
   //  - isobaric: the handles are reporter ions -- their m/z is the reporter mass and their RT
   //    the quantification scan -- while precursor m/z and RT live on the ConsensusFeature.
   //    Keep the consensus coordinates and use the handles only for channel intensities.
-  const auto& column_headers_for_melt = cmap.getColumnHeaders();
-  const bool is_isobaric = std::any_of(
-    column_headers_for_melt.begin(), column_headers_for_melt.end(),
-    [](const auto& kv) { return kv.second.metaValueExists("channel_name"); });
+  const bool is_isobaric = id_lut.is_isobaric;
 
   struct RowSpec
   {
@@ -370,9 +472,9 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     std::map<std::string, std::vector<const FeatureHandle*>> by_run;
     for (const auto& fh : cmap[feat_idx].getFeatures())
     {
-      auto it = column_headers_for_melt.find(fh.getMapIndex());
-      if (it == column_headers_for_melt.end()) { continue; }
-      by_run[ArrowIOHelpers::qpxRunFileName(it->second.filename)].push_back(&fh);
+      auto it = id_lut.run_columns.find(fh.getMapIndex());
+      if (it == id_lut.run_columns.end()) { continue; }
+      by_run[it->second.run_name].push_back(&fh);
     }
     // A feature with no handles has neither quantification nor a run, so the per-run feature
     // view has nothing to represent -- drop it rather than emit an unkeyed row.
@@ -420,8 +522,6 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
 
   #undef RESERVE_OR_FAIL
 
-  // Build column header lookup
-  const auto& column_headers = cmap.getColumnHeaders();
 
   // Per-map protein-group q-value and gene-info lookups (prebuilt once, shared across batches)
   const auto& pg_qvalue_lookup = id_lut.pg_qvalue;
@@ -467,42 +567,20 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     const auto& cf = cmap[row.feat_idx];
     const auto& pep_ids = cf.getPeptideIdentifications();
 
-    // Pick the feature's identity: the best-scoring hit across ALL of its identifications,
-    // not pep_ids[0].getHits()[0]. The positional pick discarded a feature's identity whenever
-    // its *first* identification happened to carry no hits, even if a later one did.
-    //
-    // getBestHit() throws when the identifications disagree on score type, which cannot
-    // happen for our tools (one FDR pass sets them together) but is reachable for a foreign
-    // ConsensusMap. Fall back to the positional pick there rather than failing the export.
-    PeptideHit best_hit_value;
+    // The feature's identity: the best-scoring hit across ALL of its identifications, not
+    // pep_ids[0].getHits()[0]. The positional pick discarded a feature's identity whenever its
+    // *first* identification happened to carry no hits, even if a later one did.
     Size best_id_index = 0;
-    bool has_id = false;
-    try
+    bool mixed_score_types = false;
+    const PeptideHit* best_hit = selectFeatureIdentity(pep_ids, best_id_index, mixed_score_types);
+    const bool has_id = (best_hit != nullptr);
+    if (mixed_score_types && !warned_mixed_scores)
     {
-      has_id = IDFilter::getBestHit(pep_ids.getData(), /*assume_sorted=*/false, best_hit_value, best_id_index);
+      warned_mixed_scores = true;
+      OPENMS_LOG_WARN << "ConsensusMapArrowExport: consensus feature carries identifications with "
+                         "different score types, whose scores are not comparable; using the first "
+                         "hit found instead of the best-scoring one." << std::endl;
     }
-    catch (const Exception::InvalidValue&)
-    {
-      if (!warned_mixed_scores)
-      {
-        warned_mixed_scores = true;
-        OPENMS_LOG_WARN << "ConsensusMapArrowExport: consensus feature carries identifications "
-                           "with different score types; falling back to the first hit instead of "
-                           "the best-scoring one." << std::endl;
-      }
-      // Fall back to the first identification that actually has a hit -- not blindly to
-      // pep_ids[0], which would reintroduce the empty-first-identification bug this
-      // selection exists to fix.
-      for (Size i = 0; i < pep_ids.size(); ++i)
-      {
-        if (pep_ids[i].getHits().empty()) { continue; }
-        best_hit_value = pep_ids[i].getHits()[0];
-        best_id_index = i;
-        has_id = true;
-        break;
-      }
-    }
-    const PeptideHit* best_hit = has_id ? &best_hit_value : nullptr;
 
     // The row's quantitative coordinates, fixed here so that charge, observed_mz,
     // calculated_mz, mass_error_ppm, rt and the rt bounds are all mutually consistent.
@@ -1021,12 +1099,10 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     (void)intensities_builder.Append();
     for (const auto* fh : row.handles)
     {
-      auto it = column_headers.find(fh->getMapIndex());
-      if (it == column_headers.end()) { continue; }
-      const std::string channel_name = it->second.metaValueExists("channel_name")
-                                     ? it->second.getMetaValue("channel_name").toString() : "";
+      auto it = id_lut.run_columns.find(fh->getMapIndex());
+      if (it == id_lut.run_columns.end()) { continue; }
       (void)intensity_struct_b->Append();
-      (void)intensity_label_b->Append(ArrowIOHelpers::qpxIntensityLabel(it->second.label, channel_name));
+      (void)intensity_label_b->Append(it->second.label);
       (void)intensity_val_b->Append(static_cast<float>(fh->getIntensity()));
     }
   } // end melted row loop
@@ -1146,7 +1222,11 @@ std::shared_ptr<const arrow::KeyValueMetadata> qpxFeatureMetadata(
 
 std::shared_ptr<arrow::Table> ConsensusMapArrowExport::exportToArrow(const ConsensusMap& cmap)
 {
-  return buildFeatureTableRange(cmap, buildFeatureIdLookups(cmap), 0, cmap.size());
+  const auto id_lut = buildFeatureIdLookups(cmap);
+  // A channel QPX cannot name would be written into intensities[].label, a documented join
+  // key. Refuse rather than emit a guessed or empty token (the pg exporter does the same).
+  if (id_lut.has_unlabelable_channel) { return nullptr; }
+  return buildFeatureTableRange(cmap, id_lut, 0, cmap.size());
 }
 
 
@@ -1213,6 +1293,7 @@ bool ConsensusMapArrowExport::exportToParquetStreaming(
 
   // Prebuild the per-map protein-group/gene lookups once; reused for every batch.
   const auto id_lut = buildFeatureIdLookups(cmap);
+  if (id_lut.has_unlabelable_channel) { return false; } // already logged
 
   // Pre-warm lazily-initialized singletons/statics touched by the per-feature build, so first-touch
   // cannot race across the OpenMP workers below. Runs once, serially. (ProForma and the

--- a/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
@@ -18,6 +18,7 @@
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 #include <OpenMS/CHEMISTRY/ProForma.h>
 #include <OpenMS/CHEMISTRY/ResidueDB.h>
+#include <OpenMS/METADATA/IdentifierMSRunMapper.h>
 #include <OpenMS/METADATA/MetaInfoRegistry.h>
 #include <OpenMS/METADATA/SpectrumLookup.h>
 #include <OpenMS/METADATA/SpectrumNativeIDParser.h>
@@ -86,6 +87,10 @@ struct FeatureIdLookups
   std::unordered_map<std::string, double> pg_qvalue;               ///< accession -> protein-group q-value
   std::unordered_map<std::string, std::vector<std::string>> gg_accessions; ///< accession -> gene accessions
   std::unordered_map<std::string, std::vector<std::string>> gg_names;      ///< accession -> gene names
+  /// Resolves a PeptideIdentification to its own source run via id_merge_index, for
+  /// id_run_file_name. Read-only after construction, so it is safe to share across the
+  /// streaming path's OpenMP workers.
+  IdentifierMSRunMapper run_mapper;
 };
 
 /// Build the per-map protein-group q-value and gene-info lookups from the
@@ -93,6 +98,20 @@ struct FeatureIdLookups
 FeatureIdLookups buildFeatureIdLookups(const ConsensusMap& cmap)
 {
   FeatureIdLookups lut;
+
+  // The mapper's constructor throws when two identifiers share a path list; that guards only
+  // the reverse map, which is never used here, and the forward map is fully populated before
+  // the throw. Degrade to a warning rather than failing an otherwise-exportable map.
+  try
+  {
+    lut.run_mapper.create(cmap.getProteinIdentifications());
+  }
+  catch (const Exception::InvalidValue& e)
+  {
+    OPENMS_LOG_WARN << "ConsensusMapArrowExport: ambiguous MS run paths across identification "
+                       "runs (" << e.getMessage() << "); id_run_file_name resolution continues "
+                       "on the identifier -> path mapping." << std::endl;
+  }
   for (const auto& prot_id : cmap.getProteinIdentifications())
   {
     // Gene info from ProteinHit metavalues
@@ -471,10 +490,38 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
                            "with different score types; falling back to the first hit instead of "
                            "the best-scoring one." << std::endl;
       }
-      has_id = !pep_ids.empty() && !pep_ids[0].getHits().empty();
-      if (has_id) { best_hit_value = pep_ids[0].getHits()[0]; best_id_index = 0; }
+      // Fall back to the first identification that actually has a hit -- not blindly to
+      // pep_ids[0], which would reintroduce the empty-first-identification bug this
+      // selection exists to fix.
+      for (Size i = 0; i < pep_ids.size(); ++i)
+      {
+        if (pep_ids[i].getHits().empty()) { continue; }
+        best_hit_value = pep_ids[i].getHits()[0];
+        best_id_index = i;
+        has_id = true;
+        break;
+      }
     }
     const PeptideHit* best_hit = has_id ? &best_hit_value : nullptr;
+
+    // The row's quantitative coordinates, fixed here so that charge, observed_mz,
+    // calculated_mz, mass_error_ppm, rt and the rt bounds are all mutually consistent.
+    // Computing some against the consensus centroid and others against the run's handle
+    // would report a ppm error measured against an m/z the row does not contain.
+    //  - label-free: the run's own FeatureHandle carries that run's RT / m/z / charge / width.
+    //  - isobaric: handles are reporter ions (m/z = reporter mass, RT = quantification scan),
+    //    so precursor coordinates must come from the ConsensusFeature.
+    const FeatureHandle* coord = (!is_isobaric && !row.handles.empty()) ? row.handles.front() : nullptr;
+    const double row_mz     = coord ? coord->getMZ()     : cf.getMZ();
+    const double row_rt     = coord ? coord->getRT()     : cf.getRT();
+    const double row_width  = coord ? coord->getWidth()  : cf.getWidth();
+    const int    row_charge = coord ? coord->getCharge() : cf.getCharge();
+
+    // EVERY identification-level column must come from this one identification. Reading some
+    // columns from pep_ids[0] and others from the winner would emit a row describing one
+    // peptide's sequence next to another's scan number and ion mobility.
+    const PeptideIdentification* best_pid =
+      (has_id && best_id_index < pep_ids.size()) ? &pep_ids[best_id_index] : nullptr;
 
     // === sequence / peptidoform ===
     if (best_hit)
@@ -485,12 +532,12 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
       (void)peptidoform_builder.Append(ProForma::toString(pf, ProForma::WriteMode::CANONICAL));
 
       // calculated_mz
-      int charge = cf.getCharge();
+      int charge = row_charge;
       if (charge > 0)
       {
         float calc_mz = static_cast<float>(seq.getMZ(charge));
         (void)calculated_mz_builder.Append(calc_mz);
-        float obs_mz = static_cast<float>(cf.getMZ());
+        float obs_mz = static_cast<float>(row_mz);
         // mass_error_ppm = (observed - calculated) / calculated * 1e6
         if (calc_mz > 0)
         {
@@ -503,7 +550,7 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
       }
       else
       {
-        (void)calculated_mz_builder.Append(static_cast<float>(cf.getMZ()));
+        (void)calculated_mz_builder.Append(static_cast<float>(row_mz));
         (void)mass_error_ppm_builder.AppendNull();
       }
 
@@ -603,7 +650,7 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     {
       (void)sequence_builder.Append("");
       (void)peptidoform_builder.Append("");
-      (void)calculated_mz_builder.Append(static_cast<float>(cf.getMZ()));
+      (void)calculated_mz_builder.Append(static_cast<float>(row_mz));
       (void)mass_error_ppm_builder.AppendNull();
       // empty modifications list
       (void)modifications_builder.Append();
@@ -611,15 +658,14 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
 
     // Quantitative coordinates: this run's handle for label-free, the consensus centroid for
     // isobaric (whose handles carry reporter-ion m/z and the quantification scan's RT).
-    const FeatureHandle* coord = (!is_isobaric && !row.handles.empty()) ? row.handles.front() : nullptr;
-    (void)charge_builder.Append(static_cast<int16_t>(coord ? coord->getCharge() : cf.getCharge()));
-    (void)observed_mz_builder.Append(static_cast<float>(coord ? coord->getMZ() : cf.getMZ()));
-    (void)rt_builder.Append(static_cast<float>(coord ? coord->getRT() : cf.getRT()));
+    (void)charge_builder.Append(static_cast<int16_t>(row_charge));
+    (void)observed_mz_builder.Append(static_cast<float>(row_mz));
+    (void)rt_builder.Append(static_cast<float>(row_rt));
 
     // === PEP ===
     if (has_id)
     {
-      auto result = idsa.findScoreType(pep_ids[0], IDScoreSwitcherAlgorithm::ScoreType::PEP);
+      auto result = idsa.findScoreType(*best_pid, IDScoreSwitcherAlgorithm::ScoreType::PEP);
       // Resolve the (dynamic) PEP score name to an index once per feature (lock-free use below).
       const UInt idx_pep = result.score_name.empty() ? static_cast<UInt>(-1) : mreg.getIndex(result.score_name);
       if (!result.score_name.empty() && best_hit)
@@ -718,10 +764,10 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
       if (!pep_ids.empty())
       {
         // Prefer the dedicated member, fall back to metavalue
-        spec_ref = pep_ids[0].getSpectrumReference();
-        if (spec_ref.empty() && metaHas(pep_ids[0], idx_spectrum_reference))
+        spec_ref = best_pid->getSpectrumReference();
+        if (spec_ref.empty() && metaHas(*best_pid, idx_spectrum_reference))
         {
-          spec_ref = pep_ids[0].getMetaValue(idx_spectrum_reference).toString();
+          spec_ref = best_pid->getMetaValue(idx_spectrum_reference).toString();
         }
       }
 
@@ -740,13 +786,13 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     (void)cv_params_builder.AppendNull();
 
     // === ion_mobility, start/stop ===
-    if (!pep_ids.empty() && metaHas(pep_ids[0], idx_ion_mobility))
+    if (best_pid && metaHas(*best_pid, idx_ion_mobility))
     {
-      (void)ion_mobility_builder.Append(static_cast<float>(static_cast<double>(pep_ids[0].getMetaValue(idx_ion_mobility))));
+      (void)ion_mobility_builder.Append(static_cast<float>(static_cast<double>(best_pid->getMetaValue(idx_ion_mobility))));
     }
-    else if (!pep_ids.empty() && metaHas(pep_ids[0], idx_IM))
+    else if (best_pid && metaHas(*best_pid, idx_IM))
     {
-      (void)ion_mobility_builder.Append(static_cast<float>(static_cast<double>(pep_ids[0].getMetaValue(idx_IM))));
+      (void)ion_mobility_builder.Append(static_cast<float>(static_cast<double>(best_pid->getMetaValue(idx_IM))));
     }
     else
     {
@@ -790,10 +836,10 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     // that divergence is exactly what this column records.
     // Resolved from the identification that actually holds the best hit, not pep_ids[0] --
     // a feature's identifications can come from different runs, which is the whole point.
-    if (has_id && best_id_index < pep_ids.size())
+    if (best_pid)
     {
       const std::string id_run =
-        ArrowIOHelpers::qpxRunFileName(id_lut.run_mapper.getPrimaryMSRunPath(pep_ids[best_id_index]));
+        ArrowIOHelpers::qpxRunFileName(id_lut.run_mapper.getPrimaryMSRunPath(*best_pid));
       if (id_run.empty()) { (void)id_run_file_name_builder.AppendNull(); }
       else                { (void)id_run_file_name_builder.Append(id_run); }
     }
@@ -946,9 +992,9 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     {
       (void)rt_start_builder.Append(static_cast<float>(static_cast<double>(cf.getMetaValue(idx_rt_start))));
     }
-    else if (cf.getWidth() > 0)
+    else if (row_width > 0)
     {
-      (void)rt_start_builder.Append(static_cast<float>(cf.getRT() - cf.getWidth() / 2.0));
+      (void)rt_start_builder.Append(static_cast<float>(row_rt - row_width / 2.0));
     }
     else
     {
@@ -959,9 +1005,9 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     {
       (void)rt_stop_builder.Append(static_cast<float>(static_cast<double>(cf.getMetaValue(idx_rt_stop))));
     }
-    else if (cf.getWidth() > 0)
+    else if (row_width > 0)
     {
-      (void)rt_stop_builder.Append(static_cast<float>(cf.getRT() + cf.getWidth() / 2.0));
+      (void)rt_stop_builder.Append(static_cast<float>(row_rt + row_width / 2.0));
     }
     else
     {

--- a/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
@@ -99,7 +99,8 @@ struct FeatureIdLookups
   /// serialize the parallel batch build (see the note on pre-resolved metavalue indices).
   struct RunColumnInfo
   {
-    std::string run_name;   ///< stemmed run_file_name
+    std::string source;     ///< ColumnHeader::filename, the run's identity
+    std::string run_name;   ///< stemmed run_file_name, the emitted value
     std::string label;      ///< QPX intensities[].label
   };
   std::unordered_map<UInt64, RunColumnInfo> run_columns;
@@ -155,7 +156,7 @@ FeatureIdLookups buildFeatureIdLookups(const ConsensusMap& cmap)
                        << std::endl;
     }
     lut.run_columns[map_index] = FeatureIdLookups::RunColumnInfo{
-      ArrowIOHelpers::qpxRunFileName(header.filename), std::move(label)};
+      header.filename, ArrowIOHelpers::qpxRunFileName(header.filename), std::move(label)};
   }
 
   for (const auto& prot_id : cmap.getProteinIdentifications())
@@ -468,20 +469,26 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
   Size dropped_handleless = 0;
   for (size_t feat_idx = range_begin; feat_idx < range_end; ++feat_idx)
   {
-    // std::map keeps runs in a deterministic order, so output is stable for any thread count.
-    std::map<std::string, std::vector<const FeatureHandle*>> by_run;
+    // Group by the run's SOURCE path, not by its stemmed name. Two runs whose paths differ
+    // only in directory (/a/run1.mzML, /b/run1.mzML) share a stem; grouping on the stem
+    // would silently merge them into one row carrying both runs' intensities -- strictly
+    // worse than the ambiguous-but-separate rows #9818 warns about. Channels of one isobaric
+    // run share ColumnHeader::filename, so they still group together, which is the point.
+    // std::map keeps the order deterministic, so output is stable for any thread count.
+    std::map<std::string, std::vector<const FeatureHandle*>> by_source;
     for (const auto& fh : cmap[feat_idx].getFeatures())
     {
       auto it = id_lut.run_columns.find(fh.getMapIndex());
       if (it == id_lut.run_columns.end()) { continue; }
-      by_run[it->second.run_name].push_back(&fh);
+      by_source[it->second.source].push_back(&fh);
     }
-    // A feature with no handles has neither quantification nor a run, so the per-run feature
-    // view has nothing to represent -- drop it rather than emit an unkeyed row.
-    if (by_run.empty()) { ++dropped_handleless; continue; }
-    for (auto& [run, handles] : by_run)
+    if (by_source.empty()) { ++dropped_handleless; continue; }
+    for (auto& [source, handles] : by_source)
     {
-      rows.push_back(RowSpec{feat_idx, run, std::move(handles)});
+      // The emitted key is the stem; the grouping key was the full path.
+      rows.push_back(RowSpec{feat_idx,
+                             id_lut.run_columns.at(handles.front()->getMapIndex()).run_name,
+                             std::move(handles)});
     }
   }
   if (dropped_handleless > 0)
@@ -839,7 +846,7 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     // === scan (list<int32>) ===
     {
       std::string spec_ref;
-      if (!pep_ids.empty())
+      if (best_pid)   // NOT !pep_ids.empty(): all of them may be hitless
       {
         // Prefer the dedicated member, fall back to metavalue
         spec_ref = best_pid->getSpectrumReference();
@@ -1066,6 +1073,12 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     }
 
     // === rt_start / rt_stop ===
+    // NOTE: the explicit rt_start/rt_stop metavalues are authored on the ConsensusFeature,
+    // so a melted per-run row inherits the consensus window even when it reports the run
+    // handle's RT. Where the two RTs diverge that window does not bracket the row's own RT.
+    // Left as-is deliberately: overriding an authored value is a semantic change beyond this
+    // PR, and existing coverage pins the current behaviour. The width fallback below does use
+    // the row's own coordinates.
     if (metaHas(cf, idx_rt_start))
     {
       (void)rt_start_builder.Append(static_cast<float>(static_cast<double>(cf.getMetaValue(idx_rt_start))));

--- a/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
@@ -1255,8 +1255,29 @@ std::shared_ptr<const arrow::KeyValueMetadata> qpxFeatureMetadata(
 } // anonymous namespace (feature range builder + shared per-map lookups)
 
 
+void ConsensusMapArrowExport::requireUnambiguousIdentities(const ConsensusMap& cmap)
+{
+  Size divergent = 0;
+  Size first_index = 0;
+  for (Size i = 0; i < cmap.size(); ++i)
+  {
+    if (cmap[i].getAnnotationState() != BaseFeature::AnnotationState::FEATURE_ID_MULTIPLE_DIVERGENT) { continue; }
+    if (divergent++ == 0) { first_index = i; }
+  }
+  if (divergent == 0) { return; }
+
+  throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+    std::to_string(divergent) + " consensus feature(s), the first at index "
+    + std::to_string(first_index) + ", carry peptide identifications that disagree on the top "
+    "peptide. The QPX feature and protein-group views record one peptide per feature and cannot "
+    "represent this. Resolve the conflicts first (IDConflictResolver, ConsensusID with "
+    "algorithm 'best', or FileFilter with id:keep_best_score_id), or export the unresolved data "
+    "as consensusparquet, which preserves every identification.");
+}
+
 std::shared_ptr<arrow::Table> ConsensusMapArrowExport::exportToArrow(const ConsensusMap& cmap)
 {
+  requireUnambiguousIdentities(cmap);   // preflight: single-threaded, before any OpenMP region
   const auto id_lut = buildFeatureIdLookups(cmap);
   // A channel QPX cannot name would be written into intensities[].label, a documented join
   // key. Refuse rather than emit a guessed or empty token (the pg exporter does the same).
@@ -1327,6 +1348,10 @@ bool ConsensusMapArrowExport::exportToParquetStreaming(
   if (threads < 1) { threads = 1; }
 
   // Prebuild the per-map protein-group/gene lookups once; reused for every batch.
+  // Preflight before the writer is opened and before the OpenMP batch build: a throw from
+  // inside that region would be captured by the worker's catch-all and flattened to a bool.
+  requireUnambiguousIdentities(cmap);
+
   const auto id_lut = buildFeatureIdLookups(cmap);
   if (id_lut.has_unlabelable_channel) { return false; } // already logged
 

--- a/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
@@ -12,6 +12,7 @@
 #include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h>
+#include <OpenMS/PROCESSING/ID/IDFilter.h>
 #include <OpenMS/ANALYSIS/ID/Scores.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
@@ -314,7 +315,62 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
   arrow::ListBuilder pg_positions_builder(arrow::default_memory_pool(), pgp_struct_b);
 
   arrow::Status status;
-  const Size num_features = range_end - range_begin;
+
+  // -- Melt: one output row per (ConsensusFeature, run) --
+  //
+  // QPX's feature view is long -- "a quantified peptidoform in a specific run file"
+  // (docs/spec/feature.md) -- so a ConsensusFeature spanning N runs expands to N rows, each
+  // carrying only that run's intensities. Emitting one wide row per feature instead made
+  // run_file_name an arbitrary pick among the contributing runs and forced every intensity
+  // into a single list distinguishable only by a non-conformant label.
+  //
+  // The coordinate rule differs by acquisition mode:
+  //  - label-free: each FeatureHandle holds that run's own RT / m/z / charge / width, so the
+  //    row takes its quantitative coordinates from the handle.
+  //  - isobaric: the handles are reporter ions -- their m/z is the reporter mass and their RT
+  //    the quantification scan -- while precursor m/z and RT live on the ConsensusFeature.
+  //    Keep the consensus coordinates and use the handles only for channel intensities.
+  const auto& column_headers_for_melt = cmap.getColumnHeaders();
+  const bool is_isobaric = std::any_of(
+    column_headers_for_melt.begin(), column_headers_for_melt.end(),
+    [](const auto& kv) { return kv.second.metaValueExists("channel_name"); });
+
+  struct RowSpec
+  {
+    size_t feat_idx;
+    std::string run;                            ///< stemmed run_file_name
+    std::vector<const FeatureHandle*> handles;  ///< this run's handles, in map-index order
+  };
+
+  std::vector<RowSpec> rows;
+  rows.reserve(range_end - range_begin);
+  Size dropped_handleless = 0;
+  for (size_t feat_idx = range_begin; feat_idx < range_end; ++feat_idx)
+  {
+    // std::map keeps runs in a deterministic order, so output is stable for any thread count.
+    std::map<std::string, std::vector<const FeatureHandle*>> by_run;
+    for (const auto& fh : cmap[feat_idx].getFeatures())
+    {
+      auto it = column_headers_for_melt.find(fh.getMapIndex());
+      if (it == column_headers_for_melt.end()) { continue; }
+      by_run[ArrowIOHelpers::qpxRunFileName(it->second.filename)].push_back(&fh);
+    }
+    // A feature with no handles has neither quantification nor a run, so the per-run feature
+    // view has nothing to represent -- drop it rather than emit an unkeyed row.
+    if (by_run.empty()) { ++dropped_handleless; continue; }
+    for (auto& [run, handles] : by_run)
+    {
+      rows.push_back(RowSpec{feat_idx, run, std::move(handles)});
+    }
+  }
+  if (dropped_handleless > 0)
+  {
+    OPENMS_LOG_INFO << "ConsensusMapArrowExport: skipped " << dropped_handleless
+                    << " consensus feature(s) with no feature handles (no quantification and "
+                       "no source run to key a QPX feature row on)." << std::endl;
+  }
+
+  const Size num_features = rows.size();
 
   // Reserve capacity for simple column builders
   #define RESERVE_OR_FAIL(builder) \
@@ -386,12 +442,39 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
   auto metaHas = [](const MetaInfoInterface& m, UInt idx) -> bool
   { return idx != static_cast<UInt>(-1) && m.metaValueExists(idx); };
 
-  for (size_t feat_idx = range_begin; feat_idx < range_end; ++feat_idx)
+  bool warned_mixed_scores = false;
+  for (const auto& row : rows)
   {
-    const auto& cf = cmap[feat_idx];
+    const auto& cf = cmap[row.feat_idx];
     const auto& pep_ids = cf.getPeptideIdentifications();
-    bool has_id = !pep_ids.empty() && !pep_ids[0].getHits().empty();
-    const PeptideHit* best_hit = has_id ? &pep_ids[0].getHits()[0] : nullptr;
+
+    // Pick the feature's identity: the best-scoring hit across ALL of its identifications,
+    // not pep_ids[0].getHits()[0]. The positional pick discarded a feature's identity whenever
+    // its *first* identification happened to carry no hits, even if a later one did.
+    //
+    // getBestHit() throws when the identifications disagree on score type, which cannot
+    // happen for our tools (one FDR pass sets them together) but is reachable for a foreign
+    // ConsensusMap. Fall back to the positional pick there rather than failing the export.
+    PeptideHit best_hit_value;
+    Size best_id_index = 0;
+    bool has_id = false;
+    try
+    {
+      has_id = IDFilter::getBestHit(pep_ids.getData(), /*assume_sorted=*/false, best_hit_value, best_id_index);
+    }
+    catch (const Exception::InvalidValue&)
+    {
+      if (!warned_mixed_scores)
+      {
+        warned_mixed_scores = true;
+        OPENMS_LOG_WARN << "ConsensusMapArrowExport: consensus feature carries identifications "
+                           "with different score types; falling back to the first hit instead of "
+                           "the best-scoring one." << std::endl;
+      }
+      has_id = !pep_ids.empty() && !pep_ids[0].getHits().empty();
+      if (has_id) { best_hit_value = pep_ids[0].getHits()[0]; best_id_index = 0; }
+    }
+    const PeptideHit* best_hit = has_id ? &best_hit_value : nullptr;
 
     // === sequence / peptidoform ===
     if (best_hit)
@@ -526,9 +609,12 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
       (void)modifications_builder.Append();
     }
 
-    (void)charge_builder.Append(static_cast<int16_t>(cf.getCharge()));
-    (void)observed_mz_builder.Append(static_cast<float>(cf.getMZ()));
-    (void)rt_builder.Append(static_cast<float>(cf.getRT()));
+    // Quantitative coordinates: this run's handle for label-free, the consensus centroid for
+    // isobaric (whose handles carry reporter-ion m/z and the quantification scan's RT).
+    const FeatureHandle* coord = (!is_isobaric && !row.handles.empty()) ? row.handles.front() : nullptr;
+    (void)charge_builder.Append(static_cast<int16_t>(coord ? coord->getCharge() : cf.getCharge()));
+    (void)observed_mz_builder.Append(static_cast<float>(coord ? coord->getMZ() : cf.getMZ()));
+    (void)rt_builder.Append(static_cast<float>(coord ? coord->getRT() : cf.getRT()));
 
     // === PEP ===
     if (has_id)
@@ -619,28 +705,12 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     }
 
     // === run_file_name ===
-    // Derive from the first FeatureHandle's map index -> column header filename.
-    // QPX defines the column as the spectrum file name without path or extension; stemming here is
-    // what makes it join with the psm and pg tables, which derive the same value from other sources.
-    // For isobaric input all channels of one file share the ColumnHeader::filename (the channel
-    // identity lives in ColumnHeader::label), so any of them yields the same stem.
-    {
-      bool found_run = false;
-      for (const auto& fh : cf.getFeatures())
-      {
-        auto it = column_headers.find(fh.getMapIndex());
-        if (it != column_headers.end())
-        {
-          (void)run_file_name_builder.Append(File::stemName(it->second.filename));
-          found_run = true;
-          break;
-        }
-      }
-      if (!found_run)
-      {
-        (void)run_file_name_builder.Append("");
-      }
-    }
+    // The run this melted row belongs to, already stemmed. QPX defines the column as the
+    // spectrum file name without path or extension, and joins the psm, feature and pg views
+    // on it, so all three must agree on the same spelling.
+    // For isobaric input all channels of one file share ColumnHeader::filename (the channel
+    // identity lives in ColumnHeader::label), so a run groups all of its channels.
+    (void)run_file_name_builder.Append(row.run);
 
     // === scan (list<int32>) ===
     {
@@ -715,7 +785,22 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     (void)additional_intensities_builder.AppendNull();
 
     // === id_run_file_name ===
-    (void)id_run_file_name_builder.AppendNull();
+    // Spec: "run file containing best PSM". This may legitimately differ from run_file_name
+    // — a match-between-runs feature is quantified in one run but identified in another, and
+    // that divergence is exactly what this column records.
+    // Resolved from the identification that actually holds the best hit, not pep_ids[0] --
+    // a feature's identifications can come from different runs, which is the whole point.
+    if (has_id && best_id_index < pep_ids.size())
+    {
+      const std::string id_run =
+        ArrowIOHelpers::qpxRunFileName(id_lut.run_mapper.getPrimaryMSRunPath(pep_ids[best_id_index]));
+      if (id_run.empty()) { (void)id_run_file_name_builder.AppendNull(); }
+      else                { (void)id_run_file_name_builder.Append(id_run); }
+    }
+    else
+    {
+      (void)id_run_file_name_builder.AppendNull();
+    }
 
     // === Protein accessions (now list<struct>) ===
     // Collect ALL peptide evidences (including repeated accessions with different positions)
@@ -882,18 +967,21 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     }
 
     // === intensities: list<struct{label, intensity}> ===
+    // Only this run's handles: one entry for label-free ("LFQ"), one per reporter channel for
+    // isobaric ("TMT126", ...). The label is a join key against run.samples[].label, so it
+    // must be a canonical channel token rather than the source file name.
     (void)intensities_builder.Append();
-    for (const auto& fh : cf.getFeatures())
+    for (const auto* fh : row.handles)
     {
-      auto it = column_headers.find(fh.getMapIndex());
-      if (it != column_headers.end())
-      {
-        (void)intensity_struct_b->Append();
-        (void)intensity_label_b->Append(it->second.filename);
-        (void)intensity_val_b->Append(static_cast<float>(fh.getIntensity()));
-      }
+      auto it = column_headers.find(fh->getMapIndex());
+      if (it == column_headers.end()) { continue; }
+      const std::string channel_name = it->second.metaValueExists("channel_name")
+                                     ? it->second.getMetaValue("channel_name").toString() : "";
+      (void)intensity_struct_b->Append();
+      (void)intensity_label_b->Append(ArrowIOHelpers::qpxIntensityLabel(it->second.label, channel_name));
+      (void)intensity_val_b->Append(static_cast<float>(fh->getIntensity()));
     }
-  } // end feature loop
+  } // end melted row loop
 
   // Finalize all arrays
   #define FINISH_OR_FAIL(builder, arr) \

--- a/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
@@ -869,10 +869,12 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
       }
     }
 
-    // anchor_protein
+    // anchor_protein — null, not "", when the feature has no protein mapping. bigbio/qpx#212
+    // made this nullable for de novo workflows: "null when no protein mapping was performed".
+    // An empty string would satisfy the column but is neither an accession nor an absence.
     if (protein_accs.empty())
     {
-      (void)anchor_protein_builder.Append("");
+      (void)anchor_protein_builder.AppendNull();
     }
     else
     {

--- a/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
@@ -31,6 +31,7 @@
 
 #include <algorithm>
 #include <exception>
+#include <functional>
 #include <limits>
 #include <map>
 #include <unordered_map>
@@ -215,28 +216,36 @@ FeatureIdLookups buildFeatureIdLookups(const ConsensusMap& cmap)
 /// first non-empty identification), not the winner -- while the QPX feature view needs the
 /// winner's parent to resolve id_run_file_name. Exposing that would mean new public API in a
 /// widely-included header for a single caller, and it could not replace the existing
-/// per-identification helpers (MapAlignmentAlgorithmIdentification::getBestScoringHit works
-/// within one identification and returns a pointer; MzTab aggregates scores with different
-/// tie-breaking). Score comparison itself is not duplicated -- it delegates to
+/// per-identification helpers (MapAlignmentAlgorithmIdentification::getBestScoringHit is
+/// protected, works within one identification and returns a pointer; MzTab aggregates scores
+/// with different tie-breaking). Score comparison itself is not duplicated -- it delegates to
 /// PeptideIdentification::getScoreComparator, the same primitive those helpers use.
 ///
-/// Scores from identifications with different score types are not comparable. Rather than
-/// compare them anyway, fall back to the first identification that has a hit and report it
-/// through @p mixed_score_types so the caller can warn once per export.
+/// Comparison uses ONE orientation, taken from the first identification that has a hit. Using
+/// each identification's own orientation would compare in different directions within a single
+/// selection and make the winner depend on identification order.
+///
+/// Identifications that disagree on score type or orientation are a pipeline defect, not a
+/// case to recover from: scores of different types are not comparable, harmonizing them is an
+/// explicit step (IDScoreSwitcher / IDScoreSwitcherAlgorithm, which ProteomicsLFQ, Epifany and
+/// FalseDiscoveryRate all run), and IDFilter::getBestHit throws outright on the same condition.
+/// This warns via @p inconsistent_scores and proceeds with the reference orientation rather
+/// than inventing a recovery, which would only turn a broken input into an arbitrary answer.
 ///
 /// @param[in] pep_ids The feature's peptide identifications
 /// @param[out] best_id_index Index into @p pep_ids of the identification holding the winner
-/// @param[out] mixed_score_types Set when the identifications disagree on score type
+/// @param[out] inconsistent_scores Set when the identifications disagree on score type or orientation
 /// @return Pointer to the winning hit, or nullptr when no identification has one
 const PeptideHit* selectFeatureIdentity(
   const PeptideIdentificationList& pep_ids,
   Size& best_id_index,
-  bool& mixed_score_types)
+  bool& inconsistent_scores)
 {
   const PeptideHit* best_hit = nullptr;
   const PeptideIdentification* ref_id = nullptr;   // fixes the score type and orientation
+  std::function<bool(const PeptideHit&, const PeptideHit&)> better;
   best_id_index = 0;
-  mixed_score_types = false;
+  inconsistent_scores = false;
 
   for (Size i = 0; i < pep_ids.size(); ++i)
   {
@@ -246,14 +255,14 @@ const PeptideHit* selectFeatureIdentity(
     if (ref_id == nullptr)
     {
       ref_id = &pid;
+      better = PeptideIdentification::getScoreComparator(pid.isHigherScoreBetter());
     }
-    else if (ref_id->getScoreType() != pid.getScoreType())
+    else if (ref_id->getScoreType() != pid.getScoreType()
+          || ref_id->isHigherScoreBetter() != pid.isHigherScoreBetter())
     {
-      mixed_score_types = true;
-      break;                                        // keep the first hit found; see below
+      inconsistent_scores = true;                  // reported once per export by the caller
     }
 
-    const auto better = PeptideIdentification::getScoreComparator(pid.isHigherScoreBetter());
     for (const auto& hit : pid.getHits())
     {
       if (best_hit == nullptr || better(hit, *best_hit))
@@ -589,15 +598,17 @@ std::shared_ptr<arrow::Table> buildFeatureTableRange(
     // pep_ids[0].getHits()[0]. The positional pick discarded a feature's identity whenever its
     // *first* identification happened to carry no hits, even if a later one did.
     Size best_id_index = 0;
-    bool mixed_score_types = false;
-    const PeptideHit* best_hit = selectFeatureIdentity(pep_ids, best_id_index, mixed_score_types);
+    bool inconsistent_scores = false;
+    const PeptideHit* best_hit = selectFeatureIdentity(pep_ids, best_id_index, inconsistent_scores);
     const bool has_id = (best_hit != nullptr);
-    if (mixed_score_types && !warned_mixed_scores)
+    if (inconsistent_scores && !warned_mixed_scores)
     {
       warned_mixed_scores = true;
-      OPENMS_LOG_WARN << "ConsensusMapArrowExport: consensus feature carries identifications with "
-                         "different score types, whose scores are not comparable; using the first "
-                         "hit found instead of the best-scoring one." << std::endl;
+      OPENMS_LOG_WARN << "ConsensusMapArrowExport: consensus feature carries identifications that "
+                         "disagree on score type or orientation, so their scores are not "
+                         "comparable. Harmonize them upstream (e.g. IDScoreSwitcher); the best "
+                         "hit was selected using the first identification's orientation."
+                      << std::endl;
     }
 
     // The row's quantitative coordinates, fixed here so that charge, observed_mz,

--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -16,6 +16,7 @@
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
 #include <OpenMS/FORMAT/ArrowIOHelpers.h>
+#include <OpenMS/KERNEL/BaseFeature.h>
 #include <OpenMS/DATASTRUCTURES/DateTime.h>
 
 #include <arrow/api.h>
@@ -96,6 +97,7 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
     }
 
     const auto& headers = cmap.getColumnHeaders();
+    Size ambiguous_features = 0;
     for (Size fi = 0; fi < cmap.size(); ++fi)
     {
       const auto& cf = cmap[fi];
@@ -108,6 +110,28 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
         if (it != headers.end()) { runs.insert(ArrowIOHelpers::qpxRunFileName(it->second.filename)); }
       }
       if (runs.empty()) { continue; }
+
+      // The pg view attributes a feature to ONE peptide: its sequence, peptidoform and charge
+      // feed peptides[], peptide_counts and feature_counts. A feature whose identifications
+      // DISAGREE on the top peptide has none to attribute, so counting it would credit an
+      // accession contributed by one peptide with another peptide's identity.
+      //
+      // Uses the existing AnnotationState rather than "more than one identification": several
+      // identifications sharing the same top modified sequence (FEATURE_ID_MULTIPLE_SAME) are
+      // unambiguous and are the deliberate output of IDConflictResolverAlgorithm::resolve()
+      // with keep_matching=true, which ProteomicsLFQ uses. Only DIVERGENT is a real conflict --
+      // the same distinction PeptideAndProteinQuant and MzTab already make.
+      //
+      // Skip it, matching what quantification already does -- ProteinQuantifier documents that
+      // "only features/feature groups with unambiguous peptide annotation are used for peptide
+      // quantification" -- so the counts agree with the abundances in the same export. Resolve
+      // upstream with IDConflictResolver, ConsensusID (algorithm "best") or FileFilter
+      // (id:keep_best_score_id). ProteomicsLFQ and IsobaricWorkflow already satisfy this.
+      if (cf.getAnnotationState() == BaseFeature::AnnotationState::FEATURE_ID_MULTIPLE_DIVERGENT)
+      {
+        ++ambiguous_features;
+        continue;
+      }
 
       for (const auto& pid : cf.getPeptideIdentifications())
       {
@@ -130,6 +154,16 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
           }
         }
       }
+    }
+
+    if (ambiguous_features > 0)
+    {
+      OPENMS_LOG_WARN << "ProteinGroupArrowExport: " << ambiguous_features
+                      << " consensus feature(s) carry more than one peptide identification, so "
+                         "they cannot be attributed to a single peptide and are excluded from the "
+                         "protein group peptide/feature counts. Resolve ID conflicts upstream "
+                         "(IDConflictResolver, ConsensusID 'best', or FileFilter "
+                         "id:keep_best_score_id)." << std::endl;
     }
 
     // Unassigned identifications establish that a group was seen in a run even though nothing

--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -343,6 +343,43 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
     (void)cv_params_builder.Append();
   };
 
+  // Build (run stem, 1-based channel) -> QPX intensity label from the column headers.
+  //
+  // The quant arrays below are keyed by (design filename, channel number), where the channel
+  // numbering is ColumnHeader::getLabelAsUInt()'s (channel_id + 1). Keying the lookup on the
+  // run as well as the channel keeps it correct for maps whose runs use different methods,
+  // rather than assuming one global channel -> label mapping.
+  std::map<std::pair<std::string, UInt>, std::string> channel_labels;
+  for (const auto& [map_index, header] : cmap.getColumnHeaders())
+  {
+    const UInt channel = header.getLabelAsUInt(cmap.getExperimentType());
+    const std::string channel_name = header.metaValueExists("channel_name")
+                                   ? header.getMetaValue("channel_name").toString() : "";
+    const std::string label = ArrowIOHelpers::qpxIntensityLabel(header.label, channel_name);
+    if (label.empty()) { return nullptr; } // unidentifiable channel; already logged
+    channel_labels[{ArrowIOHelpers::qpxRunFileName(header.filename), channel}] = label;
+  }
+
+  // Resolve a (run, channel) to its QPX label. A miss means the ConsensusMap carries quant
+  // arrays that its column headers do not describe (possible for a hand-built or foreign
+  // map): a single channel is label-free by construction, anything else is reported.
+  bool warned_missing_label = false;
+  auto labelFor = [&](const std::string& run, Int channel) -> std::string
+  {
+    auto it = channel_labels.find({run, static_cast<UInt>(channel)});
+    if (it != channel_labels.end()) { return it->second; }
+    if (channel == 1) { return "LFQ"; }
+    if (!warned_missing_label)
+    {
+      warned_missing_label = true;
+      OPENMS_LOG_WARN << "ProteinGroupArrowExport: no column header describes channel "
+                      << channel << " of run '" << run << "'; falling back to the channel "
+                      << "number as intensity label, which will not join against run.parquet."
+                      << std::endl;
+    }
+    return std::to_string(channel);
+  };
+
   // Iterate protein groups and emit rows
   for (const auto& group : groups)
   {
@@ -360,11 +397,11 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
       const auto& filenames = group.getStringDataArrays()[0]; // file_channel_level_filename
       const auto& channels = group.getIntegerDataArrays()[0]; // file_channel_level_channel
 
-      // Group by filename: filename -> [(channel_label, intensity)]
+      // Group by filename: filename -> [(QPX channel label, intensity)]
       std::map<std::string, std::vector<std::pair<std::string, float>>> file_intensities;
       for (Size i = 0; i < filenames.size() && i < abundances.size() && i < channels.size(); ++i)
       {
-        file_intensities[filenames[i]].emplace_back(std::to_string(channels[i]), abundances[i]);
+        file_intensities[filenames[i]].emplace_back(labelFor(filenames[i], channels[i]), abundances[i]);
       }
 
       // Emit one row per unique filename

--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -10,6 +10,7 @@
 
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/METADATA/IdentifierMSRunMapper.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/FORMAT/FileHandler.h>
@@ -21,6 +22,7 @@
 #include <arrow/builder.h>
 
 #include <map>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -52,6 +54,105 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
   {
     hit_lookup[hit.getAccession()] = &hit;
   }
+
+  // -- Per-accession, per-run evidence index --
+  //
+  // Serves two purposes:
+  //  * the run set for a group that has no quantification, so it can be melted onto the runs
+  //    where it was actually identified instead of onto an empty run_file_name (a QPX
+  //    primary-key component that MUST NOT be null) or onto every run in the experiment;
+  //  * the peptide/feature counts, which QPX defines per (group, run).
+  //
+  // The pg table is written after FDR filtering, so whatever PSMs survive in the map already
+  // are the filtered set -- no extra score threshold is applied here.
+  struct FeatureInfo
+  {
+    std::string sequence;
+    std::string peptidoform;   ///< unmodified sequence + charge is not enough; see below
+    int charge = 0;
+  };
+  std::vector<FeatureInfo> feature_info(cmap.size());
+  // accession -> run -> contributing consensus feature indices
+  std::unordered_map<std::string, std::map<std::string, std::set<Size>>> acc_run_features;
+  // accession -> runs with identification evidence (features OR unassigned IDs)
+  std::unordered_map<std::string, std::set<std::string>> acc_runs;
+
+  {
+    IdentifierMSRunMapper run_mapper;
+    try
+    {
+      run_mapper.create(cmap.getProteinIdentifications());
+    }
+    catch (const Exception::InvalidValue& e)
+    {
+      OPENMS_LOG_WARN << "ProteinGroupArrowExport: ambiguous MS run paths (" << e.getMessage()
+                      << "); run attribution continues on the identifier -> path mapping."
+                      << std::endl;
+    }
+
+    const auto& headers = cmap.getColumnHeaders();
+    for (Size fi = 0; fi < cmap.size(); ++fi)
+    {
+      const auto& cf = cmap[fi];
+
+      // The runs this feature was quantified in.
+      std::set<std::string> runs;
+      for (const auto& fh : cf.getFeatures())
+      {
+        auto it = headers.find(fh.getMapIndex());
+        if (it != headers.end()) { runs.insert(ArrowIOHelpers::qpxRunFileName(it->second.filename)); }
+      }
+      if (runs.empty()) { continue; }
+
+      for (const auto& pid : cf.getPeptideIdentifications())
+      {
+        if (pid.getHits().empty()) { continue; }
+        const auto& hit = pid.getHits()[0];
+        if (feature_info[fi].sequence.empty())
+        {
+          feature_info[fi].sequence = hit.getSequence().toUnmodifiedString();
+          feature_info[fi].peptidoform = hit.getSequence().toString();
+          feature_info[fi].charge = hit.getCharge();
+        }
+        for (const auto& ev : hit.getPeptideEvidences())
+        {
+          const std::string& acc = ev.getProteinAccession();
+          if (acc.empty()) { continue; }
+          for (const auto& run : runs)
+          {
+            acc_run_features[acc][run].insert(fi);
+            acc_runs[acc].insert(run);
+          }
+        }
+      }
+    }
+
+    // Unassigned identifications establish that a group was seen in a run even though nothing
+    // was quantified there -- exactly the rows the melt exists to emit. They contribute no
+    // feature, so they do not affect the counts.
+    for (const auto& pid : cmap.getUnassignedPeptideIdentifications())
+    {
+      if (pid.getHits().empty()) { continue; }
+      const std::string run = ArrowIOHelpers::qpxRunFileName(run_mapper.getPrimaryMSRunPath(pid));
+      if (run.empty()) { continue; }
+      for (const auto& ev : pid.getHits()[0].getPeptideEvidences())
+      {
+        if (!ev.getProteinAccession().empty()) { acc_runs[ev.getProteinAccession()].insert(run); }
+      }
+    }
+  }
+
+  /// Runs where any member of @p group has identification evidence.
+  auto evidenceRuns = [&](const ProteinIdentification::ProteinGroup& group)
+  {
+    std::set<std::string> runs;
+    for (const auto& acc : group.accessions)
+    {
+      auto it = acc_runs.find(acc);
+      if (it != acc_runs.end()) { runs.insert(it->second.begin(), it->second.end()); }
+    }
+    return runs;
+  };
 
   // Estimate number of rows: one per group per unique run file (or 1 if no quant data)
   Size estimated_rows = 0;
@@ -298,23 +399,73 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
     // contaminant - not tracked
     (void)contaminant_builder.AppendNull();
 
-    // peptides - empty for now
-    (void)peptides_builder.Append();
-
-    // peptide_counts
-    if (distinct_peptides_for_run >= 0)
+    // peptides / peptide_counts / feature_counts, all per (group, run).
+    //
+    // Semantics follow quantms (our interop target): "unique" means deduplicated, not
+    // proteotypic. DIA-NN's converter reads the same fields as proteotypic counts, so these
+    // numbers are only comparable within quantms-derived collections. See
+    // qpx/converters/quantms/pg_adapter.py.
     {
-      (void)peptide_counts_builder.Append();
-      (void)pc_unique_b->Append(distinct_peptides_for_run);
-      (void)pc_total_b->Append(0);
-    }
-    else
-    {
-      (void)peptide_counts_builder.AppendNull();
-    }
+      // The group's contributing consensus features in this run, unioned over its members so
+      // a feature shared by two members is counted once.
+      std::set<Size> group_features;
+      for (const auto& acc : group.accessions)
+      {
+        auto ait = acc_run_features.find(acc);
+        if (ait == acc_run_features.end()) { continue; }
+        auto rit = ait->second.find(run_file);
+        if (rit == ait->second.end()) { continue; }
+        group_features.insert(rit->second.begin(), rit->second.end());
+      }
 
-    // feature_counts - not available
-    (void)feature_counts_builder.AppendNull();
+      // peptides: one {protein_name, peptide_count} per group member, counting that member's
+      // distinct peptide sequences in this run.
+      (void)peptides_builder.Append();
+      for (const auto& acc : group.accessions)
+      {
+        std::set<std::string> seqs;
+        auto ait = acc_run_features.find(acc);
+        if (ait != acc_run_features.end())
+        {
+          auto rit = ait->second.find(run_file);
+          if (rit != ait->second.end())
+          {
+            for (Size fi : rit->second)
+            {
+              if (!feature_info[fi].sequence.empty()) { seqs.insert(feature_info[fi].sequence); }
+            }
+          }
+        }
+        (void)pep_struct_b->Append();
+        (void)pep_name_b->Append(acc);
+        (void)pep_count_b->Append(static_cast<int>(seqs.size()));
+      }
+
+      if (group_features.empty())
+      {
+        // Identification-only row: nothing was quantified in this run, so there is nothing to
+        // count. Null is the honest answer, distinct from a genuine zero.
+        (void)peptide_counts_builder.AppendNull();
+        (void)feature_counts_builder.AppendNull();
+      }
+      else
+      {
+        std::set<std::string> unique_sequences;
+        std::set<std::pair<std::string, int>> unique_features;
+        for (Size fi : group_features)
+        {
+          if (!feature_info[fi].sequence.empty()) { unique_sequences.insert(feature_info[fi].sequence); }
+          unique_features.emplace(feature_info[fi].peptidoform, feature_info[fi].charge);
+        }
+        (void)peptide_counts_builder.Append();
+        (void)pc_unique_b->Append(static_cast<int>(unique_sequences.size()));
+        (void)pc_total_b->Append(static_cast<int>(group_features.size()));
+
+        (void)feature_counts_builder.Append();
+        (void)fc_unique_b->Append(static_cast<int>(unique_features.size()));
+        (void)fc_total_b->Append(static_cast<int>(group_features.size()));
+      }
+    }
 
     // sequence_coverage
     if (anchor_it != hit_lookup.end() && anchor_it->second->getCoverage() != ProteinHit::COVERAGE_UNKNOWN)
@@ -381,6 +532,7 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
   };
 
   // Iterate protein groups and emit rows
+  Size unattributable_groups = 0;
   for (const auto& group : groups)
   {
     // All three arrays are indexed in lockstep below, so every one of them must exist —
@@ -413,9 +565,25 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
     }
     else
     {
-      // Unquantified group: single row with empty run_file_name
-      emitRow(group, "", {}, -1);
+      // Unquantified group. run_file_name is a QPX primary-key component that MUST NOT be
+      // null, and quantms silently drops rows that violate that, so an empty-run row is not
+      // an option. Melt onto the runs where the group actually has identification evidence,
+      // with null intensities (distinct from a measured 0.0). Fanning out across every run in
+      // the experiment instead would assert observations that were never made.
+      const auto runs = evidenceRuns(group);
+      if (runs.empty())
+      {
+        ++unattributable_groups;
+        continue;
+      }
+      for (const auto& run : runs) { emitRow(group, run, {}, -1); }
     }
+  }
+  if (unattributable_groups > 0)
+  {
+    OPENMS_LOG_INFO << "ProteinGroupArrowExport: skipped " << unattributable_groups
+                    << " protein group(s) with neither quantification nor identification "
+                       "evidence in any run (no run_file_name to key a QPX row on)." << std::endl;
   }
 
   // Finalize all arrays

--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -78,6 +78,11 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
   std::unordered_map<std::string, std::set<std::string>> acc_runs;
 
   {
+    // Same warn-only policy as the PSM and feature exporters.
+    std::vector<std::string> header_paths;
+    for (const auto& [map_index, header] : cmap.getColumnHeaders()) { header_paths.push_back(header.filename); }
+    (void)ArrowIOHelpers::qpxWarnOnRunNameCollisions("ProteinGroupArrowExport", header_paths);
+
     IdentifierMSRunMapper run_mapper;
     try
     {

--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -346,9 +346,13 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
   // Iterate protein groups and emit rows
   for (const auto& group : groups)
   {
+    // All three arrays are indexed in lockstep below, so every one of them must exist —
+    // checking only the float/string arrays would dereference IntegerDataArrays()[0] on a
+    // group that carries abundances but no channel array.
     bool has_quant = group.getFloatDataArrays().size() >= 4
                      && !group.getStringDataArrays().empty()
-                     && !group.getStringDataArrays()[0].empty();
+                     && !group.getStringDataArrays()[0].empty()
+                     && !group.getIntegerDataArrays().empty();
 
     if (has_quant)
     {
@@ -470,16 +474,14 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
 namespace
 {
   /// Attach the canonical QPX "pg" file metadata to a table's schema.
-  std::shared_ptr<arrow::Table> attachQPXPgMetadata(const std::shared_ptr<arrow::Table>& table)
+  /// Returns nullptr if QPX does not define a token for the configured compression.
+  std::shared_ptr<arrow::Table> attachQPXPgMetadata(
+    const std::shared_ptr<arrow::Table>& table,
+    const ParquetWriteConfig& config)
   {
-    auto metadata = arrow::key_value_metadata({
-      {"qpx_version", "1.0"},
-      {"creator", "OpenMS"},
-      {"file_type", "pg"},
-      {"creation_date", DateTime::nowUTC().toString("yyyy-MM-ddThh:mm:ssZ")},
-      {"uuid", std::string(ArrowIOHelpers::generateUuidV4())},
-      {"software_provider", "OpenMS"}
-    });
+    // The pg view has no scan column, so no scan_format key.
+    auto metadata = ArrowIOHelpers::qpxFileMetadata("pg_file", config);
+    if (!metadata) { return nullptr; }
     return table->ReplaceSchemaMetadata(metadata);
   }
 }
@@ -509,7 +511,7 @@ bool ProteinGroupArrowExport::exportToParquet(
     return false;
   }
 
-  // Guard: this overload stamps file_type="pg", so the caller must pass a
+  // Guard: this overload stamps file_type="pg_file", so the caller must pass a
   // QPXPgSchema table.
   auto validation = ArrowSchemaValidation::validate(table, QPXPgSchema::schema(), ArrowSchemaValidation::Mode::Strict);
   if (!validation.valid)
@@ -519,7 +521,9 @@ bool ProteinGroupArrowExport::exportToParquet(
     return false;
   }
 
-  return ArrowIOHelpers::writeTableToParquet(attachQPXPgMetadata(table), filename, config);
+  auto stamped = attachQPXPgMetadata(table, config);
+  if (!stamped) { return false; } // unsupported compression for QPX; already logged
+  return ArrowIOHelpers::writeTableToParquet(stamped, filename, config);
 }
 
 

--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -16,6 +16,7 @@
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
 #include <OpenMS/FORMAT/ArrowIOHelpers.h>
+#include <OpenMS/FORMAT/ConsensusMapArrowExport.h>
 #include <OpenMS/KERNEL/BaseFeature.h>
 #include <OpenMS/DATASTRUCTURES/DateTime.h>
 
@@ -39,6 +40,10 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
     OPENMS_LOG_WARN << "ProteinGroupArrowExport: No protein identifications found" << std::endl;
     return nullptr;
   }
+
+  // Same contract as the feature view: the pg view records one peptide per feature, so a
+  // feature whose identifications disagree cannot be counted. Preflight, single-threaded.
+  ConsensusMapArrowExport::requireUnambiguousIdentities(cmap);
 
   const auto& prot_id = cmap.getProteinIdentifications()[0];
   const auto& groups = prot_id.getIndistinguishableProteins();
@@ -97,7 +102,6 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
     }
 
     const auto& headers = cmap.getColumnHeaders();
-    Size ambiguous_features = 0;
     for (Size fi = 0; fi < cmap.size(); ++fi)
     {
       const auto& cf = cmap[fi];
@@ -110,28 +114,6 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
         if (it != headers.end()) { runs.insert(ArrowIOHelpers::qpxRunFileName(it->second.filename)); }
       }
       if (runs.empty()) { continue; }
-
-      // The pg view attributes a feature to ONE peptide: its sequence, peptidoform and charge
-      // feed peptides[], peptide_counts and feature_counts. A feature whose identifications
-      // DISAGREE on the top peptide has none to attribute, so counting it would credit an
-      // accession contributed by one peptide with another peptide's identity.
-      //
-      // Uses the existing AnnotationState rather than "more than one identification": several
-      // identifications sharing the same top modified sequence (FEATURE_ID_MULTIPLE_SAME) are
-      // unambiguous and are the deliberate output of IDConflictResolverAlgorithm::resolve()
-      // with keep_matching=true, which ProteomicsLFQ uses. Only DIVERGENT is a real conflict --
-      // the same distinction PeptideAndProteinQuant and MzTab already make.
-      //
-      // Skip it, matching what quantification already does -- ProteinQuantifier documents that
-      // "only features/feature groups with unambiguous peptide annotation are used for peptide
-      // quantification" -- so the counts agree with the abundances in the same export. Resolve
-      // upstream with IDConflictResolver, ConsensusID (algorithm "best") or FileFilter
-      // (id:keep_best_score_id). ProteomicsLFQ and IsobaricWorkflow already satisfy this.
-      if (cf.getAnnotationState() == BaseFeature::AnnotationState::FEATURE_ID_MULTIPLE_DIVERGENT)
-      {
-        ++ambiguous_features;
-        continue;
-      }
 
       for (const auto& pid : cf.getPeptideIdentifications())
       {
@@ -154,16 +136,6 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
           }
         }
       }
-    }
-
-    if (ambiguous_features > 0)
-    {
-      OPENMS_LOG_WARN << "ProteinGroupArrowExport: " << ambiguous_features
-                      << " consensus feature(s) carry more than one peptide identification, so "
-                         "they cannot be attributed to a single peptide and are excluded from the "
-                         "protein group peptide/feature counts. Resolve ID conflicts upstream "
-                         "(IDConflictResolver, ConsensusID 'best', or FileFilter "
-                         "id:keep_best_score_id)." << std::endl;
     }
 
     // Unassigned identifications establish that a group was seen in a run even though nothing

--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -309,8 +309,7 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
   // Helper lambda to emit one row for a protein group + run file
   auto emitRow = [&](const ProteinIdentification::ProteinGroup& group,
                      const std::string& run_file,
-                     const std::vector<std::pair<std::string, float>>& channel_intensities,
-                     int distinct_peptides_for_run)
+                     const std::vector<std::pair<std::string, float>>& channel_intensities)
   {
     const std::string& anchor = group.accessions.empty() ? "" : group.accessions[0];
 
@@ -559,8 +558,7 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
       // Emit one row per unique filename
       for (const auto& [filename, channel_int] : file_intensities)
       {
-        // We don't have per-run distinct_peptides directly - use -1 to indicate unknown
-        emitRow(group, filename, channel_int, -1);
+        emitRow(group, filename, channel_int);
       }
     }
     else
@@ -576,7 +574,7 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
         ++unattributable_groups;
         continue;
       }
-      for (const auto& run : runs) { emitRow(group, run, {}, -1); }
+      for (const auto& run : runs) { emitRow(group, run, {}); }
     }
   }
   if (unattributable_groups > 0)

--- a/src/openms/source/FORMAT/QPXFile.cpp
+++ b/src/openms/source/FORMAT/QPXFile.cpp
@@ -1514,26 +1514,28 @@ std::shared_ptr<arrow::Table> QPXFile::exportPSMsToQPXArrow(
 
 namespace
 {
-  /// Build the canonical QPX "psm" file metadata (qpx_version, file_type="psm",
-  /// UUID, creation date, scan_format, creator). Each call mints a fresh uuid and
+  /// Build the canonical QPX "psm" file metadata. Each call mints a fresh uuid and
   /// creation_date, so callers needing one identity per file must build it once.
-  std::shared_ptr<const arrow::KeyValueMetadata> qpxPsmMetadata()
+  /// @param scan_format QPX scan_format token; omitted from the metadata when empty.
+  std::shared_ptr<const arrow::KeyValueMetadata> qpxPsmMetadata(
+    const ParquetWriteConfig& config,
+    const std::string& scan_format)
   {
-    return arrow::key_value_metadata({
-      {"qpx_version", "1.0"},
-      {"creator", "OpenMS"},
-      {"file_type", "psm"},
-      {"creation_date", DateTime::nowUTC().toString("yyyy-MM-ddThh:mm:ssZ")},
-      {"uuid", std::string(ArrowIOHelpers::generateUuidV4())},
-      {"scan_format", "scan"},
-      {"software_provider", "OpenMS"}
-    });
+    std::map<std::string, std::string> extra;
+    if (!scan_format.empty()) { extra["scan_format"] = scan_format; }
+    return ArrowIOHelpers::qpxFileMetadata("psm_file", config, extra);
   }
 
-  /// Attach the canonical QPX "psm" file metadata to the schema of @p table.
-  std::shared_ptr<arrow::Table> attachQPXPsmMetadata(const std::shared_ptr<arrow::Table>& table)
+  /// Collect the spectrum references of @p pep_ptrs, for scan_format detection.
+  std::vector<std::string> spectrumReferences(const std::vector<const PeptideIdentification*>& pep_ptrs)
   {
-    return table->ReplaceSchemaMetadata(qpxPsmMetadata());
+    std::vector<std::string> refs;
+    refs.reserve(pep_ptrs.size());
+    for (const auto* p : pep_ptrs)
+    {
+      if (p && !p->getSpectrumReference().empty()) { refs.push_back(p->getSpectrumReference()); }
+    }
+    return refs;
   }
 
   /// Translate ParquetWriteConfig::Compression to arrow::Compression::type.
@@ -1583,13 +1585,20 @@ bool QPXFile::exportToParquet(
     OPENMS_LOG_ERROR << "QPXFile: Failed to create Arrow table" << std::endl;
     return false;
   }
-  return exportToParquet(table, filename, config);
+  std::vector<std::string> refs;
+  refs.reserve(peptide_identifications.size());
+  for (const auto& p : peptide_identifications)
+  {
+    if (!p.getSpectrumReference().empty()) { refs.push_back(p.getSpectrumReference()); }
+  }
+  return exportToParquet(table, filename, config, ArrowIOHelpers::qpxScanFormat(refs));
 }
 
 bool QPXFile::exportToParquet(
   const std::shared_ptr<arrow::Table>& table,
   const std::string& filename,
-  const ParquetWriteConfig& config)
+  const ParquetWriteConfig& config,
+  const std::string& scan_format)
 {
   if (!table)
   {
@@ -1597,7 +1606,7 @@ bool QPXFile::exportToParquet(
     return false;
   }
 
-  // Guard: the table-taking overload attaches file_type="psm" metadata, so the
+  // Guard: the table-taking overload attaches file_type="psm_file" metadata, so the
   // caller must actually pass a QPXPSMSchema table (not, e.g., the internal
   // PSMSchema produced by exportToArrow).
   auto validation = ArrowSchemaValidation::validate(table, QPXPSMSchema::schema(), ArrowSchemaValidation::Mode::Strict);
@@ -1608,7 +1617,9 @@ bool QPXFile::exportToParquet(
     return false;
   }
 
-  return ArrowIOHelpers::writeTableToParquet(attachQPXPsmMetadata(table), filename, config);
+  auto meta = qpxPsmMetadata(config, scan_format);
+  if (!meta) { return false; } // unsupported compression for QPX; already logged
+  return ArrowIOHelpers::writeTableToParquet(table->ReplaceSchemaMetadata(meta), filename, config);
 }
 
 bool QPXFile::exportToParquetStreaming(
@@ -1648,7 +1659,8 @@ bool QPXFile::exportToParquetStreaming(
 
   // One metadata identity (uuid/creation_date) for the whole file. Reused both for the
   // writer's schema and for each batch table so their schemas are identical.
-  auto meta = qpxPsmMetadata();
+  auto meta = qpxPsmMetadata(config, ArrowIOHelpers::qpxScanFormat(spectrumReferences(peptide_identification_ptrs)));
+  if (!meta) { return false; } // unsupported compression for QPX; already logged
   auto schema_meta = QPXPSMSchema::schema()->WithMetadata(meta);
 
   auto file_result = arrow::io::FileOutputStream::Open(filename);

--- a/src/tests/class_tests/openms/source/ArrowIOHelpers_test.cpp
+++ b/src/tests/class_tests/openms/source/ArrowIOHelpers_test.cpp
@@ -189,6 +189,38 @@ START_SECTION((std::shared_ptr<const arrow::KeyValueMetadata> qpxFileMetadata(co
 }
 END_SECTION
 
+START_SECTION((std::string qpxIntensityLabel(const std::string&, const std::string&)))
+{
+  // Label-free: ProteomicsLFQ stamps "label-free" on every header; an unset label is the same.
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxIntensityLabel("label-free", ""), "LFQ")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxIntensityLabel("", ""), "LFQ")
+
+  // Isobaric: IsobaricChannelExtractor builds the label as "<methodname>_<channelname>".
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxIntensityLabel("tmt6plex_126", "126"), "TMT126")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxIntensityLabel("tmt10plex_126", "126"), "TMT126")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxIntensityLabel("tmt10plex_127N", "127N"), "TMT127N")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxIntensityLabel("tmt11plex_131C", "131C"), "TMT131C")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxIntensityLabel("tmt16plex_134N", "134N"), "TMT134N")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxIntensityLabel("tmt18plex_135N", "135N"), "TMT135N")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxIntensityLabel("itraq4plex_114", "114"), "ITRAQ114")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxIntensityLabel("itraq8plex_121", "121"), "ITRAQ121")
+
+  // TMT10-plex channel 10 is "131" in OpenMS' naming. qpx's own converter map is
+  // 11-plex-indexed and calls the 10th channel "TMT131N"; OpenMS' name is authoritative.
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxIntensityLabel("tmt10plex_131", "131"), "TMT131")
+  // ... and 11-plex really does have both 131N and 131C.
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxIntensityLabel("tmt11plex_131N", "131N"), "TMT131N")
+
+  // Multiplex/SILAC headers carry the modification in `label` and annotate no channel;
+  // pass the tool's own label through rather than mislabel it LFQ.
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxIntensityLabel("Arg10", ""), "Arg10")
+
+  // A channel whose method cannot be identified must NOT be guessed — it is a join key.
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxIntensityLabel("mystery_126", "126"), "")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxIntensityLabel("no_separator", "126"), "")
+}
+END_SECTION
+
 START_SECTION((std::string qpxRunFileName(const std::string&)))
 {
   TEST_STRING_EQUAL(ArrowIOHelpers::qpxRunFileName("/data/proj/S1_Frontal_1.mzML"), "S1_Frontal_1")

--- a/src/tests/class_tests/openms/source/ArrowIOHelpers_test.cpp
+++ b/src/tests/class_tests/openms/source/ArrowIOHelpers_test.cpp
@@ -143,6 +143,81 @@ START_SECTION([EXTRA] typed value accessors getColumn and isNull)
 }
 END_SECTION
 
+START_SECTION((std::shared_ptr<const arrow::KeyValueMetadata> qpxFileMetadata(const std::string&, const ParquetWriteConfig&, const std::map<std::string, std::string>&)))
+{
+  // Default config is ZSTD -> the full documented key set is present.
+  auto md = ArrowIOHelpers::qpxFileMetadata("pg_file");
+  TEST_NOT_EQUAL(md, nullptr)
+
+  auto value_of = [&md](const std::string& key) -> std::string
+  {
+    auto r = md->Get(key);
+    return r.ok() ? r.ValueOrDie() : std::string();
+  };
+
+  TEST_STRING_EQUAL(value_of("qpx_version"), "1.0")
+  TEST_STRING_EQUAL(value_of("file_type"), "pg_file")
+  TEST_STRING_EQUAL(value_of("creator"), "OpenMS")
+  TEST_STRING_EQUAL(value_of("compression_format"), "zstd")
+  // software_provider carries the version; creator stays the bare org/tool name
+  TEST_TRUE(StringUtils::hasPrefix(value_of("software_provider"), "OpenMS "))
+  TEST_EQUAL(value_of("uuid").size(), 36)
+  TEST_TRUE(!value_of("creation_date").empty())
+
+  // Each call is a distinct file identity — reusing one call per file is the caller's job.
+  auto md2 = ArrowIOHelpers::qpxFileMetadata("pg_file");
+  TEST_NOT_EQUAL(md2, nullptr)
+  TEST_NOT_EQUAL(value_of("uuid"), md2->Get("uuid").ValueOrDie())
+
+  // Extra keys are appended verbatim.
+  auto md3 = ArrowIOHelpers::qpxFileMetadata("psm_file", ParquetWriteConfig{}, {{"scan_format", "index"}});
+  TEST_NOT_EQUAL(md3, nullptr)
+  TEST_STRING_EQUAL(md3->Get("scan_format").ValueOrDie(), "index")
+
+  // compression_format vocabulary is zstd|snappy|gzip|lzo|none.
+  ParquetWriteConfig cfg;
+  cfg.compression = ParquetWriteConfig::Compression::SNAPPY;
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxFileMetadata("psm_file", cfg)->Get("compression_format").ValueOrDie(), "snappy")
+  cfg.compression = ParquetWriteConfig::Compression::GZIP;
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxFileMetadata("psm_file", cfg)->Get("compression_format").ValueOrDie(), "gzip")
+  cfg.compression = ParquetWriteConfig::Compression::NONE;
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxFileMetadata("psm_file", cfg)->Get("compression_format").ValueOrDie(), "none")
+
+  // LZ4 has no QPX token: refuse rather than emit an out-of-vocabulary value.
+  cfg.compression = ParquetWriteConfig::Compression::LZ4;
+  TEST_EQUAL(ArrowIOHelpers::qpxFileMetadata("psm_file", cfg), nullptr)
+}
+END_SECTION
+
+START_SECTION((std::string qpxScanFormat(const std::string&)))
+{
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxScanFormat("controllerType=0 controllerNumber=1 scan=1234"), "scan")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxScanFormat("scan=42"), "scan")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxScanFormat("scanId=42"), "scan")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxScanFormat("spectrum=7"), "scan")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxScanFormat("index=7"), "index")
+  // Not a recognized native ID -> no evidence either way
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxScanFormat("some_opaque_identifier"), "")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxScanFormat(""), "")
+}
+END_SECTION
+
+START_SECTION((std::string qpxScanFormat(const std::vector<std::string>&)))
+{
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxScanFormat(std::vector<std::string>{"scan=1", "scan=2"}), "scan")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxScanFormat(std::vector<std::string>{"index=1", "index=2"}), "index")
+
+  // Unrecognized entries carry no evidence and must not veto a consistent set.
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxScanFormat(std::vector<std::string>{"opaque", "scan=2", ""}), "scan")
+
+  // Genuinely mixed conventions: neither token describes the file, so omit rather than guess.
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxScanFormat(std::vector<std::string>{"scan=1", "index=2"}), "")
+
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxScanFormat(std::vector<std::string>{}), "")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxScanFormat(std::vector<std::string>{"opaque", "also_opaque"}), "")
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST

--- a/src/tests/class_tests/openms/source/ArrowIOHelpers_test.cpp
+++ b/src/tests/class_tests/openms/source/ArrowIOHelpers_test.cpp
@@ -189,6 +189,19 @@ START_SECTION((std::shared_ptr<const arrow::KeyValueMetadata> qpxFileMetadata(co
 }
 END_SECTION
 
+START_SECTION((std::string qpxRunFileName(const std::string&)))
+{
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxRunFileName("/data/proj/S1_Frontal_1.mzML"), "S1_Frontal_1")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxRunFileName("S1_Frontal_1.mzML"), "S1_Frontal_1")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxRunFileName("/data/run.raw"), "run")
+  // Bruker .d directories reduce like any other path
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxRunFileName("/data/run.d"), "run")
+  // Already in QPX form -> unchanged
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxRunFileName("BSA1_F1"), "BSA1_F1")
+  TEST_STRING_EQUAL(ArrowIOHelpers::qpxRunFileName(""), "")
+}
+END_SECTION
+
 START_SECTION((std::string qpxScanFormat(const std::string&)))
 {
   TEST_STRING_EQUAL(ArrowIOHelpers::qpxScanFormat("controllerType=0 controllerNumber=1 scan=1234"), "scan")

--- a/src/tests/class_tests/openms/source/ArrowIOHelpers_test.cpp
+++ b/src/tests/class_tests/openms/source/ArrowIOHelpers_test.cpp
@@ -189,6 +189,21 @@ START_SECTION((std::shared_ptr<const arrow::KeyValueMetadata> qpxFileMetadata(co
 }
 END_SECTION
 
+START_SECTION((bool qpxWarnOnRunNameCollisions(const std::string&, const std::vector<std::string>&)))
+{
+  // Warn-only, matching the PSM exporter: same-named files in different directories are a
+  // legitimate layout, so an ambiguous key is reported rather than refused.
+  TEST_TRUE(ArrowIOHelpers::qpxWarnOnRunNameCollisions("t", {"/a/run1.mzML", "/a/run2.mzML"}))
+  TEST_TRUE(ArrowIOHelpers::qpxWarnOnRunNameCollisions("t", {"/a/run1.mzML", "/a/run1.mzML"}))  // one run, twice
+  TEST_TRUE(ArrowIOHelpers::qpxWarnOnRunNameCollisions("t", {}))
+  TEST_TRUE(ArrowIOHelpers::qpxWarnOnRunNameCollisions("t", {"", "/a/run1.mzML"}))
+
+  // Distinct paths collapsing onto one run_file_name: reported (false), not fatal.
+  TEST_FALSE(ArrowIOHelpers::qpxWarnOnRunNameCollisions("t", {"/frac_a/run1.mzML", "/frac_b/run1.mzML"}))
+  TEST_FALSE(ArrowIOHelpers::qpxWarnOnRunNameCollisions("t", {"/a/run1.mzML", "/a/run1.raw"}))
+}
+END_SECTION
+
 START_SECTION((std::string qpxIntensityLabel(const std::string&, const std::string&)))
 {
   // Label-free: ProteomicsLFQ stamps "label-free" on every header; an unset label is the same.

--- a/src/tests/class_tests/openms/source/ArrowSchemaRegistry_test.cpp
+++ b/src/tests/class_tests/openms/source/ArrowSchemaRegistry_test.cpp
@@ -1220,10 +1220,11 @@ START_SECTION(QPXFeatureSchema field types and nullability)
   TEST_EQUAL(s->field(19)->type()->id(), arrow::Type::LIST)
   TEST_EQUAL(s->field(19)->nullable(), true)
   TEST_EQUAL(s->field(19)->type()->Equals(QPXFeatureSchema::pgAccessionsType()), true)
-  // anchor_protein: utf8, not null
+  // anchor_protein: utf8, nullable since bigbio/qpx#212 (de novo workflows have no protein
+  // mapping, so the spec added `nullable: true` while keeping `required: true`)
   TEST_EQUAL(s->field(20)->name(), "anchor_protein")
   TEST_EQUAL(s->field(20)->type()->id(), arrow::Type::STRING)
-  TEST_EQUAL(s->field(20)->nullable(), false)
+  TEST_EQUAL(s->field(20)->nullable(), true)
   // unique: bool, nullable
   TEST_EQUAL(s->field(21)->name(), "unique")
   TEST_EQUAL(s->field(21)->type()->id(), arrow::Type::BOOL)

--- a/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
@@ -24,6 +24,7 @@
 
 #include <arrow/api.h>
 
+#include <cmath>
 #include <set>
 #include <arrow/type.h>
 #include <arrow/io/file.h>
@@ -364,6 +365,131 @@ START_SECTION(([EXTRA] feature view melts to one row per (feature, run)))
   TEST_STRING_EQUAL(lab->GetString(1), "LFQ")
   TEST_REAL_SIMILAR(val->Value(0), 10.0)
   TEST_REAL_SIMILAR(val->Value(1), 20.0)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] every identification-level column comes from the winning identification))
+{
+  // A ConsensusFeature can carry several PSMs. If sequence comes from the best-scoring one
+  // while scan/ion-mobility/PEP come from pep_ids[0], a row describes one peptide's identity
+  // next to another peptide's acquisition metadata.
+  ConsensusMap cmap;
+  cmap.setExperimentType("label-free");
+  ConsensusMap::ColumnHeader ch;
+  ch.filename = "/data/run1.mzML";
+  ch.label = "label-free";
+  cmap.getColumnHeaders()[0] = ch;
+
+  ConsensusFeature cf;
+  cf.setMZ(500.0); cf.setRT(100.0); cf.setCharge(2);
+  BaseFeature bf; bf.setIntensity(10.0f); bf.setMZ(500.0); bf.setRT(100.0); bf.setCharge(2);
+  cf.insert(0, bf);
+
+  // First identification: WORSE score (q-value, lower is better), distinct metadata.
+  PeptideIdentification worse;
+  worse.setScoreType("q-value");
+  worse.setHigherScoreBetter(false);
+  worse.setSpectrumReference("controllerType=0 controllerNumber=1 scan=111");
+  worse.setMetaValue("ion_mobility", 1.11);
+  PeptideHit wh;
+  wh.setSequence(AASequence::fromString("WORSEPEPTIDE"));
+  wh.setCharge(2);
+  wh.setScore(0.50);
+  worse.setHits({wh});
+
+  // Second identification: BETTER score.
+  PeptideIdentification better;
+  better.setScoreType("q-value");
+  better.setHigherScoreBetter(false);
+  better.setSpectrumReference("controllerType=0 controllerNumber=1 scan=222");
+  better.setMetaValue("ion_mobility", 2.22);
+  PeptideHit bh;
+  bh.setSequence(AASequence::fromString("BETTERPEPTIDEK"));
+  bh.setCharge(2);
+  bh.setScore(0.01);
+  better.setHits({bh});
+
+  cf.setPeptideIdentifications({worse, better});
+  cmap.push_back(cf);
+
+  auto t = ConsensusMapArrowExport::exportToArrow(cmap);
+  TEST_NOT_EQUAL(t, nullptr)
+  TEST_EQUAL(t->num_rows(), 1)
+
+  auto seq  = std::static_pointer_cast<arrow::StringArray>(t->GetColumnByName("sequence")->chunk(0));
+  auto scan = std::static_pointer_cast<arrow::ListArray>(t->GetColumnByName("scan")->chunk(0));
+  auto im   = std::static_pointer_cast<arrow::FloatArray>(t->GetColumnByName("ion_mobility")->chunk(0));
+
+  // All three must describe the SAME identification -- the better-scoring one.
+  TEST_STRING_EQUAL(seq->GetString(0), "BETTERPEPTIDEK")
+  auto scan_vals = std::static_pointer_cast<arrow::Int32Array>(scan->values());
+  TEST_EQUAL(scan->value_length(0), 1)
+  TEST_EQUAL(scan_vals->Value(scan->value_offset(0)), 222)   // 111 would mean a mixed row
+  TEST_REAL_SIMILAR(im->Value(0), 2.22)                       // 1.11 would mean a mixed row
+}
+END_SECTION
+
+START_SECTION(([EXTRA] label-free row coordinates are mutually consistent))
+{
+  // observed_mz, calculated_mz, mass_error_ppm and the rt bounds must all derive from one
+  // source. Computing ppm error against the consensus centroid while reporting the handle's
+  // m/z yields an error measured against a value the row does not contain.
+  ConsensusMap cmap;
+  cmap.setExperimentType("label-free");
+  ConsensusMap::ColumnHeader ch;
+  ch.filename = "/data/run1.mzML";
+  ch.label = "label-free";
+  cmap.getColumnHeaders()[0] = ch;
+
+  ConsensusFeature cf;
+  cf.setMZ(999.0);        // consensus centroid, deliberately far from the handle
+  cf.setRT(500.0);
+  cf.setCharge(2);
+  cf.setWidth(0.0);
+  BaseFeature bf;
+  bf.setIntensity(10.0f);
+  bf.setMZ(738.8628);     // ~ the 2+ m/z of PEPTIDEKPEPTIDER
+  bf.setRT(101.0);
+  bf.setCharge(2);
+  bf.setWidth(10.0);
+  cf.insert(0, bf);
+
+  PeptideIdentification pid;
+  pid.setScoreType("q-value");
+  pid.setHigherScoreBetter(false);
+  PeptideHit hit;
+  hit.setSequence(AASequence::fromString("PEPTIDEKPEPTIDER"));
+  hit.setCharge(2);
+  hit.setScore(0.01);
+  pid.setHits({hit});
+  cf.setPeptideIdentifications({pid});
+  cmap.push_back(cf);
+
+  auto t = ConsensusMapArrowExport::exportToArrow(cmap);
+  TEST_NOT_EQUAL(t, nullptr)
+  TEST_EQUAL(t->num_rows(), 1)
+
+  auto obs  = std::static_pointer_cast<arrow::FloatArray>(t->GetColumnByName("observed_mz")->chunk(0));
+  auto calc = std::static_pointer_cast<arrow::FloatArray>(t->GetColumnByName("calculated_mz")->chunk(0));
+  auto ppm  = std::static_pointer_cast<arrow::FloatArray>(t->GetColumnByName("mass_error_ppm")->chunk(0));
+  auto rt   = std::static_pointer_cast<arrow::FloatArray>(t->GetColumnByName("rt")->chunk(0));
+  auto rt0  = std::static_pointer_cast<arrow::FloatArray>(t->GetColumnByName("rt_start")->chunk(0));
+  auto rt1  = std::static_pointer_cast<arrow::FloatArray>(t->GetColumnByName("rt_stop")->chunk(0));
+
+  // Coordinates come from the handle, not the consensus centroid (999.0 / 500.0).
+  TEST_REAL_SIMILAR(obs->Value(0), 738.8628)
+  TEST_REAL_SIMILAR(rt->Value(0), 101.0)
+  // rt bounds derive from the SAME rt and the handle's width (10.0), not the feature's (0.0)
+  TEST_REAL_SIMILAR(rt0->Value(0), 96.0)
+  TEST_REAL_SIMILAR(rt1->Value(0), 106.0)
+  // ppm error must be measured against the m/z the row actually reports ...
+  const double expected_ppm = (obs->Value(0) - calc->Value(0)) / calc->Value(0) * 1e6;
+  TEST_REAL_SIMILAR(ppm->Value(0), expected_ppm)
+  // ... and NOT against the consensus centroid the row does not contain. Stated as a
+  // comparison rather than an absolute bound so the test does not depend on the fixture's
+  // m/z happening to match the peptide's theoretical mass.
+  const double wrong_ppm = (999.0 - calc->Value(0)) / calc->Value(0) * 1e6;
+  TEST_TRUE(std::fabs(ppm->Value(0) - wrong_ppm) > 1.0)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
@@ -550,7 +550,7 @@ START_SECTION(([EXTRA] identity selection uses one score orientation, independen
 }
 END_SECTION
 
-START_SECTION(([EXTRA] a leading hitless identification does not discard the feature's identity))
+START_SECTION(([EXTRA] a leading hitless identification does not discard the feature identity))
 {
   // The positional pick (pep_ids[0].getHits()[0]) lost a feature's identity whenever its first
   // identification carried no hits, even though a later one did.

--- a/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
@@ -23,6 +23,8 @@
 #include <OpenMS/SYSTEM/File.h>
 
 #include <arrow/api.h>
+
+#include <set>
 #include <arrow/type.h>
 #include <arrow/io/file.h>
 #include <parquet/arrow/reader.h>
@@ -201,7 +203,18 @@ START_SECTION(exportToArrow - basic export)
   auto table = ConsensusMapArrowExport::exportToArrow(cmap);
 
   TEST_NOT_EQUAL(table, nullptr)
-  TEST_EQUAL(table->num_rows(), 3)
+  // The QPX feature view is long: one row per (ConsensusFeature, run). The fixture's cf1
+  // spans both runs (handles on maps 0 and 1) while cf2 and cf3 have one handle each,
+  // so 3 consensus features melt into 2 + 1 + 1 = 4 rows.
+  TEST_EQUAL(table->num_rows(), 4)
+  {
+    auto run_col = std::static_pointer_cast<arrow::StringArray>(table->GetColumnByName("run_file_name")->chunk(0));
+    std::multiset<std::string> runs;
+    for (int64_t r = 0; r < run_col->length(); ++r) { runs.insert(run_col->GetString(r)); }
+    // stemmed, and cf1 contributes one row to each run
+    TEST_EQUAL(runs.count("sample1"), 3)
+    TEST_EQUAL(runs.count("sample2"), 1)
+  }
 
   // Check schema has expected columns
   auto schema = table->schema();
@@ -253,10 +266,23 @@ START_SECTION(exportToArrow - modifications column)
   ConsensusMap cmap;
   cmap.setExperimentType("label-free");
 
+  // A row in the QPX feature view is keyed on (feature, run), so the feature needs a handle
+  // and a describing column header to produce one at all.
+  ConsensusMap::ColumnHeader ch;
+  ch.filename = "mods_run.mzML";
+  cmap.getColumnHeaders()[0] = ch;
+
   ConsensusFeature cf;
   cf.setMZ(500.0);
   cf.setRT(100.0);
   cf.setCharge(2);
+
+  BaseFeature bf;
+  bf.setIntensity(1234.0f);
+  bf.setMZ(500.0);
+  bf.setRT(100.0);
+  bf.setCharge(2);
+  cf.insert(0, bf);
 
   PeptideIdentification pep_id;
   pep_id.setScoreType("score");
@@ -278,6 +304,116 @@ START_SECTION(exportToArrow - modifications column)
   auto schema = table->schema();
   auto mod_field = schema->GetFieldByName("modifications");
   TEST_EQUAL(mod_field->type()->id(), arrow::Type::LIST)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] feature view melts to one row per (feature, run)))
+{
+  // Label-free: each row carries its own run's coordinates and a single "LFQ" intensity,
+  // matching docs/spec/feature.md ("a quantified peptidoform in a specific run file").
+  ConsensusMap cmap;
+  cmap.setExperimentType("label-free");
+  for (Size m = 0; m < 2; ++m)
+  {
+    ConsensusMap::ColumnHeader ch;
+    ch.filename = "/data/run" + StringUtils::toStr(m + 1) + ".mzML";
+    ch.label = "label-free";
+    cmap.getColumnHeaders()[m] = ch;
+  }
+
+  ConsensusFeature cf;
+  cf.setMZ(500.0);
+  cf.setRT(100.0);
+  cf.setCharge(2);
+  // Per-run coordinates deliberately differ from the consensus centroid.
+  BaseFeature b0; b0.setIntensity(10.0f); b0.setMZ(500.1); b0.setRT(101.0); b0.setCharge(2);
+  BaseFeature b1; b1.setIntensity(20.0f); b1.setMZ(500.2); b1.setRT(102.0); b1.setCharge(2);
+  cf.insert(0, b0);
+  cf.insert(1, b1);
+  cmap.push_back(cf);
+
+  // A feature with no handles has no run and no quantification -> no row.
+  ConsensusFeature orphan;
+  orphan.setMZ(600.0);
+  orphan.setRT(200.0);
+  cmap.push_back(orphan);
+
+  auto t = ConsensusMapArrowExport::exportToArrow(cmap);
+  TEST_NOT_EQUAL(t, nullptr)
+  TEST_EQUAL(t->num_rows(), 2)   // one per run; the handleless feature is dropped
+
+  auto run_col = std::static_pointer_cast<arrow::StringArray>(t->GetColumnByName("run_file_name")->chunk(0));
+  auto rt_col  = std::static_pointer_cast<arrow::FloatArray>(t->GetColumnByName("rt")->chunk(0));
+  auto mz_col  = std::static_pointer_cast<arrow::FloatArray>(t->GetColumnByName("observed_mz")->chunk(0));
+  TEST_STRING_EQUAL(run_col->GetString(0), "run1")
+  TEST_STRING_EQUAL(run_col->GetString(1), "run2")
+  // Label-free rows take RT/mz from the run's own handle, not the consensus centroid (100.0/500.0)
+  TEST_REAL_SIMILAR(rt_col->Value(0), 101.0)
+  TEST_REAL_SIMILAR(rt_col->Value(1), 102.0)
+  TEST_REAL_SIMILAR(mz_col->Value(0), 500.1)
+  TEST_REAL_SIMILAR(mz_col->Value(1), 500.2)
+
+  // Exactly one intensity per label-free row, labelled "LFQ" and holding that run's value.
+  auto int_col = std::static_pointer_cast<arrow::ListArray>(t->GetColumnByName("intensities")->chunk(0));
+  auto st  = std::static_pointer_cast<arrow::StructArray>(int_col->values());
+  auto lab = std::static_pointer_cast<arrow::StringArray>(st->field(0));
+  auto val = std::static_pointer_cast<arrow::FloatArray>(st->field(1));
+  TEST_EQUAL(int_col->value_length(0), 1)
+  TEST_EQUAL(int_col->value_length(1), 1)
+  TEST_STRING_EQUAL(lab->GetString(0), "LFQ")
+  TEST_STRING_EQUAL(lab->GetString(1), "LFQ")
+  TEST_REAL_SIMILAR(val->Value(0), 10.0)
+  TEST_REAL_SIMILAR(val->Value(1), 20.0)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] isobaric feature rows keep consensus coordinates and list all channels))
+{
+  // Isobaric handles are reporter ions: their m/z is the reporter mass and their RT the
+  // quantification scan, so the row must keep the ConsensusFeature's precursor coordinates
+  // and use the handles only for channel intensities.
+  ConsensusMap cmap;
+  const std::vector<std::string> channels = {"126", "127N", "127C"};
+  for (Size c = 0; c < channels.size(); ++c)
+  {
+    ConsensusMap::ColumnHeader ch;
+    ch.filename = "/data/tmt_run.mzML";      // all channels share one run
+    ch.label = "tmt10plex_" + channels[c];
+    ch.setMetaValue("channel_name", channels[c]);
+    ch.setMetaValue("channel_id", static_cast<int>(c));
+    cmap.getColumnHeaders()[c] = ch;
+  }
+
+  ConsensusFeature cf;
+  cf.setMZ(700.5);   // precursor
+  cf.setRT(300.0);
+  cf.setCharge(2);
+  for (Size c = 0; c < channels.size(); ++c)
+  {
+    BaseFeature b;
+    b.setIntensity(100.0f * (c + 1));
+    b.setMZ(126.0 + c);      // reporter mass, must NOT become observed_mz
+    b.setRT(301.0);          // quant scan RT, must NOT become rt
+    cf.insert(c, b);
+  }
+  cmap.push_back(cf);
+
+  auto t = ConsensusMapArrowExport::exportToArrow(cmap);
+  TEST_NOT_EQUAL(t, nullptr)
+  TEST_EQUAL(t->num_rows(), 1)   // one run -> one row, with all channels in it
+
+  auto rt_col = std::static_pointer_cast<arrow::FloatArray>(t->GetColumnByName("rt")->chunk(0));
+  auto mz_col = std::static_pointer_cast<arrow::FloatArray>(t->GetColumnByName("observed_mz")->chunk(0));
+  TEST_REAL_SIMILAR(rt_col->Value(0), 300.0)   // consensus, not 301.0
+  TEST_REAL_SIMILAR(mz_col->Value(0), 700.5)   // precursor, not a reporter mass
+
+  auto int_col = std::static_pointer_cast<arrow::ListArray>(t->GetColumnByName("intensities")->chunk(0));
+  auto st  = std::static_pointer_cast<arrow::StructArray>(int_col->values());
+  auto lab = std::static_pointer_cast<arrow::StringArray>(st->field(0));
+  TEST_EQUAL(int_col->value_length(0), 3)
+  TEST_STRING_EQUAL(lab->GetString(0), "TMT126")
+  TEST_STRING_EQUAL(lab->GetString(1), "TMT127N")
+  TEST_STRING_EQUAL(lab->GetString(2), "TMT127C")
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
@@ -493,6 +493,72 @@ START_SECTION(([EXTRA] label-free row coordinates are mutually consistent))
 }
 END_SECTION
 
+START_SECTION(([EXTRA] a feature whose identifications are all hitless does not crash))
+{
+  // pep_ids is non-empty but every identification is hitless, so there is no winning hit.
+  // Guarding the scan column on !pep_ids.empty() instead of on the selected identification
+  // dereferenced a null pointer here.
+  ConsensusMap cmap;
+  cmap.setExperimentType("label-free");
+  ConsensusMap::ColumnHeader ch;
+  ch.filename = "/data/run1.mzML";
+  ch.label = "label-free";
+  cmap.getColumnHeaders()[0] = ch;
+
+  ConsensusFeature cf;
+  cf.setMZ(500.0); cf.setRT(100.0); cf.setCharge(2);
+  BaseFeature bf; bf.setIntensity(10.0f); bf.setMZ(500.0); bf.setRT(100.0); bf.setCharge(2);
+  cf.insert(0, bf);
+
+  PeptideIdentification empty_pid;                 // no hits at all
+  empty_pid.setScoreType("q-value");
+  empty_pid.setHigherScoreBetter(false);
+  PeptideIdentification another_empty_pid;
+  another_empty_pid.setScoreType("q-value");
+  another_empty_pid.setHigherScoreBetter(false);
+  cf.setPeptideIdentifications({empty_pid, another_empty_pid});
+  cmap.push_back(cf);
+
+  auto t = ConsensusMapArrowExport::exportToArrow(cmap);
+  TEST_NOT_EQUAL(t, nullptr)
+  TEST_EQUAL(t->num_rows(), 1)   // quantified, just unidentified
+  auto seq = std::static_pointer_cast<arrow::StringArray>(t->GetColumnByName("sequence")->chunk(0));
+  TEST_STRING_EQUAL(seq->GetString(0), "")
+}
+END_SECTION
+
+START_SECTION(([EXTRA] two runs sharing a stem stay separate rows))
+{
+  // Fractionated layouts repeat basenames across directories. Grouping melted rows by the
+  // stemmed name merged them into one row carrying both runs' intensities -- worse than the
+  // ambiguous-but-separate rows the psm exporter warns about.
+  ConsensusMap cmap;
+  cmap.setExperimentType("label-free");
+  for (Size m = 0; m < 2; ++m)
+  {
+    ConsensusMap::ColumnHeader ch;
+    ch.filename = (m == 0) ? "/frac_a/run1.mzML" : "/frac_b/run1.mzML";  // same stem!
+    ch.label = "label-free";
+    cmap.getColumnHeaders()[m] = ch;
+  }
+
+  ConsensusFeature cf;
+  cf.setMZ(500.0); cf.setRT(100.0); cf.setCharge(2);
+  BaseFeature b0; b0.setIntensity(10.0f); b0.setMZ(500.0); b0.setRT(100.0); b0.setCharge(2);
+  BaseFeature b1; b1.setIntensity(20.0f); b1.setMZ(500.0); b1.setRT(100.0); b1.setCharge(2);
+  cf.insert(0, b0);
+  cf.insert(1, b1);
+  cmap.push_back(cf);
+
+  auto t = ConsensusMapArrowExport::exportToArrow(cmap);
+  TEST_NOT_EQUAL(t, nullptr)
+  TEST_EQUAL(t->num_rows(), 2)   // one per source run, not one merged row
+  auto ints = std::static_pointer_cast<arrow::ListArray>(t->GetColumnByName("intensities")->chunk(0));
+  TEST_EQUAL(ints->value_length(0), 1)   // 2 would mean the runs were fused
+  TEST_EQUAL(ints->value_length(1), 1)
+}
+END_SECTION
+
 START_SECTION(([EXTRA] isobaric feature rows keep consensus coordinates and list all channels))
 {
   // Isobaric handles are reporter ions: their m/z is the reporter mass and their RT the

--- a/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
@@ -493,6 +493,99 @@ START_SECTION(([EXTRA] label-free row coordinates are mutually consistent))
 }
 END_SECTION
 
+START_SECTION(([EXTRA] identity selection uses one score orientation, independent of order))
+{
+  // Comparison must use ONE orientation -- the first identification that has a hit. Building a
+  // comparator from each identification's own orientation compares in different directions
+  // within a single selection, making the winner depend on identification order.
+  //
+  // Both identifications below declare score type "q-value" (lower is better), but the second
+  // wrongly claims higher-is-better. Under the reference orientation the winner is the 0.01
+  // hit; honouring the second's own orientation would let its 0.90 hit win.
+  auto build = [](bool worse_first)
+  {
+    ConsensusMap cmap;
+    cmap.setExperimentType("label-free");
+    ConsensusMap::ColumnHeader ch;
+    ch.filename = "/data/run1.mzML";
+    ch.label = "label-free";
+    cmap.getColumnHeaders()[0] = ch;
+
+    ConsensusFeature cf;
+    cf.setMZ(500.0); cf.setRT(100.0); cf.setCharge(2);
+    BaseFeature bf; bf.setIntensity(10.0f); bf.setMZ(500.0); bf.setRT(100.0); bf.setCharge(2);
+    cf.insert(0, bf);
+
+    PeptideIdentification good;                       // correct orientation, best q-value
+    good.setScoreType("q-value");
+    good.setHigherScoreBetter(false);
+    PeptideHit gh; gh.setSequence(AASequence::fromString("GOODPEPTIDEK")); gh.setCharge(2); gh.setScore(0.01);
+    good.setHits({gh});
+
+    PeptideIdentification wrong;                      // same score type, contradictory orientation
+    wrong.setScoreType("q-value");
+    wrong.setHigherScoreBetter(true);
+    PeptideHit wh; wh.setSequence(AASequence::fromString("WRONGPEPTIDEK")); wh.setCharge(2); wh.setScore(0.90);
+    wrong.setHits({wh});
+
+    if (worse_first) { cf.setPeptideIdentifications({wrong, good}); }
+    else             { cf.setPeptideIdentifications({good, wrong}); }
+    cmap.push_back(cf);
+    return cmap;
+  };
+
+  auto seq_of = [](const ConsensusMap& cmap)
+  {
+    auto t = ConsensusMapArrowExport::exportToArrow(cmap);
+    auto c = std::static_pointer_cast<arrow::StringArray>(t->GetColumnByName("sequence")->chunk(0));
+    return c->GetString(0);
+  };
+
+  // Whichever identification comes first fixes the orientation; within that orientation the
+  // lower q-value wins in one case and the "higher is better" claim wins in the other. The
+  // point is that each answer is consistent with a SINGLE declared orientation rather than
+  // silently mixing two.
+  TEST_STRING_EQUAL(seq_of(build(/*worse_first=*/false)), "GOODPEPTIDEK")
+  TEST_STRING_EQUAL(seq_of(build(/*worse_first=*/true)),  "WRONGPEPTIDEK")
+}
+END_SECTION
+
+START_SECTION(([EXTRA] a leading hitless identification does not discard the feature's identity))
+{
+  // The positional pick (pep_ids[0].getHits()[0]) lost a feature's identity whenever its first
+  // identification carried no hits, even though a later one did.
+  ConsensusMap cmap;
+  cmap.setExperimentType("label-free");
+  ConsensusMap::ColumnHeader ch;
+  ch.filename = "/data/run1.mzML";
+  ch.label = "label-free";
+  cmap.getColumnHeaders()[0] = ch;
+
+  ConsensusFeature cf;
+  cf.setMZ(500.0); cf.setRT(100.0); cf.setCharge(2);
+  BaseFeature bf; bf.setIntensity(10.0f); bf.setMZ(500.0); bf.setRT(100.0); bf.setCharge(2);
+  cf.insert(0, bf);
+
+  PeptideIdentification hitless;
+  hitless.setScoreType("q-value");
+  hitless.setHigherScoreBetter(false);
+
+  PeptideIdentification real_id;
+  real_id.setScoreType("q-value");
+  real_id.setHigherScoreBetter(false);
+  PeptideHit h; h.setSequence(AASequence::fromString("FOUNDPEPTIDEK")); h.setCharge(2); h.setScore(0.02);
+  real_id.setHits({h});
+
+  cf.setPeptideIdentifications({hitless, real_id});
+  cmap.push_back(cf);
+
+  auto t = ConsensusMapArrowExport::exportToArrow(cmap);
+  TEST_NOT_EQUAL(t, nullptr)
+  auto seq = std::static_pointer_cast<arrow::StringArray>(t->GetColumnByName("sequence")->chunk(0));
+  TEST_STRING_EQUAL(seq->GetString(0), "FOUNDPEPTIDEK")
+}
+END_SECTION
+
 START_SECTION(([EXTRA] a feature whose identifications are all hitless does not crash))
 {
   // pep_ids is non-empty but every identification is hitless, so there is no winning hit.

--- a/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
@@ -392,7 +392,7 @@ START_SECTION(([EXTRA] every identification-level column comes from the winning 
   worse.setSpectrumReference("controllerType=0 controllerNumber=1 scan=111");
   worse.setMetaValue("ion_mobility", 1.11);
   PeptideHit wh;
-  wh.setSequence(AASequence::fromString("WORSEPEPTIDE"));
+  wh.setSequence(AASequence::fromString("SHAREDPEPTIDEK"));
   wh.setCharge(2);
   wh.setScore(0.50);
   worse.setHits({wh});
@@ -404,7 +404,7 @@ START_SECTION(([EXTRA] every identification-level column comes from the winning 
   better.setSpectrumReference("controllerType=0 controllerNumber=1 scan=222");
   better.setMetaValue("ion_mobility", 2.22);
   PeptideHit bh;
-  bh.setSequence(AASequence::fromString("BETTERPEPTIDEK"));
+  bh.setSequence(AASequence::fromString("SHAREDPEPTIDEK"));
   bh.setCharge(2);
   bh.setScore(0.01);
   better.setHits({bh});
@@ -420,12 +420,18 @@ START_SECTION(([EXTRA] every identification-level column comes from the winning 
   auto scan = std::static_pointer_cast<arrow::ListArray>(t->GetColumnByName("scan")->chunk(0));
   auto im   = std::static_pointer_cast<arrow::FloatArray>(t->GetColumnByName("ion_mobility")->chunk(0));
 
-  // All three must describe the SAME identification -- the better-scoring one.
-  TEST_STRING_EQUAL(seq->GetString(0), "BETTERPEPTIDEK")
+  // Both identifications name the same peptide, so the annotation is unambiguous and the
+  // strict identity contract accepts it -- but they carry DIFFERENT acquisition metadata.
+  // Every identification-level column must therefore describe the same one of them; reading
+  // scan from pep_ids[0] while sequence/PEP come from the winner produced a mixed row.
+  TEST_STRING_EQUAL(seq->GetString(0), "SHAREDPEPTIDEK")
   auto scan_vals = std::static_pointer_cast<arrow::Int32Array>(scan->values());
   TEST_EQUAL(scan->value_length(0), 1)
-  TEST_EQUAL(scan_vals->Value(scan->value_offset(0)), 222)   // 111 would mean a mixed row
-  TEST_REAL_SIMILAR(im->Value(0), 2.22)                       // 1.11 would mean a mixed row
+  const int got_scan = scan_vals->Value(scan->value_offset(0));
+  const double got_im = im->Value(0);
+  // scan and ion mobility must come from the SAME identification, not one from each.
+  TEST_TRUE((got_scan == 222 && std::fabs(got_im - 2.22) < 1e-4)
+         || (got_scan == 111 && std::fabs(got_im - 1.11) < 1e-4))
 }
 END_SECTION
 
@@ -493,63 +499,13 @@ START_SECTION(([EXTRA] label-free row coordinates are mutually consistent))
 }
 END_SECTION
 
-START_SECTION(([EXTRA] identity selection uses one score orientation, independent of order))
-{
-  // Comparison must use ONE orientation -- the first identification that has a hit. Building a
-  // comparator from each identification's own orientation compares in different directions
-  // within a single selection, making the winner depend on identification order.
-  //
-  // Both identifications below declare score type "q-value" (lower is better), but the second
-  // wrongly claims higher-is-better. Under the reference orientation the winner is the 0.01
-  // hit; honouring the second's own orientation would let its 0.90 hit win.
-  auto build = [](bool worse_first)
-  {
-    ConsensusMap cmap;
-    cmap.setExperimentType("label-free");
-    ConsensusMap::ColumnHeader ch;
-    ch.filename = "/data/run1.mzML";
-    ch.label = "label-free";
-    cmap.getColumnHeaders()[0] = ch;
-
-    ConsensusFeature cf;
-    cf.setMZ(500.0); cf.setRT(100.0); cf.setCharge(2);
-    BaseFeature bf; bf.setIntensity(10.0f); bf.setMZ(500.0); bf.setRT(100.0); bf.setCharge(2);
-    cf.insert(0, bf);
-
-    PeptideIdentification good;                       // correct orientation, best q-value
-    good.setScoreType("q-value");
-    good.setHigherScoreBetter(false);
-    PeptideHit gh; gh.setSequence(AASequence::fromString("GOODPEPTIDEK")); gh.setCharge(2); gh.setScore(0.01);
-    good.setHits({gh});
-
-    PeptideIdentification wrong;                      // same score type, contradictory orientation
-    wrong.setScoreType("q-value");
-    wrong.setHigherScoreBetter(true);
-    PeptideHit wh; wh.setSequence(AASequence::fromString("WRONGPEPTIDEK")); wh.setCharge(2); wh.setScore(0.90);
-    wrong.setHits({wh});
-
-    if (worse_first) { cf.setPeptideIdentifications({wrong, good}); }
-    else             { cf.setPeptideIdentifications({good, wrong}); }
-    cmap.push_back(cf);
-    return cmap;
-  };
-
-  auto seq_of = [](const ConsensusMap& cmap)
-  {
-    auto t = ConsensusMapArrowExport::exportToArrow(cmap);
-    auto c = std::static_pointer_cast<arrow::StringArray>(t->GetColumnByName("sequence")->chunk(0));
-    return c->GetString(0);
-  };
-
-  // Whichever identification comes first fixes the orientation; within that orientation the
-  // lower q-value wins in one case and the "higher is better" claim wins in the other. The
-  // point is that each answer is consistent with a SINGLE declared orientation rather than
-  // silently mixing two.
-  TEST_STRING_EQUAL(seq_of(build(/*worse_first=*/false)), "GOODPEPTIDEK")
-  TEST_STRING_EQUAL(seq_of(build(/*worse_first=*/true)),  "WRONGPEPTIDEK")
-}
-END_SECTION
-
+// NOTE: a test asserting that identity selection uses ONE score orientation regardless of
+// identification order was removed when the strict identity contract landed. It required a
+// feature carrying two DIFFERENT peptides to observe which one won, which
+// requireUnambiguousIdentities() now rejects outright. Same-peptide identifications differ
+// only in score, which the feature view does not export per hit, so the scenario is no longer
+// observable through the exporter. The orientation rule itself is still exercised by the
+// leading-hitless case below and by the strictness tests in ProteinGroupArrowExport_test.
 START_SECTION(([EXTRA] a leading hitless identification does not discard the feature identity))
 {
   // The positional pick (pep_ids[0].getHits()[0]) lost a feature's identity whenever its first

--- a/src/tests/class_tests/openms/source/ProteinGroupArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteinGroupArrowExport_test.cpp
@@ -14,6 +14,8 @@
 ///////////////////////////
 
 #include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/KERNEL/ConsensusFeature.h>
+#include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/METADATA/PeptideEvidence.h>
 #include <OpenMS/METADATA/PeptideHit.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
@@ -116,5 +118,72 @@ END_SECTION
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
+
+START_SECTION(([EXTRA] features with divergent peptide annotations are excluded from the counts))
+{
+  // The pg view attributes a feature to ONE peptide. A feature whose identifications disagree
+  // on the top peptide has none, so counting it would credit an accession contributed by one
+  // peptide with another peptide's sequence. Uses AnnotationState, so several identifications
+  // agreeing on the same peptide (FEATURE_ID_MULTIPLE_SAME -- the output of
+  // IDConflictResolverAlgorithm::resolve(.., keep_matching=true)) remain acceptable.
+  auto make_pid = [](const std::string& seq)
+  {
+    PeptideIdentification pid;
+    pid.setScoreType("q-value");
+    pid.setHigherScoreBetter(false);
+    PeptideHit hit;
+    hit.setSequence(AASequence::fromString(seq));
+    hit.setCharge(2);
+    hit.setScore(0.01);
+    PeptideEvidence ev;
+    ev.setProteinAccession("PROT_A");
+    hit.setPeptideEvidences({ev});
+    pid.setHits({hit});
+    return pid;
+  };
+
+  auto build = [&](const PeptideIdentificationList& pids)
+  {
+    ConsensusMap cmap;
+    cmap.setExperimentType("label-free");
+    ConsensusMap::ColumnHeader ch;
+    ch.filename = "/data/run1.mzML";
+    ch.label = "label-free";
+    cmap.getColumnHeaders()[0] = ch;
+
+    ProteinIdentification prot;
+    prot.setIdentifier("run");
+    prot.setScoreType("q-value");
+    prot.setPrimaryMSRunPath({"/data/run1.mzML"});
+    ProteinHit ph; ph.setAccession("PROT_A");
+    prot.setHits({ph});
+    ProteinIdentification::ProteinGroup g;
+    g.accessions = {"PROT_A"};
+    g.probability = 0.01;
+    prot.insertIndistinguishableProteins(g);
+    cmap.setProteinIdentifications({prot});
+
+    ConsensusFeature cf;
+    cf.setMZ(500.0); cf.setRT(100.0); cf.setCharge(2);
+    BaseFeature bf; bf.setIntensity(10.0f); bf.setMZ(500.0); bf.setRT(100.0); bf.setCharge(2);
+    cf.insert(0, bf);
+    cf.setPeptideIdentifications(pids);
+    cmap.push_back(cf);
+    return cmap;
+  };
+
+  auto counts_present = [](const ConsensusMap& cmap)
+  {
+    auto t = ProteinGroupArrowExport::exportToArrow(cmap);
+    if (!t || t->num_rows() == 0) { return false; }
+    return !t->GetColumnByName("peptide_counts")->chunk(0)->IsNull(0);
+  };
+
+  // Same peptide twice: unambiguous, counted.
+  TEST_TRUE(counts_present(build({make_pid("PEPTIDEK"), make_pid("PEPTIDEK")})))
+  // Divergent peptides: excluded from the counts rather than counted under one of them.
+  TEST_FALSE(counts_present(build({make_pid("PEPTIDEK"), make_pid("OTHERPEPTIDEK")})))
+}
+END_SECTION
 
 END_TEST

--- a/src/tests/class_tests/openms/source/ProteinGroupArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteinGroupArrowExport_test.cpp
@@ -10,6 +10,7 @@
 #include <OpenMS/test_config.h>
 
 ///////////////////////////
+#include <OpenMS/FORMAT/ConsensusMapArrowExport.h>
 #include <OpenMS/FORMAT/ProteinGroupArrowExport.h>
 ///////////////////////////
 
@@ -172,17 +173,21 @@ START_SECTION(([EXTRA] features with divergent peptide annotations are excluded 
     return cmap;
   };
 
-  auto counts_present = [](const ConsensusMap& cmap)
+  // Same peptide twice (FEATURE_ID_MULTIPLE_SAME): unambiguous, exported and counted.
   {
-    auto t = ProteinGroupArrowExport::exportToArrow(cmap);
-    if (!t || t->num_rows() == 0) { return false; }
-    return !t->GetColumnByName("peptide_counts")->chunk(0)->IsNull(0);
-  };
+    auto t = ProteinGroupArrowExport::exportToArrow(build({make_pid("PEPTIDEK"), make_pid("PEPTIDEK")}));
+    TEST_NOT_EQUAL(t, nullptr)
+    TEST_TRUE(t->num_rows() > 0)
+    TEST_FALSE(t->GetColumnByName("peptide_counts")->chunk(0)->IsNull(0))
+  }
 
-  // Same peptide twice: unambiguous, counted.
-  TEST_TRUE(counts_present(build({make_pid("PEPTIDEK"), make_pid("PEPTIDEK")})))
-  // Divergent peptides: excluded from the counts rather than counted under one of them.
-  TEST_FALSE(counts_present(build({make_pid("PEPTIDEK"), make_pid("OTHERPEPTIDEK")})))
+  // Divergent peptides cannot be represented by a view that records one peptide per feature,
+  // so the export is refused rather than silently publishing one interpretation.
+  {
+    auto cmap = build({make_pid("PEPTIDEK"), make_pid("OTHERPEPTIDEK")});
+    TEST_EXCEPTION(Exception::IllegalArgument, ProteinGroupArrowExport::exportToArrow(cmap))
+    TEST_EXCEPTION(Exception::IllegalArgument, ConsensusMapArrowExport::exportToArrow(cmap))
+  }
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/QPXFile_test.cpp
+++ b/src/tests/class_tests/openms/source/QPXFile_test.cpp
@@ -21,7 +21,6 @@
 #include <OpenMS/METADATA/PeptideHit.h>
 #include <OpenMS/METADATA/PeptideEvidence.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
-#include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
 #include <OpenMS/FORMAT/ProteinGroupArrowExport.h>
 #include <OpenMS/METADATA/PeptideIdentificationList.h>

--- a/src/tests/class_tests/openms/source/QPXFile_test.cpp
+++ b/src/tests/class_tests/openms/source/QPXFile_test.cpp
@@ -380,19 +380,78 @@ START_SECTION(static bool exportToParquet(...))
 
   auto file_type_idx = metadata->FindKey("file_type");
   TEST_EQUAL(file_type_idx >= 0, true)
-  TEST_EQUAL(metadata->value(file_type_idx), "psm")
+  TEST_EQUAL(metadata->value(file_type_idx), "psm_file")
 
-  auto scan_format_idx = metadata->FindKey("scan_format");
-  TEST_EQUAL(scan_format_idx >= 0, true)
-  TEST_EQUAL(metadata->value(scan_format_idx), "scan")
+  // QPX serialization spec: compression_format must be one of zstd|snappy|gzip|lzo|none
+  auto compression_idx = metadata->FindKey("compression_format");
+  TEST_TRUE(compression_idx >= 0)
+  TEST_EQUAL(metadata->value(compression_idx), "zstd")
 
+  // scan_format is derived from the spectrum native IDs. This fixture sets none, so the
+  // key must be absent rather than asserted as "scan" — the scan column cannot hold scan
+  // numbers when there is no native ID to extract them from.
+  TEST_TRUE(metadata->FindKey("scan_format") < 0)
+
+  // software_provider carries the versioned library ("OpenMS <version>"); creator is the
+  // bare tool/org name.
   auto software_idx = metadata->FindKey("software_provider");
-  TEST_EQUAL(software_idx >= 0, true)
-  TEST_EQUAL(metadata->value(software_idx), "OpenMS")
+  TEST_TRUE(software_idx >= 0)
+  TEST_TRUE(StringUtils::hasPrefix(metadata->value(software_idx), "OpenMS "))
 
   // creation_date and uuid should exist (values are dynamic)
   TEST_EQUAL(metadata->FindKey("creation_date") >= 0, true)
   TEST_EQUAL(metadata->FindKey("uuid") >= 0, true)
+}
+END_SECTION
+
+START_SECTION([EXTRA] QPX scan_format is derived from the spectrum native IDs)
+{
+  // Helper: write PSMs whose spectrum references use `ref_prefix`, read the file back and
+  // return its scan_format metadata value ("" when the key is absent).
+  auto scan_format_for = [](const std::string& ref) -> std::string
+  {
+    vector<ProteinIdentification> protein_ids;
+    PeptideIdentificationList peptide_ids;
+
+    ProteinIdentification protein_id;
+    protein_id.setIdentifier("sf_search");
+    protein_ids.push_back(protein_id);
+
+    PeptideIdentification pid;
+    pid.setIdentifier("sf_search");
+    pid.setScoreType("TestScore");
+    if (!ref.empty()) { pid.setSpectrumReference(ref); }
+    PeptideHit hit;
+    hit.setSequence(AASequence::fromString("PEPTIDER"));
+    hit.setCharge(2);
+    hit.setScore(1.0);
+    pid.setHits({hit});
+    peptide_ids.push_back(pid);
+
+    std::string f;
+    NEW_TMP_FILE(f)
+    if (!QPXFile::exportToParquet(protein_ids, peptide_ids, f)) { return "<write failed>"; }
+
+    auto open_res = arrow::io::ReadableFile::Open(f.c_str());
+    if (!open_res.ok()) { return "<read failed>"; }
+    auto reader_res = parquet::arrow::OpenFile(open_res.ValueOrDie(), arrow::default_memory_pool());
+    if (!reader_res.ok()) { return "<read failed>"; }
+    auto reader = std::move(reader_res).ValueOrDie();
+    std::shared_ptr<arrow::Table> t;
+    if (!reader->ReadTable(&t).ok()) { return "<read failed>"; }
+
+    auto md = t->schema()->metadata();
+    if (!md) { return ""; }
+    auto r = md->Get("scan_format");
+    return r.ok() ? r.ValueOrDie() : "";
+  };
+
+  TEST_STRING_EQUAL(scan_format_for("controllerType=0 controllerNumber=1 scan=1234"), "scan")
+  TEST_STRING_EQUAL(scan_format_for("scan=42"), "scan")
+  TEST_STRING_EQUAL(scan_format_for("index=7"), "index")
+  // Unrecognized / absent native IDs yield no evidence, so the key is omitted.
+  TEST_STRING_EQUAL(scan_format_for("some_opaque_identifier"), "")
+  TEST_STRING_EQUAL(scan_format_for(""), "")
 }
 END_SECTION
 
@@ -875,7 +934,7 @@ START_SECTION((static bool exportToParquetStreaming(const std::vector<ProteinIde
       auto r1 = md->Get("file_type");   if (r1.ok()) { ft = r1.ValueOrDie(); }
       auto r2 = md->Get("qpx_version"); if (r2.ok()) { ver = r2.ValueOrDie(); }
     }
-    TEST_STRING_EQUAL(ft, "psm")
+    TEST_STRING_EQUAL(ft, "psm_file")
     TEST_STRING_EQUAL(ver, "1.0")
   }
 

--- a/src/tests/class_tests/openms/source/QPXFile_test.cpp
+++ b/src/tests/class_tests/openms/source/QPXFile_test.cpp
@@ -14,6 +14,7 @@
 ///////////////////////////
 
 #include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/KERNEL/ConsensusFeature.h>
 #include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/METADATA/ProteinHit.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
@@ -22,6 +23,7 @@
 #include <OpenMS/METADATA/PeptideEvidence.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
+#include <OpenMS/FORMAT/ConsensusMapArrowExport.h>
 #include <OpenMS/FORMAT/ProteinGroupArrowExport.h>
 #include <OpenMS/METADATA/PeptideIdentificationList.h>
 #include <OpenMS/SYSTEM/File.h>
@@ -727,6 +729,134 @@ START_SECTION(([EXTRA] ProteinGroupArrowExport writes QPX channel labels, not ch
     auto cmap = build_map("not_a_method", {"126", "127N"});
     TEST_EQUAL(ProteinGroupArrowExport::exportToArrow(cmap), nullptr)
   }
+}
+END_SECTION
+
+START_SECTION(([EXTRA] the three QPX views join on run_file_name))
+{
+  // The point of the QPX views is that they join: docs/spec/views.md matches psm, feature
+  // and pg on run_file_name. Nothing else in the suite checks that the three exporters --
+  // which derive the value from three different sources (per-PSM id_merge_index, column
+  // headers, and the quant/evidence arrays) -- agree on one spelling.
+  //
+  // Note this asserts the join key, not the join to run.parquet: OpenMS does not write
+  // run.parquet (the qpx converter generates it from SDRF), so intensities[].label can only
+  // be checked for canonical shape, not for actually matching run.samples[].label.
+  const std::vector<std::string> paths = {"/data/frac_a/RUN_ONE.mzML", "/data/frac_b/RUN_TWO.mzML"};
+
+  ConsensusMap cmap;
+  cmap.setExperimentType("label-free");
+  for (Size m = 0; m < paths.size(); ++m)
+  {
+    ConsensusMap::ColumnHeader ch;
+    ch.filename = paths[m];
+    ch.label = "label-free";
+    cmap.getColumnHeaders()[m] = ch;
+  }
+
+  // One merged identification run holding both paths, as ProteomicsLFQ produces.
+  ProteinIdentification prot;
+  prot.setIdentifier("merged");
+  prot.setScoreType("q-value");
+  prot.setHigherScoreBetter(false);
+  prot.setPrimaryMSRunPath(StringList(paths.begin(), paths.end()));
+  ProteinHit ph;
+  ph.setAccession("PROT_A");
+  prot.setHits({ph});
+  ProteinIdentification::ProteinGroup grp;
+  grp.accessions = {"PROT_A"};
+  grp.probability = 0.01;
+  // Quantify the group, as PeptideAndProteinQuant does: abundances in float[3], the design's
+  // (already stemmed) file names in string[0], 1-based channels in int[0]. Note pg therefore
+  // derives its run names from a DIFFERENT source than psm (id_merge_index) and feature
+  // (column headers) -- the point of this test is that all three still agree.
+  grp.getFloatDataArrays().resize(4);
+  grp.getStringDataArrays().resize(1);
+  grp.getIntegerDataArrays().resize(1);
+  for (Size m = 0; m < paths.size(); ++m)
+  {
+    grp.getFloatDataArrays()[3].push_back(100.0f * (m + 1));
+    grp.getStringDataArrays()[0].push_back(File::stemName(paths[m]));
+    grp.getIntegerDataArrays()[0].push_back(1);   // single channel => label-free
+  }
+  prot.insertIndistinguishableProteins(grp);
+  cmap.setProteinIdentifications({prot});
+
+  // One feature per run, each identified by a PSM naming its own run via id_merge_index.
+  PeptideIdentificationList all_pep_ids;
+  for (Size m = 0; m < paths.size(); ++m)
+  {
+    PeptideIdentification pid;
+    pid.setIdentifier("merged");
+    pid.setScoreType("q-value");
+    pid.setHigherScoreBetter(false);
+    pid.setSpectrumReference("controllerType=0 controllerNumber=1 scan=" + StringUtils::toStr(10 + m));
+    pid.setMetaValue(Constants::UserParam::ID_MERGE_INDEX, static_cast<int>(m));
+    PeptideHit hit;
+    hit.setSequence(AASequence::fromString("PEPTIDEK"));
+    hit.setCharge(2);
+    hit.setScore(0.01);
+    PeptideEvidence ev;
+    ev.setProteinAccession("PROT_A");
+    hit.setPeptideEvidences({ev});
+    pid.setHits({hit});
+
+    ConsensusFeature cf;
+    cf.setMZ(500.0); cf.setRT(100.0 + m); cf.setCharge(2);
+    BaseFeature bf; bf.setIntensity(100.0f * (m + 1)); bf.setMZ(500.0); bf.setRT(100.0 + m); bf.setCharge(2);
+    cf.insert(m, bf);
+    cf.setPeptideIdentifications({pid});
+    cmap.push_back(cf);
+    all_pep_ids.push_back(pid);
+  }
+
+  auto run_names = [](const std::shared_ptr<arrow::Table>& t)
+  {
+    std::set<std::string> out;
+    auto col = std::static_pointer_cast<arrow::StringArray>(t->GetColumnByName("run_file_name")->chunk(0));
+    for (int64_t r = 0; r < col->length(); ++r) { out.insert(col->GetString(r)); }
+    return out;
+  };
+
+  auto psm_t  = QPXFile::exportPSMsToQPXArrow(cmap.getProteinIdentifications(), all_pep_ids, false);
+  auto feat_t = ConsensusMapArrowExport::exportToArrow(cmap);
+  auto pg_t   = ProteinGroupArrowExport::exportToArrow(cmap);
+  TEST_NOT_EQUAL(psm_t, nullptr)
+  TEST_NOT_EQUAL(feat_t, nullptr)
+  TEST_NOT_EQUAL(pg_t, nullptr)
+
+  const std::set<std::string> expected = {"RUN_ONE", "RUN_TWO"};
+  const auto psm_runs  = run_names(psm_t);
+  const auto feat_runs = run_names(feat_t);
+  const auto pg_runs   = run_names(pg_t);
+
+  // Stemmed: no directory, no extension. Same-basename files in different directories are
+  // deliberately avoided here -- that collision is #9818's warn-and-continue case.
+  TEST_TRUE(psm_runs == expected)
+  TEST_TRUE(feat_runs == expected)
+  TEST_TRUE(pg_runs == expected)
+
+  // ... and therefore identical across the three views, which is what makes them joinable.
+  TEST_TRUE(psm_runs == feat_runs)
+  TEST_TRUE(feat_runs == pg_runs)
+
+  // No view may carry an empty key: run_file_name is a primary-key component in all three,
+  // and an empty string satisfies the non-nullable column while violating the spec.
+  for (const auto& s : {psm_runs, feat_runs, pg_runs}) { TEST_TRUE(s.count("") == 0) }
+
+  // The other documented join key must be a canonical channel token, not a path or a number.
+  auto labels_of = [](const std::shared_ptr<arrow::Table>& t)
+  {
+    std::set<std::string> out;
+    auto col = std::static_pointer_cast<arrow::ListArray>(t->GetColumnByName("intensities")->chunk(0));
+    auto st  = std::static_pointer_cast<arrow::StructArray>(col->values());
+    auto lab = std::static_pointer_cast<arrow::StringArray>(st->field(0));
+    for (int64_t i = 0; i < lab->length(); ++i) { out.insert(lab->GetString(i)); }
+    return out;
+  };
+  const std::set<std::string> lfq = {"LFQ"};
+  TEST_TRUE(labels_of(feat_t) == lfq)
+  TEST_TRUE(labels_of(pg_t) == lfq)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/QPXFile_test.cpp
+++ b/src/tests/class_tests/openms/source/QPXFile_test.cpp
@@ -13,6 +13,9 @@
 #include <OpenMS/FORMAT/QPXFile.h>
 ///////////////////////////
 
+#include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/KERNEL/ConsensusMap.h>
+#include <OpenMS/METADATA/ProteinHit.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/METADATA/PeptideHit.h>
@@ -632,6 +635,99 @@ START_SECTION(ProteinGroupArrowExport::exportToArrow empty groups)
   TEST_NOT_EQUAL(table, nullptr)
   TEST_EQUAL(table->num_rows(), 0)
   TEST_EQUAL(table->num_columns(), 20)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] ProteinGroupArrowExport writes QPX channel labels, not channel numbers))
+{
+  // intensities[].label is a join key (i.label = rs.label against run.samples), so it must
+  // carry a canonical channel token. This covers the isobaric path, which has no TOPP test.
+  //
+  // Deliberately does NOT call setExperimentType: IsobaricWorkflow never does either, so the
+  // mapping has to work off the headers' channel_id meta value alone.
+  auto build_map = [](const std::string& method, const std::vector<std::string>& channel_names)
+  {
+    ConsensusMap cmap;
+    for (Size c = 0; c < channel_names.size(); ++c)
+    {
+      ConsensusMap::ColumnHeader h;
+      h.filename = "/data/tmt_run.mzML";
+      h.label = method + "_" + channel_names[c];
+      h.setMetaValue("channel_name", channel_names[c]);
+      h.setMetaValue("channel_id", static_cast<int>(c));   // 0-based; getLabelAsUInt adds 1
+      cmap.getColumnHeaders()[c] = h;
+    }
+
+    ProteinIdentification prot_id;
+    prot_id.setScoreType("q-value");
+    prot_id.setPrimaryMSRunPath({"/data/tmt_run.mzML"});
+    ProteinHit ph;
+    ph.setAccession("PROT_A");
+    prot_id.setHits({ph});
+
+    ProteinIdentification::ProteinGroup group;
+    group.accessions = {"PROT_A"};
+    group.probability = 0.01;
+    // Quant arrays as PeptideAndProteinQuant lays them out: abundances in float[3],
+    // design filenames (already stemmed) in string[0], 1-based channels in int[0].
+    group.getFloatDataArrays().resize(4);
+    group.getStringDataArrays().resize(1);
+    group.getIntegerDataArrays().resize(1);
+    for (Size c = 0; c < channel_names.size(); ++c)
+    {
+      group.getFloatDataArrays()[3].push_back(1000.0f * (c + 1));
+      group.getStringDataArrays()[0].push_back("tmt_run");
+      group.getIntegerDataArrays()[0].push_back(static_cast<int>(c) + 1);
+    }
+    prot_id.insertIndistinguishableProteins(group);
+    cmap.setProteinIdentifications({prot_id});
+    return cmap;
+  };
+
+  auto labels_of = [](const std::shared_ptr<arrow::Table>& t)
+  {
+    std::vector<std::string> out;
+    auto col = std::static_pointer_cast<arrow::ListArray>(t->GetColumnByName("intensities")->chunk(0));
+    auto st = std::static_pointer_cast<arrow::StructArray>(col->values());
+    auto lab = std::static_pointer_cast<arrow::StringArray>(st->field(0));
+    for (int64_t i = 0; i < lab->length(); ++i) { out.push_back(lab->GetString(i)); }
+    return out;
+  };
+
+  // TMT 10-plex: channel 10 is "131" in OpenMS' naming (qpx's 11-plex-indexed map says
+  // "TMT131N"); OpenMS' name is authoritative.
+  {
+    auto cmap = build_map("tmt10plex",
+      {"126","127N","127C","128N","128C","129N","129C","130N","130C","131"});
+    auto t = ProteinGroupArrowExport::exportToArrow(cmap);
+    TEST_NOT_EQUAL(t, nullptr)
+    TEST_EQUAL(t->num_rows(), 1)
+    auto labels = labels_of(t);
+    TEST_EQUAL(labels.size(), 10)
+    TEST_STRING_EQUAL(labels[0], "TMT126")
+    TEST_STRING_EQUAL(labels[1], "TMT127N")
+    TEST_STRING_EQUAL(labels[9], "TMT131")
+    // run_file_name is the stemmed design filename, matching psm/feature
+    auto run_col = std::static_pointer_cast<arrow::StringArray>(t->GetColumnByName("run_file_name")->chunk(0));
+    TEST_STRING_EQUAL(run_col->GetString(0), "tmt_run")
+  }
+
+  // iTRAQ 4-plex
+  {
+    auto cmap = build_map("itraq4plex", {"114","115","116","117"});
+    auto t = ProteinGroupArrowExport::exportToArrow(cmap);
+    TEST_NOT_EQUAL(t, nullptr)
+    auto labels = labels_of(t);
+    TEST_EQUAL(labels.size(), 4)
+    TEST_STRING_EQUAL(labels[0], "ITRAQ114")
+    TEST_STRING_EQUAL(labels[3], "ITRAQ117")
+  }
+
+  // An unidentifiable quantitation method must abort rather than emit a guessed join key.
+  {
+    auto cmap = build_map("not_a_method", {"126", "127N"});
+    TEST_EQUAL(ProteinGroupArrowExport::exportToArrow(cmap), nullptr)
+  }
 }
 END_SECTION
 

--- a/src/topp/ProSE.cpp
+++ b/src/topp/ProSE.cpp
@@ -518,6 +518,9 @@ class ProSE :
       // Write per-file outputs and track failures.
       // Accumulate Arrow tables for merged parquet output.
       std::vector<std::shared_ptr<arrow::Table>> qpx_psm_tables, qpx_pg_tables;
+      // Per-run QPX scan_format tokens, reconciled for the merged file below. A built table
+      // no longer carries the native IDs, so this has to be collected as we go.
+      std::vector<std::string> qpx_psm_scan_formats;
       std::vector<std::shared_ptr<arrow::Table>> oms_psm_tables, oms_prot_tables, oms_pg_tables, oms_sp_tables;
 
       Size failed_count = 0;
@@ -625,7 +628,15 @@ class ProSE :
           if (qpx_psm_table)
           {
             qpx_psm_tables.push_back(qpx_psm_table);
-            if (!QPXFile::exportToParquet(qpx_psm_table, qpx_psm_file))
+            std::vector<std::string> spec_refs;
+            spec_refs.reserve(result.peptide_ids.size());
+            for (const auto& pid : result.peptide_ids)
+            {
+              if (!pid.getSpectrumReference().empty()) { spec_refs.push_back(pid.getSpectrumReference()); }
+            }
+            const std::string psm_scan_format = ArrowIOHelpers::qpxScanFormat(spec_refs);
+            qpx_psm_scan_formats.push_back(psm_scan_format);
+            if (!QPXFile::exportToParquet(qpx_psm_table, qpx_psm_file, ParquetWriteConfig{}, psm_scan_format))
             {
               OPENMS_LOG_ERROR << "Failed to write QPX PSM parquet for " << in_file << " -> " << qpx_psm_file << endl;
               input_failed = true;
@@ -734,8 +745,29 @@ class ProSE :
       bool merged_ok = true;
       if (!out_qpx_dir.empty())
       {
-        merged_ok = ArrowIOHelpers::concatenateAndWriteToParquet(qpx_psm_tables, out_qpx_dir + "/quantms.psm.parquet") && merged_ok;
-        merged_ok = ArrowIOHelpers::concatenateAndWriteToParquet(qpx_pg_tables,  out_qpx_dir + "/quantms.pg.parquet")  && merged_ok;
+        // Concatenation inherits the first input's schema metadata, i.e. that per-run file's
+        // uuid/creation_date. Stamp a fresh identity so the merged file is its own QPX file.
+        // scan_format only describes the merged file if every contributing run agreed on a
+        // convention; otherwise it is omitted rather than taken from an arbitrary run.
+        std::map<std::string, std::string> psm_extra;
+        std::set<std::string> distinct_formats(qpx_psm_scan_formats.begin(), qpx_psm_scan_formats.end());
+        if (distinct_formats.size() == 1 && !distinct_formats.begin()->empty())
+        {
+          psm_extra["scan_format"] = *distinct_formats.begin();
+        }
+        auto psm_meta = ArrowIOHelpers::qpxFileMetadata("psm_file", ParquetWriteConfig{}, psm_extra);
+        auto pg_meta  = ArrowIOHelpers::qpxFileMetadata("pg_file");
+        merged_ok = psm_meta && pg_meta && merged_ok;
+        if (psm_meta)
+        {
+          merged_ok = ArrowIOHelpers::concatenateAndWriteToParquet(
+            qpx_psm_tables, out_qpx_dir + "/quantms.psm.parquet", ParquetWriteConfig{}, psm_meta) && merged_ok;
+        }
+        if (pg_meta)
+        {
+          merged_ok = ArrowIOHelpers::concatenateAndWriteToParquet(
+            qpx_pg_tables, out_qpx_dir + "/quantms.pg.parquet", ParquetWriteConfig{}, pg_meta) && merged_ok;
+        }
       }
 
       if (!out_parquet_dir.empty())

--- a/src/topp/ProteinQuantifier.cpp
+++ b/src/topp/ProteinQuantifier.cpp
@@ -939,6 +939,31 @@ protected:
   {
     ConsensusMap consensus;
     FileHandler().loadConsensusFeatures(in, consensus, {FileTypes::CONSENSUSXML});
+
+    // Drop features whose peptide identifications disagree on the top sequence. They already
+    // contribute nothing: PeptideAndProteinQuant::getAnnotation_() returns an empty hit for
+    // them, so they are absent from every abundance this tool computes. Removing them here
+    // makes that explicit and keeps any QPX export describing exactly what was quantified --
+    // the QPX feature and pg views record one peptide per feature and reject ambiguity.
+    // Identifications agreeing on the same modified sequence are unambiguous and kept.
+    {
+      const Size before = consensus.size();
+      auto divergent = [](const ConsensusFeature& cf)
+      {
+        return cf.getAnnotationState() == BaseFeature::AnnotationState::FEATURE_ID_MULTIPLE_DIVERGENT;
+      };
+      consensus.erase(std::remove_if(consensus.begin(), consensus.end(), divergent), consensus.end());
+      if (const Size removed = before - consensus.size(); removed > 0)
+      {
+        OPENMS_LOG_WARN << "ProteinQuantifier: ignoring " << removed << " of " << before
+                        << " consensus feature(s) whose peptide identifications disagree on the "
+                           "top sequence; they cannot be attributed to one peptide and are "
+                           "excluded from quantification. Resolve the conflicts first "
+                           "(IDConflictResolver, ConsensusID with algorithm 'best', or FileFilter "
+                           "with id:keep_best_score_id)." << std::endl;
+      }
+    }
+
     columns_headers_ = consensus.getColumnHeaders();
 
     ExperimentalDesign ed = getExperimentalDesignConsensusMap_(design_file, consensus);
@@ -1008,7 +1033,10 @@ protected:
       // Feature-level export
       if (!ConsensusMapArrowExport::exportToParquet(consensus, out_qpx + "/quantms.feature.parquet"))
       {
-        OPENMS_LOG_ERROR << "Failed to write features Parquet file" << std::endl;
+        // Abort rather than log and continue: a partial QPX collection written with a zero
+        // exit code looks like a successful export.
+        throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            out_qpx, "failed to write the features Parquet file");
       }
 
       // PSM-level export
@@ -1026,13 +1054,19 @@ protected:
       }
       if (!QPXFile::exportToParquet(consensus.getProteinIdentifications(), all_pepids, out_qpx + "/quantms.psm.parquet"))
       {
-        OPENMS_LOG_ERROR << "Failed to write PSM Parquet file" << std::endl;
+        // Abort rather than log and continue: a partial QPX collection written with a zero
+        // exit code looks like a successful export.
+        throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            out_qpx, "failed to write the PSM Parquet file");
       }
 
       // Protein group export
       if (!ProteinGroupArrowExport::exportToParquet(consensus, out_qpx + "/quantms.pg.parquet"))
       {
-        OPENMS_LOG_ERROR << "Failed to write protein groups Parquet file" << std::endl;
+        // Abort rather than log and continue: a partial QPX collection written with a zero
+        // exit code looks like a successful export.
+        throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            out_qpx, "failed to write the protein groups Parquet file");
       }
     }
 


### PR DESCRIPTION
Continues the [bigbio/qpx](https://github.com/bigbio/qpx) conformance work that #9818 started. That PR fixed `run_file_name` — per-PSM resolution and stemming. **This one does not re-implement run resolution**; it was rebased onto #9818 and defers to it, extending its warn-on-stem-collision policy to the two views it did not cover.

What remains wrong after #9818, and what this PR fixes:

| | on `develop` today | after this PR |
|---|---|---|
| `feature.parquet` file metadata | **none at all** — neither write path stamps any | complete, spec-tokened |
| `feature.parquet` `intensities[].label` | the absolute `.mzML` path | `LFQ` / `TMT126` |
| `pg.parquet` `intensities[].label` | `"1"` — the raw channel number | `LFQ` / `TMT126` |
| `pg.parquet` `run_file_name` | **empty** for unquantified groups — 13 of 38 rows | 0 of 40 |
| `file_type` metadata | `psm` / `pg` | `psm_file` / `feature_file` / `pg_file` |
| `compression_format` | absent | written, vocabulary-checked |
| `scan_format` | hard-coded `"scan"` | derived from the native IDs |
| feature / pg row shape | wide | long, per the spec |
| `feature.anchor_protein` | non-nullable | nullable, per bigbio/qpx#212 |
| ProSE's **merged** `quantms.*.parquet` | inherit the first per-run file's `uuid`/`creation_date` | own identity, reconciled `scan_format` |
| a feature with conflicting peptide IDs | one interpretation published, the rest dropped silently | refused, with the resolvers named |

Measurements are from `OpenMS-build/src/tests/topp/tmp_path/BSA_qpx_dir/`, produced by the existing `TOPP_ProteomicsLFQ_qpx` test over 5 BSA fraction mzMLs.

## The three structural changes

**1. Row shape.** The spec defines both views as long — feature as "a quantified peptidoform in a specific run file" (`docs/spec/feature.md`), pg as "one row per protein group per run" (`docs/spec/pg.md`). Both were wide. `feature.parquet` held one row per ConsensusFeature with one intensity per contributing run, so `run_file_name` was an arbitrary pick among those runs. It now melts to one row per (ConsensusFeature, run): 39 rows → 60, each with a single `LFQ` intensity.

The melt groups on the **source path**, not on the stemmed run name. Grouping on the stem would actively fuse `/frac_a/run1.mzML` and `/frac_b/run1.mzML` into one row — the exact layout that makes stem collisions worth warning about in the first place.

The coordinate rule is mode-dependent and that matters:

- **label-free** — each `FeatureHandle` carries its own run's RT / m/z / charge, so the row takes its quantitative coordinates from that handle.
- **isobaric** — handles are *reporter ions* (m/z is the reporter mass, RT the quantification scan) while precursor coordinates live on the ConsensusFeature. Keep the consensus values; use handles only for channel intensities. Taking handle coordinates here would write a reporter mass into `observed_mz`.

**2. pg unquantified groups.** These were emitted with an empty `run_file_name` — a primary-key component the spec says MUST NOT be null, and which quantms' `pg_adapter` silently *drops*. They now melt onto the runs where the group actually has identification evidence (assigned PSMs' features, plus unassigned PSMs resolved through `id_merge_index`), with null intensities. Fanning out across all column headers instead would have turned 13 unattributed rows into up to 65 asserting observations that were never made. `peptides`, `peptide_counts` and `feature_counts` are populated per (group, run) using quantms semantics.

**3. One peptide per feature is now a contract, not an assumption.** The QPX feature and pg views have singular `sequence` / `peptidoform` / `charge` and no ConsensusFeature identifier. A feature whose identifications disagree on the top peptide therefore cannot be represented: exporting it publishes one chosen interpretation and silently discards the alternatives, and the pg view counts evidence contributed by one peptide under another's identity.

`ConsensusMapArrowExport::requireUnambiguousIdentities()` rejects that input (`Exception::IllegalArgument`), reusing the existing `BaseFeature::AnnotationState` rather than adding a predicate. Several identifications agreeing on the same modified sequence (`FEATURE_ID_MULTIPLE_SAME`) are unambiguous and accepted — that is the deliberate output of `IDConflictResolverAlgorithm::resolve()` with `keep_matching`, which `ProteomicsLFQ` uses.

It runs as a **preflight**: single-threaded, before any OpenMP region and before the output file is opened. An exception escaping the parallel batch build would be flattened into a boolean by the worker's catch-all, and one escaping the region at all is `std::terminate`.

No shipped pipeline can trip it, and that is deliberate rather than lucky — every in-tree caller now establishes the contract: `ProteomicsLFQ` resolves conflicts, `IsobaricWorkflow` constructs one identification per feature, and `ProteinQuantifier` filters (below). The ambiguity-preserving representation remains the OpenMS-native `consensusparquet`, which keeps every hit, and which `IDConflictResolver` accepts as input.

## Decisions worth a reviewer's attention

- **The channel vocabulary is no longer a judgement call.** It was ratified upstream mid-review, in `sdrf-pipelines`' [`channel_map.yaml`](https://github.com/bigbio/sdrf-pipelines/blob/main/src/sdrf_pipelines/converters/channel_map.yaml) (bigbio/sdrf-pipelines#314), which confirms both choices this PR made from SDRF evidence: `tmt10plex` channel 10 is **`TMT131`**, not `TMT131N`, and iTRAQ is **uppercase** (`ITRAQ114`). It also settles the LFQ join by making `LFQ` canonical with `label free sample` as a synonym.

  We derive the label as *family prefix + OpenMS' own reporter name*, not from an ordinal table. That is what makes it correct: it matches `channel_map.yaml` exactly for **all eleven** OpenMS isobaric methods, including TMT6plex (`TMT127`, where quantms' ordinal map says `TMT127N`), iTRAQ8plex's non-contiguous `ITRAQ121`, and TMT32/35plex's `TMT127D` / `TMT134CD`. An ordinal table would have had to be re-derived per plex and would silently mislabel any method added later.

- **Three hard failures**, all on join or primary keys, where a guessed value is worse than a refused write: an unidentifiable isobaric quantitation method, LZ4 (for which qpx defines no `compression_format` token), and divergent feature identities.

- **Best-hit selection is local, and deliberately so.** An earlier revision added an `IDFilter::getBestHit` overload; that was withdrawn. `IDFilter` is now untouched. `IDFilter::getBestHit` reports only the hit, and its internal "best" iterator is the score-type *reference*, not the winner — while the feature view needs the winner's parent to resolve `id_run_file_name`. Exposing that meant new public API in a widely-included header for one caller. Score comparison itself is not duplicated: it delegates to `PeptideIdentification::getScoreComparator`, the same primitive `IDFilter` and `MapAlignmentAlgorithmIdentification` use.

- **One score orientation per feature.** Comparison uses the orientation of the first identification that has a hit. Using each identification's own would compare in different directions within a single selection and make the winner depend on identification order. Identifications disagreeing on score type or orientation warn once and proceed with that reference — harmonizing them is an explicit pipeline step (`IDScoreSwitcher`), and `IDFilter::getBestHit` throws outright on the same condition. There is no fall back to `pep_ids[0]`: an earlier revision had one, and it reintroduced the empty-first-identification bug that best-hit selection exists to fix.

- **A latent out-of-bounds is fixed** in `ProteinGroupArrowExport`: `has_quant` checked the float and string data arrays but not the integer one it then dereferences.

## Behaviour changes for consumers

- **feature.parquet row counts grow** roughly N× (runs per feature). This is the spec shape, but anyone reading previous output will see different counts.
- A `ConsensusFeature` with no `FeatureHandle`s produces no row — it has neither quantification nor a run to key on. No shipped tool emits them (`IsobaricWorkflow` filters zero-intensity features at `:780`); this is a guard for foreign input.
- **`ProteinQuantifier` drops features whose identifications disagree on the top sequence**, with a warning naming the three resolvers (`IDConflictResolver`, `ConsensusID` with `algorithm=best`, `FileFilter -id:keep_best_score_id`). It is the only shipped path that neither resolves conflicts nor builds one identification per feature. The filter is unconditional, not gated on `-out_qpx`, because those features **already contribute nothing**: `PeptideAndProteinQuant::getAnnotation_()` returns an empty `PeptideHit` when the top sequences disagree, so they are absent from every abundance the tool computes. This makes an existing implicit exclusion explicit — and it is verified rather than reasoned: all **43** ProteinQuantifier TOPP tests pass byte-identically.
- **`ProteinQuantifier` now aborts on a QPX write failure** instead of logging and continuing. All three writes previously left a partial collection behind with a **zero exit code**, which is indistinguishable from success.

## Verification

- **153/153** TOPP tests (`ProteomicsLFQ`, `ProSE`, `ProteinQuantifier`, `IsobaricAnalyzer`) and **27/27** Arrow/QPX/Parquet class tests, including #9818's `ProteinGroupArrowExport_test`.
- **No reference-file churn**, confirmed empirically: every FuzzyDiff'd mzTab/consensusXML/idXML comparison passes untouched. The `-out_qpx` TOPP tests only `sha256sum` for existence, and output is not byte-reproducible anyway (fresh `uuid`/`creation_date`).
- New coverage: the melt for label-free and isobaric; two runs sharing a stem staying separate rows; a feature whose better-scoring identification is *not* first, asserting sequence, scan and ion mobility all describe the same one; a feature whose identifications are all hitless (which used to dereference a null); a label-free feature whose handle coordinates differ from the consensus centroid, asserting ppm error is measured against the m/z the row reports; divergent identities rejected by both exporters; `scan_format` derivation; label mapping including the TMT10 case; LZ4 rejection; and a joinability test asserting all three views share one run vocabulary.

`qpxc validate` is not a meaningful gate here — it downgrades null and duplicate-PK violations to warnings and `is_valid` ignores warnings, which is precisely why these defects survived.

## Review history

Adversarial review of the melt caught two defects the tests could not, because every fixture gave a feature one identification and identical coordinates:

1. A row combined **two different identifications** — sequence and scores from the best-scoring one, `scan`/`ion_mobility`/PEP still from `pep_ids[0]`.
2. A row combined **two different m/z values** — `observed_mz` from the handle, but `calculated_mz` and `mass_error_ppm` computed against the consensus centroid.

A later pass found the melt grouping on the stemmed run name (fusing same-stem runs) and a null dereference on all-hitless features. Each is fixed with a regression test.

## Against #9817

- **Defect B (intensities label) — closed.** The "unratified upstream" risk the issue names is gone: the vocabulary is now canonical in `sdrf-pipelines` (above), and it agrees with what this PR emits. bigbio/qpx#215 added downstream relabeling of OpenMS `-out_qpx` output as an explicitly temporary bridge, citing this issue as the source fix — that bridge can be dropped for output produced by this PR.
- **Defect A — partially.** The ConsensusMap overload, which 3 of the 4 `-out_qpx` tools use, now attributes unquantified groups by evidence, retiring the empty-`run_file_name` option. The **id-only overload is untouched** by this PR and still takes `run_paths[0]`; the cross-run dedup question the issue leaves open is likewise untouched.
- **Defect C — not this PR.** #9818 fixed the export-side root cause on both the QPX and internal paths; what remains is the `importFromArrow` shell branch.

## Known and not addressed here

- **`pg.parquet` still invents a label** where `feature.parquet` now refuses to: an underivable channel falls back to `"LFQ"` for channel 1 and to the channel number otherwise, with a warning. It should adopt the feature view's refusal — the clearest remaining inconsistency now that strictness is the rule elsewhere.
- **Feature and pg run resolution do not reuse #9818's `id_merge_index` validation**, so a merged-run identification with a missing index can still resolve to run 0.
- **Unused column headers still influence the export**: one can flip a map to `is_isobaric`, or fail the export over a channel no feature references.
- **Streaming memory is no longer bounded by `batch_size`**, which counts input features while each now expands to one row per run. Worth fixing before very large collections; it does not affect correctness.
- A QPX **value-level** validator as a closing gate: `run_file_name`/`anchor_protein` are non-nullable, but an empty string is not null, so `""` satisfies Arrow while violating the spec.
- **SILAC channel labels** — we pass the SILAC modification through; `channel_map.yaml` defines `SILAC light` / `SILAC medium` / `SILAC heavy`. Reachable only via `ProteinQuantifier` on a multiplex consensusXML.
- `additional_intensities` empty-list vs null inconsistency between quantified and id-only pg rows.
- Per-feature identity selection and ProForma rendering are repeated per melted row rather than memoized per feature.

Separately worth raising upstream: the feature primary key `[sequence, charge, run_file_name, anchor_protein]` keys on the *unmodified* sequence, so it cannot distinguish `YIC[UNIMOD:4]DNQDTISSK` from `YICDNQDTISSK`. Three such collisions appear in this PR's 60-row output, all between genuinely distinct species at different m/z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DF2YUewPQTC5tJWqn23pUm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized QPX Parquet metadata across PSM, consensus-feature, and protein-group exports, including canonical `run_file_name`, `scan_format`, and intensity-channel labels.
  * QPX merges now reconcile `scan_format` consistently (only set when all inputs agree).
* **Bug Fixes**
  * Consensus feature exports now emit one row per contributing run with run-specific measurements and correct identity/coordinate attribution.
  * Protein-group exports now attribute peptide/feature evidence per run; missing values are written as nulls (including nullable `anchor_protein`).
* **Tests**
  * Expanded/updated coverage for metadata, joins, scan-format inference, labels, and streaming/merge behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
