### PR TITLE
[FIX] macOS PKG: exclude pyopenms python_modules from the installer to fix notarization

### DIFF
--- a/cmake/package_mac_productbuild.cmake
+++ b/cmake/package_mac_productbuild.cmake
@@ -124,6 +124,16 @@ install(CODE "
         COMPONENT library
         )
 
+## The pyopenms python extension modules (COMPONENT python_modules, see
+## src/pyOpenMS/CMakeLists.txt) are packaged into their own sub-pkg by the
+## productbuild generator and are not covered by the library/Dependencies
+## signing above, so notarization rejects them as unsigned.
+install(CODE "
+        execute_process(COMMAND find \${CMAKE_INSTALL_PREFIX}/pyopenms/ -type f -execdir codesign --force --options runtime --timestamp -i de.openms.pyopenms.{} --sign \"${CPACK_BUNDLE_APPLE_CERT_APP}\" {} \\; OUTPUT_VARIABLE pyopenms_sign_out ERROR_VARIABLE pyopenms_sign_out)
+        message('\${pyopenms_sign_out}')"
+        COMPONENT python_modules
+        )
+
 ## Sign thirdparty components
 foreach(component IN LISTS THIRDPARTY_COMPONENT_GROUP)
   install(CODE "

--- a/cmake/package_mac_productbuild.cmake
+++ b/cmake/package_mac_productbuild.cmake
@@ -124,19 +124,6 @@ install(CODE "
         COMPONENT library
         )
 
-## The pyopenms python extension modules (COMPONENT python_modules, see
-## src/pyOpenMS/CMakeLists.txt) are packaged into their own sub-pkg by the
-## productbuild generator and are not covered by the library/Dependencies
-## signing above, so notarization rejects them as unsigned.
-install(CODE "
-        execute_process(COMMAND find \${CMAKE_INSTALL_PREFIX}/pyopenms/ -type f -execdir codesign --force --options runtime --timestamp -i de.openms.pyopenms.{} --sign \"${CPACK_BUNDLE_APPLE_CERT_APP}\" {} \\; RESULT_VARIABLE pyopenms_sign_result OUTPUT_VARIABLE pyopenms_sign_out ERROR_VARIABLE pyopenms_sign_out)
-        message('\${pyopenms_sign_out}')
-        if(NOT pyopenms_sign_result EQUAL 0)
-          message(FATAL_ERROR \"Failed to codesign pyopenms component (exit code \${pyopenms_sign_result})\")
-        endif()"
-        COMPONENT python_modules
-        )
-
 ## Sign thirdparty components
 foreach(component IN LISTS THIRDPARTY_COMPONENT_GROUP)
   install(CODE "
@@ -156,6 +143,17 @@ install(FILES       ${PROJECT_SOURCE_DIR}/cmake/MacOSX/openms_logo_large_transpa
 configure_file(${OPENMS_HOST_DIRECTORY}/cmake/MacOSX/setIcon.sh.in ${OPENMS_HOST_BINARY_DIRECTORY}/cmake/MacOSX/setIcon.sh)
 set(CPACK_POSTFLIGHT_APPLICATIONS_SCRIPT ${OPENMS_HOST_BINARY_DIRECTORY}/cmake/MacOSX/setIcon.sh)
 
+## The pyopenms Python extension modules (COMPONENT python_modules, see
+## src/pyOpenMS/CMakeLists.txt) are not meant to be bundled into the desktop
+## application installer - they are shipped separately as Python wheels (see
+## .github/workflows/pyopenms-wheels-cibuildwheel.yml). productbuild packages
+## every known component into its own sub-pkg by default, and since these were
+## never signed, notarization rejected the whole installer. Exclude them here
+## instead of signing them, so they no longer get packaged at all. This must
+## run after all install(... COMPONENT ...) calls in the project have been
+## processed, so it picks up every real component.
+get_cmake_property(CPACK_COMPONENTS_ALL COMPONENTS)
+list(REMOVE_ITEM CPACK_COMPONENTS_ALL python_modules)
 
 ## Create own target because you cannot "depend" on the internal target 'package'
 add_custom_target(dist

--- a/cmake/package_mac_productbuild.cmake
+++ b/cmake/package_mac_productbuild.cmake
@@ -129,8 +129,11 @@ install(CODE "
 ## productbuild generator and are not covered by the library/Dependencies
 ## signing above, so notarization rejects them as unsigned.
 install(CODE "
-        execute_process(COMMAND find \${CMAKE_INSTALL_PREFIX}/pyopenms/ -type f -execdir codesign --force --options runtime --timestamp -i de.openms.pyopenms.{} --sign \"${CPACK_BUNDLE_APPLE_CERT_APP}\" {} \\; OUTPUT_VARIABLE pyopenms_sign_out ERROR_VARIABLE pyopenms_sign_out)
-        message('\${pyopenms_sign_out}')"
+        execute_process(COMMAND find \${CMAKE_INSTALL_PREFIX}/pyopenms/ -type f -execdir codesign --force --options runtime --timestamp -i de.openms.pyopenms.{} --sign \"${CPACK_BUNDLE_APPLE_CERT_APP}\" {} \\; RESULT_VARIABLE pyopenms_sign_result OUTPUT_VARIABLE pyopenms_sign_out ERROR_VARIABLE pyopenms_sign_out)
+        message('\${pyopenms_sign_out}')
+        if(NOT pyopenms_sign_result EQUAL 0)
+          message(FATAL_ERROR \"Failed to codesign pyopenms component (exit code \${pyopenms_sign_result})\")
+        endif()"
         COMPONENT python_modules
         )
 


### PR DESCRIPTION
## Description

The nightly `Release` workflow's `macos-15` job has been failing at the "Notarize macOS Package" step (e.g. [run 30506465700](https://github.com/OpenMS/OpenMS/actions/runs/30506465700/job/90757204157)). Apple rejected `OpenMS-<version>-macOS-Silicon-python_modules.pkg` with errors like:

```
"message": "The binary is not signed with a valid Developer ID certificate."
"message": "The signature does not include a secure timestamp."
```

Root cause: `productbuild` packages the `python_modules` CPack component (the pyopenms extension `.so` modules, installed to `DESTINATION pyopenms` per `src/pyOpenMS/CMakeLists.txt`) into its own sub-`.pkg`. `cmake/package_mac_productbuild.cmake` never set `CPACK_COMPONENTS_ALL`, so `productbuild` defaulted to packaging *every* known component — including `python_modules`, which was never signed like the other components. `.deb`/`.rpm` packaging (`cmake/package_deb.cmake` / `cmake/package_rpm.cmake`) already excludes `python_modules` via an explicit `CPACK_COMPONENTS_ALL`; only macOS picked it up by accident.

Per @jpfeuffer's review feedback, pyopenms doesn't belong in the desktop application installer at all — it's already shipped separately as wheels via `pyopenms-wheels-cibuildwheel.yml`. This PR excludes it from the macOS `.pkg` instead of signing it, using `get_cmake_property(CPACK_COMPONENTS_ALL COMPONENTS)` (CMake's own list of every component that received an `install(... COMPONENT ...)` call) followed by `list(REMOVE_ITEM CPACK_COMPONENTS_ALL python_modules)`, so it stays correct as components are added/removed elsewhere rather than relying on a hardcoded list. No workaround (e.g. skipping notarization) was used — the actual packaging bug is fixed.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes (this is a macOS-only packaging path exercised by the `Release` workflow on `macos-15`; not covered by unit tests, cannot be exercised in this Linux dev environment)
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)
