### PR TITLE
[FIX] Sign pyopenms python_modules component during macOS packaging

### DIFF
--- a/cmake/package_mac_productbuild.cmake
+++ b/cmake/package_mac_productbuild.cmake
@@ -124,6 +124,15 @@ install(CODE "
         COMPONENT library
         )
 
+## The pyopenms Python extension modules (component python_modules, see src/pyOpenMS/CMakeLists.txt)
+## are their own CPack component/pkg and are otherwise never signed, which fails notarization
+## ("not signed with a valid Developer ID certificate" / "signature does not include a secure timestamp").
+install(CODE "
+        execute_process(COMMAND find \${CMAKE_INSTALL_PREFIX}/pyopenms/ -type f -name \"*.so\" -execdir codesign --force --options runtime --timestamp -i de.openms.pyopenms.{} --sign \"${CPACK_BUNDLE_APPLE_CERT_APP}\" {} \\; OUTPUT_VARIABLE pyopenms_sign_out ERROR_VARIABLE pyopenms_sign_out)
+        message('\${pyopenms_sign_out}')"
+        COMPONENT python_modules
+        )
+
 ## Sign thirdparty components
 foreach(component IN LISTS THIRDPARTY_COMPONENT_GROUP)
   install(CODE "

--- a/cmake/package_mac_productbuild.cmake
+++ b/cmake/package_mac_productbuild.cmake
@@ -127,9 +127,26 @@ install(CODE "
 ## The pyopenms Python extension modules (component python_modules, see src/pyOpenMS/CMakeLists.txt)
 ## are their own CPack component/pkg and are otherwise never signed, which fails notarization
 ## ("not signed with a valid Developer ID certificate" / "signature does not include a secure timestamp").
+## Fail the packaging step outright if there is nothing to sign, or if signing itself fails, so an
+## unsigned/unnotarizable pyopenms component can never silently make it into a shipped package.
+## Note: codesign each file directly (rather than via 'find -execdir codesign ...') since find's own
+## exit status does not reflect the exit status of the commands it invokes via -exec/-execdir.
 install(CODE "
-        execute_process(COMMAND find \${CMAKE_INSTALL_PREFIX}/pyopenms/ -type f -name \"*.so\" -execdir codesign --force --options runtime --timestamp -i de.openms.pyopenms.{} --sign \"${CPACK_BUNDLE_APPLE_CERT_APP}\" {} \\; OUTPUT_VARIABLE pyopenms_sign_out ERROR_VARIABLE pyopenms_sign_out)
-        message('\${pyopenms_sign_out}')"
+        file(GLOB_RECURSE pyopenms_so_files \"\${CMAKE_INSTALL_PREFIX}/pyopenms/*.so\")
+        list(LENGTH pyopenms_so_files pyopenms_so_count)
+        if(pyopenms_so_count EQUAL 0)
+          message(FATAL_ERROR \"No pyopenms *.so modules found to sign under \${CMAKE_INSTALL_PREFIX}/pyopenms/\")
+        endif()
+        foreach(pyopenms_so_file IN LISTS pyopenms_so_files)
+          get_filename_component(pyopenms_so_name \"\${pyopenms_so_file}\" NAME)
+          execute_process(
+            COMMAND codesign --force --options runtime --timestamp -i de.openms.pyopenms.\${pyopenms_so_name} --sign \"${CPACK_BUNDLE_APPLE_CERT_APP}\" \${pyopenms_so_file}
+            OUTPUT_VARIABLE pyopenms_sign_out ERROR_VARIABLE pyopenms_sign_out RESULT_VARIABLE pyopenms_sign_result)
+          message('\${pyopenms_sign_out}')
+          if(NOT pyopenms_sign_result EQUAL 0)
+            message(FATAL_ERROR \"Signing pyopenms module \${pyopenms_so_file} failed (exit code \${pyopenms_sign_result}): \${pyopenms_sign_out}\")
+          endif()
+        endforeach()"
         COMPONENT python_modules
         )
 


### PR DESCRIPTION
## Description

Today's nightly `Release` workflow run ([run 30506465700](https://github.com/OpenMS/OpenMS/actions/runs/30506465700)) failed on `macos-15` at the "Notarize macOS Package" step. Apple rejected the `...-python_modules.pkg` sub-package with errors for every pyopenms `.so` it contains, e.g.:

```
"message": "The binary is not signed with a valid Developer ID certificate."
"message": "The signature does not include a secure timestamp."
```

Root cause: `cmake/package_mac_productbuild.cmake` re-signs the TOPP binaries (`COMPONENT Dependencies`) and the shared libraries (`COMPONENT library`) with the Developer ID identity after `fix_dependencies.rb` rewrites their rpaths, but the pyopenms extension modules — installed under `COMPONENT python_modules` in `src/pyOpenMS/CMakeLists.txt` — were never covered by any of those `install(CODE ...)` signing steps. They therefore only carried the ad-hoc signature applied by the linker at build time, which notarization rejects.

This adds an equivalent `codesign --force --options runtime --timestamp` pass, scoped to `COMPONENT python_modules`, mirroring the existing pattern used for the `library` component.

Since this is the first real run of the new nightly `Release` workflow (added recently in #9523) with a Developer ID cert configured, this is a new/previously-unexercised code path rather than a regression or flaky failure.

Note: I don't have access to a macOS runner in this environment, so this fix could not be locally verified end-to-end (build + codesign + notarize); it should be confirmed by a subsequent `Release`/nightly CI run.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KkdYK8mytc6cGkbuvK4FAA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS packaging reliability by ensuring included Python extension modules are code signed.
  * Packaging now fails clearly when required modules are missing or cannot be signed, preventing incomplete or unverifiable installers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->