### PR TITLE
[FIX] QPX export: melt the identification-only pg view onto its evidence runs (#9817)

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/ProteinGroupArrowExport.h
+++ b/src/openms/include/OpenMS/FORMAT/ProteinGroupArrowExport.h
@@ -81,9 +81,21 @@ public:
     QPX pg fields (pg_accessions, anchor_protein, run_file_name, is_decoy, peptides)
     and sets quantification columns (intensities, additional_intensities) to null.
 
+    Like the ConsensusMap overload, this emits <b>one row per protein group per run</b>: the
+    runs are those in which a member accession has peptide evidence, resolved per PSM through
+    IdentifierMSRunMapper. A group in a single-file run is keyed on that file even without
+    evidence; a group in a merged run with no evidence anywhere is skipped with a diagnostic,
+    since @c run_file_name is a QPX primary-key component that must not be empty.
+
+    @c peptides and @c peptide_counts are scoped to the emitted run, so the same group in two
+    runs reports the peptides seen in each.
+
     @param[in] protein_identifications Protein identifications with protein groups
     @param[in] peptide_identifications Peptide identifications (for peptide-per-protein counts)
-    @return Shared pointer to Arrow Table (empty table if no groups, never nullptr)
+    @return Shared pointer to Arrow Table (empty table if no groups), or nullptr if an Arrow
+            builder fails
+    @throw Exception::MissingInformation if a PSM belongs to a merged run but carries no usable
+           @c id_merge_index, so its origin file -- and with it the row's key -- is undetermined
   */
   static std::shared_ptr<arrow::Table> exportToArrow(
     const std::vector<ProteinIdentification>& protein_identifications,

--- a/src/openms/include/OpenMS/METADATA/IdentifierMSRunMapper.h
+++ b/src/openms/include/OpenMS/METADATA/IdentifierMSRunMapper.h
@@ -61,6 +61,26 @@ namespace OpenMS
     /// Get the primary MS run path for a PeptideIdentification (using id_merge_index metadata)
     std::string getPrimaryMSRunPath(const PeptideIdentification& pepid) const;
 
+    /**
+      @brief Refuse a PSM of a merged run that cannot be attributed to an origin file
+
+      A run with several @c spectra_data entries resolves per PSM only through
+      @c id_merge_index. Without a usable one, getPrimaryMSRunPath() falls back to the run's
+      @e first file, silently labelling every PSM of the run with it. Callers that use the
+      resolved path as a key -- QPX @c run_file_name is a primary-key component of the psm,
+      feature and pg views -- must refuse such input rather than publish it, so run this as a
+      preflight before any output is opened.
+
+      Runs with 0 or 1 path are exempt: unmerged input has nothing to disambiguate, and
+      resolution cannot be wrong.
+
+      @param[in] pep_id The PSM to check
+      @param[in] psm_index Only used to make the diagnostic locatable
+      @throw Exception::MissingInformation if the run is merged and @c id_merge_index is
+             missing, is not an integer, or is out of range
+    */
+    void validateMergeIndex(const PeptideIdentification& pep_id, size_t psm_index) const;
+
     /// Check if the mapping contains an entry for the given identifier
     bool hasIdentifier(const std::string& identifier) const;
 

--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -991,6 +991,8 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
 
     // Peptide evidence for this prot_id, split by origin run: QPX defines the counts per
     // (group, run), so the run dimension has to be carried alongside the accession.
+    // Keyed on the UNMODIFIED sequence, matching the ConsensusMap overload -- peptide_counts
+    // counts sequences, while distinguishing peptidoforms is what feature_counts is for.
     std::unordered_map<std::string, std::map<std::string, std::unordered_set<std::string>>> acc_run_peptides;
     AccessionRuns acc_runs;
     auto bucket = pep_by_identifier.find(prot_id.getIdentifier());
@@ -1013,7 +1015,7 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
         if (run.empty()) continue;
         // Use the best hit (first after assuming sorted by score)
         const auto& best_hit = pep_id.getHits()[0];
-        std::string seq = best_hit.getSequence().toString();
+        std::string seq = best_hit.getSequence().toUnmodifiedString();
         for (const auto& ev : best_hit.getPeptideEvidences())
         {
           const std::string& acc = ev.getProteinAccession();
@@ -1026,7 +1028,7 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
       }
     }
 
-    /// Peptidoforms of @p acc seen in @p run, or nullptr when there are none.
+    /// Unmodified peptide sequences of @p acc seen in @p run, or nullptr when there are none.
     auto peptidesIn = [&acc_run_peptides](const std::string& acc, const std::string& run)
                         -> const std::unordered_set<std::string>*
     {

--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -40,19 +40,39 @@ namespace // anonymous
   /// accession -> runs in which that accession has identification evidence.
   using AccessionRuns = std::unordered_map<std::string, std::set<std::string>>;
 
-  /// Build the identifier -> spectra_data mapping, downgrading an ambiguous reverse mapping to a
-  /// warning. IdentifierMSRunMapper::create() throws when two identifiers share a path list, but
-  /// it populates the forward map -- the only direction used here -- completely before that, so
-  /// the salvage is sound. Same idiom as QPXFile's buildRunMapper().
+  /// Build the identifier -> spectra_data mapping used to resolve each PSM's origin run.
+  ///
+  /// Refuses duplicate identifiers: IdentifierMSRunMapper keys the forward map on the identifier
+  /// and overwrites silently (IdentifierMSRunMapper.cpp), so two runs sharing one would leave
+  /// only the last one's paths -- and every PSM of the first would then resolve to a file it
+  /// never came from, stamping a foreign run_file_name on its protein groups. Nothing downstream
+  /// could detect that, so it has to be rejected here.
+  ///
+  /// A duplicate *path list* is different: create() throws for it, but populates the forward map
+  /// -- the only direction used here -- completely first, so that one is downgraded to a warning.
+  /// Deliberately narrow: any other exception means the forward map itself is incomplete, and
+  /// silently continuing on it would turn malformed metadata into a plausible-looking export.
   IdentifierMSRunMapper buildRunMapper(const std::vector<ProteinIdentification>& prot_ids,
                                        const std::string& context)
   {
+    std::set<std::string> seen;
+    for (const auto& prot_id : prot_ids)
+    {
+      if (!seen.insert(prot_id.getIdentifier()).second)
+      {
+        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+          context + ": several identification runs share the identifier '" + prot_id.getIdentifier()
+          + "'. Their MS run paths cannot be told apart, so protein groups would be attributed to "
+            "the wrong run file.", prot_id.getIdentifier());
+      }
+    }
+
     IdentifierMSRunMapper mapper;
     try
     {
       mapper.create(prot_ids);
     }
-    catch (const Exception::BaseException& e)
+    catch (const Exception::InvalidValue& e)
     {
       OPENMS_LOG_WARN << context << ": ambiguous MS run paths (" << e.getMessage()
                       << "); run attribution continues on the identifier -> path mapping."
@@ -754,6 +774,16 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
     arr_add_scores, arr_cv_params,
   });
 
+  // Appends discard their arrow::Status throughout this file, so a failed one (e.g. under memory
+  // pressure) leaves that column shorter than the rest while every Finish() still succeeds
+  // independently. Validate() catches the resulting length mismatch, so the contract of returning
+  // nullptr on failure holds instead of handing back a malformed table.
+  if (auto valid = table->Validate(); !valid.ok())
+  {
+    OPENMS_LOG_ERROR << "ProteinGroupArrowExport: built an inconsistent table: "
+                     << valid.ToString() << std::endl;
+    return nullptr;
+  }
   return table;
 }
 
@@ -968,6 +998,7 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
   Size total_groups_found = 0;
   Size groups_without_run_name = 0;   // run carries no spectra_data at all
   Size groups_without_evidence = 0;   // merged run, but nothing identifies which file
+  Size unresolved_psms = 0;           // PSM in a run with files, but resolving to none of them
   PrimaryKeyWatch pk_watch;
   for (const auto& prot_id : protein_identifications)
   {
@@ -1012,7 +1043,14 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
         const auto& pep_id = *pep_ptr;
         if (pep_id.getHits().empty()) continue;
         const std::string run = ArrowIOHelpers::qpxRunFileName(mapper.getPrimaryMSRunPath(pep_id));
-        if (run.empty()) continue;
+        if (run.empty())
+        {
+          // The run has files but this PSM resolves to none of them -- e.g. an 'id_merge_index'
+          // left over from a merge that was later subset. Its evidence is dropped, which would
+          // otherwise surface only as a silently zero peptide_count.
+          if (!run_paths.empty()) { ++unresolved_psms; }
+          continue;
+        }
         // Use the best hit (first after assuming sorted by score)
         const auto& best_hit = pep_id.getHits()[0];
         std::string seq = best_hit.getSequence().toUnmodifiedString();
@@ -1198,6 +1236,13 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
                        "with ProteinIdentification::setPrimaryMSRunPath() before exporting."
                     << std::endl;
   }
+  if (unresolved_psms > 0)
+  {
+    OPENMS_LOG_WARN << "ProteinGroupArrowExport (id-only): ignored " << unresolved_psms
+                    << " PSM(s) that could not be resolved to any file of their identification "
+                       "run, so they contribute to no peptide count. A stale 'id_merge_index' "
+                       "left over from a merge is the usual cause." << std::endl;
+  }
   if (groups_without_evidence > 0)
   {
     OPENMS_LOG_WARN << "ProteinGroupArrowExport (id-only): skipped " << groups_without_evidence
@@ -1274,6 +1319,16 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
     arr_add_scores, arr_cv_params,
   });
 
+  // Appends discard their arrow::Status throughout this file, so a failed one (e.g. under memory
+  // pressure) leaves that column shorter than the rest while every Finish() still succeeds
+  // independently. Validate() catches the resulting length mismatch, so the contract of returning
+  // nullptr on failure holds instead of handing back a malformed table.
+  if (auto valid = table->Validate(); !valid.ok())
+  {
+    OPENMS_LOG_ERROR << "ProteinGroupArrowExport: built an inconsistent table: "
+                     << valid.ToString() << std::endl;
+    return nullptr;
+  }
   return table;
 }
 

--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -939,15 +939,9 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
   if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): is_decoy Reserve failed: " << status.ToString() << std::endl; return nullptr; }
 
   // Resolve each PSM's origin run, so a group can be melted onto the runs where it was actually
-  // identified. Preflight before any builder is touched: a merged run whose PSMs carry no usable
-  // 'id_merge_index' resolves every one of them to the run's FIRST file, which would silently
-  // mislabel a primary-key column -- refuse instead. Same guard the PSM view applies.
+  // identified.
   const IdentifierMSRunMapper mapper =
     buildRunMapper(protein_identifications, "ProteinGroupArrowExport (id-only)");
-  for (size_t i = 0; i < peptide_identifications.size(); ++i)
-  {
-    mapper.validateMergeIndex(peptide_identifications[i], i);
-  }
   {
     // Warn-only, as in the psm and feature views: two paths sharing a stem are a legitimate
     // layout that the spec's representation simply cannot tell apart.
@@ -961,17 +955,19 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
   }
 
   // Bucket the PSMs by identification run once, instead of rescanning the whole list per
-  // ProteinIdentification. Keeps the per-prot_id scoping the counts below rely on.
-  std::unordered_map<std::string, std::vector<const PeptideIdentification*>> pep_by_identifier;
-  for (const auto& pep_id : peptide_identifications)
+  // ProteinIdentification. Keeps the per-prot_id scoping the counts below rely on. The original
+  // index travels along so diagnostics can still name the offending PSM.
+  std::unordered_map<std::string, std::vector<std::pair<size_t, const PeptideIdentification*>>> pep_by_identifier;
+  for (size_t i = 0; i < peptide_identifications.size(); ++i)
   {
-    pep_by_identifier[pep_id.getIdentifier()].push_back(&pep_id);
+    pep_by_identifier[peptide_identifications[i].getIdentifier()].emplace_back(i, &peptide_identifications[i]);
   }
 
   // Iterate over all protein identifications; for each, build scoped lookup
   // structures and append one row per (indistinguishable protein group, run).
   Size total_groups_found = 0;
-  Size unattributable_groups = 0;
+  Size groups_without_run_name = 0;   // run carries no spectra_data at all
+  Size groups_without_evidence = 0;   // merged run, but nothing identifies which file
   PrimaryKeyWatch pk_watch;
   for (const auto& prot_id : protein_identifications)
   {
@@ -1000,7 +996,16 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
     auto bucket = pep_by_identifier.find(prot_id.getIdentifier());
     if (bucket != pep_by_identifier.end())
     {
-      for (const auto* pep_ptr : bucket->second)
+      // A merged run whose PSMs carry no usable 'id_merge_index' resolves every one of them to
+      // the run's FIRST file, silently mislabelling a primary-key column -- refuse instead, the
+      // same guard the PSM view applies. Scoped to the PSMs this export actually reads: input
+      // that contributes no protein group must not be able to abort an export it has no say in.
+      for (const auto& [psm_index, pep_ptr] : bucket->second)
+      {
+        mapper.validateMergeIndex(*pep_ptr, psm_index);
+      }
+
+      for (const auto& [psm_index, pep_ptr] : bucket->second)
       {
         const auto& pep_id = *pep_ptr;
         if (pep_id.getHits().empty()) continue;
@@ -1041,7 +1046,9 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
       if (runs.empty() && !sole_run.empty()) { runs.insert(sole_run); }
       if (runs.empty())
       {
-        ++unattributable_groups;
+        // Two distinct causes, reported separately below because the remedies differ.
+        if (run_paths.empty()) { ++groups_without_run_name; }
+        else                   { ++groups_without_evidence; }
         continue;
       }
 
@@ -1177,11 +1184,24 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
   }
 
   pk_watch.report("ProteinGroupArrowExport (id-only)");
-  if (unattributable_groups > 0)
+  // WARN, not INFO: for a protein-inference result this is typically *every* group, and an empty
+  // output file that was announced at INFO reads as "nothing to export" rather than "your input
+  // could not be keyed".
+  if (groups_without_run_name > 0)
   {
-    OPENMS_LOG_INFO << "ProteinGroupArrowExport (id-only): skipped " << unattributable_groups
-                    << " protein group(s) with no identification evidence in any run and no "
-                       "single-file origin (no run_file_name to key a QPX row on)." << std::endl;
+    OPENMS_LOG_WARN << "ProteinGroupArrowExport (id-only): skipped " << groups_without_run_name
+                    << " protein group(s) whose identification run carries no MS run path, so no "
+                       "run_file_name can be derived -- and QPX makes it a primary-key component "
+                       "that must not be empty. Protein inference commonly drops the path: set it "
+                       "with ProteinIdentification::setPrimaryMSRunPath() before exporting."
+                    << std::endl;
+  }
+  if (groups_without_evidence > 0)
+  {
+    OPENMS_LOG_WARN << "ProteinGroupArrowExport (id-only): skipped " << groups_without_evidence
+                    << " protein group(s) in a merged run with no peptide evidence identifying "
+                       "which of its files they came from, so no row can be keyed. Annotate the "
+                       "PSMs with 'id_merge_index', or export the runs separately." << std::endl;
   }
 
   if (total_groups_found == 0)

--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -19,6 +19,8 @@
 #include <OpenMS/FORMAT/ConsensusMapArrowExport.h>
 #include <OpenMS/KERNEL/BaseFeature.h>
 #include <OpenMS/DATASTRUCTURES/DateTime.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/CONCEPT/Exception.h>
 
 #include <arrow/api.h>
 #include <arrow/builder.h>
@@ -32,6 +34,107 @@
 
 namespace OpenMS
 {
+
+namespace // anonymous
+{
+  /// accession -> runs in which that accession has identification evidence.
+  using AccessionRuns = std::unordered_map<std::string, std::set<std::string>>;
+
+  /// Build the identifier -> spectra_data mapping, downgrading an ambiguous reverse mapping to a
+  /// warning. IdentifierMSRunMapper::create() throws when two identifiers share a path list, but
+  /// it populates the forward map -- the only direction used here -- completely before that, so
+  /// the salvage is sound. Same idiom as QPXFile's buildRunMapper().
+  IdentifierMSRunMapper buildRunMapper(const std::vector<ProteinIdentification>& prot_ids,
+                                       const std::string& context)
+  {
+    IdentifierMSRunMapper mapper;
+    try
+    {
+      mapper.create(prot_ids);
+    }
+    catch (const Exception::BaseException& e)
+    {
+      OPENMS_LOG_WARN << context << ": ambiguous MS run paths (" << e.getMessage()
+                      << "); run attribution continues on the identifier -> path mapping."
+                      << std::endl;
+    }
+    return mapper;
+  }
+
+  /// Record, for every accession a PSM supports, the run the PSM came from.
+  ///
+  /// These are identifications that contribute no quantified feature: in a ConsensusMap the
+  /// unassigned ones, and in identification-only input every one of them. They establish that a
+  /// group was seen in a run even when nothing was quantified there -- exactly the rows the melt
+  /// exists to emit -- so they feed the run set without affecting any count.
+  void indexEvidenceRuns(const IdentifierMSRunMapper& mapper,
+                         const PeptideIdentificationList& pep_ids,
+                         AccessionRuns& acc_runs)
+  {
+    for (const auto& pid : pep_ids)
+    {
+      if (pid.getHits().empty()) { continue; }
+      const std::string run = ArrowIOHelpers::qpxRunFileName(mapper.getPrimaryMSRunPath(pid));
+      if (run.empty()) { continue; }
+      for (const auto& ev : pid.getHits()[0].getPeptideEvidences())
+      {
+        if (!ev.getProteinAccession().empty()) { acc_runs[ev.getProteinAccession()].insert(run); }
+      }
+    }
+  }
+
+  /// Runs where any member of @p group has identification evidence.
+  std::set<std::string> evidenceRuns(const AccessionRuns& acc_runs,
+                                     const ProteinIdentification::ProteinGroup& group)
+  {
+    std::set<std::string> runs;
+    for (const auto& acc : group.accessions)
+    {
+      auto it = acc_runs.find(acc);
+      if (it != acc_runs.end()) { runs.insert(it->second.begin(), it->second.end()); }
+    }
+    return runs;
+  }
+
+  /// Track emitted (anchor_protein, run_file_name) pairs -- the QPX pg primary key -- and report
+  /// duplicates once per export.
+  ///
+  /// Two ProteinIdentifications whose paths share a stem, a repeated accession group, or two
+  /// identifiers mapping to one path list (which IdentifierMSRunMapper::create() overwrites
+  /// silently, throwing only on duplicate path lists) all produce byte-different rows under one
+  /// key. Emitting both is deliberate -- dropping a row loses data and no merge rule exists for
+  /// two group probabilities -- but it must not be silent, because nothing downstream enforces
+  /// the key either: qpxc validate reports duplicate PKs at severity "warning" and its is_valid
+  /// ignores warnings.
+  class PrimaryKeyWatch
+  {
+  public:
+    void add(const std::string& anchor, const std::string& run)
+    {
+      if (!seen_.emplace(anchor, run).second && examples_.size() < 3)
+      {
+        examples_.push_back(anchor + " / " + run);
+      }
+      ++emitted_;
+    }
+
+    void report(const std::string& context) const
+    {
+      const size_t duplicates = emitted_ - seen_.size();
+      if (duplicates == 0) { return; }
+      OPENMS_LOG_WARN << context << ": " << duplicates << " of " << emitted_
+                      << " rows repeat an (anchor_protein, run_file_name) primary key, e.g. "
+                      << ListUtils::concatenate(StringList(examples_.begin(), examples_.end()), "; ")
+                      << ". The rows are kept, but consumers keying on the pair will see collisions."
+                      << std::endl;
+    }
+
+  private:
+    std::set<std::pair<std::string, std::string>> seen_;
+    std::vector<std::string> examples_;
+    size_t emitted_ = 0;
+  };
+} // anonymous namespace
 
 std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const ConsensusMap& cmap)
 {
@@ -89,17 +192,8 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
     for (const auto& [map_index, header] : cmap.getColumnHeaders()) { header_paths.push_back(header.filename); }
     (void)ArrowIOHelpers::qpxWarnOnRunNameCollisions("ProteinGroupArrowExport", header_paths);
 
-    IdentifierMSRunMapper run_mapper;
-    try
-    {
-      run_mapper.create(cmap.getProteinIdentifications());
-    }
-    catch (const Exception::InvalidValue& e)
-    {
-      OPENMS_LOG_WARN << "ProteinGroupArrowExport: ambiguous MS run paths (" << e.getMessage()
-                      << "); run attribution continues on the identifier -> path mapping."
-                      << std::endl;
-    }
+    const IdentifierMSRunMapper run_mapper =
+      buildRunMapper(cmap.getProteinIdentifications(), "ProteinGroupArrowExport");
 
     const auto& headers = cmap.getColumnHeaders();
     for (Size fi = 0; fi < cmap.size(); ++fi)
@@ -138,32 +232,8 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
       }
     }
 
-    // Unassigned identifications establish that a group was seen in a run even though nothing
-    // was quantified there -- exactly the rows the melt exists to emit. They contribute no
-    // feature, so they do not affect the counts.
-    for (const auto& pid : cmap.getUnassignedPeptideIdentifications())
-    {
-      if (pid.getHits().empty()) { continue; }
-      const std::string run = ArrowIOHelpers::qpxRunFileName(run_mapper.getPrimaryMSRunPath(pid));
-      if (run.empty()) { continue; }
-      for (const auto& ev : pid.getHits()[0].getPeptideEvidences())
-      {
-        if (!ev.getProteinAccession().empty()) { acc_runs[ev.getProteinAccession()].insert(run); }
-      }
-    }
+    indexEvidenceRuns(run_mapper, cmap.getUnassignedPeptideIdentifications(), acc_runs);
   }
-
-  /// Runs where any member of @p group has identification evidence.
-  auto evidenceRuns = [&](const ProteinIdentification::ProteinGroup& group)
-  {
-    std::set<std::string> runs;
-    for (const auto& acc : group.accessions)
-    {
-      auto it = acc_runs.find(acc);
-      if (it != acc_runs.end()) { runs.insert(it->second.begin(), it->second.end()); }
-    }
-    return runs;
-  };
 
   // Estimate number of rows: one per group per unique run file (or 1 if no quant data)
   Size estimated_rows = 0;
@@ -318,11 +388,13 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
   if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport: contaminant Reserve failed: " << status.ToString() << std::endl; return nullptr; }
 
   // Helper lambda to emit one row for a protein group + run file
+  PrimaryKeyWatch pk_watch;
   auto emitRow = [&](const ProteinIdentification::ProteinGroup& group,
                      const std::string& run_file,
                      const std::vector<std::pair<std::string, float>>& channel_intensities)
   {
     const std::string& anchor = group.accessions.empty() ? "" : group.accessions[0];
+    pk_watch.add(anchor, run_file);
 
     // anchor_protein
     (void)anchor_protein_builder.Append(anchor);
@@ -579,7 +651,7 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
       // an option. Melt onto the runs where the group actually has identification evidence,
       // with null intensities (distinct from a measured 0.0). Fanning out across every run in
       // the experiment instead would assert observations that were never made.
-      const auto runs = evidenceRuns(group);
+      const auto runs = evidenceRuns(acc_runs, group);
       if (runs.empty())
       {
         ++unattributable_groups;
@@ -588,6 +660,7 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
       for (const auto& run : runs) { emitRow(group, run, {}); }
     }
   }
+  pk_watch.report("ProteinGroupArrowExport");
   if (unattributable_groups > 0)
   {
     OPENMS_LOG_INFO << "ProteinGroupArrowExport: skipped " << unattributable_groups
@@ -865,45 +938,53 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
   status = is_decoy_builder.Reserve(estimated_rows);
   if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): is_decoy Reserve failed: " << status.ToString() << std::endl; return nullptr; }
 
+  // Resolve each PSM's origin run, so a group can be melted onto the runs where it was actually
+  // identified. Preflight before any builder is touched: a merged run whose PSMs carry no usable
+  // 'id_merge_index' resolves every one of them to the run's FIRST file, which would silently
+  // mislabel a primary-key column -- refuse instead. Same guard the PSM view applies.
+  const IdentifierMSRunMapper mapper =
+    buildRunMapper(protein_identifications, "ProteinGroupArrowExport (id-only)");
+  for (size_t i = 0; i < peptide_identifications.size(); ++i)
+  {
+    mapper.validateMergeIndex(peptide_identifications[i], i);
+  }
+  {
+    // Warn-only, as in the psm and feature views: two paths sharing a stem are a legitimate
+    // layout that the spec's representation simply cannot tell apart.
+    std::vector<std::string> all_paths;
+    for (const auto& identifier : mapper.getIdentifiers())
+    {
+      const StringList& paths = mapper.getMSRunPaths(identifier);
+      all_paths.insert(all_paths.end(), paths.begin(), paths.end());
+    }
+    (void)ArrowIOHelpers::qpxWarnOnRunNameCollisions("ProteinGroupArrowExport (id-only)", all_paths);
+  }
+
+  // Bucket the PSMs by identification run once, instead of rescanning the whole list per
+  // ProteinIdentification. Keeps the per-prot_id scoping the counts below rely on.
+  std::unordered_map<std::string, std::vector<const PeptideIdentification*>> pep_by_identifier;
+  for (const auto& pep_id : peptide_identifications)
+  {
+    pep_by_identifier[pep_id.getIdentifier()].push_back(&pep_id);
+  }
+
   // Iterate over all protein identifications; for each, build scoped lookup
-  // structures and append one row per indistinguishable protein group.
+  // structures and append one row per (indistinguishable protein group, run).
   Size total_groups_found = 0;
+  Size unattributable_groups = 0;
+  PrimaryKeyWatch pk_watch;
   for (const auto& prot_id : protein_identifications)
   {
     const auto& groups = prot_id.getIndistinguishableProteins();
     if (groups.empty()) continue;
     total_groups_found += groups.size();
 
-    // Derive run file name from primary MS run path for this prot_id. QPX wants the spectrum file
-    // name without path or extension, so the value is stemmed to match the psm and feature tables.
-    // A merged run has no single origin file - and a protein group inferred across runs has no
-    // per-row origin concept at all - so emit the file's "unknown" convention ("") instead of
-    // stamping every row with the run's first file. Not an error: the pg table cannot express it.
+    // A single-file run has exactly one possible origin, so its groups can be keyed on that file
+    // even without peptide evidence. Only merged runs need evidence to disambiguate.
     StringList run_paths;
     prot_id.getPrimaryMSRunPath(run_paths);
-    std::string run_file;
-    if (run_paths.size() == 1)
-    {
-      run_file = File::stemName(run_paths[0]);
-    }
-    else if (run_paths.size() > 1)
-    {
-      // TODO(#9817): provisional, not a settled contract. The QPX spec makes
-      // (pg_accessions, run_file_name) the pg primary key and requires both to be non-null, and
-      // quantms silently DROPS rows whose run_file_name is empty - so these groups would vanish
-      // downstream rather than being flagged. qpx has no cross-run encoding at all: pg.md mandates
-      // one row per group PER RUN, and its four quantitative converters melt wide->long on per-run
-      // intensity columns. Only its identification-only converter (mzIdentML) does the opposite,
-      // emitting one global row per group labelled with the source file's basename - so upstream is
-      // self-inconsistent on exactly the shape we produce here. Melting is available to us too: the
-      // peptide loop below already matches peptides to this run, and each one's origin file is
-      // recoverable via Constants::UserParam::ID_MERGE_INDEX. Honest-but-dropped vs. lossy-but-
-      // visible is unresolved upstream (bigbio/qpx#51) and is to be decided in #9817. Unreachable
-      // from any TOPP tool today (ProSE, the only caller, always passes a single-path run).
-      OPENMS_LOG_WARN << "ProteinGroupArrowExport (id-only): identification run '" << prot_id.getIdentifier()
-                      << "' spans " << run_paths.size() << " MS runs; protein groups have no single "
-                      << "origin file, leaving run_file_name empty for its rows." << std::endl;
-    }
+    const std::string sole_run =
+      (run_paths.size() == 1) ? ArrowIOHelpers::qpxRunFileName(run_paths[0]) : std::string();
 
     // Build accession -> ProteinHit lookup scoped to this prot_id
     std::unordered_map<std::string, const ProteinHit*> hit_lookup;
@@ -912,157 +993,195 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
       hit_lookup[hit.getAccession()] = &hit;
     }
 
-    // Build per-protein peptide counts from peptide_identifications whose
-    // identifier matches this prot_id's identifier
-    std::unordered_map<std::string, std::unordered_set<std::string>> acc_to_peptides;
-    for (const auto& pep_id : peptide_identifications)
+    // Peptide evidence for this prot_id, split by origin run: QPX defines the counts per
+    // (group, run), so the run dimension has to be carried alongside the accession.
+    std::unordered_map<std::string, std::map<std::string, std::unordered_set<std::string>>> acc_run_peptides;
+    AccessionRuns acc_runs;
+    auto bucket = pep_by_identifier.find(prot_id.getIdentifier());
+    if (bucket != pep_by_identifier.end())
     {
-      if (pep_id.getIdentifier() != prot_id.getIdentifier()) continue;
-      if (pep_id.getHits().empty()) continue;
-      // Use the best hit (first after assuming sorted by score)
-      const auto& best_hit = pep_id.getHits()[0];
-      std::string seq = best_hit.getSequence().toString();
-      for (const auto& ev : best_hit.getPeptideEvidences())
+      for (const auto* pep_ptr : bucket->second)
       {
-        const std::string& acc = ev.getProteinAccession();
-        if (!acc.empty())
+        const auto& pep_id = *pep_ptr;
+        if (pep_id.getHits().empty()) continue;
+        const std::string run = ArrowIOHelpers::qpxRunFileName(mapper.getPrimaryMSRunPath(pep_id));
+        if (run.empty()) continue;
+        // Use the best hit (first after assuming sorted by score)
+        const auto& best_hit = pep_id.getHits()[0];
+        std::string seq = best_hit.getSequence().toString();
+        for (const auto& ev : best_hit.getPeptideEvidences())
         {
-          acc_to_peptides[acc].insert(seq);
+          const std::string& acc = ev.getProteinAccession();
+          if (!acc.empty())
+          {
+            acc_run_peptides[acc][run].insert(seq);
+            acc_runs[acc].insert(run);
+          }
         }
       }
     }
 
-    // Iterate protein groups for this prot_id and emit rows
+    /// Peptidoforms of @p acc seen in @p run, or nullptr when there are none.
+    auto peptidesIn = [&acc_run_peptides](const std::string& acc, const std::string& run)
+                        -> const std::unordered_set<std::string>*
+    {
+      auto ait = acc_run_peptides.find(acc);
+      if (ait == acc_run_peptides.end()) { return nullptr; }
+      auto rit = ait->second.find(run);
+      return (rit == ait->second.end()) ? nullptr : &rit->second;
+    };
+
+    // Iterate protein groups for this prot_id and emit one row per run with evidence
     for (const auto& group : groups)
     {
-      const std::string& anchor = group.accessions.empty() ? "" : group.accessions[0];
-
-      // anchor_protein
-      (void)anchor_protein_builder.Append(anchor);
-
-      // run_file_name
-      (void)run_file_name_builder.Append(run_file);
-
-      // pg_accessions
-      (void)pg_accessions_builder.Append();
-      for (const auto& acc : group.accessions)
+      // run_file_name is a QPX primary-key component that MUST NOT be null, and quantms
+      // silently drops rows that violate that -- so a group that cannot be attributed to any
+      // run is skipped with a diagnostic rather than emitted with an empty key.
+      std::set<std::string> runs = evidenceRuns(acc_runs, group);
+      if (runs.empty() && !sole_run.empty()) { runs.insert(sole_run); }
+      if (runs.empty())
       {
-        (void)pg_acc_vb->Append(acc);
+        ++unattributable_groups;
+        continue;
       }
 
-      // pg_names
-      (void)pg_names_builder.Append();
-      for (const auto& acc : group.accessions)
+      for (const auto& run_file : runs)
       {
-        auto it = hit_lookup.find(acc);
-        if (it != hit_lookup.end())
+        const std::string& anchor = group.accessions.empty() ? "" : group.accessions[0];
+        pk_watch.add(anchor, run_file);
+
+        // anchor_protein
+        (void)anchor_protein_builder.Append(anchor);
+
+        // run_file_name
+        (void)run_file_name_builder.Append(run_file);
+
+        // pg_accessions
+        (void)pg_accessions_builder.Append();
+        for (const auto& acc : group.accessions)
         {
-          (void)pg_names_vb->Append(it->second->getDescription());
+          (void)pg_acc_vb->Append(acc);
+        }
+
+        // pg_names
+        (void)pg_names_builder.Append();
+        for (const auto& acc : group.accessions)
+        {
+          auto it = hit_lookup.find(acc);
+          if (it != hit_lookup.end())
+          {
+            (void)pg_names_vb->Append(it->second->getDescription());
+          }
+          else
+          {
+            (void)pg_names_vb->Append("");
+          }
+        }
+
+        // gg_accessions, gg_names (gene groups — one entry per group member, keep
+        // parallel to pg_accessions so consumers can zip positionally; empty string
+        // when the meta value is missing).
+        (void)gg_accessions_builder.Append();
+        (void)gg_names_builder.Append();
+        for (const auto& acc : group.accessions)
+        {
+          auto it = hit_lookup.find(acc);
+          bool has_ga = (it != hit_lookup.end()) && it->second->metaValueExists("gene_accession");
+          bool has_gn = (it != hit_lookup.end()) && it->second->metaValueExists("gene_name");
+          (void)gg_acc_vb->Append(has_ga ? it->second->getMetaValue("gene_accession").toString() : "");
+          (void)gg_names_vb->Append(has_gn ? it->second->getMetaValue("gene_name").toString() : "");
+        }
+
+        // gg_qvalue - not available
+        (void)gg_qvalue_builder.AppendNull();
+
+        // global_qvalue — use group probability
+        (void)global_qvalue_builder.Append(group.probability);
+
+        // pg_qvalue - not available for id-only
+        (void)pg_qvalue_builder.AppendNull();
+
+        // intensities — null for id-only
+        (void)intensities_builder.AppendNull();
+
+        // additional_intensities — null for id-only
+        (void)additional_intensities_builder.AppendNull();
+
+        // is_decoy
+        auto anchor_it = hit_lookup.find(anchor);
+        if (anchor_it != hit_lookup.end())
+        {
+          (void)is_decoy_builder.Append(anchor_it->second->isDecoy());
         }
         else
         {
-          (void)pg_names_vb->Append("");
+          (void)is_decoy_builder.Append(false);
         }
-      }
 
-      // gg_accessions, gg_names (gene groups — one entry per group member, keep
-      // parallel to pg_accessions so consumers can zip positionally; empty string
-      // when the meta value is missing).
-      (void)gg_accessions_builder.Append();
-      (void)gg_names_builder.Append();
-      for (const auto& acc : group.accessions)
-      {
-        auto it = hit_lookup.find(acc);
-        bool has_ga = (it != hit_lookup.end()) && it->second->metaValueExists("gene_accession");
-        bool has_gn = (it != hit_lookup.end()) && it->second->metaValueExists("gene_name");
-        (void)gg_acc_vb->Append(has_ga ? it->second->getMetaValue("gene_accession").toString() : "");
-        (void)gg_names_vb->Append(has_gn ? it->second->getMetaValue("gene_name").toString() : "");
-      }
+        // contaminant - not tracked
+        (void)contaminant_builder.AppendNull();
 
-      // gg_qvalue - not available
-      (void)gg_qvalue_builder.AppendNull();
-
-      // global_qvalue — use group probability
-      (void)global_qvalue_builder.Append(group.probability);
-
-      // pg_qvalue - not available for id-only
-      (void)pg_qvalue_builder.AppendNull();
-
-      // intensities — null for id-only
-      (void)intensities_builder.AppendNull();
-
-      // additional_intensities — null for id-only
-      (void)additional_intensities_builder.AppendNull();
-
-      // is_decoy
-      auto anchor_it = hit_lookup.find(anchor);
-      if (anchor_it != hit_lookup.end())
-      {
-        (void)is_decoy_builder.Append(anchor_it->second->isDecoy());
-      }
-      else
-      {
-        (void)is_decoy_builder.Append(false);
-      }
-
-      // contaminant - not tracked
-      (void)contaminant_builder.AppendNull();
-
-      // peptides — one {protein_name, peptide_count} per group member
-      (void)peptides_builder.Append();
-      int total_sequences = 0;
-      std::unordered_set<std::string> group_unique_peptides;
-      for (const auto& acc : group.accessions)
-      {
-        auto pit = acc_to_peptides.find(acc);
-        int count = (pit != acc_to_peptides.end()) ? static_cast<int>(pit->second.size()) : 0;
-        (void)pep_struct_b->Append();
-        (void)pep_name_b->Append(acc);
-        (void)pep_count_b->Append(count);
-        total_sequences += count;
-        if (pit != acc_to_peptides.end())
+        // peptides — one {protein_name, peptide_count} per group member
+        (void)peptides_builder.Append();
+        int total_sequences = 0;
+        std::unordered_set<std::string> group_unique_peptides;
+        for (const auto& acc : group.accessions)
         {
-          group_unique_peptides.insert(pit->second.begin(), pit->second.end());
+          const auto* peps = peptidesIn(acc, run_file);
+          int count = peps ? static_cast<int>(peps->size()) : 0;
+          (void)pep_struct_b->Append();
+          (void)pep_name_b->Append(acc);
+          (void)pep_count_b->Append(count);
+          total_sequences += count;
+          if (peps) { group_unique_peptides.insert(peps->begin(), peps->end()); }
         }
-      }
 
-      // peptide_counts — unique sequences across the union of group members,
-      // total_sequences is the sum of per-protein counts (double-counts shared peptides).
-      {
-        (void)peptide_counts_builder.Append();
-        (void)pc_unique_b->Append(static_cast<int>(group_unique_peptides.size()));
-        (void)pc_total_b->Append(total_sequences);
-      }
+        // peptide_counts — unique sequences across the union of group members,
+        // total_sequences is the sum of per-protein counts (double-counts shared peptides).
+        {
+          (void)peptide_counts_builder.Append();
+          (void)pc_unique_b->Append(static_cast<int>(group_unique_peptides.size()));
+          (void)pc_total_b->Append(total_sequences);
+        }
 
-      // feature_counts - not available for id-only
-      (void)feature_counts_builder.AppendNull();
+        // feature_counts - not available for id-only
+        (void)feature_counts_builder.AppendNull();
 
-      // sequence_coverage
-      if (anchor_it != hit_lookup.end() && anchor_it->second->getCoverage() != ProteinHit::COVERAGE_UNKNOWN)
-      {
-        (void)sequence_coverage_builder.Append(static_cast<float>(anchor_it->second->getCoverage()));
-      }
-      else
-      {
-        (void)sequence_coverage_builder.AppendNull();
-      }
+        // sequence_coverage
+        if (anchor_it != hit_lookup.end() && anchor_it->second->getCoverage() != ProteinHit::COVERAGE_UNKNOWN)
+        {
+          (void)sequence_coverage_builder.Append(static_cast<float>(anchor_it->second->getCoverage()));
+        }
+        else
+        {
+          (void)sequence_coverage_builder.AppendNull();
+        }
 
-      // molecular_weight - not available
-      (void)molecular_weight_builder.AppendNull();
+        // molecular_weight - not available
+        (void)molecular_weight_builder.AppendNull();
 
-      // additional_scores — anchor protein score
-      (void)additional_scores_builder.Append();
-      if (anchor_it != hit_lookup.end())
-      {
-        (void)as_struct_b->Append();
-        (void)as_name_b->Append(prot_id.getScoreType());
-        (void)as_value_b->Append(anchor_it->second->getScore());
-        (void)as_hb_b->Append(prot_id.isHigherScoreBetter());
-      }
+        // additional_scores — anchor protein score
+        (void)additional_scores_builder.Append();
+        if (anchor_it != hit_lookup.end())
+        {
+          (void)as_struct_b->Append();
+          (void)as_name_b->Append(prot_id.getScoreType());
+          (void)as_value_b->Append(anchor_it->second->getScore());
+          (void)as_hb_b->Append(prot_id.isHigherScoreBetter());
+        }
 
-      // cv_params - empty for now
-      (void)cv_params_builder.Append();
+        // cv_params - empty for now
+        (void)cv_params_builder.Append();
+      } // per-run melt
     }
+  }
+
+  pk_watch.report("ProteinGroupArrowExport (id-only)");
+  if (unattributable_groups > 0)
+  {
+    OPENMS_LOG_INFO << "ProteinGroupArrowExport (id-only): skipped " << unattributable_groups
+                    << " protein group(s) with no identification evidence in any run and no "
+                       "single-file origin (no run_file_name to key a QPX row on)." << std::endl;
   }
 
   if (total_groups_found == 0)

--- a/src/openms/source/FORMAT/QPXFile.cpp
+++ b/src/openms/source/FORMAT/QPXFile.cpp
@@ -122,54 +122,20 @@ namespace // anonymous
     }
   }
 
-  /// Throw if @p pep_id belongs to a merged run (more than one 'spectra_data' entry) but carries
-  /// no usable 'id_merge_index'. Without it the origin file cannot be resolved and every PSM of the
-  /// run would silently be labelled with the run's first file. Mirrors the MzTab exporter, which
-  /// refuses the same input (MzTab.cpp). Runs with 0 or 1 path are exempt - unmerged input is
-  /// unaffected. @p psm_index only feeds the error message.
-  void validateMergeIndex(const IdentifierMSRunMapper& mapper, const PeptideIdentification& pep_id, size_t psm_index)
-  {
-    const StringList& paths = mapper.getMSRunPaths(pep_id.getIdentifier());
-    if (paths.size() < 2) { return; }
-
-    const std::string key = std::string(Constants::UserParam::ID_MERGE_INDEX);
-    const std::string where = "PSM #" + StringUtils::toStr(psm_index) + " of identification run '"
-                            + pep_id.getIdentifier() + "' (" + StringUtils::toStr(paths.size())
-                            + " files in the run)";
-
-    if (!pep_id.metaValueExists(Constants::UserParam::ID_MERGE_INDEX))
-    {
-      throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-        "Multiple files in a run, but no '" + key + "' in PeptideIdentification found: " + where + ".");
-    }
-
-    const DataValue& dv = pep_id.getMetaValue(Constants::UserParam::ID_MERGE_INDEX);
-    if (dv.valueType() != DataValue::INT_VALUE)
-    {
-      throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-        "'" + key + "' is not an integer: " + where + ".");
-    }
-
-    const long long merge_index = static_cast<long long>(dv);
-    if (merge_index < 0 || static_cast<size_t>(merge_index) >= paths.size())
-    {
-      throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-        "'" + key + "' = " + StringUtils::toStr(merge_index) + " is out of range: " + where + ".");
-    }
-  }
-
-  /// @copydoc validateMergeIndex
+  /// Refuse PSMs of a merged run that carry no usable 'id_merge_index'.
+  /// @see IdentifierMSRunMapper::validateMergeIndex, which holds the check itself so the pg
+  ///      exporter can apply the same refusal.
   void validateMergeIndices(const IdentifierMSRunMapper& mapper, const PeptideIdentificationList& pep_ids)
   {
-    for (size_t i = 0; i < pep_ids.size(); ++i) { validateMergeIndex(mapper, pep_ids[i], i); }
+    for (size_t i = 0; i < pep_ids.size(); ++i) { mapper.validateMergeIndex(pep_ids[i], i); }
   }
 
-  /// @copydoc validateMergeIndex
+  /// @copydoc validateMergeIndices
   void validateMergeIndices(const IdentifierMSRunMapper& mapper, const std::vector<const PeptideIdentification*>& pep_ptrs)
   {
     for (size_t i = 0; i < pep_ptrs.size(); ++i)
     {
-      if (pep_ptrs[i] != nullptr) { validateMergeIndex(mapper, *pep_ptrs[i], i); }
+      if (pep_ptrs[i] != nullptr) { mapper.validateMergeIndex(*pep_ptrs[i], i); }
     }
   }
 

--- a/src/openms/source/METADATA/IdentifierMSRunMapper.cpp
+++ b/src/openms/source/METADATA/IdentifierMSRunMapper.cpp
@@ -97,14 +97,24 @@ namespace OpenMS
   void IdentifierMSRunMapper::validateMergeIndex(const PeptideIdentification& pep_id, size_t psm_index) const
   {
     const StringList& paths = getMSRunPaths(pep_id.getIdentifier());
+    // Only a merged run can be mis-resolved: with 0 or 1 paths there is no wrong file to pick.
+    //
+    // Deliberately NOT extended to a stale index on a single-path run. That shape is produced by
+    // QPXFile::importFromArrow, whose shell run carries one path while the PSMs it restores keep
+    // their original indices -- and there it is harmless, because each hit also carries a
+    // 'reference_file_name' metavalue that resolution prefers. Refusing it would reject a round
+    // trip that produces correct output. Where no such fallback exists the index simply does not
+    // resolve, which callers see as evidence they could not attribute rather than as a wrong key.
     if (paths.size() < 2) { return; }
+
+    const bool has_index = pep_id.metaValueExists(Constants::UserParam::ID_MERGE_INDEX);
 
     const std::string key = std::string(Constants::UserParam::ID_MERGE_INDEX);
     const std::string where = "PSM #" + StringUtils::toStr(psm_index) + " of identification run '"
                             + pep_id.getIdentifier() + "' (" + StringUtils::toStr(paths.size())
                             + " files in the run)";
 
-    if (!pep_id.metaValueExists(Constants::UserParam::ID_MERGE_INDEX))
+    if (!has_index)
     {
       throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
         "Multiple files in a run, but no '" + key + "' in PeptideIdentification found: " + where + ".");

--- a/src/openms/source/METADATA/IdentifierMSRunMapper.cpp
+++ b/src/openms/source/METADATA/IdentifierMSRunMapper.cpp
@@ -94,6 +94,39 @@ namespace OpenMS
     return std::string();
   }
 
+  void IdentifierMSRunMapper::validateMergeIndex(const PeptideIdentification& pep_id, size_t psm_index) const
+  {
+    const StringList& paths = getMSRunPaths(pep_id.getIdentifier());
+    if (paths.size() < 2) { return; }
+
+    const std::string key = std::string(Constants::UserParam::ID_MERGE_INDEX);
+    const std::string where = "PSM #" + StringUtils::toStr(psm_index) + " of identification run '"
+                            + pep_id.getIdentifier() + "' (" + StringUtils::toStr(paths.size())
+                            + " files in the run)";
+
+    if (!pep_id.metaValueExists(Constants::UserParam::ID_MERGE_INDEX))
+    {
+      throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "Multiple files in a run, but no '" + key + "' in PeptideIdentification found: " + where + ".");
+    }
+
+    const DataValue& dv = pep_id.getMetaValue(Constants::UserParam::ID_MERGE_INDEX);
+    if (dv.valueType() != DataValue::INT_VALUE)
+    {
+      throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "'" + key + "' is not an integer: " + where + ".");
+    }
+
+    // long long, not Size: DataValue's unsigned conversion throws its own ConversionError on a
+    // negative value, which would escape as an undiagnosed exception instead of the message above.
+    const long long merge_index = static_cast<long long>(dv);
+    if (merge_index < 0 || static_cast<size_t>(merge_index) >= paths.size())
+    {
+      throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "'" + key + "' = " + StringUtils::toStr(merge_index) + " is out of range: " + where + ".");
+    }
+  }
+
   bool IdentifierMSRunMapper::hasIdentifier(const std::string& identifier) const
   {
     return identifier_to_msrunpath_.contains(identifier);

--- a/src/tests/class_tests/openms/source/IdentifierMSRunMapper_test.cpp
+++ b/src/tests/class_tests/openms/source/IdentifierMSRunMapper_test.cpp
@@ -255,6 +255,66 @@ START_SECTION([EXTRA] create() leaves a complete forward map even when it throws
 }
 END_SECTION
 
+START_SECTION((void validateMergeIndex(const PeptideIdentification& pep_id, size_t psm_index) const))
+{
+  // getPrimaryMSRunPath() falls back to the run's FIRST file when it cannot resolve an index,
+  // which silently mislabels every PSM of a merged run. Callers that key on the result must be
+  // able to refuse such input instead; this is that check.
+  ProteinIdentification merged;
+  merged.setIdentifier("MERGED");
+  merged.setPrimaryMSRunPath(StringList{"/data/runA.mzML", "/data/runB.mzML"});
+  ProteinIdentification single;
+  single.setIdentifier("SINGLE");
+  single.setPrimaryMSRunPath(StringList{"/data/only.mzML"});
+  ProteinIdentification none;
+  none.setIdentifier("NONE");
+
+  IdentifierMSRunMapper m;
+  m.create(std::vector<ProteinIdentification>{merged, single, none});
+
+  // Accepted: a usable index into the merged run.
+  PeptideIdentification ok;
+  ok.setIdentifier("MERGED");
+  ok.setMetaValue(Constants::UserParam::ID_MERGE_INDEX, 1);
+  m.validateMergeIndex(ok, 0);
+  TEST_STRING_EQUAL(m.getPrimaryMSRunPath(ok), "/data/runB.mzML")
+
+  // Exempt: unmerged runs have nothing to disambiguate, so a missing index is not an error.
+  // Resolution is unambiguous either way, which is what the exemption rests on.
+  PeptideIdentification one_path;
+  one_path.setIdentifier("SINGLE");
+  m.validateMergeIndex(one_path, 0);
+  TEST_STRING_EQUAL(m.getPrimaryMSRunPath(one_path), "/data/only.mzML")
+
+  PeptideIdentification no_path;
+  no_path.setIdentifier("NONE");
+  m.validateMergeIndex(no_path, 0);
+  TEST_TRUE(m.getPrimaryMSRunPath(no_path).empty())
+
+  // Refused: missing, wrongly typed, negative, and out-of-range indices.
+  PeptideIdentification missing;
+  missing.setIdentifier("MERGED");
+  TEST_EXCEPTION(Exception::MissingInformation, m.validateMergeIndex(missing, 0))
+
+  PeptideIdentification wrong_type;
+  wrong_type.setIdentifier("MERGED");
+  wrong_type.setMetaValue(Constants::UserParam::ID_MERGE_INDEX, "1");
+  TEST_EXCEPTION(Exception::MissingInformation, m.validateMergeIndex(wrong_type, 0))
+
+  // Negative must surface as MissingInformation, not as the ConversionError that an
+  // unsigned cast of the DataValue would raise.
+  PeptideIdentification negative;
+  negative.setIdentifier("MERGED");
+  negative.setMetaValue(Constants::UserParam::ID_MERGE_INDEX, -1);
+  TEST_EXCEPTION(Exception::MissingInformation, m.validateMergeIndex(negative, 0))
+
+  PeptideIdentification too_big;
+  too_big.setIdentifier("MERGED");
+  too_big.setMetaValue(Constants::UserParam::ID_MERGE_INDEX, 2);
+  TEST_EXCEPTION(Exception::MissingInformation, m.validateMergeIndex(too_big, 0))
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST

--- a/src/tests/class_tests/openms/source/ProteinGroupArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteinGroupArrowExport_test.cpp
@@ -200,6 +200,39 @@ START_SECTION(([EXTRA] exportToArrow - a single-file run keeps its group without
 }
 END_SECTION
 
+START_SECTION(([EXTRA] exportToArrow - peptide_counts counts sequences, not peptidoforms))
+{
+  // QPX splits the two: peptide_counts.unique_sequences counts SEQUENCES, while distinguishing
+  // modified forms is what feature_counts.unique_features is for. The ConsensusMap overload
+  // keys on toUnmodifiedString(); this overload must agree, or the same column means two
+  // different things depending on which one produced the file.
+  auto prot_id = makeIdOnlyRun({"/data/SimpleSearchEngine_1.mzML"});
+
+  PeptideIdentificationList peps;
+  for (const auto& seq : {"PEPTIDEK", "PEPT(Phospho)IDEK"})
+  {
+    PeptideIdentification pid;
+    pid.setIdentifier("PI_0");
+    PeptideHit hit;
+    hit.setSequence(AASequence::fromString(seq));
+    PeptideEvidence ev;
+    ev.setProteinAccession("PROT_A");
+    hit.setPeptideEvidences({ev});
+    pid.setHits({hit});
+    peps.push_back(pid);
+  }
+
+  auto table = ProteinGroupArrowExport::exportToArrow({prot_id}, peps);
+  TEST_NOT_EQUAL(table, nullptr)
+  TEST_EQUAL(table->num_rows(), 1)
+
+  // Two peptidoforms of one sequence => one unique sequence.
+  auto counts = std::static_pointer_cast<arrow::StructArray>(table->GetColumnByName("peptide_counts")->chunk(0));
+  auto unique = std::static_pointer_cast<arrow::Int32Array>(counts->field(0));
+  TEST_EQUAL(unique->Value(0), 1)
+}
+END_SECTION
+
 START_SECTION(([EXTRA] exportToArrow - a merged run without groups does not abort the export))
 {
   // The id_merge_index refusal is scoped to the PSMs the export actually reads. Input that

--- a/src/tests/class_tests/openms/source/ProteinGroupArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteinGroupArrowExport_test.cpp
@@ -15,6 +15,7 @@
 ///////////////////////////
 
 #include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/KERNEL/ConsensusFeature.h>
 #include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/METADATA/PeptideEvidence.h>
@@ -69,6 +70,35 @@ namespace
     pep_id.setHits({hit});
     return PeptideIdentificationList{pep_id};
   }
+
+  /// One PSM for @p accession, attributed to file @p merge_index of a merged run.
+  /// Pass merge_index < 0 to omit the metavalue entirely (an unattributable PSM).
+  PeptideIdentification makeMergedPeptide(const std::string& accession, int merge_index,
+                                          const std::string& sequence = "PEPTIDEK")
+  {
+    PeptideIdentification pep_id;
+    pep_id.setIdentifier("PI_0");
+    if (merge_index >= 0)
+    {
+      pep_id.setMetaValue(Constants::UserParam::ID_MERGE_INDEX, merge_index);
+    }
+    PeptideHit hit;
+    hit.setSequence(AASequence::fromString(sequence));
+    PeptideEvidence ev;
+    ev.setProteinAccession(accession);
+    hit.setPeptideEvidences({ev});
+    pep_id.setHits({hit});
+    return pep_id;
+  }
+
+  /// The run_file_name values of a table, in row order.
+  std::vector<std::string> runNames(const std::shared_ptr<arrow::Table>& table)
+  {
+    std::vector<std::string> out;
+    auto col = std::static_pointer_cast<arrow::StringArray>(table->GetColumnByName("run_file_name")->chunk(0));
+    for (int64_t i = 0; i < col->length(); ++i) { out.push_back(col->GetString(i)); }
+    return out;
+  }
 }
 
 START_TEST(ProteinGroupArrowExport, "$Id$")
@@ -89,31 +119,105 @@ START_SECTION((static std::shared_ptr<arrow::Table> exportToArrow(const std::vec
 }
 END_SECTION
 
-START_SECTION(([EXTRA] exportToArrow - a merged run has no single origin file per protein group))
+START_SECTION(([EXTRA] exportToArrow - a merged run melts onto every run with evidence))
 {
-  // A protein group inferred across several runs has no per-row origin file, and the pg table has
-  // no place to record more than one. Emit the file's "unknown" convention ("") plus a warning
-  // rather than stamping every row with the run's first file.
-  // TODO(#9817): provisional - the QPX spec requires a non-null run_file_name here and quantms
-  // drops empty-valued rows, so this may become a non-empty token instead. See the matching
-  // comment in ProteinGroupArrowExport.cpp; this assertion pins current behaviour, not a contract.
+  // A group in a merged run is emitted once per run in which one of its members was identified.
+  // The previous behaviour -- one row with an empty run_file_name -- put an empty value in a QPX
+  // primary-key component, which quantms silently drops.
   auto prot_id = makeIdOnlyRun({"/data/runA.mzML", "/data/runB.mzML"});
-  auto table = ProteinGroupArrowExport::exportToArrow({prot_id}, makePeptides());
+  PeptideIdentificationList peps{makeMergedPeptide("PROT_A", 0), makeMergedPeptide("PROT_B", 1)};
+
+  auto table = ProteinGroupArrowExport::exportToArrow({prot_id}, peps);
   TEST_NOT_EQUAL(table, nullptr)
-  TEST_EQUAL(table->num_rows(), 1)
-  auto rfn = std::static_pointer_cast<arrow::StringArray>(table->GetColumnByName("run_file_name")->chunk(0));
-  TEST_STRING_EQUAL(rfn->GetString(0), "")
+  TEST_EQUAL(table->num_rows(), 2)
+
+  const auto names = runNames(table);
+  const std::set<std::string> runs(names.begin(), names.end());
+  TEST_TRUE(runs == std::set<std::string>({"runA", "runB"}))
+  TEST_TRUE(runs.count("") == 0)
 }
 END_SECTION
 
-START_SECTION(([EXTRA] exportToArrow - a run without spectra_data yields an empty run_file_name))
+START_SECTION(([EXTRA] exportToArrow - a merged run emits only the runs that have evidence))
 {
+  // Melting must not fan out across every file in the run: a group identified in one of two
+  // files gets one row, not two, or the table asserts an observation that was never made.
+  auto prot_id = makeIdOnlyRun({"/data/runA.mzML", "/data/runB.mzML"});
+  PeptideIdentificationList peps{makeMergedPeptide("PROT_A", 0)};
+
+  auto table = ProteinGroupArrowExport::exportToArrow({prot_id}, peps);
+  TEST_NOT_EQUAL(table, nullptr)
+  TEST_EQUAL(table->num_rows(), 1)
+  TEST_STRING_EQUAL(runNames(table)[0], "runA")
+}
+END_SECTION
+
+START_SECTION(([EXTRA] exportToArrow - a merged run without id_merge_index is refused))
+{
+  // Without the index every PSM of the run resolves to its FIRST file, so the run_file_name key
+  // would be wrong rather than missing. The psm view refuses the same input.
+  auto prot_id = makeIdOnlyRun({"/data/runA.mzML", "/data/runB.mzML"});
+  PeptideIdentificationList peps{makeMergedPeptide("PROT_A", -1)};
+
+  TEST_EXCEPTION(Exception::MissingInformation,
+                 ProteinGroupArrowExport::exportToArrow({prot_id}, peps))
+}
+END_SECTION
+
+START_SECTION(([EXTRA] exportToArrow - a merged run with no evidence anywhere emits no row))
+{
+  // Nothing can key the row: several possible origins and no evidence to choose between them.
+  // Skipping is the only option that does not put an empty value in the primary key.
+  auto prot_id = makeIdOnlyRun({"/data/runA.mzML", "/data/runB.mzML"});
+  PeptideIdentificationList peps{makeMergedPeptide("PROT_UNRELATED", 0)};
+
+  auto table = ProteinGroupArrowExport::exportToArrow({prot_id}, peps);
+  TEST_NOT_EQUAL(table, nullptr)
+  TEST_EQUAL(table->num_rows(), 0)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] exportToArrow - a run without spectra_data emits no row))
+{
+  // No path to stem and no id_merge_index target, so the single-file escape hatch does not
+  // apply either. Previously this emitted a row with an empty run_file_name.
   auto prot_id = makeIdOnlyRun({});
   auto table = ProteinGroupArrowExport::exportToArrow({prot_id}, makePeptides());
   TEST_NOT_EQUAL(table, nullptr)
+  TEST_EQUAL(table->num_rows(), 0)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] exportToArrow - a single-file run keeps its group without peptide evidence))
+{
+  // The escape hatch that makes the melt non-regressive: one possible origin means no primary-key
+  // ambiguity, so a group whose members carry no peptide evidence is still emitted.
+  auto prot_id = makeIdOnlyRun({"/data/SimpleSearchEngine_1.mzML"});
+  auto table = ProteinGroupArrowExport::exportToArrow({prot_id}, PeptideIdentificationList{});
+  TEST_NOT_EQUAL(table, nullptr)
   TEST_EQUAL(table->num_rows(), 1)
-  auto rfn = std::static_pointer_cast<arrow::StringArray>(table->GetColumnByName("run_file_name")->chunk(0));
-  TEST_STRING_EQUAL(rfn->GetString(0), "")
+  TEST_STRING_EQUAL(runNames(table)[0], "SimpleSearchEngine_1")
+}
+END_SECTION
+
+START_SECTION(([EXTRA] exportToArrow - two runs sharing a stem keep both rows under one key))
+{
+  // '/a/run.mzML' and '/b/run.mzML' both stem to 'run', so the two rows collide on the
+  // (anchor_protein, run_file_name) primary key. Both are kept -- dropping one loses data and
+  // there is no rule for merging two group probabilities -- and the export warns.
+  auto prot_a = makeIdOnlyRun({"/a/run.mzML"});
+  auto prot_b = makeIdOnlyRun({"/b/run.mzML"});
+  prot_b.setIdentifier("PI_1");
+
+  auto table = ProteinGroupArrowExport::exportToArrow({prot_a, prot_b}, makePeptides());
+  TEST_NOT_EQUAL(table, nullptr)
+  TEST_EQUAL(table->num_rows(), 2)
+
+  const auto names = runNames(table);
+  TEST_STRING_EQUAL(names[0], "run")
+  TEST_STRING_EQUAL(names[1], "run")
+  auto anchors = std::static_pointer_cast<arrow::StringArray>(table->GetColumnByName("anchor_protein")->chunk(0));
+  TEST_STRING_EQUAL(anchors->GetString(0), anchors->GetString(1))
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ProteinGroupArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteinGroupArrowExport_test.cpp
@@ -200,6 +200,51 @@ START_SECTION(([EXTRA] exportToArrow - a single-file run keeps its group without
 }
 END_SECTION
 
+START_SECTION(([EXTRA] exportToArrow - a merged run without groups does not abort the export))
+{
+  // The id_merge_index refusal is scoped to the PSMs the export actually reads. Input that
+  // contributes no protein group must not be able to abort an export it has no say in --
+  // e.g. BayesianProteinInference_test.idXML, which has two spectra_data paths, nine PSMs,
+  // no id_merge_index and no groups.
+  ProteinIdentification empty_groups;
+  empty_groups.setIdentifier("PI_0");
+  empty_groups.setPrimaryMSRunPath({"/data/runA.mzML", "/data/runB.mzML"});
+  PeptideIdentificationList peps{makeMergedPeptide("PROT_A", -1)};
+
+  auto table = ProteinGroupArrowExport::exportToArrow({empty_groups}, peps);
+  TEST_NOT_EQUAL(table, nullptr)
+  TEST_EQUAL(table->num_rows(), 0)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] exportToArrow - the merge-index refusal ignores unrelated runs))
+{
+  // Only the PSMs of a run that actually contributes groups are validated. A second,
+  // group-less merged run in the same input must not veto the export of the first.
+  auto usable = makeIdOnlyRun({"/data/SimpleSearchEngine_1.mzML"});
+  ProteinIdentification unrelated;
+  unrelated.setIdentifier("PI_OTHER");
+  unrelated.setPrimaryMSRunPath({"/data/x.mzML", "/data/y.mzML"});
+
+  PeptideIdentification stray;               // merged run, no id_merge_index, no groups behind it
+  stray.setIdentifier("PI_OTHER");
+  PeptideHit sh;
+  sh.setSequence(AASequence::fromString("STRAYPEPTIDEK"));
+  PeptideEvidence sev;
+  sev.setProteinAccession("PROT_A");
+  sh.setPeptideEvidences({sev});
+  stray.setHits({sh});
+
+  PeptideIdentificationList peps = makePeptides();
+  peps.push_back(stray);
+
+  auto table = ProteinGroupArrowExport::exportToArrow({usable, unrelated}, peps);
+  TEST_NOT_EQUAL(table, nullptr)
+  TEST_EQUAL(table->num_rows(), 1)
+  TEST_STRING_EQUAL(runNames(table)[0], "SimpleSearchEngine_1")
+}
+END_SECTION
+
 START_SECTION(([EXTRA] exportToArrow - two runs sharing a stem keep both rows under one key))
 {
   // '/a/run.mzML' and '/b/run.mzML' both stem to 'run', so the two rows collide on the

--- a/src/topp/ProSE.cpp
+++ b/src/topp/ProSE.cpp
@@ -675,6 +675,16 @@ class ProSE :
                              << " -> " << out_qpx_dir << ": " << e.what() << endl;
             input_failed = true;
           }
+          catch (const std::exception& e)
+          {
+            // Unlike the sibling modes, this one calls into Arrow/Parquet, whose exceptions do
+            // not derive from Exception::BaseException. The write helpers check Status rather
+            // than throwing, but allocation and internal parquet failures still surface here,
+            // and letting one escape would skip the remaining outputs for this input.
+            OPENMS_LOG_ERROR << "Failed to write QPX output for " << in_file
+                             << " -> " << out_qpx_dir << " (Arrow/Parquet): " << e.what() << endl;
+            input_failed = true;
+          }
         }
 
         // -- OpenMS internal directory output --

--- a/src/topp/ProSE.cpp
+++ b/src/topp/ProSE.cpp
@@ -622,6 +622,11 @@ class ProSE :
         // -- QPX directory output --
         if (!out_qpx_dir.empty())
         {
+          // Wrapped like the sibling modes above: the QPX exporters refuse input they cannot key
+          // (a merged run whose PSMs lack 'id_merge_index', ambiguous feature identities), and an
+          // escaping exception would abort the whole per-file loop rather than failing this mode.
+          try
+          {
           // PSM — build table once, write to file, accumulate same table for merge.
           const std::string qpx_psm_file = out_qpx_dir + "/" + basename + ".psm.parquet";
           auto qpx_psm_table = QPXFile::exportPSMsToQPXArrow(result.protein_ids, result.peptide_ids, /*export_all_psms=*/false);
@@ -662,6 +667,13 @@ class ProSE :
           else
           {
             OPENMS_LOG_WARN << "QPX PG table build returned null for " << in_file << " — skipping " << qpx_pg_file << endl;
+          }
+          }
+          catch (const Exception::BaseException& e)
+          {
+            OPENMS_LOG_ERROR << "Failed to write QPX output for " << in_file
+                             << " -> " << out_qpx_dir << ": " << e.what() << endl;
+            input_failed = true;
           }
         }
 


### PR DESCRIPTION
Closes the remaining half of #9817 Defect A. #9825 fixed the `ConsensusMap` overload of the protein-group export; this does the same for the **identification-only** overload.

## The defect

`ProteinGroupArrowExport::exportToArrow(const std::vector<ProteinIdentification>&, const PeptideIdentificationList&)` derived `run_file_name` **once per `ProteinIdentification`** and stamped it on every group row. A merged run spanning N files has no single origin, so it emitted an **empty** `run_file_name` — a QPX primary-key component the spec says MUST NOT be null, and one that quantms' `pg_adapter` silently **drops**. Those groups vanished downstream rather than being flagged.

## The fix

Melt, exactly as the sibling overload already does: resolve each PSM's origin through `IdentifierMSRunMapper` and emit **one row per (group, run)** for the runs where a member accession actually has peptide evidence. `peptides` and `peptide_counts` are scoped to the emitted run, so the same group in two runs reports what was seen in each.

**The encoding is no longer a judgement call.** [bigbio/qpx#51](https://github.com/bigbio/qpx/issues/51) settled it on 2026-07-29: protein groups are taken to be globally defined and identical across runs, so one row per run is correct. No sentinel, no empty value, no separate provenance table. This PR is a port, not a design.

### Two policies it needs

- **A single-file run keeps its groups even without peptide evidence.** One possible origin means no key ambiguity. Without this, a group whose accessions carry no evidence would go 1 row → 0 rows for ProSE — a regression, not a fix.
- **A merged run with no evidence anywhere is skipped**, with a diagnostic. Nothing can key the row, and an empty key is the failure mode being fixed.

### Merged input is refused rather than mislabelled

A PSM in a merged run without a usable `id_merge_index` resolves to the run's **first** file, so the key would be wrong rather than missing. The psm view already refuses this; the check lived in `QPXFile.cpp`'s anonymous namespace with internal linkage, so no other exporter could apply it. The first commit moves it onto `IdentifierMSRunMapper`, which owns the resolution it guards, and `QPXFile`'s wrappers delegate — one implementation, not two.

One detail worth keeping: the value is read as `long long`, not `Size`. Casting a `DataValue` to an unsigned type raises its own `ConversionError` on a negative value, which would escape as an undiagnosed exception instead of the located message.

### Duplicate keys are surfaced, not resolved

Two `ProteinIdentification`s whose paths share a stem produce byte-different rows — different scores, counts, `global_qvalue` — under one primary key. **Both are kept**: dropping one loses data, and there is no rule for reconciling two group probabilities. But it is no longer silent — both overloads now count repeated `(anchor_protein, run_file_name)` pairs and warn with examples. Nothing downstream enforces the key either: `qpxc validate` reports duplicate PKs at severity `warning` and its `is_valid` ignores warnings.

Both overloads also now share `buildRunMapper` / `indexEvidenceRuns` / `evidenceRuns`, so the melt logic exists once.

## Verification

- **153/153** TOPP tests (`ProteomicsLFQ`, `ProSE`, `ProteinQuantifier`, `IsobaricAnalyzer`); `IdentifierMSRunMapper`, `ProteinGroupArrowExport`, `QPXFile` and `ConsensusMapArrowExport` class tests pass.
- **The `ConsensusMap` overload is behaviour-preserving on real data** — the part of this change most likely to regress something that already worked, since it was rewired onto the new shared helpers. Re-running the BSA `ProteomicsLFQ` export and diffing the pg output against the pre-change run: 40 rows both times, identical `(anchor_protein, run_file_name)` multiset, no duplicates, no empty keys. The new duplicate-key warning does not fire.
- No reference-file churn.

**Coverage caveat, stated plainly:** no TOPP test exercises the identification-only pg path. `TOPP_ProSE_3_qpx` produces a pg.parquet with **0 rows** — the per-file path yields no indistinguishable groups in that configuration, and `-FDR:protein` applies only to `-out_merged`. The class tests are its only coverage, before and after this PR.

That leaves ProSE's invariance as an argument rather than a measurement: it always passes a single-path `ProteinIdentification`, `qpxRunFileName` is literally `File::stemName`, and for a single-path run the melt resolves to that same stem whether the group has evidence (evidence path) or not (escape hatch). Pinned by a class test either way.

## Test changes

Two existing assertions flip, both deliberately:

| section | was | now |
|---|---|---|
| merged run | 1 row, `run_file_name == ""` | 2 rows, `{runA, runB}` |
| run without `spectra_data` | 1 row, `run_file_name == ""` | 0 rows |

The first carried a `TODO(#9817)` saying it pinned current behaviour rather than a contract. New sections cover evidence-scoped melting (no fan-out onto runs without evidence), the refusal on a missing `id_merge_index`, the single-file escape hatch, a merged run with no evidence anywhere, and the stem-collision duplicate key.

## What protein-inference input does

Worth stating explicitly, because it is the export's own target use case and the answer is not obvious: **protein inference does not annotate a run name.** `Epifany_1_out.idXML` carries 163 indistinguishable groups across three IdentificationRuns and *none* of them has `spectra_data`; `ProteinInference_1_output.idXML` writes `value="[]"`. **25 of 28** checked-in group-bearing idXML files have no usable run path.

There is therefore no `run_file_name` to derive, and the melt emits nothing for them. That is deliberate — `run_file_name` is a primary-key component, and the empty value the old code wrote is silently dropped by quantms, so those rows were an invisible downstream loss rather than a real export. What changes is that the user finds out **at the source**, via a `WARN` naming the remedy (`setPrimaryMSRunPath()`), instead of discovering an empty table three tools later.

Measured with a probe calling the exporter directly on real files:

| file | groups | run paths | result |
|---|---|---|---|
| `Epifany_1_out.idXML` | 163 | 0 | 0 rows + WARN |
| `ProteinInference_1_output.idXML` | 1 | 0 | 0 rows + WARN |
| `BayesianProteinInference_test.idXML` | 0 | 2, no `id_merge_index` | empty table, no throw |

The third one is a defect this PR fixes rather than introduces: the `id_merge_index` preflight originally ran over every PSM *before* the group loop, so a merged run that contributes no group could abort an export it has no say in. It is now scoped to the PSMs of runs that actually contribute groups, and still refuses a merged run that does.

`ProSE`'s QPX output block is also wrapped in `try`/`catch` like its idXML and `.pin` siblings — the block documents that one mode's failure must not skip the others, and these exporters can throw on input they cannot key.

## Known limitation, not a regression

When inference sits in one run of a multi-run file, only that run's PSMs are consulted for evidence, so sibling runs cannot receive a row. The old code was equally limited — it keyed everything on the inference run's first path — so this is not a regression, but it is a real limitation and belongs with the cross-run questions #9817 already tracks rather than being settled quietly here.

Observed while testing, not fixed here: `IdentifierMSRunMapper::create()` treats two runs that both have *empty* path lists as a duplicate-path collision, so a multi-run inference file logs a confusing "ambiguous MS run paths" warning before the actionable one. Harmless (the forward map is intact) but worth a separate tidy-up.

## Not done

`estimated_rows` is now neither an upper nor a lower bound after the melt. It is a `Reserve` hint only, and an exact count would need a full pre-pass over every group's evidence runs before any builder exists — a duplicate traversal to save one Arrow regrow.

## Still open on #9817

The cross-run **dedup** question — whether two `ProteinIdentification`s carrying the same accession group should be merged — is untouched and remains a semantic decision. Defect C's `importFromArrow` shell branch also remains; it needs the OpenMS-native format to carry an ordered path list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DF2YUewPQTC5tJWqn23pUm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Protein group Arrow exports now create per-run rows based on peptide evidence, with correctly scoped peptide details and counts.
  * Improved row-key handling preserves distinct results when run names collide.

* **Bug Fixes**
  * Merged-run exports provide clearer diagnostics for invalid or missing merge metadata and omit unsupported evidence.
  * Inconsistent Arrow tables are safely rejected.
  * Per-input QPX writing failures no longer stop other outputs.

* **Documentation**
  * Clarified export behavior, run mapping, and error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->