### PR TITLE
[FIX] QPX export: three columns that were silently wrong

### DIFF
--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -448,22 +448,19 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
       }
     }
 
-    // gg_accessions, gg_names (keep lists symmetric so they can be zipped)
+    // gg_accessions, gg_names (gene groups -- one entry per group member, keep parallel to
+    // pg_accessions so consumers can zip positionally; empty string when the meta value is
+    // missing). Appending only for annotated members would shorten these lists relative to
+    // pg_accessions and shift every later gene onto the wrong protein.
     (void)gg_accessions_builder.Append();
     (void)gg_names_builder.Append();
     for (const auto& acc : group.accessions)
     {
       auto it = hit_lookup.find(acc);
-      if (it != hit_lookup.end())
-      {
-        bool has_ga = it->second->metaValueExists("gene_accession");
-        bool has_gn = it->second->metaValueExists("gene_name");
-        if (has_ga || has_gn)
-        {
-          (void)gg_acc_vb->Append(has_ga ? it->second->getMetaValue("gene_accession").toString() : "");
-          (void)gg_names_vb->Append(has_gn ? it->second->getMetaValue("gene_name").toString() : "");
-        }
-      }
+      bool has_ga = (it != hit_lookup.end()) && it->second->metaValueExists("gene_accession");
+      bool has_gn = (it != hit_lookup.end()) && it->second->metaValueExists("gene_name");
+      (void)gg_acc_vb->Append(has_ga ? it->second->getMetaValue("gene_accession").toString() : "");
+      (void)gg_names_vb->Append(has_gn ? it->second->getMetaValue("gene_name").toString() : "");
     }
 
     // gg_qvalue - not available
@@ -523,6 +520,7 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
       // peptides: one {protein_name, peptide_count} per group member, counting that member's
       // distinct peptide sequences in this run.
       (void)peptides_builder.Append();
+      int total_sequences = 0;   // sum of the per-member counts, i.e. what peptides[] adds up to
       for (const auto& acc : group.accessions)
       {
         std::set<std::string> seqs;
@@ -541,6 +539,7 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
         (void)pep_struct_b->Append();
         (void)pep_name_b->Append(acc);
         (void)pep_count_b->Append(static_cast<int>(seqs.size()));
+        total_sequences += static_cast<int>(seqs.size());
       }
 
       if (group_features.empty())
@@ -559,9 +558,15 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
           if (!feature_info[fi].sequence.empty()) { unique_sequences.insert(feature_info[fi].sequence); }
           unique_features.emplace(feature_info[fi].peptidoform, feature_info[fi].charge);
         }
+        // peptide_counts counts SEQUENCES: unique across the group, total as the sum of the
+        // per-member counts emitted in peptides[] above (so the two agree, and shared peptides
+        // are counted once per member). Distinguishing peptidoform and charge is what
+        // feature_counts is for -- using group_features.size() here made total_sequences a
+        // feature count, identical to total_features and contradicting peptides[] in the
+        // same row.
         (void)peptide_counts_builder.Append();
         (void)pc_unique_b->Append(static_cast<int>(unique_sequences.size()));
-        (void)pc_total_b->Append(static_cast<int>(group_features.size()));
+        (void)pc_total_b->Append(total_sequences);
 
         (void)feature_counts_builder.Append();
         (void)fc_unique_b->Append(static_cast<int>(unique_features.size()));

--- a/src/openms/source/FORMAT/QPXFile.cpp
+++ b/src/openms/source/FORMAT/QPXFile.cpp
@@ -831,12 +831,16 @@ namespace // anonymous
 /// (no global/cross-row state), so any contiguous sub-range produces a self-contained table;
 /// this is what makes the streaming export safe. Shared by exportPSMsToQPXArrow() (whole
 /// range) and exportToParquetStreaming() (one batch per call).
+/// @param[out] unattributable_psms Incremented per PSM whose origin file could not be resolved,
+///             so the caller can report it once. Written only through the caller's own slot --
+///             this runs inside an OpenMP region (see exportToParquetStreaming).
 std::shared_ptr<arrow::Table> buildQPXPSMTableRange(
   const IdentifierMSRunMapper& mapper,
   const std::vector<const PeptideIdentification*>& pep_ptrs,
   size_t range_begin,
   size_t range_end,
-  bool export_all_psms)
+  bool export_all_psms,
+  size_t& unattributable_psms)
 {
   // -- Simple column builders --
   arrow::StringBuilder sequence_builder, peptidoform_builder;
@@ -1260,7 +1264,14 @@ std::shared_ptr<arrow::Table> buildQPXPSMTableRange(
         // QPX defines run_file_name as the spectrum file name without path or extension. Stem
         // every source of the value, not just this fallback, so the column is a usable join key
         // across the psm/feature/pg tables no matter which branch above supplied it.
-        (void)run_file_name_builder.Append(File::stemName(run_file)); // non-nullable, default to empty
+        const std::string run_stem = File::stemName(run_file);
+        // QPX makes run_file_name a non-nullable primary-key component, but an empty string is
+        // not null -- it satisfies Arrow while violating the spec, and consumers key on it to
+        // join psm against feature and pg. Emit the row (a PSM is a primary record; dropping it
+        // would discard an identification) but count it, so a collection that cannot be joined
+        // is not handed over silently.
+        if (run_stem.empty()) { ++unattributable_psms; }
+        (void)run_file_name_builder.Append(run_stem);
       }
 
       // === cv_params (list<struct>, nullable - null for now) ===
@@ -1474,7 +1485,17 @@ std::shared_ptr<arrow::Table> QPXFile::exportPSMsToQPXArrow(
   std::vector<const PeptideIdentification*> ptrs;
   ptrs.reserve(peptide_identifications.size());
   for (const auto& pep_id : peptide_identifications) { ptrs.push_back(&pep_id); }
-  return buildQPXPSMTableRange(mapper, ptrs, 0, ptrs.size(), export_all_psms);
+  size_t unattributable = 0;
+  auto table = buildQPXPSMTableRange(mapper, ptrs, 0, ptrs.size(), export_all_psms, unattributable);
+  if (unattributable > 0)
+  {
+    OPENMS_LOG_WARN << "QPXFile: " << unattributable << " PSM(s) have no resolvable origin file, "
+                       "so their run_file_name is empty -- a QPX primary-key component that must "
+                       "not be, and the key the psm view is joined to feature and pg on. Protein "
+                       "inference commonly drops the path: set it with "
+                       "ProteinIdentification::setPrimaryMSRunPath() before exporting." << std::endl;
+  }
+  return table;
 }
 
 
@@ -1659,12 +1680,14 @@ bool QPXFile::exportToParquetStreaming(
   // build each sub-table in parallel (OpenMP), then write them in index order (serial — the
   // FileWriter is not thread-safe). Peak memory stays batch-bounded (the W sub-tables together hold
   // one batch's rows). Row content/order is identical to the serial path (contiguous, in-order).
+  size_t unattributable_total = 0; // accumulated across batches, reported once below
   auto write_batch = [&](size_t b, size_t e) -> bool
   {
     const size_t rows = e - b;
     const int W = static_cast<int>(std::min<size_t>(static_cast<size_t>(threads), std::max<size_t>(rows, 1)));
     std::vector<std::shared_ptr<arrow::Table>> parts(W);
     std::vector<std::exception_ptr> errs(W);
+    std::vector<size_t> unattr(W, 0); // one slot per worker; summed after the region
 
     #pragma omp parallel for num_threads(W) schedule(static)
     for (int t = 0; t < W; ++t)
@@ -1674,13 +1697,15 @@ bool QPXFile::exportToParquetStreaming(
         const size_t base = rows / W, rem = rows % W;
         const size_t sb = b + t * base + std::min<size_t>(static_cast<size_t>(t), rem);
         const size_t se = sb + base + (static_cast<size_t>(t) < rem ? 1 : 0);
-        parts[t] = buildQPXPSMTableRange(mapper, peptide_identification_ptrs, sb, se, export_all_psms);
+        parts[t] = buildQPXPSMTableRange(mapper, peptide_identification_ptrs, sb, se, export_all_psms, unattr[t]);
       }
       catch (...)
       {
         errs[t] = std::current_exception(); // never let an exception escape the OpenMP region
       }
     }
+
+    for (int t = 0; t < W; ++t) { unattributable_total += unattr[t]; }
 
     // Surface any worker exception as a logged failure (convert to the bool error contract).
     for (int t = 0; t < W; ++t)
@@ -1743,6 +1768,14 @@ bool QPXFile::exportToParquetStreaming(
     OPENMS_LOG_ERROR << "QPXFile: Failed to close output stream for " << filename << ": "
                      << outfile_close.ToString() << std::endl;
     ok = false;
+  }
+  if (unattributable_total > 0)
+  {
+    OPENMS_LOG_WARN << "QPXFile: " << unattributable_total << " PSM(s) have no resolvable origin "
+                       "file, so their run_file_name is empty -- a QPX primary-key component that "
+                       "must not be, and the key the psm view is joined to feature and pg on. "
+                       "Protein inference commonly drops the path: set it with "
+                       "ProteinIdentification::setPrimaryMSRunPath() before exporting." << std::endl;
   }
   return ok;
 }

--- a/src/tests/class_tests/openms/source/ProteinGroupArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteinGroupArrowExport_test.cpp
@@ -373,4 +373,129 @@ START_SECTION(([EXTRA] features with divergent peptide annotations are excluded 
 }
 END_SECTION
 
+START_SECTION(([EXTRA] ConsensusMap overload - gene lists stay parallel to pg_accessions))
+{
+  // gg_accessions/gg_names must have one entry per group member, like pg_accessions and
+  // pg_names, so consumers can zip them positionally. Appending only for members that carry a
+  // gene metavalue shortens the lists and shifts every later gene onto the wrong protein --
+  // which is what a partially gene-annotated FASTA produces.
+  ConsensusMap cmap;
+  cmap.setExperimentType("label-free");
+  ConsensusMap::ColumnHeader ch;
+  ch.filename = "/data/run1.mzML";
+  ch.label = "label-free";
+  cmap.getColumnHeaders()[0] = ch;
+
+  ProteinIdentification prot;
+  prot.setIdentifier("run");
+  prot.setScoreType("q-value");
+  prot.setPrimaryMSRunPath({"/data/run1.mzML"});
+  ProteinHit pa; pa.setAccession("PROT_A");                       // no gene annotation
+  ProteinHit pb; pb.setAccession("PROT_B");
+  pb.setMetaValue("gene_name", "GENE_OF_B");
+  prot.setHits({pa, pb});
+  ProteinIdentification::ProteinGroup g;
+  g.accessions = {"PROT_A", "PROT_B"};
+  g.probability = 0.01;
+  prot.insertIndistinguishableProteins(g);
+  cmap.setProteinIdentifications({prot});
+
+  PeptideIdentification pid;
+  pid.setIdentifier("run");
+  pid.setScoreType("q-value");
+  pid.setHigherScoreBetter(false);
+  PeptideHit hit;
+  hit.setSequence(AASequence::fromString("PEPTIDEK"));
+  hit.setCharge(2);
+  PeptideEvidence ev; ev.setProteinAccession("PROT_A");
+  hit.setPeptideEvidences({ev});
+  pid.setHits({hit});
+
+  ConsensusFeature cf;
+  cf.setMZ(500.0); cf.setRT(100.0); cf.setCharge(2);
+  BaseFeature bf; bf.setIntensity(10.0f); bf.setMZ(500.0); bf.setRT(100.0); bf.setCharge(2);
+  cf.insert(0, bf);
+  cf.setPeptideIdentifications({pid});
+  cmap.push_back(cf);
+
+  auto t = ProteinGroupArrowExport::exportToArrow(cmap);
+  TEST_NOT_EQUAL(t, nullptr)
+  TEST_EQUAL(t->num_rows(), 1)
+
+  auto pg_acc = std::static_pointer_cast<arrow::ListArray>(t->GetColumnByName("pg_accessions")->chunk(0));
+  auto gg_acc = std::static_pointer_cast<arrow::ListArray>(t->GetColumnByName("gg_accessions")->chunk(0));
+  auto gg_nam = std::static_pointer_cast<arrow::ListArray>(t->GetColumnByName("gg_names")->chunk(0));
+  TEST_EQUAL(gg_acc->value_length(0), pg_acc->value_length(0))
+  TEST_EQUAL(gg_nam->value_length(0), pg_acc->value_length(0))
+
+  // The gene belongs to PROT_B, which is member 1 -- not member 0.
+  auto names = std::static_pointer_cast<arrow::StringArray>(gg_nam->values());
+  const int64_t off = gg_nam->value_offset(0);
+  TEST_STRING_EQUAL(names->GetString(off), "")
+  TEST_STRING_EQUAL(names->GetString(off + 1), "GENE_OF_B")
+}
+END_SECTION
+
+START_SECTION(([EXTRA] ConsensusMap overload - total_sequences counts sequences, not features))
+{
+  // peptide_counts.total_sequences must agree with what peptides[] sums to. Using the feature
+  // count made it identical to feature_counts.total_features and contradicted peptides[] in the
+  // same row -- invisible while every fixture had exactly one feature per sequence.
+  ConsensusMap cmap;
+  cmap.setExperimentType("label-free");
+  ConsensusMap::ColumnHeader ch;
+  ch.filename = "/data/run1.mzML";
+  ch.label = "label-free";
+  cmap.getColumnHeaders()[0] = ch;
+
+  ProteinIdentification prot;
+  prot.setIdentifier("run");
+  prot.setScoreType("q-value");
+  prot.setPrimaryMSRunPath({"/data/run1.mzML"});
+  ProteinHit ph; ph.setAccession("PROT_A");
+  prot.setHits({ph});
+  ProteinIdentification::ProteinGroup g;
+  g.accessions = {"PROT_A"};
+  g.probability = 0.01;
+  prot.insertIndistinguishableProteins(g);
+  cmap.setProteinIdentifications({prot});
+
+  // One sequence, two charge states => two consensus features, one peptide.
+  for (int z : {2, 3})
+  {
+    PeptideIdentification pid;
+    pid.setIdentifier("run");
+    pid.setScoreType("q-value");
+    pid.setHigherScoreBetter(false);
+    PeptideHit hit;
+    hit.setSequence(AASequence::fromString("PEPTIDEK"));
+    hit.setCharge(z);
+    PeptideEvidence ev; ev.setProteinAccession("PROT_A");
+    hit.setPeptideEvidences({ev});
+    pid.setHits({hit});
+
+    ConsensusFeature cf;
+    cf.setMZ(500.0); cf.setRT(100.0 + z); cf.setCharge(z);
+    BaseFeature bf; bf.setIntensity(10.0f); bf.setMZ(500.0); bf.setRT(100.0 + z); bf.setCharge(z);
+    cf.insert(0, bf);
+    cf.setPeptideIdentifications({pid});
+    cmap.push_back(cf);
+  }
+
+  auto t = ProteinGroupArrowExport::exportToArrow(cmap);
+  TEST_NOT_EQUAL(t, nullptr)
+  TEST_EQUAL(t->num_rows(), 1)
+
+  auto pc = std::static_pointer_cast<arrow::StructArray>(t->GetColumnByName("peptide_counts")->chunk(0));
+  auto fc = std::static_pointer_cast<arrow::StructArray>(t->GetColumnByName("feature_counts")->chunk(0));
+  auto pc_unique = std::static_pointer_cast<arrow::Int32Array>(pc->field(0));
+  auto pc_total  = std::static_pointer_cast<arrow::Int32Array>(pc->field(1));
+  auto fc_total  = std::static_pointer_cast<arrow::Int32Array>(fc->field(1));
+
+  TEST_EQUAL(pc_unique->Value(0), 1)   // one distinct sequence
+  TEST_EQUAL(pc_total->Value(0), 1)    // peptides[] sums to 1, so total_sequences must be 1
+  TEST_EQUAL(fc_total->Value(0), 2)    // two features: that is what feature_counts is for
+}
+END_SECTION
+
 END_TEST


### PR DESCRIPTION
Three defects in the QPX export columns, found by an adversarial review after #9832. All three are in **already-merged** code, none came from that PR, and each produces plausible-looking wrong data with no diagnostic — which is why the test suite never saw them.

## 1. Gene lists lose positional alignment with `pg_accessions`

`ProteinGroupArrowExport.cpp` (ConsensusMap overload). `pg_accessions` gets one entry per group member unconditionally, and `pg_names` appends `""` on a lookup miss — but `gg_accessions`/`gg_names` appended only inside `if (it != hit_lookup.end())` **and** `if (has_ga || has_gn)`. A member with no `ProteinHit`, or with a hit but no gene metavalue, contributed nothing.

So the gene lists come out shorter than `pg_accessions` and every subsequent gene shifts down one index, silently attributed to the wrong protein. A partially gene-annotated FASTA is all it takes — group `{PROT_A, PROT_B}` with a gene on `PROT_B` only yields `gg_names = ["GENE_OF_B"]`, which a consumer zips onto `PROT_A`.

The comment claimed *"keep lists symmetric so they can be zipped"*. The two gene lists were symmetric with each other, which is not the symmetry a consumer needs. The identification-only overload of the same view already did this correctly; this aligns the ConsensusMap one to it.

## 2. `peptide_counts.total_sequences` counted features, not sequences

Same file, two lines apart:

```cpp
(void)pc_total_b->Append(static_cast<int>(group_features.size()));   // peptide_counts.total_sequences
(void)fc_total_b->Append(static_cast<int>(group_features.size()));   // feature_counts.total_features
```

Character-identical expressions, so `total_sequences` was always equal to `total_features` — while the `peptides[]` list in the *same row* was built from distinct sequences. One row asserting `peptides = [{PROT_A, 1}]` next to `total_sequences = 2` is self-contradictory, and distinguishing peptidoform and charge is what `feature_counts` exists for.

`total_sequences` is now accumulated from the same per-member `seqs.size()` that `peptides[]` emits, so the two agree by construction.

This is the sibling field of the `unique_sequences` divergence fixed in #9832 — that PR corrected one half of the struct and left the other, so the two overloads still disagreed.

## 3. The psm view wrote an empty primary key with no log output

`QPXFile.cpp` appended `File::stemName(run_file)` unguarded. When neither the hit metavalue nor the mapper resolves anything, that is `""` — and QPX makes `run_file_name` a non-nullable primary-key component, and the key the psm view is joined to feature and pg on. An empty string satisfies Arrow while violating the spec.

Protein-inference output triggers it with no malformed metadata and no exception: inference commonly drops `spectra_data` entirely. The same input through the pg exporter emits a full warning naming the remedy; the psm exporter said nothing at all.

**The row is still written.** A PSM is a primary record and dropping it would discard an identification — unlike a protein group, which is a per-run aggregate that cannot exist without a run. Only the diagnostic was missing, so only the diagnostic is added: a count of unattributable PSMs and one aggregated warning naming `setPrimaryMSRunPath()`.

`buildQPXPSMTableRange` runs inside an OpenMP region, so the counter is an out-parameter written through a per-worker slot and summed by the caller after the region — the serial counter idiom used elsewhere would have been a data race. Both the streaming and single-shot paths report once per export.

## Why no test caught these

Each was invisible for a specific, checkable reason:

- **no fixture had a partially gene-annotated group** — every member either had a gene or none did, the two cases where the lists happen to line up;
- **every fixture had exactly one feature per sequence** — the single configuration in which "feature count" and "sequence count" coincide;
- the empty-key path produced a valid file with zero log output, so nothing distinguished it from success.

The new sections target exactly those gaps: a two-member group with one gene, and one sequence at two charge states. Both were confirmed to fail against the previous code before being kept.

## Verification

- new class-test sections for defects 1 and 2, each verified to fail without its fix
- Arrow/QPX class tests and the `ProteomicsLFQ` / `ProSE` / `ProteinQuantifier` / `IsobaricAnalyzer` TOPP suite
- no reference-file churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DF2YUewPQTC5tJWqn23pUm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Protein-group exports now preserve one aligned gene entry per protein, including empty entries when annotations are unavailable.
  * Consensus-map peptide totals now accurately count distinct sequences for each group member.
  * QPX exports now retain run-file information and report unresolved source files with a single summary warning.
  * Streaming exports now provide complete unresolved-file counts across all processing batches.

* **Tests**
  * Added coverage for protein-group alignment and distinct peptide-sequence counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->