### PR TITLE
[FIX] QPX export: the feature view accepted merged runs it cannot attribute

### DIFF
--- a/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
@@ -119,6 +119,25 @@ FeatureIdLookups buildFeatureIdLookups(const ConsensusMap& cmap)
 {
   FeatureIdLookups lut;
 
+  // Deliberately OUTSIDE the try below: that catch exists to tolerate a duplicate PATH LIST,
+  // for which the forward map is still complete. A duplicate IDENTIFIER is the opposite -- the
+  // forward map assigns with operator[], so only the last run's paths survive and a feature of
+  // the first would be stamped with a file it never came from, silently, since a single row
+  // gives nothing away. The pg exporter refuses the same input.
+  {
+    std::set<std::string> seen_identifiers;
+    for (const auto& prot_id : cmap.getProteinIdentifications())
+    {
+      if (!seen_identifiers.insert(prot_id.getIdentifier()).second)
+      {
+        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+          "ConsensusMapArrowExport: several identification runs share the identifier '"
+          + prot_id.getIdentifier() + "'. Their MS run paths cannot be told apart, so a feature "
+          "would be attributed to the wrong run file.", prot_id.getIdentifier());
+      }
+    }
+  }
+
   // The mapper's constructor throws when two identifiers share a path list; that guards only
   // the reverse map, which is never used here, and the forward map is fully populated before
   // the throw. Degrade to a warning rather than failing an otherwise-exportable map.
@@ -1265,13 +1284,16 @@ std::shared_ptr<const arrow::KeyValueMetadata> qpxFeatureMetadata(
 /// file is opened -- for the same reason as requireUnambiguousIdentities().
 void requireResolvableIdRuns(const ConsensusMap& cmap, const IdentifierMSRunMapper& mapper)
 {
-  size_t psm_index = 0;
-  for (const auto& cf : cmap)
+  for (Size i = 0; i < cmap.size(); ++i)
   {
-    for (const auto& pid : cf.getPeptideIdentifications())
-    {
-      mapper.validateMergeIndex(pid, psm_index++);
-    }
+    // Only the identification the row actually uses. Validating every attached one refused a
+    // feature whose winning hit resolves perfectly, because a sibling identification -- hitless,
+    // or simply not selected -- lacked an index that is never asked for.
+    const auto& pep_ids = cmap[i].getPeptideIdentifications();
+    Size best_id_index = 0;
+    bool inconsistent_scores = false;
+    if (selectFeatureIdentity(pep_ids, best_id_index, inconsistent_scores) == nullptr) { continue; }
+    mapper.validateMergeIndex(pep_ids[best_id_index], i);
   }
 }
 

--- a/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
@@ -1252,6 +1252,29 @@ std::shared_ptr<const arrow::KeyValueMetadata> qpxFeatureMetadata(
   return ArrowIOHelpers::qpxFileMetadata("feature_file", config, extra);
 }
 
+/// Refuse a merged run whose PSMs cannot be attributed to one of its files.
+///
+/// The feature view resolves id_run_file_name through IdentifierMSRunMapper, which falls back to
+/// the run's FIRST file when 'id_merge_index' is missing -- so the column would name a run the
+/// best PSM did not come from, silently. The psm and pg views already refuse this input; matching
+/// them matters beyond consistency, because ProteomicsLFQ and ProteinQuantifier write the feature
+/// view FIRST and pg third. Accepting here and refusing there leaves a wrong feature.parquet on
+/// disk next to a half-written collection; refusing here fails before anything is written.
+///
+/// Must run as a preflight -- single-threaded, before any OpenMP region and before the output
+/// file is opened -- for the same reason as requireUnambiguousIdentities().
+void requireResolvableIdRuns(const ConsensusMap& cmap, const IdentifierMSRunMapper& mapper)
+{
+  size_t psm_index = 0;
+  for (const auto& cf : cmap)
+  {
+    for (const auto& pid : cf.getPeptideIdentifications())
+    {
+      mapper.validateMergeIndex(pid, psm_index++);
+    }
+  }
+}
+
 } // anonymous namespace (feature range builder + shared per-map lookups)
 
 
@@ -1279,6 +1302,7 @@ std::shared_ptr<arrow::Table> ConsensusMapArrowExport::exportToArrow(const Conse
 {
   requireUnambiguousIdentities(cmap);   // preflight: single-threaded, before any OpenMP region
   const auto id_lut = buildFeatureIdLookups(cmap);
+  requireResolvableIdRuns(cmap, id_lut.run_mapper);
   // A channel QPX cannot name would be written into intensities[].label, a documented join
   // key. Refuse rather than emit a guessed or empty token (the pg exporter does the same).
   if (id_lut.has_unlabelable_channel) { return nullptr; }
@@ -1353,6 +1377,7 @@ bool ConsensusMapArrowExport::exportToParquetStreaming(
   requireUnambiguousIdentities(cmap);
 
   const auto id_lut = buildFeatureIdLookups(cmap);
+  requireResolvableIdRuns(cmap, id_lut.run_mapper); // preflight, before the OpenMP region below
   if (id_lut.has_unlabelable_channel) { return false; } // already logged
 
   // Pre-warm lazily-initialized singletons/statics touched by the per-feature build, so first-touch

--- a/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
@@ -1120,4 +1120,76 @@ START_SECTION(([EXTRA] a merged run without id_merge_index is refused, not resol
 }
 END_SECTION
 
+START_SECTION(([EXTRA] only the selected identification must be resolvable))
+{
+  // The row draws every identification-derived value from the winning hit, so a sibling
+  // identification that carries no hit cannot affect the output and must not be able to refuse
+  // the export. Validating every attached identification rejected input that exports correctly.
+  ConsensusMap cmap;
+  cmap.setExperimentType("label-free");
+  ConsensusMap::ColumnHeader ch;
+  ch.filename = "/data/runA.mzML";
+  ch.label = "label-free";
+  cmap.getColumnHeaders()[0] = ch;
+
+  ProteinIdentification prot;
+  prot.setIdentifier("merged");
+  prot.setScoreType("q-value");
+  prot.setHigherScoreBetter(false);
+  prot.setPrimaryMSRunPath({"/data/runA.mzML", "/data/runB.mzML"});
+  cmap.setProteinIdentifications({prot});
+
+  PeptideIdentification hitless;              // no hits, no id_merge_index: never selected
+  hitless.setIdentifier("merged");
+  hitless.setScoreType("q-value");
+  hitless.setHigherScoreBetter(false);
+
+  PeptideIdentification winner;               // carries the hit, and a usable index
+  winner.setIdentifier("merged");
+  winner.setScoreType("q-value");
+  winner.setHigherScoreBetter(false);
+  winner.setMetaValue(Constants::UserParam::ID_MERGE_INDEX, 1);
+  PeptideHit hit;
+  hit.setSequence(AASequence::fromString("PEPTIDEK"));
+  hit.setCharge(2);
+  winner.setHits({hit});
+
+  ConsensusFeature cf;
+  cf.setMZ(500.0); cf.setRT(100.0); cf.setCharge(2);
+  BaseFeature bf; bf.setIntensity(10.0f); bf.setMZ(500.0); bf.setRT(100.0); bf.setCharge(2);
+  cf.insert(0, bf);
+  cf.setPeptideIdentifications({hitless, winner});
+  cmap.push_back(cf);
+
+  auto t = ConsensusMapArrowExport::exportToArrow(cmap);
+  TEST_NOT_EQUAL(t, nullptr)
+  auto idrun = std::static_pointer_cast<arrow::StringArray>(t->GetColumnByName("id_run_file_name")->chunk(0));
+  TEST_STRING_EQUAL(idrun->GetString(0), "runB")
+}
+END_SECTION
+
+START_SECTION(([EXTRA] duplicate identification-run identifiers are refused))
+{
+  // IdentifierMSRunMapper assigns its forward map with operator[], so two runs sharing an
+  // identifier leave only the last one's paths -- and a feature of the first would then be
+  // stamped with a file it never came from, with one row and no warning to give it away.
+  ConsensusMap cmap;
+  cmap.setExperimentType("label-free");
+  ConsensusMap::ColumnHeader ch;
+  ch.filename = "/data/runA.mzML";
+  ch.label = "label-free";
+  cmap.getColumnHeaders()[0] = ch;
+
+  ProteinIdentification a;
+  a.setIdentifier("dup");
+  a.setPrimaryMSRunPath({"/data/runA.mzML"});
+  ProteinIdentification b;
+  b.setIdentifier("dup");                     // same identifier, different file
+  b.setPrimaryMSRunPath({"/data/runB.mzML"});
+  cmap.setProteinIdentifications({a, b});
+
+  TEST_EXCEPTION(Exception::InvalidValue, ConsensusMapArrowExport::exportToArrow(cmap))
+}
+END_SECTION
+
 END_TEST

--- a/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
@@ -20,6 +20,7 @@
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/ProteinHit.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/SYSTEM/File.h>
 
 #include <arrow/api.h>
@@ -1068,6 +1069,54 @@ START_SECTION([EXTRA] exportToArrow - isobaric channels of one file share one ru
   auto rfn = std::static_pointer_cast<arrow::StringArray>(table->GetColumnByName("run_file_name")->chunk(0));
   TEST_STRING_EQUAL(rfn->GetString(0), "20150820_Haura-Pilot-TMT1-bRPLC01-1")
   TEST_STRING_EQUAL(rfn->GetString(1), "20150820_Haura-Pilot-TMT1-bRPLC01-1")
+}
+END_SECTION
+
+START_SECTION(([EXTRA] a merged run without id_merge_index is refused, not resolved to file 0))
+{
+  // id_run_file_name is resolved through IdentifierMSRunMapper, which falls back to the run's
+  // FIRST file when the index is missing -- so the column would name a run the best PSM did not
+  // come from. The psm and pg views refuse this; the feature view must too, and it matters that
+  // it does: ProteomicsLFQ writes the feature view FIRST and pg third, so accepting here and
+  // refusing there leaves a wrong feature.parquet on disk beside a half-written collection.
+  ConsensusMap cmap;
+  cmap.setExperimentType("label-free");
+  ConsensusMap::ColumnHeader ch;
+  ch.filename = "/data/runA.mzML";
+  ch.label = "label-free";
+  cmap.getColumnHeaders()[0] = ch;
+
+  ProteinIdentification prot;
+  prot.setIdentifier("merged");
+  prot.setScoreType("q-value");
+  prot.setHigherScoreBetter(false);
+  prot.setPrimaryMSRunPath({"/data/runA.mzML", "/data/runB.mzML"}); // merged run
+  cmap.setProteinIdentifications({prot});
+
+  PeptideIdentification pid;                 // no id_merge_index: origin undetermined
+  pid.setIdentifier("merged");
+  pid.setScoreType("q-value");
+  pid.setHigherScoreBetter(false);
+  PeptideHit hit;
+  hit.setSequence(AASequence::fromString("PEPTIDEK"));
+  hit.setCharge(2);
+  pid.setHits({hit});
+
+  ConsensusFeature cf;
+  cf.setMZ(500.0); cf.setRT(100.0); cf.setCharge(2);
+  BaseFeature bf; bf.setIntensity(10.0f); bf.setMZ(500.0); bf.setRT(100.0); bf.setCharge(2);
+  cf.insert(0, bf);
+  cf.setPeptideIdentifications({pid});
+  cmap.push_back(cf);
+
+  TEST_EXCEPTION(Exception::MissingInformation, ConsensusMapArrowExport::exportToArrow(cmap))
+
+  // With the index present the same input exports and names the right run.
+  cmap[0].getPeptideIdentifications()[0].setMetaValue(Constants::UserParam::ID_MERGE_INDEX, 1);
+  auto t = ConsensusMapArrowExport::exportToArrow(cmap);
+  TEST_NOT_EQUAL(t, nullptr)
+  auto idrun = std::static_pointer_cast<arrow::StringArray>(t->GetColumnByName("id_run_file_name")->chunk(0));
+  TEST_STRING_EQUAL(idrun->GetString(0), "runB")
 }
 END_SECTION
 


### PR DESCRIPTION
The QPX `feature` view resolves `id_run_file_name` through `IdentifierMSRunMapper`, which falls back to the run's **first** file when a PSM carries no `id_merge_index`. For a merged run the column therefore named a file the best PSM did not come from — silently, and it is precisely the column whose purpose is to record that identification and quantification happened in different runs (match-between-runs).

The `psm` and `pg` views already refuse this input; the feature view did not.

## Why this is worth refusing rather than nulling

`ProteomicsLFQ` and `ProteinQuantifier` write the three views in a fixed order — **feature first, psm second, pg third**. Accepting the input here and refusing it in pg left a wrong `feature.parquet` on disk next to a half-written collection, with a non-zero exit code. Refusing in all three means the run fails before anything is written.

## Implementation

A preflight (`requireResolvableIdRuns`), single-threaded, before any OpenMP region and before the output file is opened — the same constraint as the existing `requireUnambiguousIdentities`, and for the same reason: an exception escaping the parallel batch build would be flattened into a boolean by the worker's catch-all, and one escaping the region at all is `std::terminate`. Wired into both `exportToArrow` and `exportToParquetStreaming`.

It reuses `IdentifierMSRunMapper::validateMergeIndex`, so all three views now apply one implementation of the check rather than three.

## Review follow-ups (second commit)

An adversarial review of the preflight itself found two defects, both fixed here:

- **It was over-scoped.** It validated every identification attached to a feature, but the row draws all identification-derived values from the winning hit alone — so a feature whose winner resolves perfectly was refused because a sibling, hitless or simply not selected, lacked an index nobody asks for. It now selects the same identity the row builder does and validates only that.
- **Duplicate identification-run identifiers were accepted here** though the pg exporter refuses them. The mapper's forward map assigns with `operator[]`, so two runs sharing an identifier leave only the last one's paths and a feature of the first is stamped with a file it never came from — one row, no warning.

  Placement mattered, and the test caught getting it wrong: the check must sit **outside** the existing `try`/`catch`, which swallows `Exception::InvalidValue`. That handler exists for the mapper's duplicate-**path-list** throw, safe to downgrade because the forward map is still complete; a duplicate **identifier** is the opposite case wearing the same exception type. Inside the `try`, the new throw was caught and logged as a warning while the export continued on the very mapping it was meant to reject.

## Known limitation

The preflight narrows the partial-collection window without closing it. Unassigned identifications do not affect feature rows, but they do reach the PSM export, which validates them and can throw after `quantms.feature.parquet` is already on disk. Closing that means validating the whole collection in the caller before the first write, across three TOPP tools — a separate change.

## Verification

- New class-test section asserting both directions: the refusal, and that the same input with `id_merge_index=1` exports and resolves to `runB`.
- **Confirmed the test discriminates** — with the preflight removed it reports `no exception thrown!`.
- 157/157 tests (`ProteomicsLFQ`, `ProSE`, `ProteinQuantifier`, `IsobaricAnalyzer`, Arrow/QPX class tests); no reference-file churn.

Found by an adversarial review pass over the QPX export surface after #9832; the gap is in code merged earlier, not from that PR. Tracked in #9817.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DF2YUewPQTC5tJWqn23pUm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ConsensusMap Arrow and Parquet export validation for merged runs.
  * Exports now reject ambiguous or incomplete identification-run mappings with clear validation errors.
  * Correctly resolves merged run information when the selected identification provides a merge index.
  * Unselected hitless identifications no longer prevent successful exports when they lack an index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->