### PR TITLE
[FIX] IsobaricWorkflow: annotate the resolved design onto the column headers

### DIFF
--- a/src/openms/include/OpenMS/METADATA/ExperimentalDesign.h
+++ b/src/openms/include/OpenMS/METADATA/ExperimentalDesign.h
@@ -284,6 +284,25 @@ namespace OpenMS
     /// Extract experimental design from consensus map
     static ExperimentalDesign fromConsensusMap(const ConsensusMap& c);
 
+    /**
+      @brief Write this design's fraction structure onto a ConsensusMap's column headers
+
+      The inverse of fromConsensusMap(): stamps @c fraction_group, @c fraction and
+      @c sample_name as meta values on every column header whose @c (basename, label) pair
+      matches a design row. Headers are matched on the 1-based label, so this works for both
+      label-free maps (one header per file) and multiplexed ones (one header per file and
+      channel).
+
+      Without this the fraction structure lives only in the design object, and consumers that
+      read the map -- exporters, converters -- cannot tell two fractions of one sample from two
+      independent runs.
+
+      @param[in,out] cmap Map whose column headers are annotated in place
+      @return Number of column headers with no matching design row, left unannotated. Non-zero
+              means the design does not describe the whole map; callers should report it.
+    */
+    Size annotateColumnHeaders(ConsensusMap& cmap) const;
+
     /// Extract experimental design from feature map
     static ExperimentalDesign fromFeatureMap(const FeatureMap& f);
 

--- a/src/openms/source/METADATA/ExperimentalDesign.cpp
+++ b/src/openms/source/METADATA/ExperimentalDesign.cpp
@@ -54,6 +54,17 @@ namespace OpenMS
       const auto& pl2f = getPathLabelToFractionMapping(true);
       const auto& pl2s = getPathLabelToSampleMapping(true);
 
+      // Two headers of one file that resolve to the same design row cannot both be that row.
+      // ColumnHeader::getLabelAsUInt() returns 1 for any header without a 'channel_id' -- which
+      // is what the Multiplex tools emit, carrying the channel in 'label' instead -- so a
+      // light/heavy pair collapses onto label 1 and would otherwise both be stamped with the
+      // first channel's sample.
+      std::map<std::pair<std::string, unsigned>, Size> key_uses;
+      for (const auto& [map_index, header] : cmap.getColumnHeaders())
+      {
+        ++key_uses[{File::basename(header.filename), header.getLabelAsUInt(cmap.getExperimentType())}];
+      }
+
       Size unannotated = 0;
       for (auto& [map_index, header] : cmap.getColumnHeaders())
       {
@@ -63,12 +74,21 @@ namespace OpenMS
                                                    header.getLabelAsUInt(cmap.getExperimentType()));
         auto fg = pl2fg.find(key);
         if (fg == pl2fg.end()) { ++unannotated; continue; }
+        if (key_uses[key] > 1) { ++unannotated; continue; } // ambiguous: several headers, one row
 
         header.setMetaValue("fraction_group", fg->second);
         auto fr = pl2f.find(key);
         if (fr != pl2f.end()) { header.setMetaValue("fraction", fr->second); }
         auto sa = pl2s.find(key);
-        if (sa != pl2s.end()) { header.setMetaValue("sample_name", getSampleSection().getSampleName(sa->second)); }
+        if (sa != pl2s.end())
+        {
+          // A design inferred by fromConsensusMap() has sample rows but no "Sample" COLUMN, so
+          // getSampleName() throws std::out_of_range on its internal column lookup. The name is
+          // optional decoration here -- fraction and fraction_group are what callers group on --
+          // so a design that cannot supply one must not cost them the annotation entirely.
+          try { header.setMetaValue("sample_name", getSampleSection().getSampleName(sa->second)); }
+          catch (const std::exception&) { /* no Sample column; fraction data above still stands */ }
+        }
       }
       return unannotated;
     }

--- a/src/openms/source/METADATA/ExperimentalDesign.cpp
+++ b/src/openms/source/METADATA/ExperimentalDesign.cpp
@@ -48,6 +48,31 @@ namespace OpenMS
       isValid_();
     }
 
+    Size ExperimentalDesign::annotateColumnHeaders(ConsensusMap& cmap) const
+    {
+      const auto& pl2fg = getPathLabelToFractionGroupMapping(true);
+      const auto& pl2f = getPathLabelToFractionMapping(true);
+      const auto& pl2s = getPathLabelToSampleMapping(true);
+
+      Size unannotated = 0;
+      for (auto& [map_index, header] : cmap.getColumnHeaders())
+      {
+        // The design is keyed on (file, label); a column header carries the file and, for a
+        // multiplexed map, the 1-based channel that getLabelAsUInt() returns.
+        const std::pair<std::string, unsigned> key(File::basename(header.filename),
+                                                   header.getLabelAsUInt(cmap.getExperimentType()));
+        auto fg = pl2fg.find(key);
+        if (fg == pl2fg.end()) { ++unannotated; continue; }
+
+        header.setMetaValue("fraction_group", fg->second);
+        auto fr = pl2f.find(key);
+        if (fr != pl2f.end()) { header.setMetaValue("fraction", fr->second); }
+        auto sa = pl2s.find(key);
+        if (sa != pl2s.end()) { header.setMetaValue("sample_name", getSampleSection().getSampleName(sa->second)); }
+      }
+      return unannotated;
+    }
+
     ExperimentalDesign ExperimentalDesign::fromConsensusMap(const ConsensusMap &cm)
     {
       ExperimentalDesign experimental_design;

--- a/src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp
+++ b/src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp
@@ -18,6 +18,7 @@
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <fstream>
 ///////////////////////////
 
 using namespace OpenMS;
@@ -665,4 +666,63 @@ START_SECTION((isValid_()))
 END_SECTION
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
+START_SECTION((Size annotateColumnHeaders(ConsensusMap& cmap) const))
+{
+  // The inverse of fromConsensusMap(). Two fraction files of one quantification unit must come
+  // out sharing a fraction_group and differing by fraction -- that shared group is the only
+  // thing distinguishing "two fractions of one sample" from "two independent runs", and a
+  // consumer reading only the map has no other way to tell.
+  ConsensusMap cmap;
+  cmap.setExperimentType("labeled_MS2");
+  for (UInt64 file = 0; file < 2; ++file)
+  {
+    for (UInt64 ch = 0; ch < 2; ++ch)
+    {
+      ConsensusMap::ColumnHeader h;
+      h.filename = "/data/run" + std::to_string(file + 1) + ".mzML";
+      h.label = "tmt10plex_12" + std::to_string(ch + 6);
+      h.setMetaValue("channel_id", static_cast<int>(ch));   // getLabelAsUInt() -> channel_id + 1
+      cmap.getColumnHeaders()[file * 2 + ch] = h;
+    }
+  }
+
+  // Both files in fraction group 1, as fractions 1 and 2; one sample per channel.
+  const std::string design_path = File::getTemporaryFile();
+  {
+    std::ofstream os(design_path.c_str());
+    os << "Fraction_Group\tFraction\tSpectra_Filepath\tLabel\tSample\n";
+    os << "1\t1\trun1.mzML\t1\t1\n";
+    os << "1\t1\trun1.mzML\t2\t2\n";
+    os << "1\t2\trun2.mzML\t1\t1\n";
+    os << "1\t2\trun2.mzML\t2\t2\n";
+  }
+  ExperimentalDesign design = ExperimentalDesignFile::load(design_path, false);
+
+  TEST_EQUAL(design.annotateColumnHeaders(cmap), 0)   // every header matched
+
+  const auto& headers = cmap.getColumnHeaders();
+  for (const auto& [mi, h] : headers)
+  {
+    TEST_TRUE(h.metaValueExists("fraction_group"))
+    TEST_TRUE(h.metaValueExists("fraction"))
+    TEST_EQUAL(static_cast<int>(h.getMetaValue("fraction_group")), 1)  // shared across both files
+  }
+  // ... and the fraction distinguishes the two files, channel by channel.
+  TEST_EQUAL(static_cast<int>(headers.at(0).getMetaValue("fraction")), 1)  // run1, ch1
+  TEST_EQUAL(static_cast<int>(headers.at(1).getMetaValue("fraction")), 1)  // run1, ch2
+  TEST_EQUAL(static_cast<int>(headers.at(2).getMetaValue("fraction")), 2)  // run2, ch1
+  TEST_EQUAL(static_cast<int>(headers.at(3).getMetaValue("fraction")), 2)  // run2, ch2
+
+  // A header the design does not describe is counted, not silently skipped: silent
+  // non-annotation is the failure mode this return value exists to expose.
+  ConsensusMap::ColumnHeader stray;
+  stray.filename = "/data/not_in_design.mzML";
+  stray.label = "tmt10plex_126";
+  stray.setMetaValue("channel_id", 0);
+  cmap.getColumnHeaders()[99] = stray;
+  TEST_EQUAL(design.annotateColumnHeaders(cmap), 1)
+  TEST_FALSE(cmap.getColumnHeaders().at(99).metaValueExists("fraction_group"))
+}
+END_SECTION
+
 END_TEST

--- a/src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp
+++ b/src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp
@@ -725,4 +725,59 @@ START_SECTION((Size annotateColumnHeaders(ConsensusMap& cmap) const))
 }
 END_SECTION
 
+START_SECTION(([EXTRA] annotateColumnHeaders - a design inferred from the map does not throw))
+{
+  // fromConsensusMap() builds sample ROWS but no "Sample" COLUMN, so getSampleName() throws
+  // std::out_of_range on its column lookup. That is the design every caller gets when no
+  // design file is supplied, so annotating with it must work: the sample name is optional
+  // decoration, while fraction and fraction_group are what callers group on.
+  ConsensusMap cmap;
+  cmap.setExperimentType("labeled_MS2");
+  for (UInt64 ch = 0; ch < 2; ++ch)
+  {
+    ConsensusMap::ColumnHeader h;
+    h.filename = "/data/run1.mzML";
+    h.label = "tmt10plex_12" + std::to_string(ch + 6);
+    h.setMetaValue("channel_id", static_cast<int>(ch));
+    cmap.getColumnHeaders()[ch] = h;
+  }
+
+  ExperimentalDesign inferred = ExperimentalDesign::fromConsensusMap(cmap);
+  TEST_EQUAL(inferred.annotateColumnHeaders(cmap), 0)
+  TEST_TRUE(cmap.getColumnHeaders().at(0).metaValueExists("fraction_group"))
+  TEST_TRUE(cmap.getColumnHeaders().at(1).metaValueExists("fraction"))
+}
+END_SECTION
+
+START_SECTION(([EXTRA] annotateColumnHeaders - headers that collapse onto one design row are refused))
+{
+  // ColumnHeader::getLabelAsUInt() returns 1 for any header with no 'channel_id' -- what the
+  // Multiplex tools emit, carrying the channel in 'label' instead. Two such headers of one file
+  // both resolve to label 1, so neither can be attributed to that design row. Annotating either
+  // would stamp one channel's sample onto the other; they must be reported instead.
+  ConsensusMap cmap;
+  cmap.setExperimentType("labeled_MS2");
+  for (UInt64 i = 0; i < 2; ++i)
+  {
+    ConsensusMap::ColumnHeader h;
+    h.filename = "/data/run1.mzML";
+    h.label = (i == 0) ? "light" : "heavy";   // no channel_id on purpose
+    cmap.getColumnHeaders()[i] = h;
+  }
+
+  const std::string design_path = File::getTemporaryFile();
+  {
+    std::ofstream os(design_path.c_str());
+    os << "Fraction_Group\tFraction\tSpectra_Filepath\tLabel\tSample\n";
+    os << "1\t1\trun1.mzML\t1\t1\n";
+    os << "1\t1\trun1.mzML\t2\t2\n";
+  }
+  ExperimentalDesign design = ExperimentalDesignFile::load(design_path, false);
+
+  TEST_EQUAL(design.annotateColumnHeaders(cmap), 2)   // both refused, neither guessed at
+  TEST_FALSE(cmap.getColumnHeaders().at(0).metaValueExists("sample_name"))
+  TEST_FALSE(cmap.getColumnHeaders().at(1).metaValueExists("sample_name"))
+}
+END_SECTION
+
 END_TEST

--- a/src/topp/IsobaricWorkflow.cpp
+++ b/src/topp/IsobaricWorkflow.cpp
@@ -809,12 +809,24 @@ protected:
     std::cout << "Merged " << merged_prot_ids[0].getHits().size() << " proteins." << std::endl;
     cmap.setProteinIdentifications(merged_prot_ids);
 
-    ExperimentalDesign design = ExperimentalDesign::fromConsensusMap(cmap);
-    if (exp_design != "")
+    // Only fall back to deriving a design from the map when none was supplied. Calling
+    // fromConsensusMap() unconditionally logged "No fractions annotated in consensusXML.
+    // Assuming unfractionated." once per column header even when -exp_design says otherwise.
+    ExperimentalDesign design = (exp_design != "") ? ExperimentalDesignFile::load(exp_design, true)
+                                                   : ExperimentalDesign::fromConsensusMap(cmap);
+
+    // Annotate the resolved design back onto the column headers. IsobaricChannelExtractor sets
+    // only the channel meta values, so without this the fraction structure is known here and
+    // nowhere else -- consumers reading the map cannot tell two fractions of one sample from
+    // two independent runs.
+    if (const Size unannotated = design.annotateColumnHeaders(cmap); unannotated > 0)
     {
-      design = ExperimentalDesignFile::load(exp_design, true);
+      OPENMS_LOG_WARN << "IsobaricWorkflow: " << unannotated << " of " << cmap.getColumnHeaders().size()
+                      << " (file, channel) column(s) have no matching row in the experimental "
+                         "design, so they carry no fraction annotation. Downstream fraction-aware "
+                         "output cannot group them." << std::endl;
     }
-    
+
     bool groups = getStringOption_("protein_quantification") != "strictly_unique_peptides";
     bool greedy_group_resolution = getStringOption_("protein_quantification") == "shared_peptides";
 


### PR DESCRIPTION
`IsobaricChannelExtractor` sets only the four channel meta values on a `ConsensusMap::ColumnHeader`, so once `IsobaricWorkflow` resolved an `ExperimentalDesign` the fraction structure lived in the design object and nowhere else. Anything reading the map back — exporters, converters — could not tell **two fractions of one sample** from **two independent runs**. `ProteomicsLFQ` has annotated its headers this way for label-free all along; the isobaric path never did.

Measured on the shipped fractionated plex (`MSstatsConverter_2_in.consensusXML` + `MSstatsConverter_2_design.tsv`, 2 files × 10 channels):

| | before | after |
|---|---|---|
| headers carrying `fraction_group` | 0 of 20 | 20 of 20 |
| grouping recoverable from the map | no | `fraction_group=1` shared, `fraction` 1 and 2 |

## Where the logic lives

This is the inverse of `ExperimentalDesign::fromConsensusMap()`, so it sits next to it as `ExperimentalDesign::annotateColumnHeaders()` rather than inline in a TOPP tool. Three reasons: it is unit-testable there, `ProteomicsLFQ` does the same thing inline and now has somewhere to converge, and the `(file, label)` key derivation is design knowledge rather than tool knowledge.

It returns the number of headers with no matching design row instead of logging, leaving the policy to callers. `IsobaricWorkflow` warns on a non-zero return — silent non-annotation is the failure mode, since a wrong key derivation would simply annotate nothing while looking like it worked.

## Second fix in the same place

`ExperimentalDesign::fromConsensusMap()` was called **unconditionally** and only then overwritten by `-exp_design`. Besides the wasted work it logged *"No fractions annotated in consensusXML. Assuming unfractionated."* once per column header — 20 times on the fixture above — even when a design file said otherwise.

## Verification

- New class test asserting the property that matters: two fraction files of one quantification unit share a `fraction_group` and differ by `fraction`; an unmatched header is counted rather than silently skipped.
- **Confirmed the test discriminates** — neutering the lookup gives `got '4', expected '0'` plus both metavalue assertions failing.
- 155/155 tests (`ProteomicsLFQ`, `ProSE`, `ProteinQuantifier`, `IsobaricAnalyzer`, `ExperimentalDesign`); no reference-file churn.

**Coverage caveat:** `IsobaricWorkflow` still has no functional TOPP test — that block is commented out with a `TODO` and every `add_test` disabled. So the sweep above exercises `IsobaricAnalyzer`, not this tool; its coverage here is the class test plus the design fixture. That gap is why this went unnoticed.

## Why now

Prerequisite for QPX 1.1 ([bigbio/qpx#220](https://github.com/bigbio/qpx/pull/220)), which keys the pg view on `grouped_runs` — the set of raw files aggregated into one quantification unit. Without `fraction_group` on the headers the isobaric path has no way to compute that grouping. Context in #9817.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DF2YUewPQTC5tJWqn23pUm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consensus-map column headers are now annotated with fraction group, fraction, and sample metadata when matched to an experimental design.
  * Isobaric workflows can use a supplied experimental-design file or derive design information from the consensus map.

* **Bug Fixes**
  * Unmatched or ambiguous file and channel columns are detected, left unannotated, and reported with a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->