### PR TITLE
[FIX] TOPP_SimpleSearchEngine_DDA passed an argument to a flag

### DIFF
--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -3561,7 +3561,7 @@ if (WITH_OPENTIMS AND OPENTIMS_DDA_TEST_DATA)
     -Search:enzyme Trypsin/P
     -Search:peptide:missed_cleavages 2
     "-Search:modifications:variable" "Oxidation (M)" "Acetyl (Protein N-term)"
-    -Search:decoys auto
+    -Search:decoys
     -threads 4)
 
   add_test("TOPP_FalseDiscoveryRate_SimpleSearchEngineDDA" ${TOPP_BIN_PATH}/FalseDiscoveryRate -test


### PR DESCRIPTION
## Summary

`TOPP_SimpleSearchEngine_DDA` invoked `-Search:decoys auto`, but `SimpleSearchEngineAlgorithm` registers `decoys` as `{true, false}`, which TOPPBase turns into a flag. The tool therefore aborted at argument parsing and never ran:

```
Invalid parameter values (InvalidParameter): Command line error:
Trailing arguments after flag '-Search:decoys': auto. Aborting!
```

`auto` is ProSE's spelling — `ProSEAlgorithm` registers `decoys` with `{auto, generate, ignore}` — and the argument looks copied from the adjacent `TOPP_ProSE_DDA` test.

## Why CI never caught it

The whole block is gated on `WITH_OPENTIMS AND OPENTIMS_DDA_TEST_DATA`, which CI does not satisfy. The test only runs where the Bruker DDA fixture is present, and there it had been failing outright.

## The fix

The flag is passed by presence, so the value is dropped. Decoys are required either way: the chain runs `FalseDiscoveryRate` at 1 % PSM FDR over the result.

With the search actually running, the downstream PSM count is **4187** — exactly the yield recorded in the floor test's own comment ("Current yield on this fixture is 4187") — so this restores what the test was written against rather than changing it. All three tests in the chain pass, with the stale temp outputs cleared first so the result is honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VcFtJVe1PcMsBzMnnnpWBJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the SimpleSearchEngine DDA test configuration to use the simplified `-Search:decoys` option format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->