### PR TITLE
[DOC] pyOpenMS: document thread-safety / GIL-release contract (#9792 R-9.5)

### DIFF
--- a/src/pyOpenMS/README.md
+++ b/src/pyOpenMS/README.md
@@ -4,6 +4,8 @@ pyOpenMS is a Python library for the analysis of mass spectrometry data. It uses
 
 Additionally, it provides convenience functions for plotting and converting from/to DataFrames or NumPy/pyarrow arrays.
 
+For binding-specific development guidance, see [the wrapping guide](README_WRAPPING_NEW_CLASSES.md) and the [thread-safety contract](THREAD_SAFETY.md).
+
 ## Build Instructions
 
 There are two main ways to build pyOpenMS:

--- a/src/pyOpenMS/THREAD_SAFETY.md
+++ b/src/pyOpenMS/THREAD_SAFETY.md
@@ -1,0 +1,33 @@
+# pyOpenMS Thread-Safety Contract
+
+## Scope
+
+pyOpenMS releases Python's Global Interpreter Lock (GIL) around selected long-running C++ calls so that other Python threads can run while the call is in progress. Releasing the GIL is an interoperability and responsiveness feature; it is **not** a general thread-safety guarantee for OpenMS objects.
+
+This document defines the guarantee made by the pyOpenMS binding layer. General thread safety of the OpenMS core is outside its scope.
+
+## Rules for callers
+
+Unless an individual OpenMS API explicitly documents stronger guarantees, follow these rules:
+
+- Do not call pyOpenMS methods concurrently on the same object.
+- Do not read or mutate an input, output, or object reachable from either while a GIL-releasing call is using it. This includes objects obtained through reference-returning accessors and writable NumPy, memoryview, or Arrow views.
+- Give each worker its own algorithm and data objects. Use copies or explicit synchronization when data must cross worker boundaries.
+- A Python callback invoked by a streaming reader reacquires the GIL before entering Python. Keep callbacks independent of the reader's input/output objects unless access is synchronized.
+
+In particular, an Arrow table or Python buffer that aliases OpenMS storage is shared mutable state for its entire lifetime. It must not be read or written concurrently with an operation that can modify that storage.
+
+## GIL-releasing binding inventory
+
+The current bindings contain 62 `nb::gil_scoped_release` sites. This is an implementation inventory, not an endorsement of calling the listed operations concurrently.
+
+| Binding source | Calls | Covered operations |
+| --- | ---: | --- |
+| `bindings/arrow_zerocopy.cpp` | 16 | Arrow import/export, including experimental zero-copy paths |
+| `bindings/bind_experiment.cpp` | 2 | `MSExperiment.sortSpectra()` and `sortChromatograms()` |
+| `bindings/bind_format.cpp` | 13 | FileHandler, imzML, and indexed mzML load/store/validation operations |
+| `bindings/bind_misc.cpp` | 31 | File I/O and long-running feature-finding, deconvolution, indexing, and search operations |
+
+**Note:** one `bind_misc.cpp` site (`TransitionListEvidenceFilter.filter`) additionally parallelizes internally via a `threads` argument; the input `swath_maps`/`transition_exp` are concurrently read by multiple worker threads for the duration of the call, not just made available to other Python threads.
+
+When adding a GIL-releasing binding, document any API-specific concurrency guarantee in the binding's docstring and update this inventory. Do not infer a thread-safety guarantee merely because the GIL is released.

--- a/src/pyOpenMS/THREAD_SAFETY.md
+++ b/src/pyOpenMS/THREAD_SAFETY.md
@@ -10,8 +10,8 @@ This document defines the guarantee made by the pyOpenMS binding layer. General 
 
 Unless an individual OpenMS API explicitly documents stronger guarantees, follow these rules:
 
-- Do not call pyOpenMS methods concurrently on the same object. (Exception: read-only calls that neither mutate the object nor return a writable alias into it are safe to run concurrently on the same object. This does not apply if any thread is also writing.)
-- Do not read or mutate an input, output, or object reachable from either while a GIL-releasing call is using it. This includes objects obtained through reference-returning accessors and writable NumPy, memoryview, or Arrow views.
+- Do not call pyOpenMS methods concurrently on the same object unless the type or API documents concurrent read-only access. The object must be fully initialized, and no thread may write to it or receive a writable alias into it.
+- Do not read or mutate an input, output, or object reachable from either concurrently with a GIL-releasing call that can modify it or expose writable aliased storage.
 - Give each worker its own algorithm and data objects. Use copies or explicit synchronization when data must cross worker boundaries.
 - Python callbacks routed through the streaming consumer caster (used by APIs like ImzMLFile.load with a Python consumer object) reacquire the GIL before entering Python. Not all streaming-style APIs use this caster; check the specific binding's docstring.
 
@@ -35,6 +35,7 @@ When adding a GIL-releasing binding, document any API-specific concurrency guara
 ## Avoiding OpenMP oversubscription
 - Many OpenMS algorithms are internally OpenMP-parallelized, invisible from Python.
 - Combining that with your own Python-level thread pool multiplies thread count (N Python workers × M OpenMP threads per call).
-- Check current cap: `OpenMSBuildInfo.getOpenMPMaxNumThreads()` .
-- Set it: `OpenMSBuildInfo.setOpenMPNumThreads(n)` , takes precedence over `OMP_NUM_THREADS` .
-- Rule of thumb: If running P Python workers concurrently, set OpenMP threads to roughly `total_cores // P` (or 1) before spinning up the pool. This only matters when you're doing your own Python-level threading or multiprocessing, a single-threaded script calling OpenMS functions has nothing to worry about and doesn't need to touch setOpenMPNumThreads at all.
+- Check current cap: `OpenMSBuildInfo.getOpenMPMaxNumThreads()`.
+- If you need to cap oversubscription, call `OpenMSBuildInfo.setOpenMPNumThreads(n)` before entering OpenMS-parallel work. This is a task-scoped override for the current worker/context, not a single worker-global setting that automatically applies everywhere.
+- After unsetting `OMP_NUM_THREADS`, each Python worker that will do OpenMS-parallel work should call `setOpenMPNumThreads(n)` itself; setting it only in the parent process does not propagate independently to workers.
+- Rule of thumb: If running P Python workers concurrently, set OpenMP threads to roughly `total_cores // P` (or 1) in each worker before it starts OpenMS work. This only matters when you're doing your own Python-level threading or multiprocessing; a single-threaded script calling OpenMS functions has nothing to worry about and doesn't need to touch `setOpenMPNumThreads()`.

--- a/src/pyOpenMS/THREAD_SAFETY.md
+++ b/src/pyOpenMS/THREAD_SAFETY.md
@@ -13,7 +13,7 @@ Unless an individual OpenMS API explicitly documents stronger guarantees, follow
 - Do not call pyOpenMS methods concurrently on the same object.
 - Do not read or mutate an input, output, or object reachable from either while a GIL-releasing call is using it. This includes objects obtained through reference-returning accessors and writable NumPy, memoryview, or Arrow views.
 - Give each worker its own algorithm and data objects. Use copies or explicit synchronization when data must cross worker boundaries.
-- A Python callback invoked by a streaming reader reacquires the GIL before entering Python. Keep callbacks independent of the reader's input/output objects unless access is synchronized.
+- Python callbacks routed through the streaming consumer caster (used by APIs like ImzMLFile.load with a Python consumer object) reacquire the GIL before entering Python. Not all streaming-style APIs use this caster; check the specific binding's docstring.
 
 In particular, an Arrow table or Python buffer that aliases OpenMS storage is shared mutable state for its entire lifetime. It must not be read or written concurrently with an operation that can modify that storage.
 
@@ -28,6 +28,6 @@ The current bindings contain 62 `nb::gil_scoped_release` sites. This is an imple
 | `bindings/bind_format.cpp` | 13 | FileHandler, imzML, and indexed mzML load/store/validation operations |
 | `bindings/bind_misc.cpp` | 31 | File I/O and long-running feature-finding, deconvolution, indexing, and search operations |
 
-**Note:** one `bind_misc.cpp` site (`TransitionListEvidenceFilter.filter`) additionally parallelizes internally via a `threads` argument; the input `swath_maps`/`transition_exp` are concurrently read by multiple worker threads for the duration of the call, not just made available to other Python threads.
+**Note:** one `bind_misc.cpp` site (`TransitionListEvidenceFilter.filter`) additionally parallelizes internally via a `threads` argument; the active SWATH maps and their spectra, plus derived `candidates`/`precursor_index`, are read by multiple worker threads during the threaded scan. `transition_exp` is read before that phase to build `candidates`.
 
 When adding a GIL-releasing binding, document any API-specific concurrency guarantee in the binding's docstring and update this inventory. Do not infer a thread-safety guarantee merely because the GIL is released.

--- a/src/pyOpenMS/THREAD_SAFETY.md
+++ b/src/pyOpenMS/THREAD_SAFETY.md
@@ -10,7 +10,7 @@ This document defines the guarantee made by the pyOpenMS binding layer. General 
 
 Unless an individual OpenMS API explicitly documents stronger guarantees, follow these rules:
 
-- Do not call pyOpenMS methods concurrently on the same object.
+- Do not call pyOpenMS methods concurrently on the same object. (Exception: read-only calls that neither mutate the object nor return a writable alias into it are safe to run concurrently on the same object. This does not apply if any thread is also writing.)
 - Do not read or mutate an input, output, or object reachable from either while a GIL-releasing call is using it. This includes objects obtained through reference-returning accessors and writable NumPy, memoryview, or Arrow views.
 - Give each worker its own algorithm and data objects. Use copies or explicit synchronization when data must cross worker boundaries.
 - Python callbacks routed through the streaming consumer caster (used by APIs like ImzMLFile.load with a Python consumer object) reacquire the GIL before entering Python. Not all streaming-style APIs use this caster; check the specific binding's docstring.
@@ -31,3 +31,10 @@ The current bindings contain 62 `nb::gil_scoped_release` sites. This is an imple
 **Note:** one `bind_misc.cpp` site (`TransitionListEvidenceFilter.filter`) additionally parallelizes internally via a `threads` argument; the active SWATH maps and their spectra, plus derived `candidates`/`precursor_index`, are read by multiple worker threads during the threaded scan. `transition_exp` is read before that phase to build `candidates`.
 
 When adding a GIL-releasing binding, document any API-specific concurrency guarantee in the binding's docstring and update this inventory. Do not infer a thread-safety guarantee merely because the GIL is released.
+
+## Avoiding OpenMP oversubscription
+- Many OpenMS algorithms are internally OpenMP-parallelized, invisible from Python.
+- Combining that with your own Python-level thread pool multiplies thread count (N Python workers × M OpenMP threads per call).
+- Check current cap: `OpenMSBuildInfo.getOpenMPMaxNumThreads()` .
+- Set it: `OpenMSBuildInfo.setOpenMPNumThreads(n)` , takes precedence over `OMP_NUM_THREADS` .
+- Rule of thumb: If running P Python workers concurrently, set OpenMP threads to roughly `total_cores // P` (or 1) before spinning up the pool. This only matters when you're doing your own Python-level threading or multiprocessing, a single-threaded script calling OpenMS functions has nothing to worry about and doesn't need to touch setOpenMPNumThreads at all.


### PR DESCRIPTION
@timosachsenberg 

## Description

Added THREAD_SAFETY.md covering what the pyOpenMS binding layer actually guarantees around concurrency, since GIL release is often mistaken for thread safety.

Covers:
- The safe concurrency boundary for callers (no concurrent calls on the same object, no concurrent access to anything reachable through a GIL-releasing call, including writable NumPy/memoryview/Arrow views)
- Callback reentry behavior for streaming readers
- A full inventory of the 62 gil_scoped_release sites, grouped by binding file, verified against source rather than paraphrased from the issue
- A callout on TransitionListEvidenceFilter.filter, which additionally parallelizes internally via a threads argument, so its inputs are read by multiple worker threads during the call, not just exposed to other Python threads

No behavior change, docs only. Linked from README.md so it's discoverable outside this PR.

Part of #9792 (R-9.5).

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

Please review this PR, and merge if it's suitable. Thanks !

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added links to the wrapping guide and thread-safety guidance for binding development.
  * Documented thread-safety expectations for concurrent access, shared data, worker isolation, and streaming callbacks.
  * Clarified that releasing Python’s GIL does not guarantee safe concurrent access to OpenMS objects.
  * Added an inventory of GIL-release points and documented internally parallelized filtering behavior.
  * Added guidance for API-specific thread-safety documentation and avoiding OpenMP oversubscription in Python workers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->