### PR TITLE
[FIX] rsync deploy action: retry transient network failures with backoff

### DIFF
--- a/.github/actions/rsync/action.yml
+++ b/.github/actions/rsync/action.yml
@@ -82,6 +82,25 @@ runs:
           exit 1
         fi
 
+        # The deploy host is occasionally unreachable for a few minutes at a
+        # time (see #9702), so retry transient failures with backoff rather
+        # than failing the whole (otherwise healthy) build.
+        rsync_with_retry() {
+          local attempt max_attempts=5 delay=15
+          for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+            if rsync "$@"; then
+              return 0
+            fi
+            if ((attempt == max_attempts)); then
+              echo >&2 "ERROR: rsync failed after ${max_attempts} attempts"
+              return 1
+            fi
+            echo >&2 "rsync attempt ${attempt}/${max_attempts} failed, retrying in ${delay}s..."
+            sleep "$delay"
+            delay=$((delay * 2))
+          done
+        }
+
         rsync_options=(
           "--progress"
           "-avz"
@@ -94,7 +113,7 @@ runs:
 
         # Allow globing on the src directory:
         # shellcheck disable=SC2086
-        rsync \
+        rsync_with_retry \
           "${rsync_options[@]}" \
           $SRC_DIR \
           "${SSH_USER}@${SSH_HOST}:${DST_DIR}"
@@ -106,7 +125,7 @@ runs:
             LATEST_DST=$(dirname "$DST_DIR")
           fi
 
-          rsync \
+          rsync_with_retry \
             "${rsync_options[@]}" \
             "latest" \
             "${SSH_USER}@${SSH_HOST}:${LATEST_DST}"


### PR DESCRIPTION
## Description

The nightly `Release` workflow's `Deploy Installer` and `Deploy Documentation` jobs intermittently fail with:

```
ssh: connect to host *** port ***: Network is unreachable
rsync: connection unexpectedly closed (0 bytes received so far) [sender]
rsync error: unexplained error (code 255) at io.c(232) [sender=3.2.7]
```

while the build-and-test matrix itself (Windows/macOS/Linux/ARM) completes successfully. This is a recurrence of #9702, which was closed as "resolved" on 2026-07-02 without a code change — it recurred on the [2026-08-05 nightly run](https://github.com/OpenMS/OpenMS/actions/runs/30967262884), where both `Deploy Installer` and `Deploy Documentation` failed identically.

Root cause is presumed to be on the deploy target's side (firewall/routing/availability), as previously assessed in #9702. Since we don't control that infra, this PR implements the retry-with-backoff mitigation `#9702` itself suggested as a follow-up but never landed: `.github/actions/rsync/action.yml` now retries a failed rsync upload up to 5 times with exponential backoff (15s, 30s, 60s, 120s) before failing the job, so short-lived network blips no longer waste an otherwise-healthy nightly build.

Fixes #9702 (recurrence)

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

This is a workflow-infrastructure change (`.github/actions/rsync/action.yml`); it does not touch C++/Python code, so there are no unit tests or python bindings to update. Verification will come from the next scheduled nightly `Release` run actually exercising the retry path.

---

🤖 Found and fixed by an automated scheduled routine monitoring OpenMS/OpenMS CI health.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01WGaVHSmQHVo5L48zB6nsBc

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGaVHSmQHVo5L48zB6nsBc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by automatically retrying failed file transfers.
  * Added exponential backoff between retry attempts and clearer error reporting after repeated failures.
  * Applied the reliability improvements to both standard uploads and latest-version link updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->