### PR TITLE
[FEATURE] ParquetDiff: primary-key-keyed, tolerant Parquet table comparison

### DIFF
--- a/doc/doxygen/public/TOPP.doxygen
+++ b/doc/doxygen/public/TOPP.doxygen
@@ -213,6 +213,7 @@
   <b>[for developers]</b>
   - @subpage TOPP_CVInspector - Visualization and validation of PSI mapping and CV files.
   - @subpage TOPP_FuzzyDiff - Compares two files, tolerating numeric differences.
+  - @subpage TOPP_ParquetDiff - Compares two Parquet tables by primary key, tolerating numeric differences.
   - @subpage TOPP_JSONExporter - Exports .oms (SQLite) files in JSON format
   - @subpage TOPP_OpenMSDatabasesInfo - prints the content of OpenMS' enzyme and modification databases to a TSV file.
   - @subpage TOPP_SemanticValidator - SemanticValidator for analysisXML and mzML files.

--- a/src/openms/include/OpenMS/FORMAT/ParquetTableComparator.h
+++ b/src/openms/include/OpenMS/FORMAT/ParquetTableComparator.h
@@ -1,0 +1,147 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/OpenMSConfig.h>
+
+#include <string>
+#include <vector>
+
+namespace OpenMS
+{
+  /**
+    @brief Settings for ParquetTableComparator
+
+    The tolerance pair mirrors FuzzyStringComparator: a numeric cell is accepted when
+    <em>either</em> @p acceptable_absdiff or @p acceptable_ratio is satisfied. Use
+    @p acceptable_absdiff for the "zero vs. epsilon" case, where no ratio is meaningful.
+  */
+  struct OPENMS_DLLAPI ParquetDiffSettings
+  {
+    /// Columns forming the primary key. Empty: derive from the file's QPX @c file_type metadata.
+    std::vector<std::string> primary_key;
+    /// Columns excluded from value comparison (they are still schema-checked).
+    std::vector<std::string> ignore_columns;
+    /// Maximum acceptable ratio max(|a|,|b|)/min(|a|,|b|) of two numbers. 1.0 = must be identical.
+    double acceptable_ratio = 1.0;
+    /// Maximum acceptable |a-b| of two numbers.
+    double acceptable_absdiff = 0.0;
+    /// Compare schemas only; skip key building and value comparison.
+    bool schema_only = false;
+    /// Compare list-valued cells as multisets rather than sequences.
+    bool unordered_lists = false;
+    /// Stop collecting messages of any one category after this many (0 = unlimited).
+    Size max_reported = 25;
+  };
+
+  /**
+    @brief Outcome of a table comparison
+
+    The three message vectors are populated independently, so a run can report a schema
+    mismatch and a value mismatch at once. @p equal is true only when all three are empty.
+  */
+  struct OPENMS_DLLAPI ParquetDiffResult
+  {
+    /// True when no schema, key or value difference was found.
+    bool equal = false;
+    /// Missing/extra columns, differing Arrow types, differing nullability.
+    std::vector<std::string> schema_errors;
+    /// Duplicate primary keys, and keys present in only one of the two tables.
+    std::vector<std::string> key_errors;
+    /// Per-cell differences, prefixed by the primary key of the row they occur in.
+    std::vector<std::string> value_errors;
+    /// Number of messages suppressed by ParquetDiffSettings::max_reported.
+    Size suppressed = 0;
+
+    Size rows_1 = 0;      ///< row count of the first table
+    Size rows_2 = 0;      ///< row count of the second table
+    Size rows_compared = 0;  ///< rows matched by primary key and compared cell-by-cell
+
+    /// Largest ratio observed between two numeric cells (1.0 when all were identical).
+    double max_ratio = 1.0;
+    /// Largest absolute difference observed between two numeric cells.
+    double max_absdiff = 0.0;
+
+    /// The primary key actually used, whether supplied or auto-detected.
+    std::vector<std::string> primary_key_used;
+  };
+
+  /**
+    @brief Primary-key-aware, order-insensitive, tolerant comparison of Parquet tables
+
+    Two Parquet files holding the same logical table may legitimately differ in row order and
+    in the low-order bits of floating-point columns, so neither a byte comparison nor a text
+    diff of a serialised form answers "are these the same result?". This class matches rows by
+    a primary key, compares the matched rows cell-by-cell with a numeric tolerance, and reports
+    schema drift separately from value drift.
+
+    It is the table-shaped counterpart of @ref TOPP_FuzzyDiff, and is exposed as
+    @ref TOPP_ParquetDiff.
+
+    @note All Arrow/Parquet API use is confined to the implementation, so binaries linking
+          libOpenMS do not need to import Arrow symbols (see ArrowIOHelpers.h).
+
+    @ingroup FileIO
+  */
+  class OPENMS_DLLAPI ParquetTableComparator
+  {
+  public:
+    /**
+      @brief Compare two Parquet files.
+
+      Rows are matched on ParquetDiffSettings::primary_key. List-valued key columns are
+      canonicalised by sorting their elements before the key is formed, matching how QPX
+      treats set-valued key columns such as @c grouped_runs.
+
+      @param[in] file_1 first Parquet file
+      @param[in] file_2 second Parquet file
+      @param[in] settings tolerance, key and reporting options
+      @return the differences found; ParquetDiffResult::equal is true when there are none
+    */
+    static ParquetDiffResult compare(const std::string& file_1,
+                                     const std::string& file_2,
+                                     const ParquetDiffSettings& settings);
+
+    /**
+      @brief Check one Parquet file against a built-in QPX schema.
+
+      Reports columns the view requires but the file lacks, columns whose Arrow type differs
+      from the schema, and columns the file carries that the view does not define. Duplicate
+      primary keys are reported as well, since a QPX primary key must be unique.
+
+      @param[in] file the Parquet file to check
+      @param[in] view one of @c psm, @c feature, @c pg
+      @param[in] settings reporting options (tolerances are unused)
+      @return the violations found; ParquetDiffResult::equal is true when there are none
+      @exception Exception::IllegalArgument if @p view is not a known view name
+    */
+    static ParquetDiffResult validate(const std::string& file,
+                                      const std::string& view,
+                                      const ParquetDiffSettings& settings);
+
+    /**
+      @brief The primary key of a QPX view.
+
+      @param[in] view one of @c psm, @c feature, @c pg
+      @return the key columns, in order
+      @exception Exception::IllegalArgument if @p view is not a known view name
+    */
+    static std::vector<std::string> qpxPrimaryKey(const std::string& view);
+
+    /**
+      @brief Map a QPX @c file_type metadata value to a view name.
+
+      @param[in] file_type e.g. @c psm_file, @c feature_file, @c pg_file
+      @return the view name, or an empty string when @p file_type is not recognised
+    */
+    static std::string viewFromFileType(const std::string& file_type);
+  };
+
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/FORMAT/sources.cmake
+++ b/src/openms/include/OpenMS/FORMAT/sources.cmake
@@ -77,6 +77,7 @@ ParamCTDFile.h
 ParamCWLFile.h
 ParamJSONFile.h
 ParamXMLFile.h
+ParquetTableComparator.h
 PEFFFile.h
 PTMXMLFile.h
 PeakTypeEstimator.h

--- a/src/openms/source/APPLICATIONS/ToolHandler.cpp
+++ b/src/openms/source/APPLICATIONS/ToolHandler.cpp
@@ -165,6 +165,7 @@ namespace OpenMS
     tools_map["ProteomicsLFQ"] = Internal::ToolDescription("ProteomicsLFQ", cat_quant);
     tools_map["PSMFeatureExtractor"] = Internal::ToolDescription("PSMFeatureExtractor", cat_ID_proc);
     tools_map["ParquetConverter"] = Internal::ToolDescription("ParquetConverter", cat_file_converter);
+    tools_map["ParquetDiff"] = Internal::ToolDescription("ParquetDiff", cat_dev);
     tools_map["QCCalculator"] = Internal::ToolDescription("QCCalculator", cat_QC);
     tools_map["QCEmbedder"] = Internal::ToolDescription("QCEmbedder", cat_QC);
     tools_map["QCExporter"] = Internal::ToolDescription("QCExporter", cat_QC);

--- a/src/openms/source/FORMAT/ParquetTableComparator.cpp
+++ b/src/openms/source/FORMAT/ParquetTableComparator.cpp
@@ -28,7 +28,7 @@ namespace OpenMS
 {
   namespace
   {
-    /// Read a Parquet file into a single-chunk Arrow table. Returns nullptr and logs on failure.
+    /// Read a Parquet file into an Arrow table. Returns nullptr and logs on failure.
     std::shared_ptr<arrow::Table> readTable_(const std::string& filename)
     {
       auto infile_result = arrow::io::ReadableFile::Open(filename);
@@ -114,10 +114,10 @@ namespace OpenMS
       happened to emit. This mirrors what the QPX reference implementation does before it
       checks primary-key uniqueness.
     */
-    std::string canonicalKey_(const std::shared_ptr<arrow::Scalar>& scalar)
+    std::string canonicalKey_(const std::shared_ptr<arrow::Scalar>& scalar, bool& ok)
     {
-      if (!scalar) { return "E;"; }        // unreadable
-      if (!scalar->is_valid) { return "N;"; } // null
+      if (!scalar) { ok = false; return "E;"; }  // unreadable: caller must not key on this
+      if (!scalar->is_valid) { return "N;"; }    // null
 
       if (isListLike_(scalar->type->id()))
       {
@@ -127,7 +127,14 @@ namespace OpenMS
         for (int64_t i = 0; i < values->length(); ++i)
         {
           auto element = values->GetScalar(i);
-          parts.push_back(element.ok() ? canonicalKey_(*element) : "E;");
+          if (!element.ok())
+          {
+            // Two different unreadable elements must not collapse to one key.
+            ok = false;
+            parts.push_back("E;");
+            continue;
+          }
+          parts.push_back(canonicalKey_(*element, ok));
         }
         std::sort(parts.begin(), parts.end());
         std::string joined = "L" + std::to_string(parts.size()) + ";";
@@ -211,6 +218,40 @@ namespace OpenMS
     }
 
     /**
+      @brief Exact |a-b| for two integer scalars.
+
+      Widening a 64-bit integer to a double loses precision, so the difference has to be taken
+      in integer space first. The result is exact whenever it fits a double's mantissa; a
+      difference larger than that is far beyond any tolerance anyway.
+    */
+    bool integerAbsDiff_(const arrow::Scalar& a, const arrow::Scalar& b, double& absdiff)
+    {
+      if (!arrow::is_integer(a.type->id()) || !arrow::is_integer(b.type->id())) { return false; }
+
+      if (arrow::is_unsigned_integer(a.type->id()) && arrow::is_unsigned_integer(b.type->id()))
+      {
+        auto ca = a.CastTo(arrow::uint64());
+        auto cb = b.CastTo(arrow::uint64());
+        if (!ca.ok() || !cb.ok()) { return false; }
+        const uint64_t ua = static_cast<const arrow::UInt64Scalar&>(**ca).value;
+        const uint64_t ub = static_cast<const arrow::UInt64Scalar&>(**cb).value;
+        absdiff = static_cast<double>(ua > ub ? ua - ub : ub - ua);
+        return true;
+      }
+
+      auto ca = a.CastTo(arrow::int64());
+      auto cb = b.CastTo(arrow::int64());
+      if (!ca.ok() || !cb.ok()) { return false; }
+      const int64_t ia = static_cast<const arrow::Int64Scalar&>(**ca).value;
+      const int64_t ib = static_cast<const arrow::Int64Scalar&>(**cb).value;
+      // Subtract in unsigned space so INT64_MIN/INT64_MAX cannot overflow.
+      const uint64_t diff = (ia > ib) ? (static_cast<uint64_t>(ia) - static_cast<uint64_t>(ib))
+                                      : (static_cast<uint64_t>(ib) - static_cast<uint64_t>(ia));
+      absdiff = static_cast<double>(diff);
+      return true;
+    }
+
+    /**
       @brief Numeric value of a scalar, if it holds one.
 
       Integers are included: "numeric" in the tolerance contract means every number, not only
@@ -265,10 +306,19 @@ namespace OpenMS
         double ratio = 1.0;
         double absdiff = 0.0;
         bool ok = numbersAcceptable_(av, bv, settings, ratio, absdiff);
-        // A 64-bit integer difference can vanish when both sides are widened to a double.
-        // Two scalars that are not exactly equal must never be accepted on a zero difference.
-        if (ok && absdiff == 0.0 && !a->Equals(*b)) { ok = false; }
-        if (std::isfinite(ratio)) { max_ratio = std::max(max_ratio, ratio); }
+
+        // Integers: retake the difference exactly, because widening a 64-bit value to a double
+        // can collapse a real difference to zero. Deliberately NOT applied to floating point --
+        // Scalar::Equals defaults to nans_equal_ = false, so using it as a tie-breaker here
+        // would report two NaNs as different, which the tolerance contract says are equal.
+        double exact = 0.0;
+        if (integerAbsDiff_(*a, *b, exact))
+        {
+          absdiff = exact;
+          ok = absdiff <= settings.acceptable_absdiff || ratio <= settings.acceptable_ratio;
+        }
+
+        max_ratio = std::max(max_ratio, ratio);   // may be inf: that is an observed ratio
         max_absdiff = std::max(max_absdiff, absdiff);
         if (!ok)
         {
@@ -303,23 +353,39 @@ namespace OpenMS
         }
         if (settings.unordered_lists)
         {
-          // Precompute one canonical key per element. Building them inside the comparator would
-          // re-derive each key O(log n) times, and canonicalKey_ recurses through nested values.
-          auto keys_of = [](const std::shared_ptr<arrow::Array>& arr) {
-            std::vector<std::string> keys(static_cast<size_t>(arr->length()));
+          // Precompute one sort key per element; building them inside the comparator would
+          // re-derive each key O(log n) times through a recursive function.
+          //
+          // Numeric elements are ordered NUMERICALLY, not by canonical text. Sorting "10","20"
+          // against "9.99","20.1" lexically pairs 10 with 20.1 and 20 with 9.99, reporting a
+          // difference for two lists that actually match within tolerance.
+          const auto elem_id = av_list->type()->id();
+          const bool numeric_elements = arrow::is_integer(elem_id) || arrow::is_floating(elem_id);
+          auto keys_of = [&](const std::shared_ptr<arrow::Array>& arr) {
+            std::vector<std::pair<double, std::string>> keys(static_cast<size_t>(arr->length()));
             for (int64_t i = 0; i < arr->length(); ++i)
             {
+              auto& slot = keys[static_cast<size_t>(i)];
               auto s = arr->GetScalar(i);
-              keys[static_cast<size_t>(i)] = s.ok() ? canonicalKey_(*s) : std::string("E;");
+              if (!s.ok()) { slot.first = 0.0; slot.second = "E;"; continue; }
+              bool key_ok = true;
+              slot.second = canonicalKey_(*s, key_ok);
+              if (!numeric_elements || !asDouble_(**s, slot.first)) { slot.first = 0.0; }
             }
             return keys;
           };
-          const std::vector<std::string> keys_a = keys_of(av_list);
-          const std::vector<std::string> keys_b = keys_of(bv_list);
-          std::stable_sort(order_a.begin(), order_a.end(),
-                           [&](int64_t l, int64_t r) { return keys_a[l] < keys_a[r]; });
-          std::stable_sort(order_b.begin(), order_b.end(),
-                           [&](int64_t l, int64_t r) { return keys_b[l] < keys_b[r]; });
+          const auto keys_a = keys_of(av_list);
+          const auto keys_b = keys_of(bv_list);
+          auto by_key = [numeric_elements](const std::vector<std::pair<double, std::string>>& k) {
+            return [&k, numeric_elements](int64_t l, int64_t r) {
+              const size_t li = static_cast<size_t>(l);
+              const size_t ri = static_cast<size_t>(r);
+              if (numeric_elements && k[li].first != k[ri].first) { return k[li].first < k[ri].first; }
+              return k[li].second < k[ri].second;
+            };
+          };
+          std::stable_sort(order_a.begin(), order_a.end(), by_key(keys_a));
+          std::stable_sort(order_b.begin(), order_b.end(), by_key(keys_b));
         }
 
         for (size_t i = 0; i < order_a.size(); ++i)
@@ -479,13 +545,24 @@ namespace OpenMS
             ok = false;
             return keys;
           }
-          key += canonicalKey_(cell);
+          // A nested element that cannot be read would otherwise encode as the same "E;" token
+          // as any other unreadable element, letting two different rows share a key.
+          bool key_ok = true;
+          key += canonicalKey_(cell, key_ok);
+          if (!key_ok)
+          {
+            report_(result.key_errors, settings.max_reported, result.suppressed,
+                    which + ": row " + std::to_string(row)
+                      + " has an unreadable nested value inside key column '" + key_columns[k] + "'");
+            ok = false;
+            return keys;
+          }
           if (k != 0) { display += ", "; }
           display += key_columns[k] + "=" + displayValue_(cell);
         }
         auto& entry = keys[key];
+        if (entry.rows.empty()) { entry.display = display; }  // .front() is the row compared
         entry.rows.push_back(row);
-        entry.display = display;
       }
 
       for (const auto& [key, entry] : keys)

--- a/src/openms/source/FORMAT/ParquetTableComparator.cpp
+++ b/src/openms/source/FORMAT/ParquetTableComparator.cpp
@@ -1,0 +1,630 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/FORMAT/ParquetTableComparator.h>
+
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
+#include <OpenMS/SYSTEM/File.h>
+
+#include <arrow/api.h>
+#include <arrow/io/file.h>
+#include <parquet/arrow/reader.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <unordered_map>
+
+namespace OpenMS
+{
+  namespace
+  {
+    /// Read a Parquet file into a single-chunk Arrow table. Returns nullptr and logs on failure.
+    std::shared_ptr<arrow::Table> readTable_(const std::string& filename)
+    {
+      auto infile_result = arrow::io::ReadableFile::Open(filename);
+      if (!infile_result.ok())
+      {
+        OPENMS_LOG_ERROR << "ParquetTableComparator: cannot open '" << filename
+                         << "': " << infile_result.status().ToString() << std::endl;
+        return nullptr;
+      }
+
+      auto reader_result = parquet::arrow::OpenFile(*infile_result, arrow::default_memory_pool());
+      if (!reader_result.ok())
+      {
+        OPENMS_LOG_ERROR << "ParquetTableComparator: '" << filename
+                         << "' is not readable as Parquet: " << reader_result.status().ToString() << std::endl;
+        return nullptr;
+      }
+      auto reader = std::move(reader_result.ValueOrDie());
+
+      auto table_result = reader->ReadTable();
+      if (!table_result.ok())
+      {
+        OPENMS_LOG_ERROR << "ParquetTableComparator: cannot read table from '" << filename
+                         << "': " << table_result.status().ToString() << std::endl;
+        return nullptr;
+      }
+      const auto& table = *table_result;
+
+      // One chunk per column keeps the row-index arithmetic below straightforward.
+      auto combined = table->CombineChunks(arrow::default_memory_pool());
+      if (!combined.ok())
+      {
+        OPENMS_LOG_ERROR << "ParquetTableComparator: cannot combine chunks of '" << filename
+                         << "': " << combined.status().ToString() << std::endl;
+        return nullptr;
+      }
+      return *combined;
+    }
+
+    /// Value of a key in the table's schema metadata, or "" when absent.
+    std::string metadataValue_(const std::shared_ptr<arrow::Table>& table, const std::string& key)
+    {
+      const auto& md = table->schema()->metadata();
+      if (!md) { return ""; }
+      const int idx = md->FindKey(key);
+      return (idx < 0) ? std::string() : md->value(idx);
+    }
+
+    /// Element at @p row of a single-chunk column, or nullptr when the column is absent/empty.
+    std::shared_ptr<arrow::Scalar> cellAt_(const std::shared_ptr<arrow::Table>& table,
+                                           int col, int64_t row)
+    {
+      if (col < 0) { return nullptr; }
+      const auto& chunked = table->column(col);
+      if (chunked->num_chunks() == 0) { return nullptr; }
+      auto scalar_result = chunked->chunk(0)->GetScalar(row);
+      if (!scalar_result.ok()) { return nullptr; }
+      return *scalar_result;
+    }
+
+    /**
+      @brief Canonical string of a scalar, used to form primary keys.
+
+      List elements are sorted so that a set-valued key column (QPX @c grouped_runs, and the
+      @c scan component of the psm key) compares equal regardless of the order the producer
+      happened to emit. This mirrors what the QPX reference implementation does before it
+      checks primary-key uniqueness.
+    */
+    std::string canonicalString_(const std::shared_ptr<arrow::Scalar>& scalar)
+    {
+      if (!scalar || !scalar->is_valid) { return "<null>"; }
+
+      if (scalar->type->id() == arrow::Type::LIST || scalar->type->id() == arrow::Type::LARGE_LIST)
+      {
+        const auto& values = static_cast<const arrow::BaseListScalar&>(*scalar).value;
+        std::vector<std::string> parts;
+        parts.reserve(static_cast<size_t>(values->length()));
+        for (int64_t i = 0; i < values->length(); ++i)
+        {
+          auto element = values->GetScalar(i);
+          parts.push_back(element.ok() ? canonicalString_(*element) : "<err>");
+        }
+        std::sort(parts.begin(), parts.end());
+        std::string joined = "[";
+        for (size_t i = 0; i < parts.size(); ++i)
+        {
+          if (i != 0) { joined += ","; }
+          joined += parts[i];
+        }
+        return joined + "]";
+      }
+      return scalar->ToString();
+    }
+
+    /// True when both are NaN, which regression comparison should treat as equal.
+    bool bothNaN_(double a, double b)
+    {
+      return std::isnan(a) && std::isnan(b);
+    }
+
+    /**
+      @brief Tolerant numeric comparison.
+
+      Mirrors FuzzyStringComparator: either the absolute difference or the ratio has to be
+      acceptable. A ratio is only meaningful for two non-zero values of the same sign; the
+      "zero vs. epsilon" case is what @p acceptable_absdiff exists for.
+    */
+    bool numbersAcceptable_(double a, double b, const ParquetDiffSettings& settings,
+                            double& ratio, double& absdiff)
+    {
+      ratio = 1.0;
+      absdiff = 0.0;
+      if (bothNaN_(a, b)) { return true; }
+      if (std::isnan(a) || std::isnan(b)) { return false; }
+      if (a == b) { return true; }
+
+      absdiff = std::fabs(a - b);
+      if (absdiff <= settings.acceptable_absdiff) { return true; }
+
+      if (a != 0.0 && b != 0.0 && ((a > 0.0) == (b > 0.0)))
+      {
+        const double aa = std::fabs(a);
+        const double bb = std::fabs(b);
+        ratio = (aa > bb) ? (aa / bb) : (bb / aa);
+        return ratio <= settings.acceptable_ratio;
+      }
+      ratio = std::numeric_limits<double>::infinity();
+      return false;
+    }
+
+    /// Numeric value of a scalar, if it holds one.
+    bool asDouble_(const arrow::Scalar& scalar, double& out)
+    {
+      switch (scalar.type->id())
+      {
+        case arrow::Type::HALF_FLOAT:
+        case arrow::Type::FLOAT:
+        case arrow::Type::DOUBLE:
+        {
+          auto casted = scalar.CastTo(arrow::float64());
+          if (!casted.ok()) { return false; }
+          out = static_cast<const arrow::DoubleScalar&>(**casted).value;
+          return true;
+        }
+        default:
+          return false;
+      }
+    }
+
+    /**
+      @brief Recursive, tolerance-aware scalar comparison.
+
+      Descends into list and struct values so that a float nested inside
+      @c intensities: list<struct{label, intensity}> is compared with the same tolerance as a
+      top-level float. @p path accumulates a human-readable location for the message.
+    */
+    bool scalarsEqual_(const std::shared_ptr<arrow::Scalar>& a,
+                       const std::shared_ptr<arrow::Scalar>& b,
+                       const ParquetDiffSettings& settings,
+                       const std::string& path,
+                       std::string& message,
+                       double& max_ratio,
+                       double& max_absdiff)
+    {
+      const bool a_valid = a && a->is_valid;
+      const bool b_valid = b && b->is_valid;
+      if (!a_valid && !b_valid) { return true; }
+      if (a_valid != b_valid)
+      {
+        message = path + ": " + (a_valid ? a->ToString() : "<null>") + " vs. "
+                  + (b_valid ? b->ToString() : "<null>");
+        return false;
+      }
+
+      if (!a->type->Equals(*b->type))
+      {
+        message = path + ": type " + a->type->ToString() + " vs. " + b->type->ToString();
+        return false;
+      }
+
+      double av = 0.0;
+      double bv = 0.0;
+      if (asDouble_(*a, av) && asDouble_(*b, bv))
+      {
+        double ratio = 1.0;
+        double absdiff = 0.0;
+        const bool ok = numbersAcceptable_(av, bv, settings, ratio, absdiff);
+        if (std::isfinite(ratio)) { max_ratio = std::max(max_ratio, ratio); }
+        max_absdiff = std::max(max_absdiff, absdiff);
+        if (!ok)
+        {
+          message = path + ": " + a->ToString() + " vs. " + b->ToString()
+                    + " (absdiff " + std::to_string(absdiff) + ", ratio "
+                    + (std::isfinite(ratio) ? std::to_string(ratio) : std::string("inf")) + ")";
+        }
+        return ok;
+      }
+
+      const auto id = a->type->id();
+      if (id == arrow::Type::LIST || id == arrow::Type::LARGE_LIST)
+      {
+        const auto& av_list = static_cast<const arrow::BaseListScalar&>(*a).value;
+        const auto& bv_list = static_cast<const arrow::BaseListScalar&>(*b).value;
+        if (av_list->length() != bv_list->length())
+        {
+          message = path + ": list length " + std::to_string(av_list->length()) + " vs. "
+                    + std::to_string(bv_list->length());
+          return false;
+        }
+
+        // Multiset semantics: pair elements by canonical string before comparing, so that a
+        // reordered list is not reported as a difference. Exact numeric tolerance still applies
+        // within each matched pair.
+        std::vector<int64_t> order_a(static_cast<size_t>(av_list->length()));
+        std::vector<int64_t> order_b(order_a.size());
+        for (size_t i = 0; i < order_a.size(); ++i)
+        {
+          order_a[i] = static_cast<int64_t>(i);
+          order_b[i] = static_cast<int64_t>(i);
+        }
+        if (settings.unordered_lists)
+        {
+          auto key_of = [](const std::shared_ptr<arrow::Array>& arr, int64_t i) {
+            auto s = arr->GetScalar(i);
+            return s.ok() ? canonicalString_(*s) : std::string("<err>");
+          };
+          std::stable_sort(order_a.begin(), order_a.end(),
+                           [&](int64_t l, int64_t r) { return key_of(av_list, l) < key_of(av_list, r); });
+          std::stable_sort(order_b.begin(), order_b.end(),
+                           [&](int64_t l, int64_t r) { return key_of(bv_list, l) < key_of(bv_list, r); });
+        }
+
+        for (size_t i = 0; i < order_a.size(); ++i)
+        {
+          auto ea = av_list->GetScalar(order_a[i]);
+          auto eb = bv_list->GetScalar(order_b[i]);
+          if (!ea.ok() || !eb.ok())
+          {
+            message = path + "[" + std::to_string(i) + "]: unreadable list element";
+            return false;
+          }
+          if (!scalarsEqual_(*ea, *eb, settings, path + "[" + std::to_string(i) + "]",
+                             message, max_ratio, max_absdiff))
+          {
+            return false;
+          }
+        }
+        return true;
+      }
+
+      if (id == arrow::Type::STRUCT)
+      {
+        const auto& fields_a = static_cast<const arrow::StructScalar&>(*a).value;
+        const auto& fields_b = static_cast<const arrow::StructScalar&>(*b).value;
+        if (fields_a.size() != fields_b.size())
+        {
+          message = path + ": struct field count " + std::to_string(fields_a.size()) + " vs. "
+                    + std::to_string(fields_b.size());
+          return false;
+        }
+        const auto& struct_type = static_cast<const arrow::StructType&>(*a->type);
+        for (size_t i = 0; i < fields_a.size(); ++i)
+        {
+          const std::string child = path + "." + struct_type.field(static_cast<int>(i))->name();
+          if (!scalarsEqual_(fields_a[i], fields_b[i], settings, child, message,
+                             max_ratio, max_absdiff))
+          {
+            return false;
+          }
+        }
+        return true;
+      }
+
+      if (!a->Equals(*b))
+      {
+        message = path + ": " + a->ToString() + " vs. " + b->ToString();
+        return false;
+      }
+      return true;
+    }
+
+    /// Append @p msg to @p sink unless the cap is reached, in which case count it as suppressed.
+    void report_(std::vector<std::string>& sink, Size max_reported, Size& suppressed,
+                 const std::string& msg)
+    {
+      if (max_reported != 0 && sink.size() >= max_reported) { ++suppressed; return; }
+      sink.push_back(msg);
+    }
+
+    /// Compare two Arrow schemas by column name, type and nullability.
+    void compareSchemas_(const std::shared_ptr<arrow::Table>& t1,
+                         const std::shared_ptr<arrow::Table>& t2,
+                         const ParquetDiffSettings& settings,
+                         ParquetDiffResult& result)
+    {
+      const auto& s1 = t1->schema();
+      const auto& s2 = t2->schema();
+
+      for (const auto& field : s1->fields())
+      {
+        const int idx = s2->GetFieldIndex(field->name());
+        if (idx < 0)
+        {
+          report_(result.schema_errors, settings.max_reported, result.suppressed,
+                  "column '" + field->name() + "' only in file 1");
+          continue;
+        }
+        const auto& other = s2->field(idx);
+        if (!field->type()->Equals(*other->type()))
+        {
+          report_(result.schema_errors, settings.max_reported, result.suppressed,
+                  "column '" + field->name() + "': type " + field->type()->ToString()
+                    + " vs. " + other->type()->ToString());
+        }
+        if (field->nullable() != other->nullable())
+        {
+          report_(result.schema_errors, settings.max_reported, result.suppressed,
+                  "column '" + field->name() + "': nullable " + (field->nullable() ? "true" : "false")
+                    + " vs. " + (other->nullable() ? "true" : "false"));
+        }
+      }
+      for (const auto& field : s2->fields())
+      {
+        if (s1->GetFieldIndex(field->name()) < 0)
+        {
+          report_(result.schema_errors, settings.max_reported, result.suppressed,
+                  "column '" + field->name() + "' only in file 2");
+        }
+      }
+    }
+
+    /// Build primary keys for every row; reports duplicates, which a QPX key must not have.
+    std::unordered_map<std::string, int64_t> buildKeys_(const std::shared_ptr<arrow::Table>& table,
+                                                        const std::vector<std::string>& key_columns,
+                                                        const std::string& which,
+                                                        const ParquetDiffSettings& settings,
+                                                        ParquetDiffResult& result,
+                                                        bool& ok)
+    {
+      ok = true;
+      std::unordered_map<std::string, int64_t> keys;
+
+      std::vector<int> indices;
+      indices.reserve(key_columns.size());
+      for (const auto& name : key_columns)
+      {
+        const int idx = table->schema()->GetFieldIndex(name);
+        if (idx < 0)
+        {
+          report_(result.key_errors, settings.max_reported, result.suppressed,
+                  which + ": primary-key column '" + name + "' does not exist");
+          ok = false;
+        }
+        indices.push_back(idx);
+      }
+      if (!ok) { return keys; }
+
+      keys.reserve(static_cast<size_t>(table->num_rows()));
+      for (int64_t row = 0; row < table->num_rows(); ++row)
+      {
+        std::string key;
+        for (size_t k = 0; k < indices.size(); ++k)
+        {
+          if (k != 0) { key += "\x1f"; } // unit separator: cannot occur in a canonical value
+          key += canonicalString_(cellAt_(table, indices[k], row));
+        }
+        auto inserted = keys.emplace(key, row);
+        if (!inserted.second)
+        {
+          report_(result.key_errors, settings.max_reported, result.suppressed,
+                  which + ": duplicate primary key {" + key + "} at rows "
+                    + std::to_string(inserted.first->second) + " and " + std::to_string(row));
+        }
+      }
+      return keys;
+    }
+  } // anonymous namespace
+
+  std::string ParquetTableComparator::viewFromFileType(const std::string& file_type)
+  {
+    if (file_type == "psm_file" || file_type == "psm") { return "psm"; }
+    if (file_type == "feature_file" || file_type == "feature") { return "feature"; }
+    if (file_type == "pg_file" || file_type == "pg") { return "pg"; }
+    return "";
+  }
+
+  std::vector<std::string> ParquetTableComparator::qpxPrimaryKey(const std::string& view)
+  {
+    // The keys OpenMS currently emits. QPX >= the identity-id change additionally defines a
+    // single surrogate key per view; pass -pk explicitly when comparing such files.
+    if (view == "psm")
+    {
+      return {QPXPSMSchema::PEPTIDOFORM, QPXPSMSchema::CHARGE,
+              QPXPSMSchema::RUN_FILE_NAME, QPXPSMSchema::SCAN};
+    }
+    if (view == "feature")
+    {
+      return {QPXFeatureSchema::PEPTIDOFORM, QPXFeatureSchema::CHARGE,
+              QPXFeatureSchema::RUN_FILE_NAME, QPXFeatureSchema::RT};
+    }
+    if (view == "pg")
+    {
+      return {QPXPgSchema::ANCHOR_PROTEIN, QPXPgSchema::GROUPED_RUNS, QPXPgSchema::LABEL};
+    }
+    throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                     "unknown QPX view '" + view + "' (expected psm, feature or pg)");
+  }
+
+  ParquetDiffResult ParquetTableComparator::compare(const std::string& file_1,
+                                                    const std::string& file_2,
+                                                    const ParquetDiffSettings& settings)
+  {
+    ParquetDiffResult result;
+
+    auto t1 = readTable_(file_1);
+    auto t2 = readTable_(file_2);
+    if (!t1 || !t2)
+    {
+      result.schema_errors.push_back("one or both files could not be read as Parquet");
+      return result;
+    }
+    result.rows_1 = static_cast<Size>(t1->num_rows());
+    result.rows_2 = static_cast<Size>(t2->num_rows());
+
+    compareSchemas_(t1, t2, settings, result);
+
+    if (settings.schema_only)
+    {
+      result.equal = result.schema_errors.empty();
+      return result;
+    }
+
+    // Resolve the primary key: explicit setting first, then the file's QPX file_type.
+    std::vector<std::string> key_columns = settings.primary_key;
+    if (key_columns.empty())
+    {
+      const std::string view = viewFromFileType(metadataValue_(t1, "file_type"));
+      if (view.empty())
+      {
+        result.schema_errors.push_back(
+          "no primary key given and file 1 carries no recognised QPX 'file_type' metadata; "
+          "pass the key columns explicitly");
+        return result;
+      }
+      key_columns = qpxPrimaryKey(view);
+    }
+    result.primary_key_used = key_columns;
+
+    // A type mismatch on a key column makes every key differ, which would bury the real cause.
+    if (!result.schema_errors.empty())
+    {
+      for (const auto& key : key_columns)
+      {
+        const int i1 = t1->schema()->GetFieldIndex(key);
+        const int i2 = t2->schema()->GetFieldIndex(key);
+        if (i1 < 0 || i2 < 0 || !t1->schema()->field(i1)->type()->Equals(*t2->schema()->field(i2)->type()))
+        {
+          result.key_errors.push_back(
+            "primary-key column '" + key + "' differs in schema; skipping value comparison");
+          return result;
+        }
+      }
+    }
+
+    bool ok_1 = false;
+    bool ok_2 = false;
+    const auto keys_1 = buildKeys_(t1, key_columns, "file 1", settings, result, ok_1);
+    const auto keys_2 = buildKeys_(t2, key_columns, "file 2", settings, result, ok_2);
+    if (!ok_1 || !ok_2) { return result; }
+
+    for (const auto& [key, row] : keys_1)
+    {
+      if (!keys_2.count(key))
+      {
+        report_(result.key_errors, settings.max_reported, result.suppressed,
+                "row only in file 1: {" + key + "}");
+      }
+      (void)row;
+    }
+    for (const auto& [key, row] : keys_2)
+    {
+      if (!keys_1.count(key))
+      {
+        report_(result.key_errors, settings.max_reported, result.suppressed,
+                "row only in file 2: {" + key + "}");
+      }
+      (void)row;
+    }
+
+    // Compare the columns both tables agree on, minus the ignored ones.
+    std::vector<std::pair<int, int>> columns;
+    std::vector<std::string> column_names;
+    for (const auto& field : t1->schema()->fields())
+    {
+      if (std::find(settings.ignore_columns.begin(), settings.ignore_columns.end(), field->name())
+          != settings.ignore_columns.end())
+      {
+        continue;
+      }
+      const int idx2 = t2->schema()->GetFieldIndex(field->name());
+      if (idx2 < 0) { continue; }
+      if (!field->type()->Equals(*t2->schema()->field(idx2)->type())) { continue; }
+      columns.emplace_back(t1->schema()->GetFieldIndex(field->name()), idx2);
+      column_names.push_back(field->name());
+    }
+
+    for (const auto& [key, row_1] : keys_1)
+    {
+      const auto it = keys_2.find(key);
+      if (it == keys_2.end()) { continue; }
+      const int64_t row_2 = it->second;
+      ++result.rows_compared;
+
+      for (size_t c = 0; c < columns.size(); ++c)
+      {
+        std::string message;
+        if (!scalarsEqual_(cellAt_(t1, columns[c].first, row_1),
+                           cellAt_(t2, columns[c].second, row_2),
+                           settings, column_names[c], message,
+                           result.max_ratio, result.max_absdiff))
+        {
+          report_(result.value_errors, settings.max_reported, result.suppressed,
+                  "{" + key + "} " + message);
+        }
+      }
+    }
+
+    result.equal = result.schema_errors.empty() && result.key_errors.empty()
+                   && result.value_errors.empty();
+    return result;
+  }
+
+  ParquetDiffResult ParquetTableComparator::validate(const std::string& file,
+                                                     const std::string& view,
+                                                     const ParquetDiffSettings& settings)
+  {
+    ParquetDiffResult result;
+
+    std::shared_ptr<arrow::Schema> expected;
+    if (view == "psm") { expected = QPXPSMSchema::schema(); }
+    else if (view == "feature") { expected = QPXFeatureSchema::schema(); }
+    else if (view == "pg") { expected = QPXPgSchema::schema(); }
+    else
+    {
+      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                       "unknown QPX view '" + view + "' (expected psm, feature or pg)");
+    }
+
+    auto table = readTable_(file);
+    if (!table)
+    {
+      result.schema_errors.push_back("file could not be read as Parquet");
+      return result;
+    }
+    result.rows_1 = static_cast<Size>(table->num_rows());
+
+    const auto& actual = table->schema();
+    for (const auto& field : expected->fields())
+    {
+      const int idx = actual->GetFieldIndex(field->name());
+      if (idx < 0)
+      {
+        report_(result.schema_errors, settings.max_reported, result.suppressed,
+                "missing required column '" + field->name() + "' ("
+                  + field->type()->ToString() + ")");
+        continue;
+      }
+      const auto& present = actual->field(idx);
+      if (!field->type()->Equals(*present->type()))
+      {
+        report_(result.schema_errors, settings.max_reported, result.suppressed,
+                "column '" + field->name() + "': expected " + field->type()->ToString()
+                  + ", found " + present->type()->ToString());
+      }
+      if (!field->nullable() && present->nullable())
+      {
+        report_(result.schema_errors, settings.max_reported, result.suppressed,
+                "column '" + field->name() + "' must not be nullable");
+      }
+    }
+    for (const auto& field : actual->fields())
+    {
+      if (expected->GetFieldIndex(field->name()) < 0)
+      {
+        report_(result.schema_errors, settings.max_reported, result.suppressed,
+                "column '" + field->name() + "' is not part of the " + view + " view");
+      }
+    }
+
+    // A QPX primary key must be unique; buildKeys_ reports any duplicate it finds.
+    const auto key_columns = settings.primary_key.empty() ? qpxPrimaryKey(view) : settings.primary_key;
+    result.primary_key_used = key_columns;
+    bool ok = false;
+    (void)buildKeys_(table, key_columns, File::basename(file), settings, result, ok);
+
+    result.equal = result.schema_errors.empty() && result.key_errors.empty();
+    return result;
+  }
+
+} // namespace OpenMS

--- a/src/openms/source/FORMAT/ParquetTableComparator.cpp
+++ b/src/openms/source/FORMAT/ParquetTableComparator.cpp
@@ -21,7 +21,6 @@
 #include <cmath>
 #include <limits>
 #include <map>
-#include <unordered_map>
 
 namespace OpenMS
 {
@@ -59,15 +58,10 @@ namespace OpenMS
         return nullptr;
       }
 
-      // One chunk per column keeps the row-index arithmetic below straightforward.
-      auto combined = table->CombineChunks(arrow::default_memory_pool());
-      if (!combined.ok())
-      {
-        OPENMS_LOG_ERROR << "ParquetTableComparator: cannot combine chunks of '" << filename
-                         << "': " << combined.status().ToString() << std::endl;
-        return nullptr;
-      }
-      return *combined;
+      // Deliberately NOT CombineChunks(): it documents that "binary columns may be combined
+      // into multiple chunks" to avoid offset overflow, so a single chunk is not guaranteed
+      // for large string columns. cellAt_ indexes the ChunkedArray globally instead.
+      return table;
     }
 
     /// Value of a key in the table's schema metadata, or "" when absent.
@@ -79,31 +73,51 @@ namespace OpenMS
       return (idx < 0) ? std::string() : md->value(idx);
     }
 
-    /// Element at @p row of a single-chunk column, or nullptr when the column is absent/empty.
+    /**
+      @brief Element at @p row of a column.
+
+      Indexes the ChunkedArray globally rather than assuming a single chunk: a large string
+      column can legitimately span several chunks. @p ok distinguishes "this cell is null"
+      from "this cell could not be read" -- conflating the two would let an unreadable cell
+      on both sides compare equal.
+    */
     std::shared_ptr<arrow::Scalar> cellAt_(const std::shared_ptr<arrow::Table>& table,
-                                           int col, int64_t row)
+                                           int col, int64_t row, bool& ok)
     {
+      ok = false;
       if (col < 0) { return nullptr; }
-      const auto& chunked = table->column(col);
-      if (chunked->num_chunks() == 0) { return nullptr; }
-      auto scalar_result = chunked->chunk(0)->GetScalar(row);
+      auto scalar_result = table->column(col)->GetScalar(row);
       if (!scalar_result.ok()) { return nullptr; }
+      ok = true;
       return *scalar_result;
     }
 
+    /// True for the Arrow scalar types that derive from BaseListScalar.
+    bool isListLike_(arrow::Type::type id)
+    {
+      return id == arrow::Type::LIST || id == arrow::Type::LARGE_LIST
+             || id == arrow::Type::FIXED_SIZE_LIST || id == arrow::Type::MAP;
+    }
+
     /**
-      @brief Canonical string of a scalar, used to form primary keys.
+      @brief Canonical, self-delimiting encoding of a scalar, used to form primary keys.
+
+      Every part is length-prefixed, so concatenating the encodings of several key columns is
+      unambiguous: a value containing any byte -- including a separator character or the text
+      of the null marker -- cannot be confused with a structural boundary. A plain delimiter
+      would not be safe, because Arrow string values may contain arbitrary bytes.
 
       List elements are sorted so that a set-valued key column (QPX @c grouped_runs, and the
       @c scan component of the psm key) compares equal regardless of the order the producer
       happened to emit. This mirrors what the QPX reference implementation does before it
       checks primary-key uniqueness.
     */
-    std::string canonicalString_(const std::shared_ptr<arrow::Scalar>& scalar)
+    std::string canonicalKey_(const std::shared_ptr<arrow::Scalar>& scalar)
     {
-      if (!scalar || !scalar->is_valid) { return "<null>"; }
+      if (!scalar) { return "E;"; }        // unreadable
+      if (!scalar->is_valid) { return "N;"; } // null
 
-      if (scalar->type->id() == arrow::Type::LIST || scalar->type->id() == arrow::Type::LARGE_LIST)
+      if (isListLike_(scalar->type->id()))
       {
         const auto& values = static_cast<const arrow::BaseListScalar&>(*scalar).value;
         std::vector<std::string> parts;
@@ -111,18 +125,16 @@ namespace OpenMS
         for (int64_t i = 0; i < values->length(); ++i)
         {
           auto element = values->GetScalar(i);
-          parts.push_back(element.ok() ? canonicalString_(*element) : "<err>");
+          parts.push_back(element.ok() ? canonicalKey_(*element) : "E;");
         }
         std::sort(parts.begin(), parts.end());
-        std::string joined = "[";
-        for (size_t i = 0; i < parts.size(); ++i)
-        {
-          if (i != 0) { joined += ","; }
-          joined += parts[i];
-        }
-        return joined + "]";
+        std::string joined = "L" + std::to_string(parts.size()) + ";";
+        for (const auto& p : parts) { joined += p; }
+        return joined;
       }
-      return scalar->ToString();
+
+      const std::string text = scalar->ToString();
+      return "V" + std::to_string(text.size()) + ":" + text;
     }
 
     /// True when both are NaN, which regression comparison should treat as equal.
@@ -148,36 +160,39 @@ namespace OpenMS
       if (a == b) { return true; }
 
       absdiff = std::fabs(a - b);
-      if (absdiff <= settings.acceptable_absdiff) { return true; }
 
+      // Both metrics are computed unconditionally, even when the first one already accepts,
+      // so that ParquetDiffResult::max_ratio / max_absdiff really are the largest observed.
       if (a != 0.0 && b != 0.0 && ((a > 0.0) == (b > 0.0)))
       {
         const double aa = std::fabs(a);
         const double bb = std::fabs(b);
         ratio = (aa > bb) ? (aa / bb) : (bb / aa);
-        return ratio <= settings.acceptable_ratio;
       }
-      ratio = std::numeric_limits<double>::infinity();
-      return false;
+      else
+      {
+        // No ratio bridges zero to non-zero, or opposite signs; only absdiff can accept those.
+        ratio = std::numeric_limits<double>::infinity();
+      }
+      return absdiff <= settings.acceptable_absdiff || ratio <= settings.acceptable_ratio;
     }
 
-    /// Numeric value of a scalar, if it holds one.
+    /**
+      @brief Numeric value of a scalar, if it holds one.
+
+      Integers are included: "numeric" in the tolerance contract means every number, not only
+      the floating-point ones. Values wider than the 53-bit mantissa of a double lose precision
+      here, which the caller compensates for by never accepting a zero difference between two
+      scalars that are not exactly equal.
+    */
     bool asDouble_(const arrow::Scalar& scalar, double& out)
     {
-      switch (scalar.type->id())
-      {
-        case arrow::Type::HALF_FLOAT:
-        case arrow::Type::FLOAT:
-        case arrow::Type::DOUBLE:
-        {
-          auto casted = scalar.CastTo(arrow::float64());
-          if (!casted.ok()) { return false; }
-          out = static_cast<const arrow::DoubleScalar&>(**casted).value;
-          return true;
-        }
-        default:
-          return false;
-      }
+      const auto id = scalar.type->id();
+      if (!arrow::is_integer(id) && !arrow::is_floating(id)) { return false; }
+      auto casted = scalar.CastTo(arrow::float64());
+      if (!casted.ok()) { return false; }
+      out = static_cast<const arrow::DoubleScalar&>(**casted).value;
+      return true;
     }
 
     /**
@@ -217,7 +232,10 @@ namespace OpenMS
       {
         double ratio = 1.0;
         double absdiff = 0.0;
-        const bool ok = numbersAcceptable_(av, bv, settings, ratio, absdiff);
+        bool ok = numbersAcceptable_(av, bv, settings, ratio, absdiff);
+        // A 64-bit integer difference can vanish when both sides are widened to a double.
+        // Two scalars that are not exactly equal must never be accepted on a zero difference.
+        if (ok && absdiff == 0.0 && !a->Equals(*b)) { ok = false; }
         if (std::isfinite(ratio)) { max_ratio = std::max(max_ratio, ratio); }
         max_absdiff = std::max(max_absdiff, absdiff);
         if (!ok)
@@ -230,7 +248,7 @@ namespace OpenMS
       }
 
       const auto id = a->type->id();
-      if (id == arrow::Type::LIST || id == arrow::Type::LARGE_LIST)
+      if (isListLike_(id))
       {
         const auto& av_list = static_cast<const arrow::BaseListScalar&>(*a).value;
         const auto& bv_list = static_cast<const arrow::BaseListScalar&>(*b).value;
@@ -255,7 +273,7 @@ namespace OpenMS
         {
           auto key_of = [](const std::shared_ptr<arrow::Array>& arr, int64_t i) {
             auto s = arr->GetScalar(i);
-            return s.ok() ? canonicalString_(*s) : std::string("<err>");
+            return s.ok() ? canonicalKey_(*s) : std::string("E;");
           };
           std::stable_sort(order_a.begin(), order_a.end(),
                            [&](int64_t l, int64_t r) { return key_of(av_list, l) < key_of(av_list, r); });
@@ -362,16 +380,23 @@ namespace OpenMS
       }
     }
 
-    /// Build primary keys for every row; reports duplicates, which a QPX key must not have.
-    std::unordered_map<std::string, int64_t> buildKeys_(const std::shared_ptr<arrow::Table>& table,
-                                                        const std::vector<std::string>& key_columns,
-                                                        const std::string& which,
-                                                        const ParquetDiffSettings& settings,
-                                                        ParquetDiffResult& result,
-                                                        bool& ok)
+    /**
+      @brief Build primary keys for every row.
+
+      Returns key -> all rows carrying it, ordered, so that a duplicated key is visible as a
+      multiplicity rather than silently collapsing to its first occurrence. A std::map keeps
+      iteration deterministic, which matters because ParquetDiffSettings::max_reported decides
+      which differences are shown.
+    */
+    std::map<std::string, std::vector<int64_t>> buildKeys_(const std::shared_ptr<arrow::Table>& table,
+                                                           const std::vector<std::string>& key_columns,
+                                                           const std::string& which,
+                                                           const ParquetDiffSettings& settings,
+                                                           ParquetDiffResult& result,
+                                                           bool& ok)
     {
       ok = true;
-      std::unordered_map<std::string, int64_t> keys;
+      std::map<std::string, std::vector<int64_t>> keys;
 
       std::vector<int> indices;
       indices.reserve(key_columns.size());
@@ -388,25 +413,45 @@ namespace OpenMS
       }
       if (!ok) { return keys; }
 
-      keys.reserve(static_cast<size_t>(table->num_rows()));
       for (int64_t row = 0; row < table->num_rows(); ++row)
       {
+        // canonicalKey_ is self-delimiting, so plain concatenation is unambiguous.
         std::string key;
-        for (size_t k = 0; k < indices.size(); ++k)
+        for (const int index : indices)
         {
-          if (k != 0) { key += "\x1f"; } // unit separator: cannot occur in a canonical value
-          key += canonicalString_(cellAt_(table, indices[k], row));
+          bool cell_ok = false;
+          auto cell = cellAt_(table, index, row, cell_ok);
+          if (!cell_ok)
+          {
+            report_(result.key_errors, settings.max_reported, result.suppressed,
+                    which + ": row " + std::to_string(row) + " has an unreadable key cell in '"
+                      + table->schema()->field(index)->name() + "'");
+            ok = false;
+            return keys;
+          }
+          key += canonicalKey_(cell);
         }
-        auto inserted = keys.emplace(key, row);
-        if (!inserted.second)
+        keys[key].push_back(row);
+      }
+
+      for (const auto& [key, rows] : keys)
+      {
+        if (rows.size() > 1)
         {
+          std::string row_list;
+          for (size_t i = 0; i < rows.size(); ++i)
+          {
+            if (i != 0) { row_list += ", "; }
+            row_list += std::to_string(rows[i]);
+          }
           report_(result.key_errors, settings.max_reported, result.suppressed,
-                  which + ": duplicate primary key {" + key + "} at rows "
-                    + std::to_string(inserted.first->second) + " and " + std::to_string(row));
+                  which + ": primary key occurs " + std::to_string(rows.size())
+                    + " times (rows " + row_list + "): " + key);
         }
       }
       return keys;
     }
+
   } // anonymous namespace
 
   std::string ParquetTableComparator::viewFromFileType(const std::string& file_type)
@@ -470,7 +515,7 @@ namespace OpenMS
       const std::string view = viewFromFileType(metadataValue_(t1, "file_type"));
       if (view.empty())
       {
-        result.schema_errors.push_back(
+        result.key_errors.push_back(
           "no primary key given and file 1 carries no recognised QPX 'file_type' metadata; "
           "pass the key columns explicitly");
         return result;
@@ -501,32 +546,47 @@ namespace OpenMS
     const auto keys_2 = buildKeys_(t2, key_columns, "file 2", settings, result, ok_2);
     if (!ok_1 || !ok_2) { return result; }
 
-    for (const auto& [key, row] : keys_1)
+    // Key-set drift, including multiplicity: a key present twice on one side and once on the
+    // other is a real difference, not something to collapse.
+    for (const auto& [key, rows] : keys_1)
     {
-      if (!keys_2.count(key))
+      const auto it = keys_2.find(key);
+      if (it == keys_2.end())
       {
         report_(result.key_errors, settings.max_reported, result.suppressed,
-                "row only in file 1: {" + key + "}");
+                "row only in file 1: " + key);
       }
-      (void)row;
+      else if (it->second.size() != rows.size())
+      {
+        report_(result.key_errors, settings.max_reported, result.suppressed,
+                "key occurs " + std::to_string(rows.size()) + " times in file 1 but "
+                  + std::to_string(it->second.size()) + " times in file 2: " + key);
+      }
     }
-    for (const auto& [key, row] : keys_2)
+    for (const auto& [key, rows] : keys_2)
     {
-      if (!keys_1.count(key))
+      (void)rows;
+      if (keys_1.find(key) == keys_1.end())
       {
         report_(result.key_errors, settings.max_reported, result.suppressed,
-                "row only in file 2: {" + key + "}");
+                "row only in file 2: " + key);
       }
-      (void)row;
     }
 
-    // Compare the columns both tables agree on, minus the ignored ones.
+    // Columns to compare: those both tables agree on, minus the ignored ones, and minus the
+    // primary-key columns. The key columns already matched the rows, and they matched under
+    // canonical (order-insensitive) semantics -- re-comparing them as ordinary values would
+    // contradict that by reporting a reordered grouped_runs as a difference.
     std::vector<std::pair<int, int>> columns;
     std::vector<std::string> column_names;
     for (const auto& field : t1->schema()->fields())
     {
       if (std::find(settings.ignore_columns.begin(), settings.ignore_columns.end(), field->name())
           != settings.ignore_columns.end())
+      {
+        continue;
+      }
+      if (std::find(key_columns.begin(), key_columns.end(), field->name()) != key_columns.end())
       {
         continue;
       }
@@ -537,23 +597,35 @@ namespace OpenMS
       column_names.push_back(field->name());
     }
 
-    for (const auto& [key, row_1] : keys_1)
+    for (const auto& [key, rows_1] : keys_1)
     {
       const auto it = keys_2.find(key);
       if (it == keys_2.end()) { continue; }
-      const int64_t row_2 = it->second;
+      // With a well-formed key both sides hold exactly one row; duplicates were reported above
+      // and the first occurrence is compared so that the value report is still useful.
+      const int64_t row_1 = rows_1.front();
+      const int64_t row_2 = it->second.front();
       ++result.rows_compared;
 
       for (size_t c = 0; c < columns.size(); ++c)
       {
+        bool ok_a = false;
+        bool ok_b = false;
+        auto cell_a = cellAt_(t1, columns[c].first, row_1, ok_a);
+        auto cell_b = cellAt_(t2, columns[c].second, row_2, ok_b);
+        if (!ok_a || !ok_b)
+        {
+          report_(result.value_errors, settings.max_reported, result.suppressed,
+                  key + " " + column_names[c] + ": cell could not be read");
+          continue;
+        }
+
         std::string message;
-        if (!scalarsEqual_(cellAt_(t1, columns[c].first, row_1),
-                           cellAt_(t2, columns[c].second, row_2),
-                           settings, column_names[c], message,
+        if (!scalarsEqual_(cell_a, cell_b, settings, column_names[c], message,
                            result.max_ratio, result.max_absdiff))
         {
           report_(result.value_errors, settings.max_reported, result.suppressed,
-                  "{" + key + "} " + message);
+                  key + " " + message);
         }
       }
     }
@@ -562,7 +634,6 @@ namespace OpenMS
                    && result.value_errors.empty();
     return result;
   }
-
   ParquetDiffResult ParquetTableComparator::validate(const std::string& file,
                                                      const std::string& view,
                                                      const ParquetDiffSettings& settings)
@@ -605,10 +676,12 @@ namespace OpenMS
                 "column '" + field->name() + "': expected " + field->type()->ToString()
                   + ", found " + present->type()->ToString());
       }
-      if (!field->nullable() && present->nullable())
+      if (field->nullable() != present->nullable())
       {
         report_(result.schema_errors, settings.max_reported, result.suppressed,
-                "column '" + field->name() + "' must not be nullable");
+                "column '" + field->name() + "': expected nullable "
+                  + (field->nullable() ? "true" : "false") + ", found "
+                  + (present->nullable() ? "true" : "false"));
       }
     }
     for (const auto& field : actual->fields())

--- a/src/openms/source/FORMAT/ParquetTableComparator.cpp
+++ b/src/openms/source/FORMAT/ParquetTableComparator.cpp
@@ -303,14 +303,23 @@ namespace OpenMS
         }
         if (settings.unordered_lists)
         {
-          auto key_of = [](const std::shared_ptr<arrow::Array>& arr, int64_t i) {
-            auto s = arr->GetScalar(i);
-            return s.ok() ? canonicalKey_(*s) : std::string("E;");
+          // Precompute one canonical key per element. Building them inside the comparator would
+          // re-derive each key O(log n) times, and canonicalKey_ recurses through nested values.
+          auto keys_of = [](const std::shared_ptr<arrow::Array>& arr) {
+            std::vector<std::string> keys(static_cast<size_t>(arr->length()));
+            for (int64_t i = 0; i < arr->length(); ++i)
+            {
+              auto s = arr->GetScalar(i);
+              keys[static_cast<size_t>(i)] = s.ok() ? canonicalKey_(*s) : std::string("E;");
+            }
+            return keys;
           };
+          const std::vector<std::string> keys_a = keys_of(av_list);
+          const std::vector<std::string> keys_b = keys_of(bv_list);
           std::stable_sort(order_a.begin(), order_a.end(),
-                           [&](int64_t l, int64_t r) { return key_of(av_list, l) < key_of(av_list, r); });
+                           [&](int64_t l, int64_t r) { return keys_a[l] < keys_a[r]; });
           std::stable_sort(order_b.begin(), order_b.end(),
-                           [&](int64_t l, int64_t r) { return key_of(bv_list, l) < key_of(bv_list, r); });
+                           [&](int64_t l, int64_t r) { return keys_b[l] < keys_b[r]; });
         }
 
         for (size_t i = 0; i < order_a.size(); ++i)
@@ -739,11 +748,15 @@ namespace OpenMS
       }
     }
 
-    // A QPX primary key must be unique; buildKeys_ reports any duplicate it finds.
-    const auto key_columns = settings.primary_key.empty() ? qpxPrimaryKey(view) : settings.primary_key;
-    result.primary_key_used = key_columns;
-    bool ok = false;
-    (void)buildKeys_(table, key_columns, File::basename(file), settings, result, ok);
+    // A QPX primary key must be unique; buildKeys_ reports any duplicate it finds. Skipped under
+    // schema_only, which the settings contract defines as "schemas only, no key building".
+    if (!settings.schema_only)
+    {
+      const auto key_columns = settings.primary_key.empty() ? qpxPrimaryKey(view) : settings.primary_key;
+      result.primary_key_used = key_columns;
+      bool ok = false;
+      (void)buildKeys_(table, key_columns, File::basename(file), settings, result, ok);
+    }
 
     result.equal = result.schema_errors.empty() && result.key_errors.empty();
     return result;

--- a/src/openms/source/FORMAT/ParquetTableComparator.cpp
+++ b/src/openms/source/FORMAT/ParquetTableComparator.cpp
@@ -19,8 +19,10 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iomanip>
 #include <limits>
 #include <map>
+#include <sstream>
 
 namespace OpenMS
 {
@@ -137,6 +139,37 @@ namespace OpenMS
       return "V" + std::to_string(text.size()) + ":" + text;
     }
 
+    /// Human-readable rendering of a scalar, for messages (never used for matching).
+    std::string displayValue_(const std::shared_ptr<arrow::Scalar>& scalar)
+    {
+      if (!scalar) { return "<unreadable>"; }
+      if (!scalar->is_valid) { return "null"; }
+
+      if (isListLike_(scalar->type->id()))
+      {
+        const auto& values = static_cast<const arrow::BaseListScalar&>(*scalar).value;
+        std::string rendered = "[";
+        for (int64_t i = 0; i < values->length(); ++i)
+        {
+          if (i != 0) { rendered += ", "; }
+          auto element = values->GetScalar(i);
+          rendered += element.ok() ? displayValue_(*element) : "<unreadable>";
+        }
+        return rendered + "]";
+      }
+      return scalar->ToString();
+    }
+
+    /// Format a double without the trailing-zero noise of std::to_string.
+    std::string formatNumber_(double value)
+    {
+      if (std::isinf(value)) { return value > 0 ? "inf" : "-inf"; }
+      if (std::isnan(value)) { return "nan"; }
+      std::ostringstream out;
+      out << std::setprecision(10) << std::defaultfloat << value;
+      return out.str();
+    }
+
     /// True when both are NaN, which regression comparison should treat as equal.
     bool bothNaN_(double a, double b)
     {
@@ -215,8 +248,7 @@ namespace OpenMS
       if (!a_valid && !b_valid) { return true; }
       if (a_valid != b_valid)
       {
-        message = path + ": " + (a_valid ? a->ToString() : "<null>") + " vs. "
-                  + (b_valid ? b->ToString() : "<null>");
+        message = path + ": " + displayValue_(a) + " vs. " + displayValue_(b);
         return false;
       }
 
@@ -241,8 +273,8 @@ namespace OpenMS
         if (!ok)
         {
           message = path + ": " + a->ToString() + " vs. " + b->ToString()
-                    + " (absdiff " + std::to_string(absdiff) + ", ratio "
-                    + (std::isfinite(ratio) ? std::to_string(ratio) : std::string("inf")) + ")";
+                    + " (absdiff " + formatNumber_(absdiff)
+                    + ", ratio " + formatNumber_(ratio) + ")";
         }
         return ok;
       }
@@ -388,7 +420,14 @@ namespace OpenMS
       iteration deterministic, which matters because ParquetDiffSettings::max_reported decides
       which differences are shown.
     */
-    std::map<std::string, std::vector<int64_t>> buildKeys_(const std::shared_ptr<arrow::Table>& table,
+    /// Rows carrying one primary key, plus a readable rendering of that key for messages.
+    struct KeyEntry
+    {
+      std::vector<int64_t> rows;
+      std::string display;
+    };
+
+    std::map<std::string, KeyEntry> buildKeys_(const std::shared_ptr<arrow::Table>& table,
                                                            const std::vector<std::string>& key_columns,
                                                            const std::string& which,
                                                            const ParquetDiffSettings& settings,
@@ -396,7 +435,7 @@ namespace OpenMS
                                                            bool& ok)
     {
       ok = true;
-      std::map<std::string, std::vector<int64_t>> keys;
+      std::map<std::string, KeyEntry> keys;
 
       std::vector<int> indices;
       indices.reserve(key_columns.size());
@@ -415,38 +454,45 @@ namespace OpenMS
 
       for (int64_t row = 0; row < table->num_rows(); ++row)
       {
-        // canonicalKey_ is self-delimiting, so plain concatenation is unambiguous.
+        // canonicalKey_ is self-delimiting, so plain concatenation is unambiguous. It is an
+        // identity, not a label: messages use the readable rendering built alongside it.
         std::string key;
-        for (const int index : indices)
+        std::string display;
+        for (size_t k = 0; k < indices.size(); ++k)
         {
           bool cell_ok = false;
-          auto cell = cellAt_(table, index, row, cell_ok);
+          auto cell = cellAt_(table, indices[k], row, cell_ok);
           if (!cell_ok)
           {
             report_(result.key_errors, settings.max_reported, result.suppressed,
                     which + ": row " + std::to_string(row) + " has an unreadable key cell in '"
-                      + table->schema()->field(index)->name() + "'");
+                      + key_columns[k] + "'");
             ok = false;
             return keys;
           }
           key += canonicalKey_(cell);
+          if (k != 0) { display += ", "; }
+          display += key_columns[k] + "=" + displayValue_(cell);
         }
-        keys[key].push_back(row);
+        auto& entry = keys[key];
+        entry.rows.push_back(row);
+        entry.display = display;
       }
 
-      for (const auto& [key, rows] : keys)
+      for (const auto& [key, entry] : keys)
       {
-        if (rows.size() > 1)
+        (void)key;
+        if (entry.rows.size() > 1)
         {
           std::string row_list;
-          for (size_t i = 0; i < rows.size(); ++i)
+          for (size_t i = 0; i < entry.rows.size(); ++i)
           {
             if (i != 0) { row_list += ", "; }
-            row_list += std::to_string(rows[i]);
+            row_list += std::to_string(entry.rows[i]);
           }
           report_(result.key_errors, settings.max_reported, result.suppressed,
-                  which + ": primary key occurs " + std::to_string(rows.size())
-                    + " times (rows " + row_list + "): " + key);
+                  which + ": primary key occurs " + std::to_string(entry.rows.size())
+                    + " times (rows " + row_list + "): [" + entry.display + "]");
         }
       }
       return keys;
@@ -548,28 +594,28 @@ namespace OpenMS
 
     // Key-set drift, including multiplicity: a key present twice on one side and once on the
     // other is a real difference, not something to collapse.
-    for (const auto& [key, rows] : keys_1)
+    for (const auto& [key, entry] : keys_1)
     {
       const auto it = keys_2.find(key);
       if (it == keys_2.end())
       {
         report_(result.key_errors, settings.max_reported, result.suppressed,
-                "row only in file 1: " + key);
+                "row only in file 1: [" + entry.display + "]");
       }
-      else if (it->second.size() != rows.size())
+      else if (it->second.rows.size() != entry.rows.size())
       {
         report_(result.key_errors, settings.max_reported, result.suppressed,
-                "key occurs " + std::to_string(rows.size()) + " times in file 1 but "
-                  + std::to_string(it->second.size()) + " times in file 2: " + key);
+                "key occurs " + std::to_string(entry.rows.size()) + "x in file 1 but "
+                  + std::to_string(it->second.rows.size()) + "x in file 2: ["
+                  + entry.display + "]");
       }
     }
-    for (const auto& [key, rows] : keys_2)
+    for (const auto& [key, entry] : keys_2)
     {
-      (void)rows;
       if (keys_1.find(key) == keys_1.end())
       {
         report_(result.key_errors, settings.max_reported, result.suppressed,
-                "row only in file 2: " + key);
+                "row only in file 2: [" + entry.display + "]");
       }
     }
 
@@ -597,14 +643,14 @@ namespace OpenMS
       column_names.push_back(field->name());
     }
 
-    for (const auto& [key, rows_1] : keys_1)
+    for (const auto& [key, entry] : keys_1)
     {
       const auto it = keys_2.find(key);
       if (it == keys_2.end()) { continue; }
       // With a well-formed key both sides hold exactly one row; duplicates were reported above
       // and the first occurrence is compared so that the value report is still useful.
-      const int64_t row_1 = rows_1.front();
-      const int64_t row_2 = it->second.front();
+      const int64_t row_1 = entry.rows.front();
+      const int64_t row_2 = it->second.rows.front();
       ++result.rows_compared;
 
       for (size_t c = 0; c < columns.size(); ++c)
@@ -616,7 +662,7 @@ namespace OpenMS
         if (!ok_a || !ok_b)
         {
           report_(result.value_errors, settings.max_reported, result.suppressed,
-                  key + " " + column_names[c] + ": cell could not be read");
+                  "[" + entry.display + "] " + column_names[c] + ": cell could not be read");
           continue;
         }
 
@@ -625,7 +671,7 @@ namespace OpenMS
                            result.max_ratio, result.max_absdiff))
         {
           report_(result.value_errors, settings.max_reported, result.suppressed,
-                  key + " " + message);
+                  "[" + entry.display + "] " + message);
         }
       }
     }

--- a/src/openms/source/FORMAT/ParquetTableComparator.cpp
+++ b/src/openms/source/FORMAT/ParquetTableComparator.cpp
@@ -224,7 +224,8 @@ namespace OpenMS
       in integer space first. The result is exact whenever it fits a double's mantissa; a
       difference larger than that is far beyond any tolerance anyway.
     */
-    bool integerAbsDiff_(const arrow::Scalar& a, const arrow::Scalar& b, double& absdiff)
+    bool integerAbsDiff_(const arrow::Scalar& a, const arrow::Scalar& b,
+                         double& absdiff, double& min_magnitude, bool& same_sign)
     {
       if (!arrow::is_integer(a.type->id()) || !arrow::is_integer(b.type->id())) { return false; }
 
@@ -236,6 +237,8 @@ namespace OpenMS
         const uint64_t ua = static_cast<const arrow::UInt64Scalar&>(**ca).value;
         const uint64_t ub = static_cast<const arrow::UInt64Scalar&>(**cb).value;
         absdiff = static_cast<double>(ua > ub ? ua - ub : ub - ua);
+        min_magnitude = static_cast<double>(std::min(ua, ub));
+        same_sign = (ua != 0 && ub != 0);
         return true;
       }
 
@@ -248,6 +251,10 @@ namespace OpenMS
       const uint64_t diff = (ia > ib) ? (static_cast<uint64_t>(ia) - static_cast<uint64_t>(ib))
                                       : (static_cast<uint64_t>(ib) - static_cast<uint64_t>(ia));
       absdiff = static_cast<double>(diff);
+      const double fa = std::fabs(static_cast<double>(ia));
+      const double fb = std::fabs(static_cast<double>(ib));
+      min_magnitude = std::min(fa, fb);
+      same_sign = (ia != 0 && ib != 0 && ((ia > 0) == (ib > 0)));
       return true;
     }
 
@@ -312,10 +319,19 @@ namespace OpenMS
         // Scalar::Equals defaults to nans_equal_ = false, so using it as a tie-breaker here
         // would report two NaNs as different, which the tolerance contract says are equal.
         double exact = 0.0;
-        if (integerAbsDiff_(*a, *b, exact))
+        double min_magnitude = 0.0;
+        bool same_sign = false;
+        if (integerAbsDiff_(*a, *b, exact, min_magnitude, same_sign))
         {
           absdiff = exact;
-          ok = absdiff <= settings.acceptable_absdiff || ratio <= settings.acceptable_ratio;
+          // The ratio test is applied as absdiff <= (tolerance - 1) * min, never by forming the
+          // ratio: 1 + 1/2^53 rounds back to exactly 1.0, so a formed ratio would accept a real
+          // difference under the default tolerance of 1.0.
+          const bool ratio_ok = same_sign && min_magnitude > 0.0
+                                && absdiff <= (settings.acceptable_ratio - 1.0) * min_magnitude;
+          ratio = (same_sign && min_magnitude > 0.0) ? (1.0 + absdiff / min_magnitude)
+                                                     : std::numeric_limits<double>::infinity();
+          ok = absdiff <= settings.acceptable_absdiff || ratio_ok;
         }
 
         max_ratio = std::max(max_ratio, ratio);   // may be inf: that is an observed ratio

--- a/src/openms/source/FORMAT/ParquetTableComparator.cpp
+++ b/src/openms/source/FORMAT/ParquetTableComparator.cpp
@@ -47,14 +47,17 @@ namespace OpenMS
       }
       auto reader = std::move(reader_result.ValueOrDie());
 
-      auto table_result = reader->ReadTable();
-      if (!table_result.ok())
+      // The Result-returning overload is newer than the Arrow in contrib, so use the
+      // pointer-out form that ConsensusMapArrowIO uses. It is deprecated in recent Arrow,
+      // which is why -Wdeprecated-declarations fires here on newer system installs.
+      std::shared_ptr<arrow::Table> table;
+      const auto read_status = reader->ReadTable(&table);
+      if (!read_status.ok())
       {
         OPENMS_LOG_ERROR << "ParquetTableComparator: cannot read table from '" << filename
-                         << "': " << table_result.status().ToString() << std::endl;
+                         << "': " << read_status.ToString() << std::endl;
         return nullptr;
       }
-      const auto& table = *table_result;
 
       // One chunk per column keeps the row-index arithmetic below straightforward.
       auto combined = table->CombineChunks(arrow::default_memory_pool());

--- a/src/openms/source/FORMAT/sources.cmake
+++ b/src/openms/source/FORMAT/sources.cmake
@@ -72,6 +72,7 @@ ParamCTDFile.cpp
 ParamCWLFile.cpp
 ParamJSONFile.cpp
 ParamXMLFile.cpp
+ParquetTableComparator.cpp
 PEFFFile.cpp
 PTMXMLFile.cpp
 PeakTypeEstimator.cpp

--- a/src/tests/class_tests/openms/CMakeLists.txt
+++ b/src/tests/class_tests/openms/CMakeLists.txt
@@ -250,6 +250,14 @@ if (TARGET ArrowIOHelpers_test)
     ${OPENMS_PARQUET_TARGET}
   )
 endif()
+# Builds its fixture tables with arrow::*Builder rather than through an exporter, so it needs
+# Arrow itself, not just what OpenMS re-exports -- the same reason QPXValueValidation_test does.
+if (TARGET ParquetTableComparator_test)
+  target_link_libraries(ParquetTableComparator_test
+    ${OPENMS_ARROW_TARGET}
+    ${OPENMS_PARQUET_TARGET}
+  )
+endif()
 if (TARGET ParquetFile_test)
   target_link_libraries(ParquetFile_test
     ${OPENMS_ARROW_TARGET}

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -349,7 +349,8 @@ list(APPEND format_executables_list Arrow_test MSExperimentArrowExport_test Cons
   ConsensusMapArrowIO_test
   PSMArrowIO_test
   ArrowSchemaRegistry_test
-  ArrowIOHelpers_test)
+  ArrowIOHelpers_test
+  ParquetTableComparator_test)
 
 set(math_executables_list
   BasicStatistics_test

--- a/src/tests/class_tests/openms/source/ParquetTableComparator_test.cpp
+++ b/src/tests/class_tests/openms/source/ParquetTableComparator_test.cpp
@@ -1,0 +1,276 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/FORMAT/ParquetTableComparator.h>
+
+#include <OpenMS/FORMAT/ArrowIOHelpers.h>
+#include <OpenMS/SYSTEM/File.h>
+
+#include <arrow/api.h>
+
+///////////////////////////
+
+using namespace OpenMS;
+using namespace std;
+
+namespace
+{
+  /// A minimal three-column table: key (string), value (float32), tags (list<string>).
+  std::shared_ptr<arrow::Table> makeTable(const std::vector<std::string>& keys,
+                                          const std::vector<double>& values,
+                                          const std::vector<std::vector<std::string>>& tags)
+  {
+    arrow::StringBuilder key_b;
+    for (const auto& k : keys) { (void)key_b.Append(k); }
+    std::shared_ptr<arrow::Array> key_a;
+    (void)key_b.Finish(&key_a);
+
+    arrow::FloatBuilder value_b;
+    for (double v : values) { (void)value_b.Append(static_cast<float>(v)); }
+    std::shared_ptr<arrow::Array> value_a;
+    (void)value_b.Finish(&value_a);
+
+    auto tag_values = std::make_shared<arrow::StringBuilder>();
+    arrow::ListBuilder tag_b(arrow::default_memory_pool(), tag_values);
+    for (const auto& row : tags)
+    {
+      (void)tag_b.Append();
+      for (const auto& t : row) { (void)tag_values->Append(t); }
+    }
+    std::shared_ptr<arrow::Array> tag_a;
+    (void)tag_b.Finish(&tag_a);
+
+    auto schema = arrow::schema({arrow::field("key", arrow::utf8(), false),
+                                 arrow::field("value", arrow::float32(), true),
+                                 arrow::field("tags", arrow::list(arrow::utf8()), true)});
+    return arrow::Table::Make(schema, {key_a, value_a, tag_a});
+  }
+
+  /// Write @p table to a fresh temporary file and return its path.
+  std::string writeTemp(const std::shared_ptr<arrow::Table>& table, const std::string& stem)
+  {
+    const std::string path = File::getTempDirectory() + "/" + stem + "_"
+                             + File::getUniqueName() + ".parquet";
+    ArrowIOHelpers::writeTableToParquet(table, path);
+    return path;
+  }
+}
+
+START_TEST(ParquetTableComparator, "$Id$")
+
+/////////////////////////////////////////////////////////////
+
+ParquetDiffSettings pk_settings;
+pk_settings.primary_key = {"key"};
+
+START_SECTION((static ParquetDiffResult compare(const std::string& file_1, const std::string& file_2, const ParquetDiffSettings& settings)))
+{
+  // identical content -> equal
+  const std::string a = writeTemp(makeTable({"p1", "p2"}, {10.0, 20.0}, {{"x"}, {"y"}}), "pd_a");
+  const std::string b = writeTemp(makeTable({"p1", "p2"}, {10.0, 20.0}, {{"x"}, {"y"}}), "pd_b");
+  ParquetDiffResult r = ParquetTableComparator::compare(a, b, pk_settings);
+  TEST_EQUAL(r.equal, true)
+  TEST_EQUAL(r.rows_compared, 2)
+  TEST_EQUAL(r.schema_errors.empty(), true)
+
+  // row order must not matter: the whole point of keying on the primary key
+  const std::string c = writeTemp(makeTable({"p2", "p1"}, {20.0, 10.0}, {{"y"}, {"x"}}), "pd_c");
+  r = ParquetTableComparator::compare(a, c, pk_settings);
+  TEST_EQUAL(r.equal, true)
+  TEST_EQUAL(r.rows_compared, 2)
+
+  File::remove(a);
+  File::remove(b);
+  File::remove(c);
+}
+END_SECTION
+
+START_SECTION([EXTRA] numeric tolerance is satisfied by either ratio or absdiff)
+{
+  const std::string a = writeTemp(makeTable({"p1"}, {100.0}, {{"x"}}), "pd_tol_a");
+  const std::string b = writeTemp(makeTable({"p1"}, {101.0}, {{"x"}}), "pd_tol_b");
+
+  // exact comparison fails
+  ParquetDiffResult r = ParquetTableComparator::compare(a, b, pk_settings);
+  TEST_EQUAL(r.equal, false)
+  TEST_EQUAL(r.value_errors.size(), 1)
+
+  // ratio 101/100 = 1.01 accepted
+  ParquetDiffSettings ratio_settings = pk_settings;
+  ratio_settings.acceptable_ratio = 1.02;
+  r = ParquetTableComparator::compare(a, b, ratio_settings);
+  TEST_EQUAL(r.equal, true)
+
+  // absdiff alone is also sufficient
+  ParquetDiffSettings abs_settings = pk_settings;
+  abs_settings.acceptable_absdiff = 2.0;
+  r = ParquetTableComparator::compare(a, b, abs_settings);
+  TEST_EQUAL(r.equal, true)
+
+  File::remove(a);
+  File::remove(b);
+}
+END_SECTION
+
+START_SECTION([EXTRA] zero vs. epsilon is only reachable through absdiff)
+{
+  const std::string a = writeTemp(makeTable({"p1"}, {0.0}, {{"x"}}), "pd_zero_a");
+  const std::string b = writeTemp(makeTable({"p1"}, {1e-6}, {{"x"}}), "pd_zero_b");
+
+  // no ratio can bridge zero to non-zero
+  ParquetDiffSettings huge_ratio = pk_settings;
+  huge_ratio.acceptable_ratio = 1e9;
+  ParquetDiffResult r = ParquetTableComparator::compare(a, b, huge_ratio);
+  TEST_EQUAL(r.equal, false)
+
+  ParquetDiffSettings abs_settings = pk_settings;
+  abs_settings.acceptable_absdiff = 1e-5;
+  r = ParquetTableComparator::compare(a, b, abs_settings);
+  TEST_EQUAL(r.equal, true)
+
+  File::remove(a);
+  File::remove(b);
+}
+END_SECTION
+
+START_SECTION([EXTRA] rows present in only one file are reported as key differences)
+{
+  const std::string a = writeTemp(makeTable({"p1", "p2"}, {1.0, 2.0}, {{"x"}, {"y"}}), "pd_k_a");
+  const std::string b = writeTemp(makeTable({"p1"}, {1.0}, {{"x"}}), "pd_k_b");
+
+  const ParquetDiffResult r = ParquetTableComparator::compare(a, b, pk_settings);
+  TEST_EQUAL(r.equal, false)
+  TEST_EQUAL(r.key_errors.size(), 1)
+  TEST_EQUAL(r.rows_compared, 1)
+  TEST_EQUAL(r.rows_1, 2)
+  TEST_EQUAL(r.rows_2, 1)
+
+  File::remove(a);
+  File::remove(b);
+}
+END_SECTION
+
+START_SECTION([EXTRA] a duplicate primary key is itself an error)
+{
+  const std::string a = writeTemp(makeTable({"p1", "p1"}, {1.0, 2.0}, {{"x"}, {"y"}}), "pd_dup_a");
+  const std::string b = writeTemp(makeTable({"p1"}, {1.0}, {{"x"}}), "pd_dup_b");
+
+  const ParquetDiffResult r = ParquetTableComparator::compare(a, b, pk_settings);
+  TEST_EQUAL(r.equal, false)
+  TEST_NOT_EQUAL(r.key_errors.size(), 0)
+
+  File::remove(a);
+  File::remove(b);
+}
+END_SECTION
+
+START_SECTION([EXTRA] a list-valued cell compares element-wise or as a multiset on request)
+{
+  const std::string a = writeTemp(makeTable({"p1"}, {1.0}, {{"x", "y"}}), "pd_l_a");
+  const std::string b = writeTemp(makeTable({"p1"}, {1.0}, {{"y", "x"}}), "pd_l_b");
+
+  // sequence semantics by default: the reordering is a difference
+  ParquetDiffResult r = ParquetTableComparator::compare(a, b, pk_settings);
+  TEST_EQUAL(r.equal, false)
+
+  ParquetDiffSettings unordered = pk_settings;
+  unordered.unordered_lists = true;
+  r = ParquetTableComparator::compare(a, b, unordered);
+  TEST_EQUAL(r.equal, true)
+
+  File::remove(a);
+  File::remove(b);
+}
+END_SECTION
+
+START_SECTION([EXTRA] a column present in only one file is a schema difference)
+{
+  const std::string a = writeTemp(makeTable({"p1"}, {1.0}, {{"x"}}), "pd_s_a");
+
+  arrow::StringBuilder key_b;
+  (void)key_b.Append("p1");
+  std::shared_ptr<arrow::Array> key_a;
+  (void)key_b.Finish(&key_a);
+  auto narrow = arrow::Table::Make(arrow::schema({arrow::field("key", arrow::utf8(), false)}),
+                                   {key_a});
+  const std::string b = writeTemp(narrow, "pd_s_b");
+
+  const ParquetDiffResult r = ParquetTableComparator::compare(a, b, pk_settings);
+  TEST_EQUAL(r.equal, false)
+  TEST_EQUAL(r.schema_errors.size(), 2) // 'value' and 'tags' only in file 1
+
+  File::remove(a);
+  File::remove(b);
+}
+END_SECTION
+
+START_SECTION([EXTRA] ignored columns are excluded from value comparison)
+{
+  const std::string a = writeTemp(makeTable({"p1"}, {1.0}, {{"x"}}), "pd_i_a");
+  const std::string b = writeTemp(makeTable({"p1"}, {99.0}, {{"x"}}), "pd_i_b");
+
+  ParquetDiffSettings ignore_value = pk_settings;
+  ignore_value.ignore_columns = {"value"};
+  const ParquetDiffResult r = ParquetTableComparator::compare(a, b, ignore_value);
+  TEST_EQUAL(r.equal, true)
+
+  File::remove(a);
+  File::remove(b);
+}
+END_SECTION
+
+START_SECTION((static std::vector<std::string> qpxPrimaryKey(const std::string& view)))
+{
+  const auto pg = ParquetTableComparator::qpxPrimaryKey("pg");
+  TEST_EQUAL(pg.size(), 3)
+  TEST_STRING_EQUAL(pg[0], "anchor_protein")
+  TEST_STRING_EQUAL(pg[1], "grouped_runs")
+  TEST_STRING_EQUAL(pg[2], "label")
+
+  const auto feature = ParquetTableComparator::qpxPrimaryKey("feature");
+  TEST_EQUAL(feature.size(), 4)
+
+  TEST_EXCEPTION(Exception::IllegalArgument, ParquetTableComparator::qpxPrimaryKey("nosuchview"))
+}
+END_SECTION
+
+START_SECTION((static std::string viewFromFileType(const std::string& file_type)))
+{
+  TEST_STRING_EQUAL(ParquetTableComparator::viewFromFileType("pg_file"), "pg")
+  TEST_STRING_EQUAL(ParquetTableComparator::viewFromFileType("feature_file"), "feature")
+  TEST_STRING_EQUAL(ParquetTableComparator::viewFromFileType("psm_file"), "psm")
+  TEST_STRING_EQUAL(ParquetTableComparator::viewFromFileType("something_else"), "")
+}
+END_SECTION
+
+START_SECTION((static ParquetDiffResult validate(const std::string& file, const std::string& view, const ParquetDiffSettings& settings)))
+{
+  // a table that is plainly not a QPX pg view: every required column is missing
+  const std::string a = writeTemp(makeTable({"p1"}, {1.0}, {{"x"}}), "pd_v_a");
+
+  ParquetDiffSettings settings;
+  settings.primary_key = {"key"}; // the file has no QPX key; check schema reporting only
+  settings.max_reported = 0;      // unlimited
+  const ParquetDiffResult r = ParquetTableComparator::validate(a, "pg", settings);
+  TEST_EQUAL(r.equal, false)
+  TEST_NOT_EQUAL(r.schema_errors.size(), 0)
+
+  TEST_EXCEPTION(Exception::IllegalArgument,
+                 ParquetTableComparator::validate(a, "nosuchview", settings))
+
+  File::remove(a);
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+END_TEST

--- a/src/tests/class_tests/openms/source/ParquetTableComparator_test.cpp
+++ b/src/tests/class_tests/openms/source/ParquetTableComparator_test.cpp
@@ -18,6 +18,8 @@
 
 #include <arrow/api.h>
 
+#include <limits>
+
 ///////////////////////////
 
 using namespace OpenMS;
@@ -54,6 +56,68 @@ namespace
                                  arrow::field("value", arrow::float32(), true),
                                  arrow::field("tags", arrow::list(arrow::utf8()), true)});
     return arrow::Table::Make(schema, {key_a, value_a, tag_a});
+  }
+
+  /// key (string) + value (float64), for NaN / infinity cases.
+  std::shared_ptr<arrow::Table> makeDoubleTable(const std::vector<std::string>& keys,
+                                                const std::vector<double>& values)
+  {
+    arrow::StringBuilder key_b;
+    for (const auto& k : keys) { (void)key_b.Append(k); }
+    std::shared_ptr<arrow::Array> key_a;
+    (void)key_b.Finish(&key_a);
+
+    arrow::DoubleBuilder value_b;
+    for (double v : values) { (void)value_b.Append(v); }
+    std::shared_ptr<arrow::Array> value_a;
+    (void)value_b.Finish(&value_a);
+
+    return arrow::Table::Make(arrow::schema({arrow::field("key", arrow::utf8(), false),
+                                             arrow::field("value", arrow::float64(), true)}),
+                              {key_a, value_a});
+  }
+
+  /// key (string) + value (int64), for the wide-integer case.
+  std::shared_ptr<arrow::Table> makeIntTable(const std::vector<std::string>& keys,
+                                             const std::vector<int64_t>& values)
+  {
+    arrow::StringBuilder key_b;
+    for (const auto& k : keys) { (void)key_b.Append(k); }
+    std::shared_ptr<arrow::Array> key_a;
+    (void)key_b.Finish(&key_a);
+
+    arrow::Int64Builder value_b;
+    for (int64_t v : values) { (void)value_b.Append(v); }
+    std::shared_ptr<arrow::Array> value_a;
+    (void)value_b.Finish(&value_a);
+
+    return arrow::Table::Make(arrow::schema({arrow::field("key", arrow::utf8(), false),
+                                             arrow::field("value", arrow::int64(), true)}),
+                              {key_a, value_a});
+  }
+
+  /// key (string) + nums (list<double>), for multiset pairing of numeric lists.
+  std::shared_ptr<arrow::Table> makeNumListTable(const std::vector<std::string>& keys,
+                                                 const std::vector<std::vector<double>>& nums)
+  {
+    arrow::StringBuilder key_b;
+    for (const auto& k : keys) { (void)key_b.Append(k); }
+    std::shared_ptr<arrow::Array> key_a;
+    (void)key_b.Finish(&key_a);
+
+    auto num_values = std::make_shared<arrow::DoubleBuilder>();
+    arrow::ListBuilder num_b(arrow::default_memory_pool(), num_values);
+    for (const auto& row : nums)
+    {
+      (void)num_b.Append();
+      for (double v : row) { (void)num_values->Append(v); }
+    }
+    std::shared_ptr<arrow::Array> num_a;
+    (void)num_b.Finish(&num_a);
+
+    return arrow::Table::Make(arrow::schema({arrow::field("key", arrow::utf8(), false),
+                                             arrow::field("nums", arrow::list(arrow::float64()), true)}),
+                              {key_a, num_a});
   }
 
   /// Write @p table to @p path. The caller supplies the path via NEW_TMP_FILE_EXT, which is
@@ -341,6 +405,71 @@ START_SECTION([EXTRA] max_reported caps each diagnostic and the remainder is cou
   TEST_EQUAL(r.equal, false)
   TEST_EQUAL(r.value_errors.size(), 1)
   TEST_EQUAL(r.suppressed, 2)  // the two it did not list
+}
+END_SECTION
+
+START_SECTION([EXTRA] two NaNs compare equal and a NaN never matches a number)
+{
+  const double nan_v = std::numeric_limits<double>::quiet_NaN();
+  std::string a;
+  NEW_TMP_FILE_EXT(a, "parquet")
+  TEST_TRUE(writeTo(makeDoubleTable({"p1"}, {nan_v}), a))
+  std::string b;
+  NEW_TMP_FILE_EXT(b, "parquet")
+  TEST_TRUE(writeTo(makeDoubleTable({"p1"}, {nan_v}), b))
+
+  ParquetDiffResult r = ParquetTableComparator::compare(a, b, pk_settings);
+  TEST_EQUAL(r.equal, true)
+
+  // ... but NaN against a real number is a difference no tolerance can accept
+  std::string c;
+  NEW_TMP_FILE_EXT(c, "parquet")
+  TEST_TRUE(writeTo(makeDoubleTable({"p1"}, {1.0}), c))
+  ParquetDiffSettings loose = pk_settings;
+  loose.acceptable_absdiff = 1e9;
+  r = ParquetTableComparator::compare(a, c, loose);
+  TEST_EQUAL(r.equal, false)
+}
+END_SECTION
+
+START_SECTION([EXTRA] a 64-bit integer difference survives the widening to double)
+{
+  // 2^53 and 2^53+1 are the same double; the difference must still be seen exactly.
+  const int64_t big = 9007199254740992LL;   // 2^53
+  std::string a;
+  NEW_TMP_FILE_EXT(a, "parquet")
+  TEST_TRUE(writeTo(makeIntTable({"p1"}, {big}), a))
+  std::string b;
+  NEW_TMP_FILE_EXT(b, "parquet")
+  TEST_TRUE(writeTo(makeIntTable({"p1"}, {big + 1}), b))
+
+  // exact comparison must report the difference rather than lose it to rounding
+  ParquetDiffResult r = ParquetTableComparator::compare(a, b, pk_settings);
+  TEST_EQUAL(r.equal, false)
+
+  // and a tolerance of 1 must accept it
+  ParquetDiffSettings tol = pk_settings;
+  tol.acceptable_absdiff = 1.0;
+  r = ParquetTableComparator::compare(a, b, tol);
+  TEST_EQUAL(r.equal, true)
+}
+END_SECTION
+
+START_SECTION([EXTRA] unordered numeric lists are paired by value not by canonical text)
+{
+  // Lexically "10" < "20" but "20.1" < "9.99"; pairing by text would compare 10 against 20.1.
+  std::string a;
+  NEW_TMP_FILE_EXT(a, "parquet")
+  TEST_TRUE(writeTo(makeNumListTable({"p1"}, {{10.0, 20.0}}), a))
+  std::string b;
+  NEW_TMP_FILE_EXT(b, "parquet")
+  TEST_TRUE(writeTo(makeNumListTable({"p1"}, {{20.1, 9.99}}), b))
+
+  ParquetDiffSettings unordered = pk_settings;
+  unordered.unordered_lists = true;
+  unordered.acceptable_absdiff = 0.11;
+  const ParquetDiffResult r = ParquetTableComparator::compare(a, b, unordered);
+  TEST_EQUAL(r.equal, true)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ParquetTableComparator_test.cpp
+++ b/src/tests/class_tests/openms/source/ParquetTableComparator_test.cpp
@@ -56,13 +56,11 @@ namespace
     return arrow::Table::Make(schema, {key_a, value_a, tag_a});
   }
 
-  /// Write @p table to a fresh temporary file and return its path.
-  std::string writeTemp(const std::shared_ptr<arrow::Table>& table, const std::string& stem)
+  /// Write @p table to @p path. The caller supplies the path via NEW_TMP_FILE_EXT, which is
+  /// line-based and so must be expanded at the call site rather than inside this helper.
+  bool writeTo(const std::shared_ptr<arrow::Table>& table, const std::string& path)
   {
-    const std::string path = File::getTempDirectory() + "/" + stem + "_"
-                             + File::getUniqueName() + ".parquet";
-    ArrowIOHelpers::writeTableToParquet(table, path);
-    return path;
+    return ArrowIOHelpers::writeTableToParquet(table, path);
   }
 }
 
@@ -76,29 +74,36 @@ pk_settings.primary_key = {"key"};
 START_SECTION((static ParquetDiffResult compare(const std::string& file_1, const std::string& file_2, const ParquetDiffSettings& settings)))
 {
   // identical content -> equal
-  const std::string a = writeTemp(makeTable({"p1", "p2"}, {10.0, 20.0}, {{"x"}, {"y"}}), "pd_a");
-  const std::string b = writeTemp(makeTable({"p1", "p2"}, {10.0, 20.0}, {{"x"}, {"y"}}), "pd_b");
+  std::string a;
+  NEW_TMP_FILE_EXT(a, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1", "p2"}, {10.0, 20.0}, {{"x"}, {"y"}}), a))
+  std::string b;
+  NEW_TMP_FILE_EXT(b, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1", "p2"}, {10.0, 20.0}, {{"x"}, {"y"}}), b))
   ParquetDiffResult r = ParquetTableComparator::compare(a, b, pk_settings);
   TEST_EQUAL(r.equal, true)
   TEST_EQUAL(r.rows_compared, 2)
   TEST_EQUAL(r.schema_errors.empty(), true)
 
   // row order must not matter: the whole point of keying on the primary key
-  const std::string c = writeTemp(makeTable({"p2", "p1"}, {20.0, 10.0}, {{"y"}, {"x"}}), "pd_c");
+  std::string c;
+  NEW_TMP_FILE_EXT(c, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p2", "p1"}, {20.0, 10.0}, {{"y"}, {"x"}}), c))
   r = ParquetTableComparator::compare(a, c, pk_settings);
   TEST_EQUAL(r.equal, true)
   TEST_EQUAL(r.rows_compared, 2)
 
-  File::remove(a);
-  File::remove(b);
-  File::remove(c);
 }
 END_SECTION
 
 START_SECTION([EXTRA] numeric tolerance is satisfied by either ratio or absdiff)
 {
-  const std::string a = writeTemp(makeTable({"p1"}, {100.0}, {{"x"}}), "pd_tol_a");
-  const std::string b = writeTemp(makeTable({"p1"}, {101.0}, {{"x"}}), "pd_tol_b");
+  std::string a;
+  NEW_TMP_FILE_EXT(a, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1"}, {100.0}, {{"x"}}), a))
+  std::string b;
+  NEW_TMP_FILE_EXT(b, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1"}, {101.0}, {{"x"}}), b))
 
   // exact comparison fails
   ParquetDiffResult r = ParquetTableComparator::compare(a, b, pk_settings);
@@ -117,15 +122,17 @@ START_SECTION([EXTRA] numeric tolerance is satisfied by either ratio or absdiff)
   r = ParquetTableComparator::compare(a, b, abs_settings);
   TEST_EQUAL(r.equal, true)
 
-  File::remove(a);
-  File::remove(b);
 }
 END_SECTION
 
 START_SECTION([EXTRA] zero vs. epsilon is only reachable through absdiff)
 {
-  const std::string a = writeTemp(makeTable({"p1"}, {0.0}, {{"x"}}), "pd_zero_a");
-  const std::string b = writeTemp(makeTable({"p1"}, {1e-6}, {{"x"}}), "pd_zero_b");
+  std::string a;
+  NEW_TMP_FILE_EXT(a, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1"}, {0.0}, {{"x"}}), a))
+  std::string b;
+  NEW_TMP_FILE_EXT(b, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1"}, {1e-6}, {{"x"}}), b))
 
   // no ratio can bridge zero to non-zero
   ParquetDiffSettings huge_ratio = pk_settings;
@@ -138,15 +145,17 @@ START_SECTION([EXTRA] zero vs. epsilon is only reachable through absdiff)
   r = ParquetTableComparator::compare(a, b, abs_settings);
   TEST_EQUAL(r.equal, true)
 
-  File::remove(a);
-  File::remove(b);
 }
 END_SECTION
 
 START_SECTION([EXTRA] rows present in only one file are reported as key differences)
 {
-  const std::string a = writeTemp(makeTable({"p1", "p2"}, {1.0, 2.0}, {{"x"}, {"y"}}), "pd_k_a");
-  const std::string b = writeTemp(makeTable({"p1"}, {1.0}, {{"x"}}), "pd_k_b");
+  std::string a;
+  NEW_TMP_FILE_EXT(a, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1", "p2"}, {1.0, 2.0}, {{"x"}, {"y"}}), a))
+  std::string b;
+  NEW_TMP_FILE_EXT(b, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1"}, {1.0}, {{"x"}}), b))
 
   const ParquetDiffResult r = ParquetTableComparator::compare(a, b, pk_settings);
   TEST_EQUAL(r.equal, false)
@@ -155,29 +164,33 @@ START_SECTION([EXTRA] rows present in only one file are reported as key differen
   TEST_EQUAL(r.rows_1, 2)
   TEST_EQUAL(r.rows_2, 1)
 
-  File::remove(a);
-  File::remove(b);
 }
 END_SECTION
 
 START_SECTION([EXTRA] a duplicate primary key is itself an error)
 {
-  const std::string a = writeTemp(makeTable({"p1", "p1"}, {1.0, 2.0}, {{"x"}, {"y"}}), "pd_dup_a");
-  const std::string b = writeTemp(makeTable({"p1"}, {1.0}, {{"x"}}), "pd_dup_b");
+  std::string a;
+  NEW_TMP_FILE_EXT(a, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1", "p1"}, {1.0, 2.0}, {{"x"}, {"y"}}), a))
+  std::string b;
+  NEW_TMP_FILE_EXT(b, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1"}, {1.0}, {{"x"}}), b))
 
   const ParquetDiffResult r = ParquetTableComparator::compare(a, b, pk_settings);
   TEST_EQUAL(r.equal, false)
   TEST_NOT_EQUAL(r.key_errors.size(), 0)
 
-  File::remove(a);
-  File::remove(b);
 }
 END_SECTION
 
 START_SECTION([EXTRA] a list-valued cell compares element-wise or as a multiset on request)
 {
-  const std::string a = writeTemp(makeTable({"p1"}, {1.0}, {{"x", "y"}}), "pd_l_a");
-  const std::string b = writeTemp(makeTable({"p1"}, {1.0}, {{"y", "x"}}), "pd_l_b");
+  std::string a;
+  NEW_TMP_FILE_EXT(a, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1"}, {1.0}, {{"x", "y"}}), a))
+  std::string b;
+  NEW_TMP_FILE_EXT(b, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1"}, {1.0}, {{"y", "x"}}), b))
 
   // sequence semantics by default: the reordering is a difference
   ParquetDiffResult r = ParquetTableComparator::compare(a, b, pk_settings);
@@ -188,14 +201,14 @@ START_SECTION([EXTRA] a list-valued cell compares element-wise or as a multiset 
   r = ParquetTableComparator::compare(a, b, unordered);
   TEST_EQUAL(r.equal, true)
 
-  File::remove(a);
-  File::remove(b);
 }
 END_SECTION
 
 START_SECTION([EXTRA] a column present in only one file is a schema difference)
 {
-  const std::string a = writeTemp(makeTable({"p1"}, {1.0}, {{"x"}}), "pd_s_a");
+  std::string a;
+  NEW_TMP_FILE_EXT(a, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1"}, {1.0}, {{"x"}}), a))
 
   arrow::StringBuilder key_b;
   (void)key_b.Append("p1");
@@ -203,29 +216,31 @@ START_SECTION([EXTRA] a column present in only one file is a schema difference)
   (void)key_b.Finish(&key_a);
   auto narrow = arrow::Table::Make(arrow::schema({arrow::field("key", arrow::utf8(), false)}),
                                    {key_a});
-  const std::string b = writeTemp(narrow, "pd_s_b");
+  std::string b;
+  NEW_TMP_FILE_EXT(b, "parquet")
+  TEST_TRUE(writeTo(narrow, b))
 
   const ParquetDiffResult r = ParquetTableComparator::compare(a, b, pk_settings);
   TEST_EQUAL(r.equal, false)
   TEST_EQUAL(r.schema_errors.size(), 2) // 'value' and 'tags' only in file 1
 
-  File::remove(a);
-  File::remove(b);
 }
 END_SECTION
 
 START_SECTION([EXTRA] ignored columns are excluded from value comparison)
 {
-  const std::string a = writeTemp(makeTable({"p1"}, {1.0}, {{"x"}}), "pd_i_a");
-  const std::string b = writeTemp(makeTable({"p1"}, {99.0}, {{"x"}}), "pd_i_b");
+  std::string a;
+  NEW_TMP_FILE_EXT(a, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1"}, {1.0}, {{"x"}}), a))
+  std::string b;
+  NEW_TMP_FILE_EXT(b, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1"}, {99.0}, {{"x"}}), b))
 
   ParquetDiffSettings ignore_value = pk_settings;
   ignore_value.ignore_columns = {"value"};
   const ParquetDiffResult r = ParquetTableComparator::compare(a, b, ignore_value);
   TEST_EQUAL(r.equal, true)
 
-  File::remove(a);
-  File::remove(b);
 }
 END_SECTION
 
@@ -256,7 +271,9 @@ END_SECTION
 START_SECTION((static ParquetDiffResult validate(const std::string& file, const std::string& view, const ParquetDiffSettings& settings)))
 {
   // a table that is plainly not a QPX pg view: every required column is missing
-  const std::string a = writeTemp(makeTable({"p1"}, {1.0}, {{"x"}}), "pd_v_a");
+  std::string a;
+  NEW_TMP_FILE_EXT(a, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1"}, {1.0}, {{"x"}}), a))
 
   ParquetDiffSettings settings;
   settings.primary_key = {"key"}; // the file has no QPX key; check schema reporting only
@@ -268,7 +285,62 @@ START_SECTION((static ParquetDiffResult validate(const std::string& file, const 
   TEST_EXCEPTION(Exception::IllegalArgument,
                  ParquetTableComparator::validate(a, "nosuchview", settings))
 
-  File::remove(a);
+}
+END_SECTION
+
+START_SECTION([EXTRA] schema_only reports schema drift without building keys or comparing values)
+{
+  // Differs in BOTH schema and values, and carries a duplicate primary key: under schema_only
+  // only the schema difference may be reported.
+  std::string a;
+  NEW_TMP_FILE_EXT(a, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1", "p1"}, {1.0, 2.0}, {{"x"}, {"y"}}), a))
+
+  arrow::StringBuilder key_b;
+  (void)key_b.Append("p1");
+  (void)key_b.Append("p1");
+  std::shared_ptr<arrow::Array> key_a;
+  (void)key_b.Finish(&key_a);
+  auto narrow = arrow::Table::Make(arrow::schema({arrow::field("key", arrow::utf8(), false)}),
+                                   {key_a});
+  std::string b;
+  NEW_TMP_FILE_EXT(b, "parquet")
+  TEST_TRUE(writeTo(narrow, b))
+
+  ParquetDiffSettings schema_only = pk_settings;
+  schema_only.schema_only = true;
+  const ParquetDiffResult r = ParquetTableComparator::compare(a, b, schema_only);
+  TEST_EQUAL(r.equal, false)
+  TEST_NOT_EQUAL(r.schema_errors.size(), 0)
+  TEST_EQUAL(r.key_errors.size(), 0)     // no key building, so no duplicate-key report
+  TEST_EQUAL(r.value_errors.size(), 0)
+  TEST_EQUAL(r.rows_compared, 0)
+}
+END_SECTION
+
+START_SECTION([EXTRA] max_reported caps each diagnostic and the remainder is counted as suppressed)
+{
+  // Three rows that all differ in 'value'.
+  std::string a;
+  NEW_TMP_FILE_EXT(a, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1", "p2", "p3"}, {1.0, 2.0, 3.0}, {{"x"}, {"y"}, {"z"}}), a))
+  std::string b;
+  NEW_TMP_FILE_EXT(b, "parquet")
+  TEST_TRUE(writeTo(makeTable({"p1", "p2", "p3"}, {9.0, 8.0, 7.0}, {{"x"}, {"y"}, {"z"}}), b))
+
+  ParquetDiffSettings uncapped = pk_settings;
+  uncapped.max_reported = 0;   // unlimited
+  ParquetDiffResult r = ParquetTableComparator::compare(a, b, uncapped);
+  TEST_EQUAL(r.equal, false)
+  TEST_EQUAL(r.value_errors.size(), 3)
+  TEST_EQUAL(r.suppressed, 0)
+
+  ParquetDiffSettings capped = pk_settings;
+  capped.max_reported = 1;
+  r = ParquetTableComparator::compare(a, b, capped);
+  TEST_EQUAL(r.equal, false)
+  TEST_EQUAL(r.value_errors.size(), 1)
+  TEST_EQUAL(r.suppressed, 2)  // the two it did not list
 }
 END_SECTION
 

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -188,6 +188,42 @@ add_test("TOPP_IDMerger_idparquet_diff"
     -whitelist "IdentificationRun date" "UserParam.*file_origin")
 set_tests_properties("TOPP_IDMerger_idparquet_diff" PROPERTIES DEPENDS "TOPP_IDMerger_idparquet_convert")
 
+### ParquetDiff ###
+# Uses the checked-in .idparquet psm tables as fixtures: both have the same 29-column schema,
+# (peptidoform, precursor_charge) is unique in each, and the two share no key at all -- so a
+# self-comparison must report equal and a cross-comparison must report differences. No
+# generated reference file is needed.
+add_test("TOPP_ParquetDiff_1" ${TOPP_BIN_PATH}/ParquetDiff
+  -in1 ${DATA_DIR_TOPP}/IDMerger_idparquet_input1.idparquet/psms.parquet
+  -in2 ${DATA_DIR_TOPP}/IDMerger_idparquet_input1.idparquet/psms.parquet
+  -pk peptidoform precursor_charge)
+
+# Schema-only mode: the value comparison is skipped entirely, so identical schemas are equal.
+add_test("TOPP_ParquetDiff_2" ${TOPP_BIN_PATH}/ParquetDiff
+  -in1 ${DATA_DIR_TOPP}/IDMerger_idparquet_input2.idparquet/psms.parquet
+  -in2 ${DATA_DIR_TOPP}/IDMerger_idparquet_input2.idparquet/psms.parquet
+  -pk peptidoform precursor_charge
+  -schema_only)
+
+# Two different tables: the key sets are disjoint, so this must exit non-zero.
+add_test("TOPP_ParquetDiff_3" ${TOPP_BIN_PATH}/ParquetDiff
+  -in1 ${DATA_DIR_TOPP}/IDMerger_idparquet_input1.idparquet/psms.parquet
+  -in2 ${DATA_DIR_TOPP}/IDMerger_idparquet_input2.idparquet/psms.parquet
+  -pk peptidoform precursor_charge)
+set_tests_properties("TOPP_ParquetDiff_3" PROPERTIES WILL_FAIL 1)
+
+# A primary-key column that does not exist must be reported, not silently ignored.
+add_test("TOPP_ParquetDiff_4" ${TOPP_BIN_PATH}/ParquetDiff
+  -in1 ${DATA_DIR_TOPP}/IDMerger_idparquet_input1.idparquet/psms.parquet
+  -in2 ${DATA_DIR_TOPP}/IDMerger_idparquet_input1.idparquet/psms.parquet
+  -pk no_such_column)
+set_tests_properties("TOPP_ParquetDiff_4" PROPERTIES WILL_FAIL 1)
+
+# Neither 'in2' nor 'schema' given: illegal parameters.
+add_test("TOPP_ParquetDiff_5" ${TOPP_BIN_PATH}/ParquetDiff
+  -in1 ${DATA_DIR_TOPP}/IDMerger_idparquet_input1.idparquet/psms.parquet)
+set_tests_properties("TOPP_ParquetDiff_5" PROPERTIES WILL_FAIL 1)
+
 # .idparquet rip: split the merged .idparquet from TOPP_IDMerger_idparquet back into
 # per-run .idparquet directories.  -numeric_filenames + -split_ident_runs make output
 # names deterministic (merged_<ident_run_idx>_<file_origin_idx>.idparquet) so the diff

--- a/src/topp/ParquetDiff.cpp
+++ b/src/topp/ParquetDiff.cpp
@@ -1,0 +1,195 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/config.h>
+#include <OpenMS/APPLICATIONS/TOPPBase.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/FORMAT/ParquetTableComparator.h>
+
+#include <iostream>
+
+using namespace OpenMS;
+using namespace std;
+
+//-------------------------------------------------------------
+//Doxygen docu
+//-------------------------------------------------------------
+
+/**
+@page TOPP_ParquetDiff ParquetDiff
+
+@brief Compares two Parquet tables by primary key, tolerating numeric differences.
+
+The table counterpart of @ref TOPP_FuzzyDiff. Two Parquet files holding the same logical result
+may legitimately differ in row order and in the low-order bits of floating-point columns, so
+neither a byte comparison nor a text diff answers "is this the same result?". ParquetDiff matches
+rows by a primary key, compares matched rows cell by cell with a numeric tolerance, and reports
+schema drift separately from value drift.
+
+Only one of 'ratio' or 'absdiff' has to be satisfied. Use "absdiff" to deal with cases like
+"zero vs. epsilon".
+
+Rows are matched on 'pk'. For a QPX file (psm, feature or pg) the key is derived from the file's
+own @c file_type metadata when 'pk' is not given. List-valued key columns are canonicalised by
+sorting their elements, so a set-valued key such as @c grouped_runs matches regardless of the
+order the producer emitted.
+
+With 'schema' the tool takes a single input and checks it against the built-in QPX schema for
+that view instead of comparing two files; this reports missing or extra columns, wrong Arrow
+types, wrong nullability, and duplicate primary keys.
+
+<B>The command line parameters of this tool are:</B>
+@verbinclude TOPP_ParquetDiff.cli
+<B>INI file documentation of this tool:</B>
+@htmlinclude TOPP_ParquetDiff.html
+*/
+
+// We do not want this class to show up in the docu:
+/// @cond TOPPCLASSES
+
+class TOPPParquetDiff :
+  public TOPPBase
+{
+public:
+  TOPPParquetDiff() :
+    TOPPBase("ParquetDiff", "Compares two Parquet tables by primary key, tolerating numeric differences.")
+  {
+  }
+
+protected:
+
+  void registerOptionsAndFlags_() override
+  {
+    addEmptyLine_();
+    registerInputFile_("in1", "<file>", "", "first input file", true, false);
+    setValidFormats_("in1", ListUtils::create<std::string>("parquet"));
+    registerInputFile_("in2", "<file>", "", "second input file (omit when 'schema' is given)", false, false);
+    setValidFormats_("in2", ListUtils::create<std::string>("parquet"));
+    addEmptyLine_();
+
+    registerStringList_("pk", "<string list>", ListUtils::create<std::string>(""),
+                        "primary-key columns used to match rows. If empty, derived from the QPX "
+                        "'file_type' metadata of the first file.", false, false);
+    registerStringOption_("schema", "<view>", "",
+                          "instead of comparing two files, check 'in1' against the built-in QPX "
+                          "schema of this view", false, false);
+    setValidStrings_("schema", ListUtils::create<std::string>("psm,feature,pg"));
+    addEmptyLine_();
+
+    registerDoubleOption_("ratio", "<double>", 1, R"(acceptable relative error. Only one of 'ratio' or 'absdiff' has to be satisfied.  Use "absdiff" to deal with cases like "zero vs. epsilon".)", false, false);
+    setMinFloat_("ratio", 1);
+    registerDoubleOption_("absdiff", "<double>", 0, "acceptable absolute difference. Only one of 'ratio' or 'absdiff' has to be satisfied. ", false, false);
+    setMinFloat_("absdiff", 0);
+    addEmptyLine_();
+
+    registerStringList_("ignore", "<string list>", ListUtils::create<std::string>(""),
+                        "columns excluded from value comparison. They are still schema-checked.", false, true);
+    registerFlag_("schema_only", "compare schemas only; do not compare values", true);
+    registerFlag_("unordered_lists", "compare list-valued cells as multisets rather than sequences", true);
+    registerIntOption_("max_reported", "<int>", 25,
+                       "stop listing differences of one kind after this many (0 = unlimited)", false, true);
+    setMinInt_("max_reported", 0);
+
+    registerIntOption_("verbose", "<int>", 2, "set verbose level:\n"
+                                              "0 = very quiet mode (absolutely no output)\n"
+                                              "1 = quiet mode (no output unless differences detected)\n"
+                                              "2 = default (include summary at end)\n",
+                       false, false);
+    setMinInt_("verbose", 0);
+    setMaxInt_("verbose", 2);
+  }
+
+  /// Print one category of messages, honouring the verbose level.
+  static void printSection_(int verbose, const std::string& title,
+                            const std::vector<std::string>& messages)
+  {
+    if (verbose < 1 || messages.empty()) { return; }
+    std::cout << title << " (" << messages.size() << "):" << std::endl;
+    for (const auto& m : messages) { std::cout << "  " << m << std::endl; }
+  }
+
+  ExitCodes main_(int, const char**) override
+  {
+    const std::string in1 = getStringOption_("in1");
+    const std::string in2 = getStringOption_("in2");
+    const std::string view = getStringOption_("schema");
+    const int verbose = getIntOption_("verbose");
+
+    if (view.empty() && in2.empty())
+    {
+      writeLogError_("Error: 'in2' is required unless 'schema' is given.");
+      return ILLEGAL_PARAMETERS;
+    }
+
+    ParquetDiffSettings settings;
+    settings.acceptable_ratio = getDoubleOption_("ratio");
+    settings.acceptable_absdiff = getDoubleOption_("absdiff");
+    settings.schema_only = getFlag_("schema_only");
+    settings.unordered_lists = getFlag_("unordered_lists");
+    settings.max_reported = static_cast<Size>(getIntOption_("max_reported"));
+
+    // An empty StringList parameter arrives as one empty string; drop it.
+    for (const auto& c : getStringList_("pk"))
+    {
+      if (!c.empty()) { settings.primary_key.push_back(c); }
+    }
+    for (const auto& c : getStringList_("ignore"))
+    {
+      if (!c.empty()) { settings.ignore_columns.push_back(c); }
+    }
+
+    const ParquetDiffResult result = view.empty()
+      ? ParquetTableComparator::compare(in1, in2, settings)
+      : ParquetTableComparator::validate(in1, view, settings);
+
+    if (!result.equal || verbose >= 2)
+    {
+      printSection_(verbose, "Schema differences", result.schema_errors);
+      printSection_(verbose, "Key differences", result.key_errors);
+      printSection_(verbose, "Value differences", result.value_errors);
+    }
+
+    if (verbose >= 2)
+    {
+      std::cout << "Summary:" << std::endl;
+      if (view.empty())
+      {
+        std::cout << "  rows: " << result.rows_1 << " vs. " << result.rows_2
+                  << ", compared: " << result.rows_compared << std::endl;
+        std::cout << "  max ratio observed:   " << result.max_ratio << std::endl;
+        std::cout << "  max absdiff observed: " << result.max_absdiff << std::endl;
+      }
+      else
+      {
+        std::cout << "  view: " << view << ", rows: " << result.rows_1 << std::endl;
+      }
+      if (!result.primary_key_used.empty())
+      {
+        std::cout << "  primary key: "
+                  << ListUtils::concatenate(result.primary_key_used, ", ") << std::endl;
+      }
+      if (result.suppressed != 0)
+      {
+        std::cout << "  " << result.suppressed
+                  << " further difference(s) not shown (see 'max_reported')" << std::endl;
+      }
+      std::cout << (result.equal ? "  RESULT: equal" : "  RESULT: differ") << std::endl;
+    }
+
+    return result.equal ? EXECUTION_OK : INCOMPATIBLE_INPUT_DATA;
+  }
+
+};
+
+int main(int argc, const char** argv)
+{
+  TOPPParquetDiff tool;
+  return tool.main(argc, argv);
+}
+
+/// @endcond

--- a/src/topp/ParquetDiff.cpp
+++ b/src/topp/ParquetDiff.cpp
@@ -133,7 +133,7 @@ protected:
     settings.unordered_lists = getFlag_("unordered_lists");
     settings.max_reported = static_cast<Size>(getIntOption_("max_reported"));
 
-    // An empty StringList parameter arrives as one empty string; drop it.
+    // Drop empty entries a user may have supplied explicitly; the default is already empty.
     for (const auto& c : getStringList_("pk"))
     {
       if (!c.empty()) { settings.primary_key.push_back(c); }

--- a/src/topp/executables.cmake
+++ b/src/topp/executables.cmake
@@ -163,6 +163,7 @@ endif(NOT DISABLE_OPENSWATH)
 set(TOPP_executables
   ${TOPP_executables}
   ParquetConverter
+  ParquetDiff
 )
 
 if(WITH_WNETALIGN)


### PR DESCRIPTION
## Why

`FuzzyDiff` is string-based and cannot read Parquet. The established idiom for testing Parquet output — convert it back to text and `FuzzyDiff` that, as `TOPP_IDMerger_idparquet` does — has no route for the QPX `psm`/`feature`/`pg` views, because OpenMS has no QPX reader (`ParquetConverter` only handles the native feature/consensus Arrow format).

The consequence, from the audit in #9864: **every QPX assertion in the test suite is a `cmake -E sha256sum` existence check.** No value on the QPX exchange surface is compared against anything.

A byte comparison does not work either: two Parquet files holding the same logical result may legitimately differ in row order and in the low-order bits of float columns.

## What

`ParquetTableComparator` matches rows by primary key, compares matched rows cell-by-cell with a numeric tolerance, and reports schema drift separately from value drift.

- **Tolerance mirrors `FuzzyStringComparator`** — either `ratio` or `absdiff` has to be satisfied, so "zero vs. epsilon" stays expressible.
- **Recurses into `list` and `struct`**, so a float nested in `intensities: list<struct{label, intensity}>` gets the same tolerance as a top-level float.
- **List-valued key columns are canonicalised by sorting**, matching how QPX treats set-valued keys such as `grouped_runs`.
- **Duplicate primary keys are errors in their own right** — a QPX primary key must be unique.
- **Two NaNs compare equal**, which is what regression comparison wants.

For QPX files the key is derived from the file's own `file_type` metadata, so no flags are needed:

```bash
ParquetDiff -in1 ref/quantms.pg.parquet -in2 new/quantms.pg.parquet
ParquetDiff -in1 ref/quantms.feature.parquet -in2 new/quantms.feature.parquet -ratio 1.0001
ParquetDiff -in1 a.parquet -in2 b.parquet -pk sample_id run_id     # any table
ParquetDiff -in1 quantms.pg.parquet -schema pg                     # single-file schema check
```

Exit code is `EXECUTION_OK` when equal and `INCOMPATIBLE_INPUT_DATA` otherwise, so it drops into CTest the way `FuzzyDiff` does.

All Arrow/Parquet API use stays inside libOpenMS, per the constraint documented at `ArrowIOHelpers.h:36-40`, so the TOPP tool imports no Arrow symbols.

## What is verified, and what is not

**Verified:** `-fsyntax-only -Wall` on the library class, the TOPP tool and the class test, using flags taken from an existing build. All clean.

**Not verified — please treat as review-blocking:**
- **No build or run.** The 11 class-test sections assert specific counts (e.g. `schema_errors.size() == 2`) that were reasoned out, not executed. Those are the most likely thing to need adjustment on first run.
- **TOPP tests use the checked-in `.idparquet` psm tables**, not QPX output: no QPX reference table is checked in anywhere. Pointing this at the QPX surface is the follow-up, and belongs to issue #9864 Phase 0.1.

  `-schema pg` is largely redundant for OpenMS's *own* pg output: `ProteinGroupArrowExport` builds the table from `QPXPgSchema::schema()` (`:828`) and already Strict-validates against it at write time (`:904`), covering field count, names, type compatibility and nullability. The validation mode earns its place elsewhere — on files from other producers, on files after a round trip through qpx, on a file on disk rather than an in-memory table, and for **primary-key uniqueness**, which `ArrowSchemaValidation` does not check at all.
- A value-regression TOPP test additionally needs a checked-in reference `.parquet`, which has to be generated from a build.

Adding the class test requires a `cmake` reconfigure before `--build --target ParquetTableComparator_test` will resolve.

## Open design question

`ParquetDiffResult::equal` currently requires `schema_errors` to be empty, so an extra column always means "differ". That is right for regression testing but strict if you ever want to diff across schema versions — an `-ignore_schema` flag would relax it. Happy to add if reviewers prefer.

Relates to #9864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116KfSuJaXf4izEGg79PgM4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to compare Parquet tables or validate them against QPX schemas.
  * Supports primary-key matching, numeric tolerances, schema-only validation, ignored columns, configurable list ordering, verbosity/report limits, and QPX view/key resolution.
  * Produces detailed difference reports, including schema mismatches, missing/duplicate primary keys, and value mismatches (with NaN-aware numeric handling).
* **Tests**
  * Added unit and integration coverage for comparisons, tolerances, ordering rules, schema-only mode, ignored columns, diagnostics limits, and QPX error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->