### PR TITLE
[PARAM,IO,TEST] Make workflow mzTab outputs optional

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -317,6 +317,9 @@ TOPP tools:
       - Fix: memory leaks in the in-process backend (Normalizer singleton and Logger file handles)
         (#9257)
     ProteomicsLFQ:
+      - The mzTab output (-out) is optional when another output is requested; -out_cxml, -out_qpx,
+        -out_msstats, or -out_triqler can now be the sole output. Invocations without any output still
+        fail during parameter validation (#9866)
       - BREAKING: no normalization is applied, under any combination of output flags. A median scaling
         used to run over each fraction's consensus map unless -out_msstats or -out_triqler was requested,
         so the same input written to the same -out_qpx directory held normalized or raw intensities
@@ -362,6 +365,9 @@ TOPP tools:
       - Fix: mzTab export no longer aborts when search settings contain non-string DataValues (e.g.
         integer missed_cleavages) (#9666)
     IsobaricWorkflow:
+      - The consensusXML (-out), mzTab (-out_mzTab), and QPX (-out_qpx) outputs are optional
+        individually; any one can now be the sole output. Invocations without an output still fail
+        during parameter validation (#9866)
       - Added TMT 32-plex and 35-plex quantitation; the isotope correction matrix defaults to identity
         until calibrated values are provided (#9003)
       - Optional SPS match counting (-count_sps_matches): counts, per identified PSM, how many

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -1078,6 +1078,11 @@ set_tests_properties("TOPP_IsobaricAnalyzer_MS3TMT10Plex_1_out1" PROPERTIES DEPE
 
 #------------------------------------------------------------------------------
 # IsobaricWorkflow tests
+# The three functional runs below request consensusXML, mzTab, and QPX individually. This guards
+# that every output is optional on its own while the separate parameter test keeps one output required.
+add_test("TOPP_IsobaricWorkflow_requires_output" ${TOPP_BIN_PATH}/IsobaricWorkflow -test)
+set_tests_properties("TOPP_IsobaricWorkflow_requires_output" PROPERTIES PASS_REGULAR_EXPRESSION "out/out_mzTab/out_qpx")
+
 # TMT-10plex, one file, 10 channels/samples. The consensusXML check covers the protein-group
 # quantities: with remove_unquantified=true every group that survives carries data arrays, so this
 # is the path where dropping them on store is most visible.
@@ -1085,8 +1090,7 @@ add_test("TOPP_IsobaricWorkflow_1" ${TOPP_BIN_PATH}/IsobaricWorkflow -test -type
   -in ${DATA_DIR_TOPP}/TMTTenPlexMethod_test.mzML
   -in_id ${DATA_DIR_TOPP}/IsobaricWorkflow_1_input.idXML
   -exp_design ${DATA_DIR_TOPP}/IsobaricWorkflow_1_design.tsv
-  -out ${TESTS_TEMP_DIR}/IsobaricWorkflow_1_out.tmp.consensusXML
-  -out_mzTab ${TESTS_TEMP_DIR}/IsobaricWorkflow_1_out.tmp.mzTab)
+  -out ${TESTS_TEMP_DIR}/IsobaricWorkflow_1_out.tmp.consensusXML)
 add_test("TOPP_IsobaricWorkflow_1_out1" ${DIFF} -whitelist "?xml-stylesheet" "spectra_data" "InferenceEngineVersion" -in1 ${TESTS_TEMP_DIR}/IsobaricWorkflow_1_out.tmp.consensusXML -in2 ${DATA_DIR_TOPP}/IsobaricWorkflow_1_out.consensusXML )
 set_tests_properties("TOPP_IsobaricWorkflow_1_out1" PROPERTIES DEPENDS "TOPP_IsobaricWorkflow_1")
 
@@ -1098,7 +1102,6 @@ add_test("TOPP_IsobaricWorkflow_2_no_preceding_ms1" ${TOPP_BIN_PATH}/IsobaricWor
          -in ${DATA_DIR_TOPP}/TMTTenPlexMethod_test.mzML
          -in_id ${DATA_DIR_TOPP}/IsobaricWorkflow_2_input.idXML
          -type tmt10plex
-         -out ${TESTS_TEMP_DIR}/IsobaricWorkflow_2_output.tmp.consensusXML
          -out_mzTab ${TESTS_TEMP_DIR}/IsobaricWorkflow_2_output.tmp.mzTab)
 
 # QPX Parquet export. IsobaricWorkflow is the only -out_qpx producer that uses the STREAMING
@@ -1120,8 +1123,6 @@ add_test("TOPP_IsobaricWorkflow_qpx" ${TOPP_BIN_PATH}/IsobaricWorkflow -test
          -in_id ${DATA_DIR_TOPP}/IsobaricWorkflow_1_input.idXML
          -exp_design ${DATA_DIR_TOPP}/IsobaricWorkflow_1_design.tsv
          -type tmt10plex
-         -out ${TESTS_TEMP_DIR}/IsobaricWorkflow_qpx.tmp.consensusXML
-         -out_mzTab ${TESTS_TEMP_DIR}/IsobaricWorkflow_qpx.tmp.mzTab
          -out_qpx ${TESTS_TEMP_DIR}/IsobaricWorkflow_qpx_dir)
 set_tests_properties("TOPP_IsobaricWorkflow_qpx" PROPERTIES DEPENDS "TOPP_IsobaricWorkflow_qpx_clean")
 add_test("TOPP_IsobaricWorkflow_qpx_features" ${TOPP_BIN_PATH}/ParquetDiff
@@ -4038,6 +4039,11 @@ add_test("TOPP_TICCalculator_3" ${TOPP_BIN_PATH}/TICCalculator -test -in ${DATA_
 add_test("TOPP_TICCalculator_4" ${TOPP_BIN_PATH}/TICCalculator -test -in ${DATA_DIR_TOPP}/MapNormalizer_output.mzML -read_method indexed)
 add_test("TOPP_TICCalculator_5" ${TOPP_BIN_PATH}/TICCalculator -test -in ${DATA_DIR_TOPP}/MapNormalizer_output.mzML -read_method indexed_parallel)
 
+# ProteomicsLFQ rejects an invocation without outputs; existing functional runs below exercise
+# mzTab plus alternate-only consensusXML and QPX output paths.
+add_test("TOPP_ProteomicsLFQ_requires_output" ${TOPP_BIN_PATH}/ProteomicsLFQ -test)
+set_tests_properties("TOPP_ProteomicsLFQ_requires_output" PROPERTIES PASS_REGULAR_EXPRESSION "out/out_msstats/out_triqler/out_cxml/out_qpx")
+
 # ProteomicsLFQ test with a subset of the experimental design. Also tests the nonconsecutiveness of the design:
 add_test("TOPP_ProteomicsLFQ_1_subset" ${TOPP_BIN_PATH}/ProteomicsLFQ
          -in
@@ -4185,7 +4191,7 @@ set_tests_properties("TOPP_ProteomicsLFQ_1_subset_out_4" PROPERTIES DEPENDS "TOP
            -in2 ${TESTS_TEMP_DIR}/BSA_qpx_flags.tmp.mzTab)
   set_tests_properties("TOPP_ProteomicsLFQ_qpx_flags_mztab" PROPERTIES DEPENDS "TOPP_ProteomicsLFQ_qpx;TOPP_ProteomicsLFQ_qpx_flags")
 
-# QPX Parquet export from the SEEDED configuration (same setup as TOPP_ProteomicsLFQ_3).
+# QPX-only Parquet export from the SEEDED configuration (same setup as TOPP_ProteomicsLFQ_3).
 # The test above runs -targeted_only true, whose consensus features are all identified: 0 of its 60
 # feature rows are unmapped. Seeding makes unmapped features the majority -- 210 of 298 rows here --
 # and those carry an empty peptidoform, so they lean on the rest of the QPX feature primary key to
@@ -4222,7 +4228,6 @@ set_tests_properties("TOPP_ProteomicsLFQ_1_subset_out_4" PROPERTIES DEPENDS "TOP
            -targeted_only false
            -mass_recalibration false
            -PeptideQuantification:seed_apex_rt_tolerance 0
-           -out ${TESTS_TEMP_DIR}/BSA_qpx_seeds.tmp.mzTab
            -out_qpx ${TESTS_TEMP_DIR}/BSA_qpx_seeds_dir
            -threads 1
            -proteinFDR 0.3
@@ -4660,7 +4665,6 @@ add_test("TOPP_ProteomicsLFQ_biosaur2_seeds" ${TOPP_BIN_PATH}/ProteomicsLFQ
          -mass_recalibration false
          -Seeding:algorithm biosaur2
          -out_cxml ${TESTS_TEMP_DIR}/BSA_biosaur2_seeds.tmp.consensusXML
-         -out ${TESTS_TEMP_DIR}/BSA_biosaur2_seeds.tmp.mzTab
          -threads 1
          -proteinFDR 0.8
          -test

--- a/src/topp/IsobaricWorkflow.cpp
+++ b/src/topp/IsobaricWorkflow.cpp
@@ -82,6 +82,7 @@ using namespace std;
   This tool currently supports iTRAQ 4-plex and 8-plex, and TMT 6-plex, 10-plex, 11-plex, 16-plex, 18-plex, 32-plex, and 35-plex labeling methods.
   It extracts the isobaric reporter ion intensities from centroided MS2 or MS3 data (MSn), then performs isotope correction and stores the resulting quantitation in a consensus map,
   in which each consensus feature represents one identified PSM together with its reporter ions.
+  At least one of @p out, @p out_mzTab, or @p out_qpx must be specified; each output is optional individually.
   The MS level for quantification is chosen automatically per PSM: if MS3 is present, the MS3 product spectrum of the identifying MS2 scan is used (SPS-MS3), otherwise the MS2 scan itself.
   Unlike @ref TOPP_IsobaricAnalyzer, this tool does NOT filter quantification scans by activation method (@p extraction:select_activation is ignored),
   because SPS-MS3 reporter scans are frequently labelled as plain CID rather than HCD; selection is therefore based on the MS-level structure alone.
@@ -188,12 +189,12 @@ protected:
     setValidFormats_("in_id", {"idXML", "mzId", "idparquet"});
     registerInputFile_("exp_design", "<file>", "", "experimental design file (optional). If not given, the design is assumed to be unfractionated.", false);
     setValidFormats_("exp_design", {"tsv"});
-    registerOutputFile_("out", "<file>", "", "output consensusXML file");
+    registerOutputFile_("out", "<file>", "", "Optional output consensusXML file. At least one output must be specified.", false, false);
     setValidFormats_("out", {"consensusXML"});
-    registerOutputFile_("out_mzTab", "<file>", "", "output mzTab file with quantitative information");
+    registerOutputFile_("out_mzTab", "<file>", "", "Optional output mzTab file with quantitative information. At least one output must be specified.", false, false);
     setValidFormats_("out_mzTab", {"mzTab"});
 
-    registerOutputDir_("out_qpx", "<directory>", "", "Output directory for QPX Parquet files (quantms.feature.parquet, quantms.psm.parquet, quantms.pg.parquet)", false, false);
+    registerOutputDir_("out_qpx", "<directory>", "", "Optional output directory for QPX Parquet files (quantms.feature.parquet, quantms.psm.parquet, quantms.pg.parquet). At least one output must be specified.", false, false);
     registerFlag_("calculate_id_purity", "Calculate the purity of the precursor ion based on the MS1 spectrum. Only used for MS3, otherwise it is the same as the quant. precursor purity.");
     registerFlag_("count_sps_matches", "For SPS-MS3: count how many of the co-isolated MS3 precursors (SPS ions) match a b/y fragment ion of the identified peptide. The count is stored as meta value 'sps_matched_ions' on the consensus feature. Off by default.", true);
     registerDoubleOption_("sps_fragment_mass_tolerance", "<tolerance>", 20.0, "Mass tolerance for matching MS3 SPS precursors to theoretical b/y fragment ions of the identified peptide (only used with 'count_sps_matches').", false, true);
@@ -480,8 +481,16 @@ protected:
     //-------------------------------------------------------------
     // parameter handling
     //-------------------------------------------------------------
-    std::string out = getStringOption_("out");
-    std::string exp_design = getStringOption_("exp_design");
+    const std::string out = getStringOption_("out");
+    const std::string out_mzTab = getStringOption_("out_mzTab");
+    const std::string out_qpx = getOutputDirOption("out_qpx");
+    if (out.empty() && out_mzTab.empty() && out_qpx.empty())
+    {
+      throw Exception::RequiredParameterNotGiven(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                                 "out/out_mzTab/out_qpx");
+    }
+
+    const std::string exp_design = getStringOption_("exp_design");
     bool bayesian = getStringOption_("inference_method") == "bayesian";
     
     Param pq_param = getParam_().copy("ProteinQuantification:", true);
@@ -981,7 +990,6 @@ protected:
       protein_quants, inferred_proteins, true);
 
     {
-      std::string out_qpx = getOutputDirOption("out_qpx");
       if (!out_qpx.empty())
       {
         OPENMS_LOG_INFO << "Exporting QPX Parquet files to: " << out_qpx << std::endl;
@@ -1060,10 +1068,12 @@ protected:
       }
     }
 
-    FileHandler().storeConsensusFeatures(out, cmap);
-    
-    std::string out_mzTab = getStringOption_("out_mzTab");
-    if (! out_mzTab.empty()) 
+    if (!out.empty())
+    {
+      FileHandler().storeConsensusFeatures(out, cmap);
+    }
+
+    if (!out_mzTab.empty())
     {
       const bool report_unidentified_features(false);
       const bool report_unmapped(true);

--- a/src/topp/ProteomicsLFQ.cpp
+++ b/src/topp/ProteomicsLFQ.cpp
@@ -144,10 +144,12 @@ Normalization: @n
     - the downstream tool itself. MSstats, Triqler and comparable consumers normalize their input
       by design.
 
-Output:
-  - mzTab file with analysis results
-  - MSstats file with analysis results for statistical downstream analysis in MSstats
-  - ConsensusXML file for visualization and further processing in OpenMS
+Output (at least one required; each output is optional individually):
+  - mzTab file with analysis results (@p out)
+  - MSstats file with analysis results for statistical downstream analysis in MSstats (@p out_msstats)
+  - Triqler input file (@p out_triqler)
+  - consensusXML file for visualization and further processing in OpenMS (@p out_cxml)
+  - QPX Parquet collection (@p out_qpx)
 
 
 Potential scripts to perform the search can be found under src/tests/topp/ProteomicsLFQTestScripts
@@ -199,19 +201,19 @@ protected:
     registerInputFile_("fasta", "<file>", "", "fasta file", false);
     setValidFormats_("fasta", ListUtils::create<std::string>("fasta"));
 
-    registerOutputFile_("out", "<file>", "", "output mzTab file");
+    registerOutputFile_("out", "<file>", "", "Optional output mzTab file. At least one output must be specified.", false, false);
     setValidFormats_("out", ListUtils::create<std::string>("mzTab"));
 
-    registerOutputFile_("out_msstats", "<file>", "", "output MSstats input file", false, false);
+    registerOutputFile_("out_msstats", "<file>", "", "Optional output MSstats input file. At least one output must be specified.", false, false);
     setValidFormats_("out_msstats", ListUtils::create<std::string>("csv"));
 
-    registerOutputFile_("out_triqler", "<file>", "", "output Triqler input file", false, false);
+    registerOutputFile_("out_triqler", "<file>", "", "Optional output Triqler input file. At least one output must be specified.", false, false);
     setValidFormats_("out_triqler", ListUtils::create<std::string>("tsv"));
 
-    registerOutputFile_("out_cxml", "<file>", "", "output consensusXML file", false, false);
+    registerOutputFile_("out_cxml", "<file>", "", "Optional output consensusXML file. At least one output must be specified.", false, false);
     setValidFormats_("out_cxml", ListUtils::create<std::string>("consensusXML"));
 
-    registerOutputDir_("out_qpx", "<directory>", "", "Output directory for QPX Parquet files (quantms.feature.parquet, quantms.psm.parquet, quantms.pg.parquet)", false, false);
+    registerOutputDir_("out_qpx", "<directory>", "", "Optional output directory for QPX Parquet files (quantms.feature.parquet, quantms.psm.parquet, quantms.pg.parquet). At least one output must be specified.", false, false);
 
     registerDoubleOption_("proteinFDR", "<threshold>", 0.05, "Protein FDR threshold (0.05=5%).", false);
     setMinFloat_("proteinFDR", 0.0);
@@ -1588,10 +1590,18 @@ protected:
     //-------------------------------------------------------------
 
     // Read tool parameters
+    const std::string out = getStringOption_("out");
+    const std::string out_msstats = getStringOption_("out_msstats");
+    const std::string out_triqler = getStringOption_("out_triqler");
+    const std::string out_cxml = getStringOption_("out_cxml");
+    const std::string out_qpx = getOutputDirOption("out_qpx");
+    if (out.empty() && out_msstats.empty() && out_triqler.empty() && out_cxml.empty() && out_qpx.empty())
+    {
+      throw Exception::RequiredParameterNotGiven(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                                 "out/out_msstats/out_triqler/out_cxml/out_qpx");
+    }
+
     StringList in = getStringList_("in");
-    std::string out = getStringOption_("out");
-    std::string out_msstats = getStringOption_("out_msstats");
-    std::string out_triqler = getStringOption_("out_triqler");
     StringList in_ids = getStringList_("ids");
     std::string design_file = getStringOption_("design");
     std::string in_db = getStringOption_("fasta");
@@ -1916,7 +1926,6 @@ protected:
     consensus.resolveUniqueIdConflicts(); // TODO: find out if this is still needed
 
     {
-      std::string out_qpx = getOutputDirOption("out_qpx");
       if (!out_qpx.empty())
       {
         OPENMS_LOG_INFO << "Exporting QPX Parquet files to: " << out_qpx << std::endl;
@@ -1974,24 +1983,27 @@ protected:
       }
     }
 
-    if (!getStringOption_("out_cxml").empty())
+    if (!out_cxml.empty())
     {
       // Note: idXML and consensusXML doesn't support writing quantification at protein groups
       // (they are nevertheless stored and passed to mzTab for proper export)
-      FileHandler().storeConsensusFeatures(getStringOption_("out_cxml"), consensus, {FileTypes::CONSENSUSXML}, log_type_);
+      FileHandler().storeConsensusFeatures(out_cxml, consensus, {FileTypes::CONSENSUSXML}, log_type_);
     }
 
-    // Fill MzTab with meta data and quants annotated in identification data structure
-    const bool report_unidentified_features(false);
-    const bool report_unmapped(true); // TODO we should make a distinction from unassigned after conflict resolution and unassigned because unmappable
-    const bool report_subfeatures(false);
-    const bool report_unidentified_spectra(false);
-    const bool report_not_only_best_psm_per_spectrum(false);
+    if (!out.empty())
+    {
+      // Fill mzTab with meta data and quants annotated in identification data structure
+      const bool report_unidentified_features(false);
+      const bool report_unmapped(true); // TODO we should make a distinction from unassigned after conflict resolution and unassigned because unmappable
+      const bool report_subfeatures(false);
+      const bool report_unidentified_spectra(false);
+      const bool report_not_only_best_psm_per_spectrum(false);
 
-    MzTabFile().store(out, consensus,
-                      false, // first run is inference but also a properly merged run, so we don't need the hack
-                      report_unidentified_features, report_unmapped, report_subfeatures, report_unidentified_spectra,
-                      report_not_only_best_psm_per_spectrum);
+      MzTabFile().store(out, consensus,
+                        false, // first run is inference but also a properly merged run, so we don't need the hack
+                        report_unidentified_features, report_unmapped, report_subfeatures, report_unidentified_spectra,
+                        report_not_only_best_psm_per_spectrum);
+    }
 
     if (! out_msstats.empty())
     {


### PR DESCRIPTION
## Summary

- make `ProteomicsLFQ -out` optional when any of `-out_msstats`, `-out_triqler`, `-out_cxml`, or `-out_qpx` is requested
- make `IsobaricWorkflow -out` and `-out_mzTab` individually optional when another supported output is requested
- reject invocations without any output during parameter handling and guard each optional writer
- update TOPP documentation, changelog entries, and regression coverage

## Root cause

The mzTab parameters were registered as required, and the mzTab/consensusXML writers were called unconditionally. Consequently, QPX-only and other alternate-output workflows still had to produce an unused mzTab artifact.

## User impact

Pipelines can publish QPX, consensusXML, MSstats, or Triqler output without creating an unwanted mzTab file. Existing invocations that request mzTab continue to behave unchanged, and an invocation with no output still fails.

## Validation

- `git diff --check`
- targeted OpenMS cpplint invocation; it reported only pre-existing diagnostics outside the changed hunks
- added zero-output parameter checks and alternate-only functional TOPP test paths for consensusXML, mzTab, and QPX
- compiled TOPP tests were not run because this clean worktree has no configured build and repository instructions prohibit building unless explicitly requested

Closes #9866

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ProteomicsLFQ now supports generating mzTab, MSstats, Triqler, consensusXML, or QPX output independently.
  * IsobaricWorkflow now supports generating consensusXML, mzTab, or QPX output independently.
  * Output files are generated only when their corresponding options are selected.
* **Bug Fixes**
  * Improved output validation prevents runs without any requested output.
  * QPX export now validates required data and safely rolls back partial output files if export fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->