### PR TITLE
[FIX] Docker: pin Arrow/Parquet apt packages in library stage

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -216,6 +216,9 @@ RUN apt-get update \
   # to the keyring the .deb pins via Signed-By (see issue #9729). wget already
   # fails the RUN on a bad download, so no extra guard is needed here.
   && wget -qO- https://downloads.apache.org/arrow/KEYS >> /usr/share/keyrings/apache-arrow-apt-source.asc \
+  # Pin Arrow/Parquet to v23 so these runtime libs match the build-time dev libs
+  # installed by the same pin in the base stage (see #9890)
+  && printf 'Package: libarrow* libparquet*\nPin: version 23.*\nPin-Priority: 999\n' > /etc/apt/preferences.d/arrow \
   && apt-get update && apt-get install -y --no-install-recommends --no-install-suggests \
     libarrow2300 \
     libparquet2300 \


### PR DESCRIPTION
## Summary
- The nightly `Deploy container images` workflow failed building the `library` stage of `dockerfiles/Dockerfile` (arm64): https://github.com/OpenMS/OpenMS/actions/runs/31233273717
- Root cause: the `base` stage pins Arrow/Parquet apt packages to v23 (`/etc/apt/preferences.d/arrow`) before installing `libparquet-dev`, so the pinned SONAME packages (`libarrow2300`/`libparquet2300`) resolve correctly. The `library` stage installs those same runtime packages directly, without the matching pin. Now that `apache-arrow-apt-source-latest-noble.deb` defaults to Arrow 25.0.0, the unpinned `apt-get install libarrow2300 libparquet2300` in the `library` stage fails (`exit code: 4`).
- Fix: add the identical apt pin to the `library` stage before installing `libarrow2300`/`libparquet2300`, mirroring the existing `base` stage logic exactly.

Fixes #9890

## Test plan
- [ ] `Deploy container images` nightly workflow builds successfully (I couldn't verify locally — no Docker daemon available in this session; the change is a minimal, well-understood mirror of the identical, already-working pin used in the `base` stage of the same Dockerfile).
- [ ] Manually confirm `docker buildx build --target library ...` succeeds for both `linux/amd64` and `linux/arm64`.


---
_Generated by [Claude Code](https://claude.ai/code/session_014Kw7HpFkSQNkjrYutFHZej)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pinned Arrow and Parquet runtime packages to version 23 for consistent application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->