### PR TITLE
[FIX,TOPP,ID] ProteomicsLFQ, IsobaricWorkflow: reduce identifications to one per spectrum (#9871)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -330,13 +330,6 @@ TOPP tools:
         in-process path, which previously produced different output than the subprocess path (#9240)
       - Fix: memory leaks in the in-process backend (Normalizer singleton and Logger file handles)
         (#9257)
-    IsobaricWorkflow:
-      - Identifications are now reduced to one per (spectrum, peptidoform, charge), as for
-        ProteomicsLFQ. This tool builds one consensus feature per identification and all
-        identifications of one spectrum read the same MS2/MS3 scan, so a repeated identification
-        contributed the same reporter intensities twice to every abundance derived from them
-        (measured: +37% on a protein abundance from a single duplicated identification) (#9871)
-
     ProteomicsLFQ:
       - Identifications are now reduced to one per (spectrum, peptidoform, charge) when the input
         carries several of them -- the shape produced by concatenating search engine results rather
@@ -393,6 +386,11 @@ TOPP tools:
       - Fix: mzTab export no longer aborts when search settings contain non-string DataValues (e.g.
         integer missed_cleavages) (#9666)
     IsobaricWorkflow:
+      - Identifications are now reduced to one per (spectrum, peptidoform, charge), as for
+        ProteomicsLFQ. This tool builds one consensus feature per identification and all
+        identifications of one spectrum read the same MS2/MS3 scan, so a repeated identification
+        contributed the same reporter intensities twice to every abundance derived from them
+        (measured: +37% on a protein abundance from a single duplicated identification) (#9871)
       - The consensusXML (-out), mzTab (-out_mzTab), and QPX (-out_qpx) outputs are optional
         individually; any one can now be the sole output. Invocations without an output still fail
         during parameter validation (#9866)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -330,7 +330,23 @@ TOPP tools:
         in-process path, which previously produced different output than the subprocess path (#9240)
       - Fix: memory leaks in the in-process backend (Normalizer singleton and Logger file handles)
         (#9257)
+    IsobaricWorkflow:
+      - Identifications are now reduced to one per (spectrum, peptidoform, charge), as for
+        ProteomicsLFQ. This tool builds one consensus feature per identification and all
+        identifications of one spectrum read the same MS2/MS3 scan, so a repeated identification
+        contributed the same reporter intensities twice to every abundance derived from them
+        (measured: +37% on a protein abundance from a single duplicated identification) (#9871)
+
     ProteomicsLFQ:
+      - Identifications are now reduced to one per (spectrum, peptidoform, charge) when the input
+        carries several of them -- the shape produced by concatenating search engine results rather
+        than combining them (e.g. PSMFeatureExtractor -multiple_search_engines -concat, or
+        PercolatorAdapter at its default -score:fdr 1.0, which retains PSMs it marked as not
+        identified). The best-scoring one is kept and the reduction is reported. Keeping all of them
+        counted one measurement several times: in the PSM-level FDR, in the mzTab PSM rows, and, with
+        -out_qpx, as a duplicate psm_id that the QPX writers refuse. Identifications of one spectrum
+        naming different peptidoforms (a chimeric spectrum) are left alone. Combine search engine
+        results with ConsensusID (-algorithm best -keep_old_scores) to control this upstream (#9871)
       - The mzTab output (-out) is optional when another output is requested; -out_cxml, -out_qpx,
         -out_msstats, or -out_triqler can now be the sole output. Invocations without any output still
         fail during parameter validation (#9866)

--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDConflictResolverAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDConflictResolverAlgorithm.h
@@ -101,7 +101,48 @@ public:
    appears only once, i.e. no multiplicities.
    **/
   static void resolveBetweenFeatures(ConsensusMap& features);
-  
+
+  /// What reduceToOnePerSpectrum() found and did. All counts are over the input list.
+  struct OPENMS_DLLAPI UnresolvedIdentifications
+  {
+    /// Identifications removed because another one claimed the same
+    /// (spectrum reference, top-hit sequence, top-hit charge).
+    Size removed = 0;
+    /// Spectra that still carry more than one identification AFTER the reduction, i.e. ones
+    /// whose identifications name different peptidoforms (a chimeric spectrum, or search
+    /// engines that disagree). Not reduced - both are quantifiable - but worth reporting.
+    Size multiply_identified_spectra = 0;
+    /// Identifications that could not be keyed because they carry no spectrum reference.
+    /// Left untouched: without a reference there is nothing to tell them apart by.
+    Size without_spectrum_reference = 0;
+    /// Identifications whose group disagreed on isHigherScoreBetter(), so "best" was undefined.
+    /// Left untouched rather than reduced by a coin flip.
+    Size inconsistent_score_direction = 0;
+    /// First reduced group, as "<spectrum reference> / <sequence> / charge <n>", for logging.
+    std::string example;
+  };
+
+  /**
+    @brief Reduce identifications a quantification workflow cannot tell apart to one per spectrum.
+
+    Quantification tools measure one value per (spectrum, peptidoform, charge). Where the input
+    carries several identifications of that same triple - e.g. two search engines that agree,
+    concatenated rather than combined - only one of them can own the measurement, and keeping
+    all of them counts one measurement several times.
+
+    This keeps the best-scoring identification of each such group and removes the rest. That is a
+    tie-break on scores something upstream already assigned, not a scoring decision: combining
+    scores from different engines is ConsensusIDAlgorithm's job and is deliberately not done here.
+
+    Identifications are keyed on the top hit as stored; hits are never re-sorted, so the key
+    matches what the exporters and quantifiers read. Surviving identifications keep their
+    original relative order.
+
+    @param[in,out] ids One identification run's peptide identifications.
+    @return What was found and removed; see UnresolvedIdentifications.
+  **/
+  static UnresolvedIdentifications reduceToOnePerSpectrum(PeptideIdentificationList& ids);
+
 protected:
 
   template<class T>

--- a/src/openms/source/ANALYSIS/ID/IDConflictResolverAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDConflictResolverAlgorithm.cpp
@@ -45,6 +45,144 @@ namespace OpenMS
     resolveBetweenFeatures_(features);
   }
 
+  IDConflictResolverAlgorithm::UnresolvedIdentifications
+  IDConflictResolverAlgorithm::reduceToOnePerSpectrum(PeptideIdentificationList& ids)
+  {
+    UnresolvedIdentifications report;
+
+    // One keyable entry per identification. The spectrum reference is a metavalue, so
+    // getSpectrumReference() builds a string on every call - read it once here rather than
+    // from inside the comparator. The sequence is referenced, never copied.
+    struct Entry
+    {
+      const std::string* reference;
+      const AASequence* sequence;
+      Int charge;
+      Size index;
+    };
+    std::vector<std::string> references(ids.size());
+    std::vector<Entry> entries;
+    entries.reserve(ids.size());
+
+    for (Size i = 0; i < ids.size(); ++i)
+    {
+      const PeptideIdentification& id = ids[i];
+      if (id.getHits().empty())
+      {
+        continue; // nothing to key on, and nothing that could be double-counted
+      }
+      references[i] = id.getSpectrumReference();
+      if (references[i].empty())
+      {
+        ++report.without_spectrum_reference;
+        continue;
+      }
+      const PeptideHit& hit = id.getHits().front();
+      entries.push_back({&references[i], &hit.getSequence(), hit.getCharge(), i});
+    }
+
+    // Sort by the key, then by input position so the surviving member of a group is
+    // deterministic when scores tie.
+    std::sort(entries.begin(), entries.end(), [](const Entry& left, const Entry& right)
+    {
+      if (*left.reference != *right.reference) { return *left.reference < *right.reference; }
+      if (*left.sequence != *right.sequence)   { return *left.sequence < *right.sequence; }
+      if (left.charge != right.charge)         { return left.charge < right.charge; }
+      return left.index < right.index;
+    });
+
+    std::vector<bool> remove(ids.size(), false);
+
+    for (Size begin = 0; begin < entries.size();)
+    {
+      // One spectrum's entries: [begin, spectrum_end).
+      Size spectrum_end = begin;
+      while (spectrum_end < entries.size()
+             && *entries[spectrum_end].reference == *entries[begin].reference)
+      {
+        ++spectrum_end;
+      }
+
+      Size surviving_here = 0;
+      for (Size group = begin; group < spectrum_end;)
+      {
+        // One (reference, sequence, charge) group: [group, group_end).
+        // Sequence membership is tested with the ordering used to sort, not with operator==:
+        // the two disagree on what identifies a residue (operator< compares the one-letter code,
+        // operator== the interned Residue*), so a pair that operator< calls equivalent could be
+        // split apart here and its duplicate silently missed. Since the range is sorted
+        // ascending, "not less than its group leader" is exactly "sorts equal to it".
+        Size group_end = group;
+        while (group_end < spectrum_end
+               && !(*entries[group].sequence < *entries[group_end].sequence)
+               && entries[group_end].charge == entries[group].charge)
+        {
+          ++group_end;
+        }
+
+        if (group_end - group == 1) { ++surviving_here; group = group_end; continue; }
+
+        // "Best" is only defined if the group agrees on which direction is better. It normally
+        // does - a caller that got here has one score type - but a disagreement would otherwise
+        // be resolved by a coin flip, silently discarding a measurement.
+        const bool higher_better = ids[entries[group].index].isHigherScoreBetter();
+        bool consistent = true;
+        for (Size i = group + 1; i < group_end; ++i)
+        {
+          if (ids[entries[i].index].isHigherScoreBetter() != higher_better) { consistent = false; break; }
+        }
+        if (!consistent)
+        {
+          ++report.inconsistent_score_direction;
+          surviving_here += group_end - group;
+          group = group_end;
+          continue;
+        }
+
+        Size best = group;
+        for (Size i = group + 1; i < group_end; ++i)
+        {
+          const double score = ids[entries[i].index].getHits().front().getScore();
+          const double best_score = ids[entries[best].index].getHits().front().getScore();
+          if (higher_better ? (score > best_score) : (score < best_score)) { best = i; }
+        }
+
+        for (Size i = group; i < group_end; ++i)
+        {
+          if (i != best) { remove[entries[i].index] = true; }
+        }
+        report.removed += group_end - group - 1;
+        ++surviving_here;
+
+        if (report.example.empty())
+        {
+          report.example = *entries[group].reference + " / " + entries[group].sequence->toString()
+                         + " / charge " + StringUtils::toStr(entries[group].charge);
+        }
+
+        group = group_end;
+      }
+
+      if (surviving_here > 1) { ++report.multiply_identified_spectra; }
+      begin = spectrum_end;
+    }
+
+    if (report.removed > 0)
+    {
+      auto& data = ids.getData();
+      Size out = 0;
+      for (Size i = 0; i < data.size(); ++i)
+      {
+        if (remove[i]) { continue; }
+        if (out != i) { data[out] = std::move(data[i]); }
+        ++out;
+      }
+      data.resize(out);
+    }
+
+    return report;
+  }
+
   // static
   void IDConflictResolverAlgorithm::resolveConflictKeepMatching_(
       PeptideIdentificationList & peptides,

--- a/src/openms/source/ANALYSIS/ID/IDConflictResolverAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDConflictResolverAlgorithm.cpp
@@ -134,7 +134,11 @@ namespace OpenMS
         if (!consistent)
         {
           ++report.inconsistent_score_direction;
-          surviving_here += group_end - group;
+          // Counted as ONE, like the reduced branch: this group is a single peptidoform that
+          // could not be reduced, not evidence that the spectrum carries several. Counting its
+          // members individually would push multiply_identified_spectra above 1 and report the
+          // spectrum as chimeric, which is the opposite of what happened.
+          ++surviving_here;
           group = group_end;
           continue;
         }

--- a/src/pyOpenMS/bindings/bind_analysis.cpp
+++ b/src/pyOpenMS/bindings/bind_analysis.cpp
@@ -559,6 +559,15 @@ Contains: PrecalculatedAveragine, MassFeature, IsobaricQuantities, LogMzPeak
     // -----------------------------------------------------------------------
     // IDConflictResolverAlgorithm
     // -----------------------------------------------------------------------
+    nb::class_<OpenMS::IDConflictResolverAlgorithm::UnresolvedIdentifications>(
+            m, "UnresolvedIdentifications", "What IDConflictResolverAlgorithm.reduceToOnePerSpectrum did")
+        .def(nb::init<>())
+        .def_ro("removed", &OpenMS::IDConflictResolverAlgorithm::UnresolvedIdentifications::removed)
+        .def_ro("multiply_identified_spectra", &OpenMS::IDConflictResolverAlgorithm::UnresolvedIdentifications::multiply_identified_spectra)
+        .def_ro("without_spectrum_reference", &OpenMS::IDConflictResolverAlgorithm::UnresolvedIdentifications::without_spectrum_reference)
+        .def_ro("inconsistent_score_direction", &OpenMS::IDConflictResolverAlgorithm::UnresolvedIdentifications::inconsistent_score_direction)
+        .def_ro("example", &OpenMS::IDConflictResolverAlgorithm::UnresolvedIdentifications::example);
+
     nb::class_<OpenMS::IDConflictResolverAlgorithm>(m, "IDConflictResolverAlgorithm", "OpenMS class IDConflictResolverAlgorithm")
         .def(nb::init<>())
         .def(nb::init<const OpenMS::IDConflictResolverAlgorithm &>())
@@ -566,6 +575,18 @@ Contains: PrecalculatedAveragine, MassFeature, IsobaricQuantities, LogMzPeak
         .def("__deepcopy__", [](const OpenMS::IDConflictResolverAlgorithm& self, nb::dict) { return OpenMS::IDConflictResolverAlgorithm(self); }, "memo"_a)
         .def_static("resolve", [](OpenMS::FeatureMap& features, bool keep_matching) { return OpenMS::IDConflictResolverAlgorithm::resolve(features, keep_matching); }, "features"_a, "keep_matching"_a)
         .def_static("resolve", [](OpenMS::ConsensusMap& features, bool keep_matching) { return OpenMS::IDConflictResolverAlgorithm::resolve(features, keep_matching); }, "features"_a, "keep_matching"_a)
+        .def_static("reduceToOnePerSpectrum", [](OpenMS::PeptideIdentificationList& ids) { return OpenMS::IDConflictResolverAlgorithm::reduceToOnePerSpectrum(ids); }, "ids"_a,
+            R"doc(
+Reduce identifications a quantification workflow cannot tell apart to one per spectrum.
+
+Keeps the best-scoring identification of each (spectrum reference, top-hit peptidoform,
+top-hit charge) group and removes the rest. Identifications are keyed on the top hit as
+stored; hits are never re-sorted. Identifications of one spectrum naming different
+peptidoforms are left alone, as are those without a spectrum reference or without hits.
+
+:param ids: one identification run's peptide identifications (modified in-place)
+:returns: an UnresolvedIdentifications report of what was found and removed
+)doc")
         .def_static("resolveAllHitRankAggregation", [](OpenMS::FeatureMap& features) { return OpenMS::IDConflictResolverAlgorithm::resolveAllHitRankAggregation(features); }, "features"_a,
             R"doc(
 Resolves ambiguous annotations of features with peptide identifications using rank aggregation.

--- a/src/tests/class_tests/openms/source/IDConflictResolverAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/IDConflictResolverAlgorithm_test.cpp
@@ -298,6 +298,9 @@ START_SECTION((static UnresolvedIdentifications reduceToOnePerSpectrum(PeptideId
     TEST_EQUAL(report.removed, 0)
     TEST_EQUAL(ids.size(), 2)
     TEST_EQUAL(report.inconsistent_score_direction, 1)
+    // ...and it must NOT also be reported as a chimeric spectrum: the group is one peptidoform
+    // that could not be reduced, not two peptidoforms.
+    TEST_EQUAL(report.multiply_identified_spectra, 0)
   }
 
   // (7) Different spectra are never merged, and survivors keep their input order.

--- a/src/tests/class_tests/openms/source/IDConflictResolverAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/IDConflictResolverAlgorithm_test.cpp
@@ -13,6 +13,29 @@
 using namespace OpenMS;
 using namespace std;
 
+// One identification of one spectrum. Hits are deliberately not sorted by the helper:
+// reduceToOnePerSpectrum() reads hits.front() as stored, exactly like the exporters do.
+static PeptideIdentification makePepID_(const std::string& reference,
+                                        const std::string& sequence,
+                                        int charge,
+                                        double score,
+                                        bool higher_better = false)
+{
+  PeptideIdentification id;
+  if (!reference.empty()) { id.setSpectrumReference(reference); }
+  id.setScoreType("Posterior Error Probability");
+  id.setHigherScoreBetter(higher_better);
+  if (!sequence.empty())
+  {
+    PeptideHit hit;
+    hit.setSequence(AASequence::fromString(sequence));
+    hit.setCharge(charge);
+    hit.setScore(score);
+    id.insertHit(hit);
+  }
+  return id;
+}
+
 START_TEST(IDConflictResolverAlgorithm, "$Id$")
 
 START_SECTION(resolveBetweenFeatures())
@@ -182,6 +205,123 @@ START_SECTION(resolveAllHitRankAggregation())
 
   // The other 2 IDs should have been moved to unassigned
   TEST_EQUAL(cmap.getUnassignedPeptideIdentifications().size(), 2)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+// reduceToOnePerSpectrum
+/////////////////////////////////////////////////////////////
+
+START_SECTION((static UnresolvedIdentifications reduceToOnePerSpectrum(PeptideIdentificationList& ids)))
+{
+  const std::string ref = "controllerType=0 controllerNumber=1 scan=2075";
+
+  // (1) Two identifications of one spectrum agreeing on peptidoform and charge: the
+  // better-scoring one survives. Lower is better here.
+  {
+    PeptideIdentificationList ids;
+    ids.push_back(makePepID_(ref, "PEPTIDEK", 2, 0.9));
+    ids.push_back(makePepID_(ref, "PEPTIDEK", 2, 0.1));
+    auto report = IDConflictResolverAlgorithm::reduceToOnePerSpectrum(ids);
+    TEST_EQUAL(report.removed, 1)
+    TEST_EQUAL(ids.size(), 1)
+    TEST_REAL_SIMILAR(ids[0].getHits()[0].getScore(), 0.1)
+    TEST_EQUAL(report.multiply_identified_spectra, 0)
+    TEST_FALSE(report.example.empty())
+  }
+
+  // (2) Same, but higher-is-better. Getting the direction backwards is the easiest way to
+  // discard the good identification, and PercolatorAdapter emits both directions.
+  {
+    PeptideIdentificationList ids;
+    ids.push_back(makePepID_(ref, "PEPTIDEK", 2, 0.1, true));
+    ids.push_back(makePepID_(ref, "PEPTIDEK", 2, 0.9, true));
+    auto report = IDConflictResolverAlgorithm::reduceToOnePerSpectrum(ids);
+    TEST_EQUAL(report.removed, 1)
+    TEST_EQUAL(ids.size(), 1)
+    TEST_REAL_SIMILAR(ids[0].getHits()[0].getScore(), 0.9)
+  }
+
+  // (3) Chimeric spectrum: one spectrum, two different peptidoforms. Both are quantifiable,
+  // so both must survive. This is the section that pins the design decision.
+  {
+    PeptideIdentificationList ids;
+    ids.push_back(makePepID_(ref, "PEPTIDEK", 2, 0.1));
+    ids.push_back(makePepID_(ref, "ANOTHERPEPTIDER", 2, 0.2));
+    auto report = IDConflictResolverAlgorithm::reduceToOnePerSpectrum(ids);
+    TEST_EQUAL(report.removed, 0)
+    TEST_EQUAL(ids.size(), 2)
+    TEST_EQUAL(report.multiply_identified_spectra, 1)
+    TEST_TRUE(report.example.empty())
+  }
+
+  // Same peptidoform but a different charge is likewise two measurements.
+  {
+    PeptideIdentificationList ids;
+    ids.push_back(makePepID_(ref, "PEPTIDEK", 2, 0.1));
+    ids.push_back(makePepID_(ref, "PEPTIDEK", 3, 0.2));
+    auto report = IDConflictResolverAlgorithm::reduceToOnePerSpectrum(ids);
+    TEST_EQUAL(report.removed, 0)
+    TEST_EQUAL(ids.size(), 2)
+  }
+
+  // (4) No spectrum reference: nothing tells them apart, so leave them alone and say so.
+  {
+    PeptideIdentificationList ids;
+    ids.push_back(makePepID_("", "PEPTIDEK", 2, 0.1));
+    ids.push_back(makePepID_("", "PEPTIDEK", 2, 0.9));
+    auto report = IDConflictResolverAlgorithm::reduceToOnePerSpectrum(ids);
+    TEST_EQUAL(report.removed, 0)
+    TEST_EQUAL(ids.size(), 2)
+    TEST_EQUAL(report.without_spectrum_reference, 2)
+  }
+
+  // (5) An identification without hits is untouched and moves no counter.
+  {
+    PeptideIdentificationList ids;
+    ids.push_back(makePepID_(ref, "", 0, 0.0));
+    ids.push_back(makePepID_(ref, "PEPTIDEK", 2, 0.1));
+    auto report = IDConflictResolverAlgorithm::reduceToOnePerSpectrum(ids);
+    TEST_EQUAL(report.removed, 0)
+    TEST_EQUAL(ids.size(), 2)
+    TEST_EQUAL(report.without_spectrum_reference, 0)
+    TEST_EQUAL(report.multiply_identified_spectra, 0)
+  }
+
+  // (6) A group that disagrees on the score direction has no defined "best", so it is left
+  // alone rather than reduced by a coin flip.
+  {
+    PeptideIdentificationList ids;
+    ids.push_back(makePepID_(ref, "PEPTIDEK", 2, 0.1, false));
+    ids.push_back(makePepID_(ref, "PEPTIDEK", 2, 0.9, true));
+    auto report = IDConflictResolverAlgorithm::reduceToOnePerSpectrum(ids);
+    TEST_EQUAL(report.removed, 0)
+    TEST_EQUAL(ids.size(), 2)
+    TEST_EQUAL(report.inconsistent_score_direction, 1)
+  }
+
+  // (7) Different spectra are never merged, and survivors keep their input order.
+  {
+    PeptideIdentificationList ids;
+    ids.push_back(makePepID_("controllerType=0 controllerNumber=1 scan=1", "AAAK", 2, 0.5));
+    ids.push_back(makePepID_(ref, "PEPTIDEK", 2, 0.9));
+    ids.push_back(makePepID_(ref, "PEPTIDEK", 2, 0.1));
+    ids.push_back(makePepID_("controllerType=0 controllerNumber=1 scan=9", "CCCK", 2, 0.5));
+    auto report = IDConflictResolverAlgorithm::reduceToOnePerSpectrum(ids);
+    TEST_EQUAL(report.removed, 1)
+    TEST_EQUAL(ids.size(), 3)
+    TEST_EQUAL(ids[0].getHits()[0].getSequence().toString(), "AAAK")
+    TEST_REAL_SIMILAR(ids[1].getHits()[0].getScore(), 0.1)
+    TEST_EQUAL(ids[2].getHits()[0].getSequence().toString(), "CCCK")
+  }
+
+  // (8) An empty list is not a special case.
+  {
+    PeptideIdentificationList ids;
+    auto report = IDConflictResolverAlgorithm::reduceToOnePerSpectrum(ids);
+    TEST_EQUAL(report.removed, 0)
+    TEST_TRUE(ids.empty())
+  }
 }
 END_SECTION
 

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -1094,6 +1094,22 @@ add_test("TOPP_IsobaricWorkflow_1" ${TOPP_BIN_PATH}/IsobaricWorkflow -test -type
 add_test("TOPP_IsobaricWorkflow_1_out1" ${DIFF} -whitelist "?xml-stylesheet" "spectra_data" "InferenceEngineVersion" -in1 ${TESTS_TEMP_DIR}/IsobaricWorkflow_1_out.tmp.consensusXML -in2 ${DATA_DIR_TOPP}/IsobaricWorkflow_1_out.consensusXML )
 set_tests_properties("TOPP_IsobaricWorkflow_1_out1" PROPERTIES DEPENDS "TOPP_IsobaricWorkflow_1")
 
+# Same run as TOPP_IsobaricWorkflow_1, but one identification appears twice (same spectrum,
+# peptidoform and charge; the copy scored worse). IsobaricWorkflow builds one ConsensusFeature
+# per identification and all of a spectrum's identifications read the same MS2/MS3 scan, so
+# without the reduction that scan's reporter intensities would enter the quantification twice.
+# Diffed against IsobaricWorkflow_1's OWN reference on purpose: the assertion is that the
+# duplicate changed nothing.
+add_test("TOPP_IsobaricWorkflow_duplicate_psm" ${TOPP_BIN_PATH}/IsobaricWorkflow -test -type tmt10plex
+  -in ${DATA_DIR_TOPP}/TMTTenPlexMethod_test.mzML
+  -in_id ${DATA_DIR_TOPP}/IsobaricWorkflow_duplicate_psm_input.idXML
+  -exp_design ${DATA_DIR_TOPP}/IsobaricWorkflow_1_design.tsv
+  -out ${TESTS_TEMP_DIR}/IsobaricWorkflow_duplicate_psm_out.tmp.consensusXML)
+# An identical output could also mean the reduction never ran, so require that it reported.
+set_tests_properties("TOPP_IsobaricWorkflow_duplicate_psm" PROPERTIES PASS_REGULAR_EXPRESSION "repeat a .spectrum, peptidoform, charge. already claimed")
+add_test("TOPP_IsobaricWorkflow_duplicate_psm_out1" ${DIFF} -whitelist "?xml-stylesheet" "spectra_data" "InferenceEngineVersion" -in1 ${TESTS_TEMP_DIR}/IsobaricWorkflow_duplicate_psm_out.tmp.consensusXML -in2 ${DATA_DIR_TOPP}/IsobaricWorkflow_1_out.consensusXML )
+set_tests_properties("TOPP_IsobaricWorkflow_duplicate_psm_out1" PROPERTIES DEPENDS "TOPP_IsobaricWorkflow_duplicate_psm")
+
 # An MS2 with no preceding MS1 has no survey scan to measure isolation purity against.
 # TMTTenPlexMethod_test.mzML begins with one (its MS1 is the SECOND spectrum), which made
 # MSExperiment::getPrecursorSpectrum() return -1 and PrecursorPurity index before the start of
@@ -4292,6 +4308,52 @@ add_test("TOPP_ProteomicsLFQ_1_out_3" ${DIFF} -whitelist "software" "location" "
 set_tests_properties("TOPP_ProteomicsLFQ_1_out_3" PROPERTIES DEPENDS "TOPP_ProteomicsLFQ_1")
 add_test("TOPP_ProteomicsLFQ_1_out_4" ${DIFF} -in1 ${TESTS_TEMP_DIR}/BSA.tmp.tsv -in2 ${DATA_DIR_TOPP}/ProteomicsLFQ_1_out.tsv )
 set_tests_properties("TOPP_ProteomicsLFQ_1_out_4" PROPERTIES DEPENDS "TOPP_ProteomicsLFQ_1")
+
+# Identical to TOPP_ProteomicsLFQ_1, except that BSA1_F1's identifications carry one
+# PeptideIdentification twice (same spectrum, peptidoform and charge; the copy scored worse).
+# ProteomicsLFQ reduces those to one at load, so every output must come out identical to the
+# un-duplicated run above -- the SAME reference files are reused deliberately, since "the
+# duplicate changed no number" is exactly what needs asserting.
+add_test("TOPP_ProteomicsLFQ_duplicate_psm" ${TOPP_BIN_PATH}/ProteomicsLFQ
+         -in
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA1_F1.mzML
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA1_F2.mzML
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA2_F1.mzML
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA2_F2.mzML
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA3_F1.mzML
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA3_F2.mzML
+         -ids
+         ${DATA_DIR_TOPP}/ProteomicsLFQ_duplicate_psm_1.idXML
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA1_F2.idXML
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA2_F1.idXML
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA2_F2.idXML
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA3_F1.idXML
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA3_F2.idXML
+         -design
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA_design.tsv
+         -Alignment:align_algorithm:max_rt_shift 0
+         -fasta
+         ${DATA_DIR_SHARE}/examples/TOPPAS/data/BSA_Identification/18Protein_SoCe_Tr_detergents_trace_target_decoy.fasta
+         -targeted_only true
+         -mass_recalibration false
+         -out_cxml ${TESTS_TEMP_DIR}/BSA_dup.tmp.consensusXML
+         -out_msstats ${TESTS_TEMP_DIR}/BSA_dup.tmp.csv
+         -out ${TESTS_TEMP_DIR}/BSA_dup.tmp.mztab
+         -out_triqler ${TESTS_TEMP_DIR}/BSA_dup.tmp.tsv
+         -threads 1
+         -proteinFDR 0.3
+         -test
+         )
+# The reduction must actually have fired -- an identical output could also mean it never ran.
+set_tests_properties("TOPP_ProteomicsLFQ_duplicate_psm" PROPERTIES PASS_REGULAR_EXPRESSION "repeat a .spectrum, peptidoform, charge. already claimed")
+add_test("TOPP_ProteomicsLFQ_duplicate_psm_out_1" ${DIFF} -whitelist "spectra_data" "map id=" "InferenceEngineVersion" -in1 ${TESTS_TEMP_DIR}/BSA_dup.tmp.consensusXML -in2 ${DATA_DIR_TOPP}/ProteomicsLFQ_1_out.consensusXML )
+set_tests_properties("TOPP_ProteomicsLFQ_duplicate_psm_out_1" PROPERTIES DEPENDS "TOPP_ProteomicsLFQ_duplicate_psm")
+add_test("TOPP_ProteomicsLFQ_duplicate_psm_out_2" ${DIFF} -whitelist "software" "location" -in1 ${TESTS_TEMP_DIR}/BSA_dup.tmp.csv -in2 ${DATA_DIR_TOPP}/ProteomicsLFQ_1_out.csv )
+set_tests_properties("TOPP_ProteomicsLFQ_duplicate_psm_out_2" PROPERTIES DEPENDS "TOPP_ProteomicsLFQ_duplicate_psm")
+add_test("TOPP_ProteomicsLFQ_duplicate_psm_out_3" ${DIFF} -whitelist "software" "location" "InferenceEngineVersion" "TOPPProteinInference q-value" -in1 ${TESTS_TEMP_DIR}/BSA_dup.tmp.mztab -in2 ${DATA_DIR_TOPP}/ProteomicsLFQ_1_out.mzTab )
+set_tests_properties("TOPP_ProteomicsLFQ_duplicate_psm_out_3" PROPERTIES DEPENDS "TOPP_ProteomicsLFQ_duplicate_psm")
+add_test("TOPP_ProteomicsLFQ_duplicate_psm_out_4" ${DIFF} -in1 ${TESTS_TEMP_DIR}/BSA_dup.tmp.tsv -in2 ${DATA_DIR_TOPP}/ProteomicsLFQ_1_out.tsv )
+set_tests_properties("TOPP_ProteomicsLFQ_duplicate_psm_out_4" PROPERTIES DEPENDS "TOPP_ProteomicsLFQ_duplicate_psm")
 
 # regression test (decoys in ID files)
 add_test("TOPP_ProteomicsLFQ_2" ${TOPP_BIN_PATH}/ProteomicsLFQ

--- a/src/tests/topp/IsobaricWorkflow_duplicate_psm_input.idXML
+++ b/src/tests/topp/IsobaricWorkflow_duplicate_psm_input.idXML
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
+<IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<SearchParameters id="SP_0" db="" db_version="" taxonomy="" mass_type="monoisotopic" charges="1:5" enzyme="Trypsin/P" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="20" peak_mass_tolerance_ppm="true" >
+	</SearchParameters>
+	<IdentificationRun date="2026-01-01T00:00:00" search_engine="" search_engine_version="" search_parameters_ref="SP_0" >
+		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
+			<ProteinHit id="PH_0" accession="PROTA" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</ProteinHit>
+			<ProteinHit id="PH_1" accession="PROTB" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</ProteinHit>
+			<ProteinHit id="PH_2" accession="DECOY_PROTC" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+			</ProteinHit>
+			<UserParam type="stringList" name="spectra_data" value="[TMTTenPlexMethod_test.mzML]"/>
+		</ProteinIdentification>
+		<!-- Note: scan=24215 is the first spectrum in the file and has no preceding MS1, which the
+		     precursor-purity code cannot handle, so no PSM is placed on it. -->
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="436.7035" RT="4881.49476" spectrum_reference="controllerType=0 controllerNumber=1 scan=24221" >
+			<PeptideHit score="0.01" sequence="ELEFANTK" charge="2" aa_before="[" aa_after="I" start="0" end="7" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="436.7035" RT="4881.49476" spectrum_reference="controllerType=0 controllerNumber=1 scan=24221" >
+			<PeptideHit score="0.30" sequence="ELEFANTK" charge="2" aa_before="[" aa_after="I" start="0" end="7" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="768.950003899738" RT="4880.56854" spectrum_reference="controllerType=0 controllerNumber=1 scan=24217" >
+			<PeptideHit score="0.02" sequence="IMTELLERK" charge="2" aa_before="K" aa_after="M" start="8" end="16" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="544.813" RT="4880.80014" spectrum_reference="controllerType=0 controllerNumber=1 scan=24218" >
+			<PeptideHit score="0.03" sequence="MYFINGERK" charge="2" aa_before="K" aa_after="[" start="17" end="25" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="489.278535890617" RT="4881.03162" spectrum_reference="controllerType=0 controllerNumber=1 scan=24219" >
+			<PeptideHit score="0.04" sequence="GIRAFFERK" charge="2" aa_before="K" aa_after="M" start="0" end="8" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="479.744303406726" RT="4881.26316" spectrum_reference="controllerType=0 controllerNumber=1 scan=24220" >
+			<PeptideHit score="0.90" sequence="MYTIGERK" charge="2" aa_before="K" aa_after="[" start="0" end="7" protein_refs="PH_2" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+			</PeptideHit>
+		</PeptideIdentification>
+	</IdentificationRun>
+</IdXML>

--- a/src/tests/topp/ProteomicsLFQ_duplicate_psm_1.idXML
+++ b/src/tests/topp/ProteomicsLFQ_duplicate_psm_1.idXML
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
+<IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<SearchParameters id="SP_0" db="18Protein_SoCe_Tr_detergents_trace_target_decoy.fasta" db_version="" taxonomy="0" mass_type="monoisotopic" charges="+1-+3" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="0.05" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.3" peak_mass_tolerance_ppm="false" >
+		<VariableModification name="Carbamidomethyl (C)" />
+		<VariableModification name="Oxidation (M)" />
+	</SearchParameters>
+	<IdentificationRun date="2009-11-17T11:11:11" search_engine="OMSSA" search_engine_version="2.1.4" search_parameters_ref="SP_0" >
+		<ProteinIdentification score_type="FDR" higher_score_better="false" significance_threshold="0" >
+			<ProteinHit id="PH_0" accession="P02769|ALBU_BOVIN" score="0" sequence="" >
+				<UserParam type="float" name="OMSSA_score" value="0"/>
+			</ProteinHit>
+			<ProteinHit id="PH_1" accession="tr|A9G8G1|A9G8G1_SORC5" score="0" sequence="" >
+				<UserParam type="float" name="OMSSA_score" value="0"/>
+			</ProteinHit>
+			<ProteinHit id="PH_2" accession="tr|A9GID7|A9GID7_SORC5" score="0" sequence="" >
+				<UserParam type="float" name="OMSSA_score" value="0"/>
+			</ProteinHit>
+			<ProteinHit id="PH_3" accession="tr|A9GN44|A9GN44_SORC5" score="0" sequence="" >
+				<UserParam type="float" name="OMSSA_score" value="0"/>
+			</ProteinHit>
+			<ProteinHit id="PH_4" accession="tr|A9GV08|A9GV08_SORC5" score="0" sequence="" >
+				<UserParam type="float" name="OMSSA_score" value="0"/>
+			</ProteinHit>
+                        <UserParam type="stringList" name="spectra_data" value="[share/OpenMS/examples/FRACTIONS/BSA1_F1.mzML]"/>
+		</ProteinIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="358.174682617188" RT="1554.4921875" >
+			<PeptideHit score="0" sequence="SHC(Carbamidomethyl)IAEVEK" charge="3" aa_before="K" aa_after="D" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.000624514018064888"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="358.174682617188" RT="1554.4921875" >
+			<PeptideHit score="0.5" sequence="SHC(Carbamidomethyl)IAEVEK" charge="3" aa_before="K" aa_after="D" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.000624514018064888"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="368.832153320312" RT="1607.2958984375" >
+			<PeptideHit score="0.0454545454545455" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="0.134752265696133"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="532.23974609375" RT="1654.26513671875" >
+			<PeptideHit score="0.0454545454545455" sequence="KSDDGGEVEK" charge="2" aa_before="R" aa_after="R" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.140841796155119"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="368.832061767578" RT="1697.94360351562" >
+			<PeptideHit score="0.0344827586206897" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="0.0325713993888641"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="722.325378417969" RT="1736.66821289062" >
+			<PeptideHit score="0.0344827586206897" sequence="YIC(Carbamidomethyl)DNQDTISSK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0173429321700537"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="443.711242675781" RT="1738.03344726562" >
+			<PeptideHit score="0.0344827586206897" sequence="DDSPDLPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.00395109914742618"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="569.752807617188" RT="1750.91589355469" >
+			<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.00235357253308681"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="646.304504394531" RT="1759.0947265625" >
+			<PeptideHit score="0.0454545454545455" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.161429888187637"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="300.165985107422" RT="1772.36950683594" >
+			<PeptideHit score="0.0344827586206897" sequence="LALDLVVR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_3" >
+				<UserParam type="float" name="OMSSA_score" value="0.00409018563530312"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="449.744232177734" RT="1776.05004882812" >
+			<PeptideHit score="0.0344827586206897" sequence="LC(Carbamidomethyl)VLHEK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0227663017779976"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="569.752258300781" RT="1793.82604980469" >
+			<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0108172080557891"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="431.205261230469" RT="1797.83959960938" >
+			<PeptideHit score="0.0344827586206897" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="3" aa_before="K" aa_after="S" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.042177146646692"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="300.165954589844" RT="1800.23291015625" >
+			<PeptideHit score="0" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.000343916960401279"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="722.32470703125" RT="1804.15795898438" >
+			<PeptideHit score="0" sequence="YIC(Carbamidomethyl)DNQDTISSK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="3.85390695500564e-05"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="646.3037109375" RT="1804.53405761719" >
+			<PeptideHit score="0.0344827586206897" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0423622396613216"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="325.491180419922" RT="1840.79333496094" >
+			<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0602120422006692"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="487.732299804688" RT="1875.54736328125" >
+			<PeptideHit score="0.0344827586206897" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0435747980539929"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="408.840087890625" RT="1880.01599121094" >
+			<PeptideHit score="0.0454545454545455" sequence="GM(Oxidation)LWAVFEQK" charge="3" aa_before="K" aa_after="A" protein_refs="PH_4" >
+				<UserParam type="float" name="OMSSA_score" value="0.0850109548251393"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="487.732391357422" RT="1906.96594238281" >
+			<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0917668515948288"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="722.327209472656" RT="1918.60864257812" >
+			<PeptideHit score="0.0344827586206897" sequence="YIC(Carbamidomethyl)DNQDTISSK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0326599590408071"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="395.239349365234" RT="1933.40515136719" >
+			<PeptideHit score="0" sequence="LVTDLTK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.00108437147303181"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="487.732177734375" RT="1942.3701171875" >
+			<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0918514920664644"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="300.165802001953" RT="1949.05554199219" >
+			<PeptideHit score="0.0454545454545455" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.188627296280199"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="300.166046142578" RT="1970.11474609375" >
+			<PeptideHit score="0.0454545454545455" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0707872514634683"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+	</IdentificationRun>
+</IdXML>

--- a/src/topp/IsobaricWorkflow.cpp
+++ b/src/topp/IsobaricWorkflow.cpp
@@ -32,6 +32,7 @@
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/FORMAT/MzTabFile.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/ANALYSIS/ID/IDConflictResolverAlgorithm.h>
 #include <OpenMS/PROCESSING/ID/IDFilter.h>
 #include <string>
 #include <vector>
@@ -83,6 +84,17 @@ using namespace std;
   This tool currently supports iTRAQ 4-plex and 8-plex, and TMT 6-plex, 10-plex, 11-plex, 16-plex, 18-plex, 32-plex, and 35-plex labeling methods.
   It extracts the isobaric reporter ion intensities from centroided MS2 or MS3 data (MSn), then performs isotope correction and stores the resulting quantitation in a consensus map,
   in which each consensus feature represents one identified PSM together with its reporter ions.
+
+  Because a consensus feature is created per identification, and all identifications of one
+  spectrum read the same MS2/MS3 scan, the input is expected to carry one identification per
+  spectrum. Where several of them agree on peptidoform and charge, only the best-scoring one is
+  kept and the reduction is reported; the others would otherwise contribute the same reporter
+  intensities a second time to every abundance derived from them. Results from several search
+  engines must therefore be combined - with @ref TOPP_ConsensusID (@p -algorithm best
+  @p -keep_old_scores, which preserves each engine's score) - rather than simply concatenated.
+  Identifications of one spectrum naming *different* peptidoforms are left alone and each
+  quantified separately.
+
   At least one of @p out, @p out_mzTab, or @p out_qpx must be specified; each output is optional individually.
   The MS level for quantification is chosen automatically per PSM: if MS3 is present, the MS3 product spectrum of the identifying MS2 scan is used (SPS-MS3), otherwise the MS2 scan itself.
   Unlike @ref TOPP_IsobaricAnalyzer, this tool does NOT filter quantification scans by activation method (@p extraction:select_activation is ignored),
@@ -186,7 +198,13 @@ protected:
 
     registerInputFileList_("in", "<file>", {}, "input centroided spectrum files");
     setValidFormats_("in", {"mzML"});
-    registerInputFileList_("in_id", "<file>", {}, "corresponding input PSMs");
+    registerInputFileList_("in_id", "<file>", {},
+      "corresponding input PSMs.\n"
+      "One identification per spectrum is expected: this tool quantifies one consensus feature\n"
+      "per identification, so several identifications of one spectrum agreeing on peptidoform\n"
+      "and charge would contribute the same reporter intensities more than once. Only the\n"
+      "best-scoring one of such a group is kept. Combine results from several search engines\n"
+      "with ConsensusID rather than concatenating them.");
     setValidFormats_("in_id", {"idXML", "mzId", "idparquet"});
     registerInputFile_("exp_design", "<file>", "", "experimental design file (optional). If not given, the design is assumed to be unfractionated.", false);
     setValidFormats_("exp_design", {"tsv"});
@@ -618,7 +636,40 @@ protected:
         OPENMS_LOG_INFO << "Filtering by PSM score (better than " << psm_score << ")..." << endl;
         IDFilter::filterHitsByScore(pep_ids, psm_score);
       }
-      
+
+      // This tool quantifies one ConsensusFeature per identification (see the resize below), and
+      // all identifications of one spectrum read the same MS2/MS3 scan. Two of them agreeing on
+      // peptidoform and charge would therefore contribute the SAME reporter intensities twice,
+      // to every abundance derived from them. Keep the best-scoring one of each such group.
+      {
+        const auto report = IDConflictResolverAlgorithm::reduceToOnePerSpectrum(pep_ids);
+        if (report.removed > 0)
+        {
+          OPENMS_LOG_WARN << "Warning: " << report.removed << " identification(s) in " << id_file
+                          << " repeat a (spectrum, peptidoform, charge) already claimed by another"
+                             " identification, e.g. " << report.example << ".\n"
+                             "Kept the best-scoring one of each group; the others would have"
+                             " contributed the same reporter intensities a second time. To control"
+                             " this upstream, combine search engine results with ConsensusID"
+                             " (-algorithm best -keep_old_scores) rather than concatenating them."
+                          << endl;
+        }
+        if (report.inconsistent_score_direction > 0)
+        {
+          OPENMS_LOG_WARN << "Warning: " << report.inconsistent_score_direction << " group(s) of"
+                             " repeated identifications in " << id_file << " disagree on whether a"
+                             " higher score is better, so no best one could be chosen. They were"
+                             " left as they are and their reporter intensities will be counted"
+                             " more than once." << endl;
+        }
+        if (report.without_spectrum_reference > 0)
+        {
+          OPENMS_LOG_INFO << report.without_spectrum_reference << " identification(s) in " << id_file
+                          << " carry no spectrum reference and were therefore not checked for"
+                             " repeats. They cannot be quantified either." << endl;
+        }
+      }
+
       merger.insertRuns(std::move(prot_ids), {}); // pep IDs will be stored in the consensus features
 
       std::vector<ChannelQC> qc;

--- a/src/topp/ProteomicsLFQ.cpp
+++ b/src/topp/ProteomicsLFQ.cpp
@@ -90,6 +90,16 @@ Input: @n
     3. PercolatorAdapter tool (score_type = 'q-value', -post-processing-tdc)
     4. IDFilter (pep:score = 0.01) to filter PSMs at 1% FDR
 
+   Exactly one identification run per ID file is required, and merged ID runs are not supported.
+   One identification per spectrum is expected as well: ProteomicsLFQ measures one value per
+   (spectrum, peptidoform, charge), so where several identifications of one spectrum agree on
+   all three, only the best-scoring one is kept and the reduction is reported. The others would
+   otherwise count the same measurement more than once, in the PSM-level FDR and in every output.
+   Results from several search engines must therefore be combined - with @ref TOPP_ConsensusID
+   (@p -algorithm best @p -keep_old_scores, which preserves each engine's score) - rather than
+   simply concatenated. Identifications of one spectrum that name *different* peptidoforms are
+   left alone: a chimeric spectrum yields two distinct measurements.
+
   - An experimental design file: @n
    (see @ref OpenMS::ExperimentalDesign "ExperimentalDesign" for details) @n
   - A protein database in with appended decoy sequences in FASTA format @n
@@ -190,7 +200,11 @@ protected:
       "2. PercolatorAdapter tool (score_type = 'q-value', -post-processing-tdc)\n"
       "3. IDFilter (pep:score = 0.05)\n"
       "To obtain well calibrated PEPs and an initial reduction of PSMs\n"
-      "ID files must be provided in same order as spectra files.");
+      "ID files must be provided in same order as spectra files.\n"
+      "One identification per spectrum is expected: where several identifications of one\n"
+      "spectrum agree on peptidoform and charge, only the best-scoring one is kept, since\n"
+      "the others would count the same measurement more than once. Combine results from\n"
+      "several search engines with ConsensusID rather than concatenating them.");
     setValidFormats_("ids", ListUtils::create<std::string>("idXML,mzId,idparquet"));
 
     registerInputFile_("design", "<file>", "", "design file", false);
@@ -928,7 +942,58 @@ protected:
       SpectrumMetaDataLookup::addMissingSpectrumReferences(peptide_ids, mz_file_abs_path, true);
     }
 
+    // Deliberately last, i.e. after the spectrum-reference repair above: an identification with
+    // no reference cannot be keyed at all, so reducing any earlier would silently skip exactly
+    // the files whose references had to be reannotated.
+    reduceToOnePerSpectrum_(peptide_ids, id_file_abs_path);
+
     return EXECUTION_OK;
+  }
+
+  /**
+    @brief Reduce identifications this tool cannot tell apart to one per spectrum.
+
+    ProteomicsLFQ measures one value per (spectrum, peptidoform, charge). Input that carries
+    several identifications of that same triple - two search engines concatenated rather than
+    combined, for instance - leaves it undecided which of them owns the measurement, and keeping
+    all of them counts one identification several times in the PSM-level FDR and repeats it in
+    every output. Keep the best-scoring one and say what went.
+  **/
+  void reduceToOnePerSpectrum_(PeptideIdentificationList& peptide_ids,
+                               const std::string& id_file_abs_path)
+  {
+    const auto report = IDConflictResolverAlgorithm::reduceToOnePerSpectrum(peptide_ids);
+
+    if (report.removed > 0)
+    {
+      OPENMS_LOG_WARN << "Warning: " << report.removed << " identification(s) in " << id_file_abs_path
+                      << " repeat a (spectrum, peptidoform, charge) already claimed by another"
+                         " identification, e.g. " << report.example << ".\n"
+                         "Kept the best-scoring one of each group; the others would have counted"
+                         " the same measurement more than once. To control this upstream, combine"
+                         " search engine results with ConsensusID (-algorithm best"
+                         " -keep_old_scores) rather than concatenating them." << endl;
+    }
+    if (report.inconsistent_score_direction > 0)
+    {
+      OPENMS_LOG_WARN << "Warning: " << report.inconsistent_score_direction << " group(s) of"
+                         " repeated identifications in " << id_file_abs_path << " disagree on"
+                         " whether a higher score is better, so no best one could be chosen."
+                         " They were left as they are and will be counted more than once." << endl;
+    }
+    if (report.without_spectrum_reference > 0)
+    {
+      OPENMS_LOG_INFO << report.without_spectrum_reference << " identification(s) in "
+                      << id_file_abs_path << " carry no spectrum reference and were therefore not"
+                         " checked for repeats." << endl;
+    }
+    if (report.multiply_identified_spectra > 0)
+    {
+      OPENMS_LOG_INFO << report.multiply_identified_spectra << " spectra in " << id_file_abs_path
+                      << " carry more than one identification naming different peptidoforms"
+                         " (a chimeric spectrum, or search engines that disagree). Each is"
+                         " quantified separately." << endl;
+    }
   }
 
 


### PR DESCRIPTION
`ProteomicsLFQ` and `IsobaricWorkflow` measure one value per `(spectrum, peptidoform, charge)`. Input carrying several identifications of that same triple leaves it undecided which one owns the measurement, and both tools silently took *all* of them. This reduces to the best-scoring one at load, in both tools, and documents the precondition.

## The shape, and why this reduces rather than refuses

Two OpenMS tools produce it deliberately, so refusing would refuse the library's own output:

- **`PSMFeatureExtractor -multiple_search_engines -concat`** — documented as *"Naive merging of PSMs from different search engines: concatenate multiple search results instead of merging on scan level"* (`PSMFeatureExtractor.cpp:94`), assigning every engine's identifications one run identifier (`:257-260`). The repo already ships a fixture of it: `combined.concat.perco.in.idXML:137,594` — same `scan=334`, same sequence `HYSEEEYDSEFDDADDDEEQ`, same charge.
- **`PercolatorAdapter` at its default `-score:fdr 1.0`** — `:1449-1470`, verbatim: *"If the input contains multiple PSMs per spectrum, Percolator only reports the top scoring PSM. The remaining PSMs should be reported as not identified"* (PEP and q-value set to `1.0`).

Both are **resolved but not reduced**: something upstream already ranked them, it just did not delete the losers. Picking the better of two scores on one scale is a tie-break, not a scoring decision — combining scores from different engines stays `ConsensusIDAlgorithm`'s job and is deliberately not done here.

The one genuinely unresolvable case needs no new code: `ProteomicsLFQ::switchScoreType_` (`:764-779`) already refuses input lacking a PEP score everywhere, so an un-rescored `-concat` file (`MS-GF:RawScore` higher-better vs `expect` lower-better) is rejected today, for the right reason. What reaches the reduction is always one comparable scale.

## Measured effect of a single duplicated identification

**`IsobaricWorkflow`** — 7 consensus features instead of 6, the extra one bit-identical. It builds one consensus feature per identification (`:631`) and all identifications of one spectrum read the same MS2/MS3 scan, so the same reporter intensities enter quantification twice:

| | unreduced | reduced |
|---|---|---|
| consensus features | 7 | 6 |
| PSM rows / PEP rows | 5 / 5 | 4 / 4 |
| PEP abundances | unchanged | unchanged |
| **PRT abundance** (PROTA, ch1) | **2.176e04** | **1.584e04** (+37%) |
| PSM q-value column | 0.1667 | 0.2 |

Worth noting the damage is *not* a doubled peptide abundance — the peptide row duplicates with identical values, and the inflation lands at protein level. Not a clean 2× either, since a protein aggregates several peptides and only one is duplicated.

**`ProteomicsLFQ`** — 116 mzTab PSM rows against 115, plus a consensusXML difference. MSstats and Triqler output is unaffected; the damage from a duplicate is not uniform across exporters.

## Placement

In `ProteomicsLFQ` the reduction runs **after** the missing-spectrum-reference repair (`SpectrumMetaDataLookup::addMissingSpectrumReferences`). An identification with no reference cannot be keyed at all, so reducing earlier would silently skip exactly the files whose references had to be reannotated. The fixture demonstrates this rather than asserting it: `BSA1_F1.idXML` carries no spectrum references at all, so at the earlier position the test would pass green while doing nothing.

## Implementation notes

- Identifications are keyed on the top hit **as stored** — hits are never re-sorted, so the key matches what the exporters and quantifiers read (`QPXFile` writes `hits[0]` unsorted, as does `ConsensusMapArrowExport::topHitPsmIdentity`).
- Group membership uses the ordering the range was sorted with, **not** `operator==`. `AASequence`'s two operators disagree on what identifies a residue — `operator<` compares the one-letter code (`AASequence.cpp:354-363`), `operator==` the interned `Residue*` (`:873-884`) — so a pair `operator<` calls equivalent could otherwise be split apart and its duplicate silently missed.
- A group disagreeing on `isHigherScoreBetter()` has no defined "best" and is left intact rather than reduced by a coin flip.
- Ties break on input position, so the survivor is deterministic; survivors keep their original relative order.
- Identifications without a spectrum reference, and those without hits, are left untouched.
- Chimeric spectra are unaffected: two identifications of one spectrum naming *different* peptidoforms are two distinct measurements and both survive.

## Testing

Both TOPP tests diff against the **existing** un-duplicated reference files rather than new ones — "the duplicate changed no number" is exactly the assertion — so there is **zero reference-file churn**. Each also requires the reduction to report, since an identical output could otherwise mean it never ran.

- `IDConflictResolverAlgorithm_test`: 8 cases, including both score directions, chimeric, missing reference, hitless, ordering, and empty input.
- `TOPP_ProteomicsLFQ_duplicate_psm` (+4 diffs), `TOPP_IsobaricWorkflow_duplicate_psm` (+1 diff).
- **95/95** `TOPP_ProteomicsLFQ` + `TOPP_IsobaricWorkflow` pass.
- Each check was **verified able to fail**: reverting each reduction in turn turns the relevant tests red for the right reason, and inverting the score direction in the primitive turns its direction test red.
- `doc` target rebuilt; the Doxygen log contains only the two pre-existing `HAVE_DOT` warnings.

## Relation to #9871

#9871 reported this as *"one PSM row per search engine"* from a quantms run. That diagnosis does not hold — the reported parquet predates #9818 and its collisions are the pre-#9818 `run_file_name` collapse ([analysis](https://github.com/OpenMS/OpenMS/issues/9871#issuecomment-5226922283)). But the underlying shape is real and OpenMS mishandled it, which is what this fixes. The issue's actual request — one PSM carrying per-engine scores — is **not** implementable in the exporter, since no per-hit engine label survives Percolator or ConsensusID; it belongs at `ConsensusIDAlgorithm.cpp:107` (`//TODO add SE name`) and is left for a follow-up.

Not in scope, each worth its own issue: the `qpxScanComponents` vendor truncation (every Sciex MS2 collapses onto its `experiment` index; merged PASEF takes the wrong token), and moving duplicate-primary-key detection into `QPXCollectionExport::requireExportable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7QNzj4dhRnX5htcHZFmDm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved peptide identification handling by retaining the best-scoring match for duplicate spectrum, peptidoform, and charge combinations.
  * Preserved distinct peptidoforms from chimeric spectra as separate identifications.
  * Added diagnostics for unresolved duplicates, missing spectrum references, and conflicting score directions.
  * Added filename utilities for extracting names and validating file-list matches.

* **Documentation**
  * Clarified input requirements and recommendations for combining search results in IsobaricWorkflow and ProteomicsLFQ.

* **Tests**
  * Added regression coverage for duplicate peptide-spectrum matches, filename handling, and identification edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->