### PR TITLE
[FIX,TOPP] MSstatsConverter: return ILLEGAL_PARAMETERS instead of aborting (SIGABRT) on an unidentifiable input

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -496,6 +496,12 @@ TOPP tools:
       - Added -remove_shared_peptides (default true) to explicitly control whether shared peptides are
         removed; this filtering was previously silent and hardcoded, and a warning now reports how many
         hits were dropped (#9068)
+      - Fix: an input file whose type could not be determined crashed the tool (SIGABRT) instead of
+        returning an error. fatalErrorIf_ threw an int while main_ catches ExitCodes; exception
+        matching does not convert an int to an enum and TOPPBase has no catch-all, so the throw
+        escaped main(). It now returns ILLEGAL_PARAMETERS. Present since the tool was merged in
+        #3485 (2018); only reachable with an input unidentifiable by both extension and content,
+        since a recognized-but-wrong format is rejected before main_ runs (#9901)
     Triqler support removed:
       - BREAKING: Triqler export was removed from OpenMS entirely -- the TriqlerConverter tool, the
         ProteomicsLFQ -out_triqler output, and the TriqlerFile library class and its test.

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -1615,6 +1615,18 @@ set_tests_properties("TOPP_MetaboliteAdductDecharger_2_out2" PROPERTIES DEPENDS 
 
 #------------------------------------------------------------------------------
 # MSstatsConverter tests
+# An input whose type cannot be determined must return ILLEGAL_PARAMETERS (6), not abort.
+# fatalErrorIf_ used to throw an int while main_ catches ExitCodes, and TOPPBase has no
+# catch-all, so the throw escaped main() and the process died with SIGABRT (exit 134).
+# The exact code is the assertion: WILL_FAIL treats a crash and a clean error alike, and
+# PASS_REGULAR_EXPRESSION ignores the exit code (the FATAL line is printed in both cases).
+# Only an input that is unidentifiable by BOTH extension and content reaches this path --
+# a recognized-but-wrong format is rejected by TOPPBase before main_ runs.
+add_test(NAME "TOPP_MSstatsConverter_unknown_input_type" COMMAND ${CMAKE_COMMAND}
+  "-DCOMMAND=${TOPP_BIN_PATH}/MSstatsConverter;-test;-in;${DATA_DIR_TOPP}/MSstatsConverter_unknown_type_in.dat;-in_design;${DATA_DIR_TOPP}/MSstatsConverter_1_design.tsv;-out;${TESTS_TEMP_DIR}/MSstatsConverter_unknown_type_out.tmp.csv"
+  -DEXPECTED_CODE=6
+  -P ${DATA_DIR_TOPP}/check_exit_code.cmake)
+
 add_test("TOPP_MSstatsConverter_1" ${TOPP_BIN_PATH}/MSstatsConverter -test -in ${DATA_DIR_TOPP}/MSstatsConverter_1_in.consensusXML -retention_time_summarization_method max -in_design ${DATA_DIR_TOPP}/MSstatsConverter_1_design.tsv -out ${TESTS_TEMP_DIR}/MSstatsConverter_1_out.tmp.csv)
 add_test("TOPP_MSstatsConverter_1_out1" ${DIFF} -in1 ${TESTS_TEMP_DIR}/MSstatsConverter_1_out.tmp.csv -in2 ${DATA_DIR_TOPP}/MSstatsConverter_1_out.csv )
 set_tests_properties("TOPP_MSstatsConverter_1_out1" PROPERTIES DEPENDS "TOPP_MSstatsConverter_1")

--- a/src/tests/topp/MSstatsConverter_unknown_type_in.dat
+++ b/src/tests/topp/MSstatsConverter_unknown_type_in.dat
@@ -1,0 +1,3 @@
+This file is deliberately unidentifiable: neither its extension nor its content
+matches any format OpenMS knows, so FileHandler::getType() returns UNKNOWN.
+See TOPP_MSstatsConverter_unknown_input_type.

--- a/src/tests/topp/check_exit_code.cmake
+++ b/src/tests/topp/check_exit_code.cmake
@@ -1,0 +1,25 @@
+# Run a command and require an EXACT exit code.
+#
+# ctest's WILL_FAIL only distinguishes "zero" from "non-zero", and PASS_REGULAR_EXPRESSION
+# ignores the exit code entirely -- neither can tell a clean error return from a crash, which
+# is exactly the distinction some regression tests need (e.g. a tool that must return
+# ILLEGAL_PARAMETERS rather than abort). Use this when the specific code is the assertion.
+#
+# Required: -DCOMMAND=<;-separated argv> -DEXPECTED_CODE=<int>
+if(NOT DEFINED COMMAND)
+  message(FATAL_ERROR "check_exit_code.cmake: -DCOMMAND=... is required")
+endif()
+if(NOT DEFINED EXPECTED_CODE)
+  message(FATAL_ERROR "check_exit_code.cmake: -DEXPECTED_CODE=... is required")
+endif()
+
+execute_process(COMMAND ${COMMAND} RESULT_VARIABLE actual_code OUTPUT_VARIABLE out ERROR_VARIABLE err)
+
+if(NOT actual_code STREQUAL EXPECTED_CODE)
+  # A signal name (e.g. "SIGABRT") rather than a number means the process died, which is what
+  # this check most often exists to catch.
+  message(FATAL_ERROR
+    "Expected exit code ${EXPECTED_CODE}, got '${actual_code}'.\n"
+    "--- stdout ---\n${out}\n--- stderr ---\n${err}")
+endif()
+message(STATUS "Exit code ${actual_code} as expected")

--- a/src/topp/MSstatsConverter.cpp
+++ b/src/topp/MSstatsConverter.cpp
@@ -191,7 +191,11 @@ protected:
     static const std::string param_remove_shared_peptides;
 
 private:
-    static void fatalErrorIf_(const bool error_condition, const std::string &message, const int exit_code)
+    /// Throws @p exit_code as an ExitCodes, not an int. main_ catches `const ExitCodes&`, and
+    /// exception matching does not convert an int to an enum -- with an int the throw escaped
+    /// main_, and TOPPBase has no catch-all, so the process terminated instead of returning the
+    /// exit code.
+    static void fatalErrorIf_(const bool error_condition, const std::string &message, const ExitCodes exit_code)
     {
       if (error_condition)
       {


### PR DESCRIPTION
## Summary

`MSstatsConverter` aborts with **SIGABRT** instead of returning an error when handed an input file whose type OpenMS cannot determine.

```console
$ MSstatsConverter -in unidentifiable.dat -in_design design.tsv -out out.csv
Warning: Could not determine format of input file 'unidentifiable.dat'!
MSstatsConverter.cpp(198): FATAL: Input type is not consensusXML!
terminate called after throwing an instance of 'int'
Aborted (core dumped)          # exit 134
```

`fatalErrorIf_` took its exit code as an `int` and threw it, while `main_` catches `const ExitCodes&`. C++ exception matching does not convert an `int` to an enum, and `TOPPBase` has no `catch(...)`, so the throw escaped `main()`.

**Fix:** one type change — the helper takes `ExitCodes`, so the thrown object matches the existing handler. Verified end to end: **exit 134 → exit 6** (`ILLEGAL_PARAMETERS`).

## This is not a regression

It has been on `develop` since the tool was merged in #3485 (`ab6cf7ed75d9`, 2018-05-30). The defect was introduced two months earlier by `04e4be810495`, which did:

```diff
- catch(int)
+ catch(const ExitCodes &exit_code)
- static void _conditionalFatalError(const String & message, bool error_condition)
+ static void _conditionalFatalError(const String & message, bool error_condition, int exit_code)
- throw 1;
+ throw exit_code;
```

The pre-merge feature-branch version — `catch(int)` matching `throw 1` — was correct, and is the only version that ever worked. It never reached `develop`.

## Why it went unnoticed for eight years

The path is narrow, not unreachable. `TOPPBase` has warned rather than refused on an undeterminable input type since ~2008, but `FileHandler::getType` sniffs **content as well as extension**:

| input | result |
|---|---|
| valid `.consensusXML` | works |
| `.mzML` / `.tsv` (recognized, wrong) | clean `Invalid parameter`, exit 6, **before `main_` runs** |
| consensusXML content renamed `.dat` | identified by content — processed normally |
| unidentifiable by **both** extension and content | **the crash** |

Only the last row reaches `fatalErrorIf_`, and no test supplied such a file.

## Regression test

`TOPP_MSstatsConverter_unknown_input_type` asserts the **exact** exit code, via a new `check_exit_code.cmake` helper.

This mattered: neither existing ctest mechanism can express the assertion.

- `WILL_FAIL` only distinguishes zero from non-zero, so it treats a crash and a clean error alike — **it would have passed on the bug**.
- `PASS_REGULAR_EXPRESSION` ignores the exit code entirely, and the `FATAL:` line is printed in both cases.

Confirmed to fail on purpose — restoring the `int` gives:

```text
Expected exit code 6, got 'Subprocess aborted'.
```

All 9 `MSstatsConverter` TOPP tests pass with the fix.

## Scope

`TriqlerConverter` had the identical copy-paste defect; it is removed in #9898. A repo-wide sweep found no other TOPP tool throwing a numeric type without a matching handler (`MSFraggerAdapter` throws ints but catches them).

The new `check_exit_code.cmake` is reusable for any test where the specific exit code is the assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7QNzj4dhRnX5htcHZFmDm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MSstatsConverter now exits gracefully with `ILLEGAL_PARAMETERS` when it cannot determine the input file type, instead of crashing.
  * Improved handling of command-line errors to return the correct exit status.

* **Tests**
  * Added regression coverage to verify the expected exit code and diagnostic behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->