### PR TITLE
Update CHANGELOG: Docker library-stage Arrow/Parquet pin fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1042,6 +1042,10 @@ Build System:
     canonical KEYS to the pinned keyring, reducing NO_PUBKEY nightly failures (#9728, #9729, #9750); the
     Bioconda sync merges instead of rebasing, which had failed every nightly run for 16 days (#9798);
     pyOpenMS wheel builds exclude pyarrow 25.0.0, which segfaults on cp310-macosx_arm64 (#9196, #9726)
+  - Fix: the Dockerfile's library stage installed libarrow2300/libparquet2300 without the Arrow/Parquet
+    apt pin the base stage applies before the same install, so a new upstream Arrow release (25.0.0)
+    made the unpinned SONAME packages unresolvable and broke the nightly container build on arm64. The
+    library stage now applies the identical pin (#9890, #9891)
   - CI: removed the check-tool-handler.yml and check-authors-file.yml pull_request_target workflows; both
     broke for every fork PR after an actions/checkout change and gave external contributors an unconditional
     unrelated failure (#9785, #9787)


### PR DESCRIPTION
## Description

Routine changelog audit of PRs merged since the last CHANGELOG update (#9881, merged 2026-08-06).

13 PRs merged in that window: #9879, #9880, #9882, #9884, #9886, #9888, #9891, #9892, #9896, #9898, #9900, #9901 (plus #9881 itself). Checking each against the current `CHANGELOG` (`OpenMS 3.6.0 (under development)` section) showed nearly all of them already carry their own entry — including the two BREAKING ProteomicsLFQ changes (raw intensities, one-PSM-per-spectrum reduction), the QPX identity/cross-reference columns, the Triqler removal, the PSMFeatureExtractor multi-engine removal, the MSstatsConverter SIGABRT fix, and the OpenSWATH canonical library IDs.

Two exceptions, both expected:
- #9882 (`ProteomicsLFQ`: remove `-in_feat`/`-out_feat`) intentionally *removed* its own prior CHANGELOG entries rather than adding a new one, since neither flag had ever shipped in a release — correct as is.
- #9891 (Docker: pin Arrow/Parquet apt packages in the `library` build stage, fixing the nightly arm64 container build) had no CHANGELOG entry. Added one next to the existing Docker/Arrow CI note, following the same style.

## Changes
- `CHANGELOG`: new bullet under `Dependencies:` documenting the `library`-stage Arrow/Parquet apt pin fix (#9890, #9891).

## Checklist
- [x] Add relevant changes and new features to the CHANGELOG file
- [ ] New and existing unit tests pass locally with my changes (docs-only change, no code touched)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jgrv6mFL3oawgLdYs1efPH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Docker package configuration to consistently pin Arrow and Parquet dependencies.
  * Prevents installation failures caused by unavailable unpinned library versions after upstream releases.

* **Documentation**
  * Added a changelog entry describing the dependency pinning update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->