### PR TITLE
Update CHANGELOG: pyOpenMS thread-safety contract doc

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -146,6 +146,10 @@ PyOpenMS:
   - Fix: audit of all 108 nb::enum_ registrations against their C++ definitions found 4 enums with
     missing enumerators (NASequence::NASFragmentType, ProteomicsPkaScale, OSWHierarchy::Level,
     LPWrapper::SOLVER); existing bound values were unaffected (#9705)
+  - New src/pyOpenMS/THREAD_SAFETY.md documents the binding layer's thread-safety contract: releasing
+    the GIL around a call is not a thread-safety guarantee, the concurrency rules callers must follow,
+    an inventory of the 62 nb::gil_scoped_release sites, and how to avoid OpenMP oversubscription when
+    combining Python-level threading/multiprocessing with OpenMS' internal parallelism (#9792, #9857)
   - Fix: FileTypes wrapping updated with missing enum values and static methods (#8720); backward
     compatibility restored for the file I/O methods of IdXMLFile, PepXMLFile and MzIdentMLFile (#8553);
     getAAFrequencies() loop bug in the AASequence addon (#8502)


### PR DESCRIPTION
## Description

Routine changelog audit of PRs merged since the last CHANGELOG update (#9902, merged 2026-08-11 06:20 UTC).

Two PRs merged in that window: #9857 and #9887.

- **#9887** (Improve ccache strategy and statistics reporting in CI builds) is a CI-workflow-only change with no code changes; its own PR description explicitly notes no AUTHORS/CHANGELOG entry applies.
- **#9857** ([DOC] pyOpenMS: document thread-safety / GIL-release contract) added `src/pyOpenMS/THREAD_SAFETY.md`, a new document defining the pyOpenMS binding layer's thread-safety contract (part of #9792, R-9.5). It had no CHANGELOG entry, so I added one under the `PyOpenMS:` section, next to the other #9792-related entries already documenting that effort's fixes.

## Changes
- `CHANGELOG`: new bullet under `PyOpenMS:` documenting the new `THREAD_SAFETY.md` contract doc (#9792, #9857).

## Checklist
- [x] Add relevant changes and new features to the CHANGELOG file
- [ ] New and existing unit tests pass locally with my changes (docs-only change, no code touched)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DSb74HLQfeUBPEWRGjgHMy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on thread safety for Python bindings.
  * Documented when the Python GIL is released and the requirements for concurrent callers.
  * Listed all GIL-release points and provided guidance for avoiding OpenMP oversubscription.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->