### PR TITLE
Pin ruff version and add explicit lint rule selection for docs

### DIFF
--- a/.github/workflows/doc-validate.yml
+++ b/.github/workflows/doc-validate.yml
@@ -31,8 +31,16 @@ jobs:
           (cd doc/pyopenms/docs && make html)
 
       # Lint and formatting checks:
+      # Keep `version` pinned. An unpinned action installs the latest ruff, and a
+      # ruff release can change both the default rule set and the formatter
+      # style -- which is what turned this job red with no commit in between
+      # (#9899). doc/pyopenms/ruff.toml pins the lint rules, this pins the
+      # formatter. Bump both deliberately, in a PR that touches doc/**, so that
+      # this workflow actually runs on it.
       - uses: astral-sh/ruff-action@v3
-        with: {src: "doc/pyopenms"}
+        with:
+          src: "doc/pyopenms"
+          version: "0.16.2"
       - run: ruff format --check --diff doc/pyopenms
 
       # Not running because there are a *lot* of broken links.

--- a/doc/pyopenms/ruff.toml
+++ b/doc/pyopenms/ruff.toml
@@ -3,17 +3,56 @@
 # Ruff 0.16 widened its *default* lint selection from 59 rules to 413. Because
 # the doc-validate workflow ran an unpinned `astral-sh/ruff-action`, that
 # widening turned the build-sphinx job red with no commit in between
-# (OpenMS/OpenMS#9899).
+# (OpenMS/OpenMS#9899). Selecting the rules explicitly here makes the lint
+# result independent of whichever ruff version happens to be installed.
 #
-# Selecting the rules explicitly makes the lint result independent of whichever
-# ruff version happens to be installed. The set below is exactly ruff's
-# pre-0.16 default, i.e. the rules these sources were written against, so it is
-# a no-op for the current tree while removing the version dependency.
+# The selection is E4/E7/E9/F -- ruff's pre-0.16 default, i.e. the rules these
+# sources were written against -- plus every further rule group that is
+# currently clean, so the whole file is a no-op for the tree as it stands.
+# Verified green on ruff 0.15.9 and 0.16.2.
 #
-# Adopting more of the modern rule set is a separate, deliberate decision:
-# extend `select` and fix (or `per-file-ignores`) the findings in one change.
-# For reference, the full 0.16 defaults currently report 35 findings here,
-# 13 of them auto-fixable.
+# Deliberately NOT selected, because these sources are teaching examples rather
+# than library code and the rules fight that on purpose:
+#   T20  26 findings -- `print()` is the point of an example script
+#   N    29 findings -- example variable naming
+#   ARG  14 findings -- unused arguments in Sphinx extension callbacks
+#   RUF   7 findings -- unpacked-but-unused names that show what an API returns
+#   UP   11, BLE 3, SIM 4, B 2, PTH 3, DTZ 1, S 1 -- see #9899
+# Adopting any of them is a separate, deliberate decision: extend `select` and
+# fix (or `per-file-ignores`) the findings in the same change. `I` (import
+# sorting) is the cheapest of these -- 4 findings, all auto-fixable.
+#
+# `Q` (flake8-quotes) is omitted rather than ignored: ruff documents Q000-Q004
+# as conflicting with its own formatter, which already normalises quotes.
 
 [lint]
-select = ["E4", "E7", "E9", "F"]
+select = [
+    "E4",
+    "E7",
+    "E9",
+    "F",
+    "ASYNC",
+    "C4",
+    "EXE",
+    "FA",
+    "FLY",
+    "INT",
+    "ISC",
+    "LOG",
+    "PERF",
+    "PGH",
+    "PIE",
+    "PT",
+    "PYI",
+    "RET",
+    "TRY",
+    "W",
+    "YTT",
+]
+
+# Documented as conflicting with the ruff formatter, which is the authority on
+# both points here. See https://docs.astral.sh/ruff/formatter/.
+ignore = [
+    "W191",   # tab-indentation
+    "ISC002", # multi-line implicit string concatenation
+]

--- a/doc/pyopenms/ruff.toml
+++ b/doc/pyopenms/ruff.toml
@@ -1,0 +1,19 @@
+# Ruff configuration for the pyOpenMS documentation sources.
+#
+# Ruff 0.16 widened its *default* lint selection from 59 rules to 413. Because
+# the doc-validate workflow ran an unpinned `astral-sh/ruff-action`, that
+# widening turned the build-sphinx job red with no commit in between
+# (OpenMS/OpenMS#9899).
+#
+# Selecting the rules explicitly makes the lint result independent of whichever
+# ruff version happens to be installed. The set below is exactly ruff's
+# pre-0.16 default, i.e. the rules these sources were written against, so it is
+# a no-op for the current tree while removing the version dependency.
+#
+# Adopting more of the modern rule set is a separate, deliberate decision:
+# extend `select` and fix (or `per-file-ignores`) the findings in one change.
+# For reference, the full 0.16 defaults currently report 35 findings here,
+# 13 of them auto-fixable.
+
+[lint]
+select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
## Description

This PR fixes the doc-validate workflow to be resilient to ruff version changes. The issue (OpenMS/OpenMS#9899) occurred when ruff 0.16 widened its default lint rule selection from 59 to 413 rules, causing the unpinned `astral-sh/ruff-action` to suddenly fail with no code changes.

### Changes:

1. **Added `doc/pyopenms/ruff.toml`**: Explicitly selects the lint rules that the documentation sources were written against (ruff's pre-0.16 default: E4/E7/E9/F) plus all currently clean rule groups. This makes the lint result independent of ruff version changes.

2. **Updated `.github/workflows/doc-validate.yml`**: 
   - Pinned `astral-sh/ruff-action` to version `0.16.2` to prevent unexpected formatter style changes
   - Added explanatory comments about why both the action version and the ruff.toml configuration need to be pinned and updated together
   - Reformatted the action configuration for clarity

The configuration deliberately excludes rules that conflict with the teaching/example nature of the documentation (T20, N, ARG, RUF, UP, BLE, SIM, B, PTH, DTZ, S) and omits Q (flake8-quotes) as it conflicts with ruff's formatter.

## Checklist
- [x] Changes are documentation/workflow configuration only (no code changes requiring AUTHORS/CHANGELOG updates)
- [x] No new tests needed (workflow configuration change)
- [x] Verified configuration is clean on ruff 0.15.9 and 0.16.2

https://claude.ai/code/session_01SKka5hGu2GB4e5Yw1fWhsd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation quality checks with consistent Ruff formatting and linting settings.
  * Added explicit guidance for maintaining formatter and linting version pins.
  * Configured documentation sources for reliable validation across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->