### PR TITLE
[FIX,CI] Bioconda deploy: drop the python pin so the nightly tracks current bioconda-utils (#9905)

### DIFF
--- a/.github/workflows/bioconda_deploy.yaml
+++ b/.github/workflows/bioconda_deploy.yaml
@@ -24,9 +24,12 @@ jobs:
         with:
           activate-environment: bioconda_env
           auto-update-conda: true
-          # Must match the bioconda-utils version pinned below: 4.1.0 is built for
-          # python 3.12, everything from 4.2.0 on is built for python 3.13 only.
-          python-version: "3.12"
+          # Deliberately no python-version: bioconda-utils is built for exactly one
+          # python minor per release (4.2.0+ is python 3.13 only), so pinning python
+          # here silently caps which bioconda-utils the solver may pick. That is what
+          # broke #9905 -- python 3.12 held bioconda-utils at 4.1.0 and with it a
+          # conda-forge-pinning snapshot from 2024. Letting conda choose the python
+          # keeps this from recurring when bioconda-utils moves to 3.14.
           channels: conda-forge,bioconda,defaults
           channel-priority: true
 
@@ -35,25 +38,18 @@ jobs:
           mkdir -p $GITHUB_WORKSPACE/output/noarch
           mkdir -p $GITHUB_WORKSPACE/output/linux-64
           touch $GITHUB_WORKSPACE/output/noarch/repodata.json
-          # Pin bioconda-utils AND the conda-forge pinning snapshot it carries.
-          # The snapshot decides how the recipe's unversioned host dependencies
-          # resolve: bioconda-utils copies it into the build container and hands
-          # it to conda-build via --variant-config-files. The 2024.11.29 snapshot
-          # pins xerces_c to 3.2, so libOpenMS built against xerces-c 3.2.5 (icu
-          # 75) and exported a run constraint that no longer co-installs with the
-          # icu 78 chains of current libarrow/libcurl, leaving the package solve
-          # unsatisfiable. The 2026.01.07 snapshot pins xerces_c to 3.3, which
-          # resolves to a xerces-c built against icu 78.
-          # Naming the snapshot also selects the bioconda-utils build that
-          # requires it (4.1.0 build 1) rather than the older build 0.
-          # Moving further, to bioconda-utils >=4.2, additionally needs two recipe
-          # fixes in OpenMS/bioconda-recipes (openms-meta declares no c stdlib and
-          # pyopenms needs its build number reset for the stricter linter), and
-          # 4.5.0 has no build-env image published at
-          # https://quay.io/repository/bioconda/bioconda-utils-build-env-cos7?tab=tags
-          # -- `--docker` derives the image tag from the tool version, so that
-          # would fail the image pull.
-          conda install bioconda-utils=4.1.0 conda-forge-pinning=2026.01.07.13.16.30 conda-index -y
+          # Deliberately unpinned, including conda-forge-pinning. This nightly exists
+          # to mimic upstream bioconda and surface breakage against the pinnings they
+          # currently build with, so it has to track whatever bioconda-utils is
+          # current. bioconda-utils declares the conda-forge-pinning snapshot it
+          # wants, so that version decides the pinning; constraining either one here
+          # would hide exactly the breakage this workflow is meant to catch.
+          conda install bioconda-utils conda-index -y
+          # #9905 was a *silent* downgrade to a bioconda-utils carrying a 2024
+          # pinning, which is invisible unless you read the solver output. Record the
+          # resolved versions so the next such drift is one grep away in the log.
+          echo "--- resolved build tooling ---"
+          conda list --export | grep -E '^(bioconda-utils|conda-forge-pinning|conda-build|conda-index)=' || true
           python -m conda_index $GITHUB_WORKSPACE/output
           # Register the local output directory as a conda channel so that
           # host-side metadata finalization can resolve packages built in
@@ -87,6 +83,14 @@ jobs:
           git merge --no-edit bioconda/master
 
       - name: Lint and build OpenMS Bioconda packages
+        env:
+          # `--docker` derives the build-env image tag from bioconda-utils' own
+          # version, but the image for a new release lands on quay.io some time after
+          # the conda package does (4.5.0 had no image tag as of 2026-08-12). Tracking
+          # the rolling `latest` image keeps "always build with the latest utils" from
+          # failing on a docker pull during that window. Still unpinned -- this follows
+          # whatever image bioconda publishes as current.
+          BUILD_ENV_IMAGE: quay.io/bioconda/bioconda-utils-build-env-cos7:latest
         run: |
           cd bioconda-recipes
           bioconda-utils lint --packages pyopenms openms-meta
@@ -94,6 +98,8 @@ jobs:
           python -m conda_index $GITHUB_WORKSPACE/output
 
       - name: Build pyopenms package
+        env:
+          BUILD_ENV_IMAGE: quay.io/bioconda/bioconda-utils-build-env-cos7:latest
         run: |
           cd bioconda-recipes
           bioconda-utils build --docker --mulled-test --pkg-dir $GITHUB_WORKSPACE/output --packages pyopenms || true
@@ -102,8 +108,8 @@ jobs:
       - name: Upload Conda packages
         run: |
           # Safety net: anaconda-client 1.13.x still uses the removed pkg_resources.
-          # bioconda-utils 4.1.0 build 1 already requires 1.14.*, so this is a no-op
-          # as long as the pin above holds.
+          # Current bioconda-utils already requires 1.14.*, so this is normally a
+          # no-op; it only matters if the solver lands on an older one.
           pip install "anaconda-client>=1.14"
           ls -l $GITHUB_WORKSPACE/output
           shopt -s nullglob

--- a/.github/workflows/bioconda_deploy.yaml
+++ b/.github/workflows/bioconda_deploy.yaml
@@ -24,10 +24,9 @@ jobs:
         with:
           activate-environment: bioconda_env
           auto-update-conda: true
-          # bioconda-utils >=4.2.0 is built for python 3.13 only. With python 3.12 the
-          # solver silently falls back to bioconda-utils 4.1.0, which drags in a
-          # conda-forge-pinning snapshot from 2024 (see the pin below).
-          python-version: "3.13"
+          # Must match the bioconda-utils version pinned below: 4.1.0 is built for
+          # python 3.12, everything from 4.2.0 on is built for python 3.13 only.
+          python-version: "3.12"
           channels: conda-forge,bioconda,defaults
           channel-priority: true
 
@@ -36,15 +35,25 @@ jobs:
           mkdir -p $GITHUB_WORKSPACE/output/noarch
           mkdir -p $GITHUB_WORKSPACE/output/linux-64
           touch $GITHUB_WORKSPACE/output/noarch/repodata.json
-          # Pin bioconda-utils explicitly: its version selects both the
-          # conda-forge-pinning snapshot used to resolve the recipe's host
-          # dependencies and the quay.io/bioconda/bioconda-utils-build-env-cos7
-          # tag used by `--docker`. Leaving it unpinned lets the solver pick an
-          # old build whose stale pinning breaks the package solve, and bumping
-          # past the newest published build-env image would fail the docker pull.
-          # When raising this, check that a matching image tag exists at
+          # Pin bioconda-utils AND the conda-forge pinning snapshot it carries.
+          # The snapshot decides how the recipe's unversioned host dependencies
+          # resolve: bioconda-utils copies it into the build container and hands
+          # it to conda-build via --variant-config-files. The 2024.11.29 snapshot
+          # pins xerces_c to 3.2, so libOpenMS built against xerces-c 3.2.5 (icu
+          # 75) and exported a run constraint that no longer co-installs with the
+          # icu 78 chains of current libarrow/libcurl, leaving the package solve
+          # unsatisfiable. The 2026.01.07 snapshot pins xerces_c to 3.3, which
+          # resolves to a xerces-c built against icu 78.
+          # Naming the snapshot also selects the bioconda-utils build that
+          # requires it (4.1.0 build 1) rather than the older build 0.
+          # Moving further, to bioconda-utils >=4.2, additionally needs two recipe
+          # fixes in OpenMS/bioconda-recipes (openms-meta declares no c stdlib and
+          # pyopenms needs its build number reset for the stricter linter), and
+          # 4.5.0 has no build-env image published at
           # https://quay.io/repository/bioconda/bioconda-utils-build-env-cos7?tab=tags
-          conda install bioconda-utils=4.4.1 conda-index -y
+          # -- `--docker` derives the image tag from the tool version, so that
+          # would fail the image pull.
+          conda install bioconda-utils=4.1.0 conda-forge-pinning=2026.01.07.13.16.30 conda-index -y
           python -m conda_index $GITHUB_WORKSPACE/output
           # Register the local output directory as a conda channel so that
           # host-side metadata finalization can resolve packages built in
@@ -93,7 +102,8 @@ jobs:
       - name: Upload Conda packages
         run: |
           # Safety net: anaconda-client 1.13.x still uses the removed pkg_resources.
-          # bioconda-utils 4.4.1 already requires 1.14.*, so this is normally a no-op.
+          # bioconda-utils 4.1.0 build 1 already requires 1.14.*, so this is a no-op
+          # as long as the pin above holds.
           pip install "anaconda-client>=1.14"
           ls -l $GITHUB_WORKSPACE/output
           shopt -s nullglob

--- a/.github/workflows/bioconda_deploy.yaml
+++ b/.github/workflows/bioconda_deploy.yaml
@@ -24,7 +24,10 @@ jobs:
         with:
           activate-environment: bioconda_env
           auto-update-conda: true
-          python-version: "3.12"
+          # bioconda-utils >=4.2.0 is built for python 3.13 only. With python 3.12 the
+          # solver silently falls back to bioconda-utils 4.1.0, which drags in a
+          # conda-forge-pinning snapshot from 2024 (see the pin below).
+          python-version: "3.13"
           channels: conda-forge,bioconda,defaults
           channel-priority: true
 
@@ -33,7 +36,15 @@ jobs:
           mkdir -p $GITHUB_WORKSPACE/output/noarch
           mkdir -p $GITHUB_WORKSPACE/output/linux-64
           touch $GITHUB_WORKSPACE/output/noarch/repodata.json
-          conda install bioconda-utils conda-index -y
+          # Pin bioconda-utils explicitly: its version selects both the
+          # conda-forge-pinning snapshot used to resolve the recipe's host
+          # dependencies and the quay.io/bioconda/bioconda-utils-build-env-cos7
+          # tag used by `--docker`. Leaving it unpinned lets the solver pick an
+          # old build whose stale pinning breaks the package solve, and bumping
+          # past the newest published build-env image would fail the docker pull.
+          # When raising this, check that a matching image tag exists at
+          # https://quay.io/repository/bioconda/bioconda-utils-build-env-cos7?tab=tags
+          conda install bioconda-utils=4.4.1 conda-index -y
           python -m conda_index $GITHUB_WORKSPACE/output
           # Register the local output directory as a conda channel so that
           # host-side metadata finalization can resolve packages built in
@@ -81,7 +92,9 @@ jobs:
 
       - name: Upload Conda packages
         run: |
-          pip install "anaconda-client>=1.14"  # bioconda-utils pulls 1.13.x which still uses removed pkg_resources
+          # Safety net: anaconda-client 1.13.x still uses the removed pkg_resources.
+          # bioconda-utils 4.4.1 already requires 1.14.*, so this is normally a no-op.
+          pip install "anaconda-client>=1.14"
           ls -l $GITHUB_WORKSPACE/output
           shopt -s nullglob
           pkgs=($GITHUB_WORKSPACE/output/linux-64/*.tar.bz2 $GITHUB_WORKSPACE/output/linux-64/*.conda)

--- a/.github/workflows/bioconda_deploy.yaml
+++ b/.github/workflows/bioconda_deploy.yaml
@@ -48,8 +48,25 @@ jobs:
           # #9905 was a *silent* downgrade to a bioconda-utils carrying a 2024
           # pinning, which is invisible unless you read the solver output. Record the
           # resolved versions so the next such drift is one grep away in the log.
+          # python is included deliberately: it is the lever that caused #9905, since
+          # each bioconda-utils release is built for exactly one python minor.
           echo "--- resolved build tooling ---"
-          conda list --export | grep -E '^(bioconda-utils|conda-forge-pinning|conda-build|conda-index)=' || true
+          conda list --export | grep -E '^(python|bioconda-utils|conda-forge-pinning|conda-build|conda-index)=' || true
+          # Prefer the build-env image matching the bioconda-utils we just resolved;
+          # `--docker` derives that tag itself, but the image is published to quay.io
+          # some time after the conda package, so a brand new release would fail the
+          # pull (4.5.0 was current on the bioconda channel with no image tag on
+          # 2026-08-12). Fall back to the rolling `latest` tag during that window.
+          # Nothing is pinned here -- the tag tracks whatever we actually installed.
+          image_repo=quay.io/bioconda/bioconda-utils-build-env-cos7
+          bu_version=$(conda list --export | sed -n 's/^bioconda-utils=\([^=]*\)=.*/\1/p')
+          if [ -n "$bu_version" ] && docker manifest inspect "$image_repo:$bu_version" >/dev/null 2>&1; then
+            echo "Using build-env image matching bioconda-utils $bu_version"
+            echo "BUILD_ENV_IMAGE=$image_repo:$bu_version" >> $GITHUB_ENV
+          else
+            echo "No build-env image published for bioconda-utils ${bu_version:-unknown} yet; falling back to :latest"
+            echo "BUILD_ENV_IMAGE=$image_repo:latest" >> $GITHUB_ENV
+          fi
           python -m conda_index $GITHUB_WORKSPACE/output
           # Register the local output directory as a conda channel so that
           # host-side metadata finalization can resolve packages built in
@@ -82,15 +99,8 @@ jobs:
           # history, so it only conflicts on genuinely unresolved changes.
           git merge --no-edit bioconda/master
 
+      # BUILD_ENV_IMAGE comes from the preflight in "Prepare output directory".
       - name: Lint and build OpenMS Bioconda packages
-        env:
-          # `--docker` derives the build-env image tag from bioconda-utils' own
-          # version, but the image for a new release lands on quay.io some time after
-          # the conda package does (4.5.0 had no image tag as of 2026-08-12). Tracking
-          # the rolling `latest` image keeps "always build with the latest utils" from
-          # failing on a docker pull during that window. Still unpinned -- this follows
-          # whatever image bioconda publishes as current.
-          BUILD_ENV_IMAGE: quay.io/bioconda/bioconda-utils-build-env-cos7:latest
         run: |
           cd bioconda-recipes
           bioconda-utils lint --packages pyopenms openms-meta
@@ -98,8 +108,6 @@ jobs:
           python -m conda_index $GITHUB_WORKSPACE/output
 
       - name: Build pyopenms package
-        env:
-          BUILD_ENV_IMAGE: quay.io/bioconda/bioconda-utils-build-env-cos7:latest
         run: |
           cd bioconda-recipes
           bioconda-utils build --docker --mulled-test --pkg-dir $GITHUB_WORKSPACE/output --packages pyopenms || true

--- a/.github/workflows/bioconda_deploy.yaml
+++ b/.github/workflows/bioconda_deploy.yaml
@@ -58,15 +58,33 @@ jobs:
           # pull (4.5.0 was current on the bioconda channel with no image tag on
           # 2026-08-12). Fall back to the rolling `latest` tag during that window.
           # Nothing is pinned here -- the tag tracks whatever we actually installed.
+          #
+          # Ask quay's API rather than `docker manifest inspect`: the API separates
+          # "tag is not published" (HTTP 200 with an empty tag list) from "we could
+          # not find out" (curl fails), which a single exit status cannot, and it
+          # does not depend on `docker manifest` being enabled on the runner.
           image_repo=quay.io/bioconda/bioconda-utils-build-env-cos7
+          tag_api="https://quay.io/api/v1/repository/bioconda/bioconda-utils-build-env-cos7/tag/"
           bu_version=$(conda list --export | sed -n 's/^bioconda-utils=\([^=]*\)=.*/\1/p')
-          if [ -n "$bu_version" ] && docker manifest inspect "$image_repo:$bu_version" >/dev/null 2>&1; then
-            echo "Using build-env image matching bioconda-utils $bu_version"
-            echo "BUILD_ENV_IMAGE=$image_repo:$bu_version" >> $GITHUB_ENV
-          else
-            echo "No build-env image published for bioconda-utils ${bu_version:-unknown} yet; falling back to :latest"
-            echo "BUILD_ENV_IMAGE=$image_repo:latest" >> $GITHUB_ENV
+          image_tag=latest
+          if [ -n "$bu_version" ]; then
+            for attempt in 1 2 3; do
+              if tags=$(curl -fsSL --max-time 30 "${tag_api}?onlyActiveTags=true&specificTag=${bu_version}"); then
+                if printf '%s' "$tags" | grep -q "\"name\": *\"${bu_version}\""; then
+                  image_tag=$bu_version
+                else
+                  echo "quay.io has no build-env image for bioconda-utils ${bu_version} yet"
+                fi
+                break
+              fi
+              # Only a lookup failure is retried. Staying on :latest is a safe
+              # outcome, so a flaky registry must not fail the nightly outright.
+              echo "quay.io tag lookup failed (attempt ${attempt}/3)"
+              if [ "$attempt" -lt 3 ]; then sleep $((attempt * 5)); fi
+            done
           fi
+          echo "Using build-env image ${image_repo}:${image_tag} (bioconda-utils ${bu_version:-unknown})"
+          echo "BUILD_ENV_IMAGE=${image_repo}:${image_tag}" >> $GITHUB_ENV
           python -m conda_index $GITHUB_WORKSPACE/output
           # Register the local output directory as a conda channel so that
           # host-side metadata finalization can resolve packages built in

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1046,13 +1046,16 @@ Build System:
     apt pin the base stage applies before the same install, so a new upstream Arrow release (25.0.0)
     made the unpinned SONAME packages unresolvable and broke the nightly container build on arm64. The
     library stage now applies the identical pin (#9890, #9891)
-  - Fix: the Bioconda deploy workflow installed bioconda-utils unpinned, which resolved to a build
-    carrying the 2024.11.29 conda-forge-pinning snapshot. That snapshot pins xerces_c to 3.2, so
-    libOpenMS was built against xerces-c 3.2.5 (icu 75) and exported a `xerces-c >=3.2.5,<3.3.0a0` run
-    constraint, which no longer co-installs with the icu 78 dependency chains of current
-    libarrow/libcurl -- the openms test environment became unsolvable and no nightly package was
-    published. The workflow now pins the conda-forge-pinning snapshot (2026.01.07, xerces_c 3.3)
-    alongside bioconda-utils, so the build resolves a xerces-c built against icu 78 (#9905)
+  - Fix: the Bioconda deploy workflow created its conda environment with a hardcoded python 3.12.
+    bioconda-utils ships for one python minor per release (4.2.0+ is python 3.13 only), so that pin
+    silently capped it at 4.1.0 and with it a conda-forge-pinning snapshot from 2024. That snapshot
+    pins xerces_c to 3.2, so libOpenMS was built against xerces-c 3.2.5 (icu 75) and exported a
+    `xerces-c >=3.2.5,<3.3.0a0` run constraint, which no longer co-installs with the icu 78 dependency
+    chains of current libarrow/libcurl -- the openms test environment became unsolvable and no nightly
+    package was published. The python pin is gone, so the nightly now tracks the current
+    bioconda-utils and the pinnings upstream bioconda actually builds against; the resolved tooling
+    versions are echoed into the log, and the build-env image follows the rolling `latest` tag, whose
+    publication lags a new bioconda-utils release (#9905)
   - CI: removed the check-tool-handler.yml and check-authors-file.yml pull_request_target workflows; both
     broke for every fork PR after an actions/checkout change and gave external contributors an unconditional
     unrelated failure (#9785, #9787)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1046,14 +1046,13 @@ Build System:
     apt pin the base stage applies before the same install, so a new upstream Arrow release (25.0.0)
     made the unpinned SONAME packages unresolvable and broke the nightly container build on arm64. The
     library stage now applies the identical pin (#9890, #9891)
-  - Fix: the Bioconda deploy workflow set up its conda environment with python 3.12, but bioconda-utils
-    is built for python 3.13 since 4.2.0, so the solver silently fell back to bioconda-utils 4.1.0 and
-    its 2024.11.29 conda-forge-pinning snapshot. That snapshot pins xerces_c to 3.2, so libOpenMS was
-    built against xerces-c 3.2.5 (icu 75) and exported a `xerces-c >=3.2.5,<3.3.0a0` run constraint,
-    which no longer co-installs with the icu 78 dependency chains of current libarrow/libcurl -- the
-    openms test environment became unsolvable and no nightly package was published. The workflow now
-    uses python 3.13 and pins bioconda-utils to the newest version with a published build-env image, so
-    the build resolves xerces-c 3.3.0 (icu 78) (#9905)
+  - Fix: the Bioconda deploy workflow installed bioconda-utils unpinned, which resolved to a build
+    carrying the 2024.11.29 conda-forge-pinning snapshot. That snapshot pins xerces_c to 3.2, so
+    libOpenMS was built against xerces-c 3.2.5 (icu 75) and exported a `xerces-c >=3.2.5,<3.3.0a0` run
+    constraint, which no longer co-installs with the icu 78 dependency chains of current
+    libarrow/libcurl -- the openms test environment became unsolvable and no nightly package was
+    published. The workflow now pins the conda-forge-pinning snapshot (2026.01.07, xerces_c 3.3)
+    alongside bioconda-utils, so the build resolves a xerces-c built against icu 78 (#9905)
   - CI: removed the check-tool-handler.yml and check-authors-file.yml pull_request_target workflows; both
     broke for every fork PR after an actions/checkout change and gave external contributors an unconditional
     unrelated failure (#9785, #9787)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1046,6 +1046,14 @@ Build System:
     apt pin the base stage applies before the same install, so a new upstream Arrow release (25.0.0)
     made the unpinned SONAME packages unresolvable and broke the nightly container build on arm64. The
     library stage now applies the identical pin (#9890, #9891)
+  - Fix: the Bioconda deploy workflow set up its conda environment with python 3.12, but bioconda-utils
+    is built for python 3.13 since 4.2.0, so the solver silently fell back to bioconda-utils 4.1.0 and
+    its 2024.11.29 conda-forge-pinning snapshot. That snapshot pins xerces_c to 3.2, so libOpenMS was
+    built against xerces-c 3.2.5 (icu 75) and exported a `xerces-c >=3.2.5,<3.3.0a0` run constraint,
+    which no longer co-installs with the icu 78 dependency chains of current libarrow/libcurl -- the
+    openms test environment became unsolvable and no nightly package was published. The workflow now
+    uses python 3.13 and pins bioconda-utils to the newest version with a published build-env image, so
+    the build resolves xerces-c 3.3.0 (icu 78) (#9905)
   - CI: removed the check-tool-handler.yml and check-authors-file.yml pull_request_target workflows; both
     broke for every fork PR after an actions/checkout change and gave external contributors an unconditional
     unrelated failure (#9785, #9787)


### PR DESCRIPTION
## Description

Fixes the dependency-solve failure in the nightly `Deploy to Bioconda` workflow tracked in #9905. **Partial fix — see "What this does not fix" below.**

> Rewritten after review. The first version of this PR pinned `bioconda-utils` and the `conda-forge-pinning` snapshot; per @jpfeuffer's feedback it now removes pins instead, so the nightly mimics upstream bioconda and surfaces breakage against the pinnings they currently build with. The pinned form is commit 828d649 if it is ever wanted as a stopgap.

### Root cause

The root cause was not a missing pin — it was an existing one.

The conda environment was created with a hardcoded `python-version: "3.12"`. Each `bioconda-utils` release is built for exactly one python minor, and 4.2.0+ are python 3.13 only. So the already-unpinned `conda install bioconda-utils` could never resolve anything newer than 4.1.0, and 4.1.0 build 0 requires `conda-forge-pinning 2024.11.29.12.37.53`, which pins `xerces_c: 3.2`.

That matters because the recipe lists `xerces-c` unversioned in `host:`, so conda-build applies the variant. The build resolved `xerces-c 3.2.5` (linked against icu 75), and `{{ pin_compatible('xerces-c', max_pin='x.x') }}` exported a `xerces-c >=3.2.5,<3.3.0a0` run constraint. Every xerces-c 3.2.5 build links icu 73 or 75, while current `libarrow` and `libcurl` chains require icu >=78 — so the test environment became unsatisfiable and no nightly package has been published since 2026-07-09.

conda-forge has had a xerces-c built against icu 78 since 2025-12-21 (`3.3.0 hd9031aa_1`, all platforms). The workflow simply never saw a pinning that allowed it.

### Change

Remove `python-version` entirely, rather than bumping it to 3.13 — otherwise the same trap returns when bioconda-utils moves to python 3.14. conda now picks the python that the current bioconda-utils requires:

```
+ bioconda-utils         4.5.0   pyhdfd78af_0        bioconda
+ conda-forge-pinning    2026.01.07.13.16.30         conda-forge
+ python                 3.13.15                     conda-forge
```

`bioconda-utils` declares the `conda-forge-pinning` snapshot it wants, so the tool version decides the pinning. Nothing is pinned here.

Two supporting changes:

- **Report the resolved tooling** (`python`, `bioconda-utils`, `conda-forge-pinning`, `conda-build`, `conda-index`) after install. #9905 was a *silent* downgrade, invisible unless you read the solver output; this makes the next drift one grep away in the log. python is included deliberately — it is the lever that caused this.
- **Match the build-env image to the resolved bioconda-utils**, falling back to the rolling `latest` tag when that image has not been published yet. `--docker` derives the image tag from the tool version, but the image reaches quay.io *after* the conda package does: 4.5.0 is current on the bioconda channel and has no image tag as of 2026-08-12, so deriving it would fail the docker pull. The preflight keeps host and container on the same version whenever bioconda has published it, and still pins nothing.

### Verification

The pinned form of this change was dispatched on this branch ([run 31581583017](https://github.com/OpenMS/OpenMS/actions/runs/31581583017)) and confirmed the mechanism: the host environment resolved `xerces-c 3.3.0 hd9031aa_1` with `icu 78.3 h54a6638_2`, the xerces-c leg of the solver tree went green, and the openms-meta build ran to completion (~49 min) instead of dying in the solve.

### What this does not fix

**One blocker remains**, in `OpenMS/bioconda-recipes`, which this automation can read but not push to.

**Recipe lint, now that we track current bioconda-utils.** ≥4.2 lints more strictly than 4.1.0 did ([run 31578751706](https://github.com/OpenMS/OpenMS/actions/runs/31578751706), failed at lint in 60s):

```
ERROR recipes/openms-meta/meta.yaml: compiler_needs_stdlib_c   # rule does not exist in 4.1.0's linter
ERROR recipes/pyopenms/meta.yaml:   build_number_needs_reset
```

The two recipes have complementary gaps: `pyopenms` already skip-lints `compiler_needs_stdlib_c` but `openms-meta` does not, and `openms-meta` skip-lints `build_number_needs_reset` but `pyopenms` does not. Fixes: add `{{ stdlib("c") }}` next to the compiler in `openms-meta` (worth checking against the existing `sysroot_linux-64 =2.17` in `host:`, which may make it redundant), reset `build: number:` to 0 in `pyopenms`. Surfacing this is the intended effect of tracking upstream.

### Resolved since this PR was opened

**The `openms-thirdparty` test environment.** This was previously unsolvable — conda-forge's `gnuplot` pulls `qt-main`/`cairo` needing `icu >=78`, while `percolator 3.9` depended on the legacy `boost-cpp`, a compatibility shim frozen at 1.85.0 that capped it at `icu >=75.1,<76`.

Fixed upstream: `percolator 3.9 he32743f_1` was published on 2026-08-12, built against `libboost >=1.86.0,<1.87.0a0`. The full set now resolves under strict channel priority (220 packages), landing on `libboost 1.86.0 hd24cca6_5`, `icu 78.3`, `xerces-c 3.3.0 hd9031aa_1` and `gnuplot 6.0.5` with `qt-main 5.15.15` — so gnuplot needs no change. Details in [this comment](https://github.com/OpenMS/OpenMS/issues/9905#issuecomment-5276786090).

## Checklist
- [x] Make sure that you are listed in the AUTHORS file <!-- no new author: CI-only change -->
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes <!-- n/a: no library code changed; verified by dispatching the workflow itself -->
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>

- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds

</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W23deDEGt84Rvxqt35wnXy