### PR TITLE
 Support per-peak ion mobility aux arrays in imzML

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLHandler.h
@@ -126,7 +126,8 @@ namespace Internal
     // ------------------------------------------------------------------
     // IMS CV dispatch
     // ------------------------------------------------------------------
-    void handleIMSCvParam_(const std::string& acc, const std::string& name, const std::string& val);
+    void handleIMSCvParam_(const std::string& acc, const std::string& name, const std::string& val,
+                           const std::string& unit_accession = "");
     void applyRefGroup_   (const std::string& id);
 
     // ------------------------------------------------------------------
@@ -141,12 +142,15 @@ namespace Internal
       uint64_t offset { 0 };     ///< IMS:1000102 — byte offset
       uint64_t count  { 0 };     ///< IMS:1000103 — element count
       uint64_t encoded_bytes { 0 }; ///< IMS:1000104 — stored byte length (required for zlib)
-      bool     compressed { false }; ///< MS:1000574 — zlib compressed payload (unsupported: hard error)
+      /// True for any child of MS:1000572 other than MS:1000576 (zlib, numpress, …).
+      bool     compressed { false };
       /// PSI-MS accession of the array type (child of MS:1000513, or MS:1000786).
       std::string accession;
       /// Ontology / free-text array name matching MzMLHandler FloatDataArray naming:
       /// CV term name for MS:1000513 children, @c value for MS:1000786.
       std::string name;
+      /// unitAccession on the array-identity cvParam (copied to FloatDataArray as unit_accession).
+      std::string unit_accession;
 
       void reset() noexcept { *this = ArrayMeta{}; }
     };
@@ -161,6 +165,8 @@ namespace Internal
       ArrayMeta int_meta;
       /// Auxiliary external arrays (ion mobility, SNR, …) in document order.
       std::vector<ArrayMeta> aux_meta;
+      /// Non-external aux arrays seen while peaks come from the .ibd (warned and dropped).
+      std::vector<std::string> inline_aux_names;
     };
 
     // ------------------------------------------------------------------
@@ -179,16 +185,18 @@ namespace Internal
     ArrayMeta  cur_mz_meta_;
     ArrayMeta  cur_int_meta_;
     std::vector<ArrayMeta> cur_aux_metas_;
+    std::vector<std::string> cur_inline_aux_names_;
 
     std::vector<SpecIMS>             spec_ims_;  ///< IMS state per spectrum (document order)
     std::vector<ImzMLSpectrumIndex>  index_;     ///< Full index for OnDiscImzMLExperiment
 
-    /// A cvParam captured inside a referenceableParamGroup: accession, name, value.
+    /// A cvParam captured inside a referenceableParamGroup.
     struct CvEntry
     {
       std::string accession;
       std::string name;
       std::string value;
+      std::string unit_accession;
     };
     std::unordered_map<std::string, std::vector<CvEntry>> ref_groups_;
     std::string cur_ref_id_;

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLHandler.h
@@ -35,7 +35,7 @@ namespace Internal
 
     imzML (HUPO-PSI v1.1.0) stores MSI data across two files:
     - @c .imzML  — mzML 1.1.0 XML with IMS ontology CV extensions
-    - @c .ibd    — raw binary companion (m/z and intensity arrays)
+    - @c .ibd    — raw binary companion (m/z, intensity, and optional auxiliary arrays)
 
     This handler extends @p MzMLHandler so that all standard mzML metadata
     (instrument, data processing, scan settings, RT, MS level) is parsed by the
@@ -126,7 +126,7 @@ namespace Internal
     // ------------------------------------------------------------------
     // IMS CV dispatch
     // ------------------------------------------------------------------
-    void handleIMSCvParam_(const std::string& acc, const std::string& val);
+    void handleIMSCvParam_(const std::string& acc, const std::string& name, const std::string& val);
     void applyRefGroup_   (const std::string& id);
 
     // ------------------------------------------------------------------
@@ -140,6 +140,13 @@ namespace Internal
       bool     is_ext { false };  ///< IMS:1000101 — external (in .ibd)
       uint64_t offset { 0 };     ///< IMS:1000102 — byte offset
       uint64_t count  { 0 };     ///< IMS:1000103 — element count
+      uint64_t encoded_bytes { 0 }; ///< IMS:1000104 — stored byte length (required for zlib)
+      bool     compressed { false }; ///< MS:1000574 — zlib compressed payload (unsupported: hard error)
+      /// PSI-MS accession of the array type (child of MS:1000513, or MS:1000786).
+      std::string accession;
+      /// Ontology / free-text array name matching MzMLHandler FloatDataArray naming:
+      /// CV term name for MS:1000513 children, @c value for MS:1000786.
+      std::string name;
 
       void reset() noexcept { *this = ArrayMeta{}; }
     };
@@ -152,6 +159,8 @@ namespace Internal
       uint32_t  x {0}, y {0}, z {1};
       ArrayMeta mz_meta;
       ArrayMeta int_meta;
+      /// Auxiliary external arrays (ion mobility, SNR, …) in document order.
+      std::vector<ArrayMeta> aux_meta;
     };
 
     // ------------------------------------------------------------------
@@ -169,12 +178,19 @@ namespace Internal
     ArrayMeta  cur_array_;
     ArrayMeta  cur_mz_meta_;
     ArrayMeta  cur_int_meta_;
+    std::vector<ArrayMeta> cur_aux_metas_;
 
     std::vector<SpecIMS>             spec_ims_;  ///< IMS state per spectrum (document order)
     std::vector<ImzMLSpectrumIndex>  index_;     ///< Full index for OnDiscImzMLExperiment
 
-    using CvPair = std::pair<std::string, std::string>;
-    std::unordered_map<std::string, std::vector<CvPair>> ref_groups_;
+    /// A cvParam captured inside a referenceableParamGroup: accession, name, value.
+    struct CvEntry
+    {
+      std::string accession;
+      std::string name;
+      std::string value;
+    };
+    std::unordered_map<std::string, std::vector<CvEntry>> ref_groups_;
     std::string cur_ref_id_;
     bool   in_ref_group_ { false };
     bool   decode_ibd_ { true };

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLHandlerHelper.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLHandlerHelper.h
@@ -85,9 +85,11 @@ namespace OpenMS
 
     Records the byte offset and element count for the m/z and intensity
     arrays in the companion .ibd file, together with the pixel (x,y,z)
-    coordinates.  Built during ImzMLHandler parsing and stored inside
-    OnDiscImzMLExperiment so that random-access spectrum decoding requires
-    only a single fseek + fread per call.
+    coordinates and zlib-compression flags (@c MS:1000574).  Built during
+    ImzMLHandler parsing and stored inside OnDiscImzMLExperiment so that
+    random-access spectrum decoding requires only a single fseek + fread
+    per call. Compressed m/z, intensity, and auxiliary arrays are rejected
+    at decode time (inflate of external arrays is not supported).
 
     Optional @p aux entries describe additional external arrays (ion mobility
     and other @c FloatDataArray values). Both in-memory @p ImzMLFile::load and
@@ -126,9 +128,11 @@ namespace OpenMS
     uint64_t mz_offset  {0};              ///< Byte offset of m/z array (IMS:1000102)
     uint64_t mz_length  {0};              ///< Element count             (IMS:1000103)
     DataType mz_type    {DataType::UNKNOWN};
+    bool mz_compressed {false};           ///< MS:1000574 on m/z array (unsupported for decode)
     uint64_t int_offset {0};              ///< Byte offset of intensity array
     uint64_t int_length {0};              ///< Element count
     DataType int_type   {DataType::UNKNOWN};
+    bool int_compressed {false};          ///< MS:1000574 on intensity array (unsupported for decode)
     std::vector<AuxArray> aux;            ///< Extra external arrays (IM, …) in document order
   };
 

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLHandlerHelper.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLHandlerHelper.h
@@ -83,11 +83,16 @@ namespace OpenMS
   /**
     @brief Per-spectrum binary index entry for an imzML dataset.
 
-    Records the byte offset and element count for both the m/z and intensity
+    Records the byte offset and element count for the m/z and intensity
     arrays in the companion .ibd file, together with the pixel (x,y,z)
     coordinates.  Built during ImzMLHandler parsing and stored inside
     OnDiscImzMLExperiment so that random-access spectrum decoding requires
     only a single fseek + fread per call.
+
+    Optional @p aux entries describe additional external arrays (ion mobility
+    and other @c FloatDataArray values). Both in-memory @p ImzMLFile::load and
+    @p OnDiscImzMLExperiment::getSpectrum() attach those as @c FloatDataArray
+    on the returned spectrum when present.
 
     @ingroup FileIO
   */
@@ -95,6 +100,24 @@ namespace OpenMS
   {
     /// Scalar type identifier for binary array elements.
     enum class DataType : uint8_t { FLOAT32, FLOAT64, INT32, INT64, UNKNOWN };
+
+    /**
+      @brief Index entry for one auxiliary (non-m/z, non-intensity) external array.
+
+      Used for ion mobility and other per-peak FloatDataArrays so on-disc and
+      in-memory loaders expose the same viewer contract (@c containsIMData(),
+      equal length to peaks).
+    */
+    struct AuxArray
+    {
+      std::string name;                 ///< Ontology / free-text array name (FloatDataArray::getName)
+      std::string accession;            ///< MS accession (e.g. MS:1003006), may be empty
+      uint64_t offset {0};              ///< IMS:1000102
+      uint64_t length {0};              ///< IMS:1000103 element count
+      uint64_t encoded_bytes {0};       ///< IMS:1000104 byte length on disk
+      DataType type {DataType::UNKNOWN};
+      bool compressed {false};          ///< MS:1000574 (unsupported for decode)
+    };
 
     int32_t  index      {0};               ///< 0-based document order
     uint32_t x          {0};               ///< Pixel column (1-based, IMS:1000050)
@@ -106,6 +129,7 @@ namespace OpenMS
     uint64_t int_offset {0};              ///< Byte offset of intensity array
     uint64_t int_length {0};              ///< Element count
     DataType int_type   {DataType::UNKNOWN};
+    std::vector<AuxArray> aux;            ///< Extra external arrays (IM, …) in document order
   };
 
   /**
@@ -146,6 +170,31 @@ namespace OpenMS
                              ImzMLSpectrumIndex::DataType dt,
                              std::vector<float>& out,
                              const std::string& ibd_path);
+
+    /**
+      @brief Read an auxiliary (non-m/z, non-intensity) array from the .ibd file.
+
+      imzML permits additional @c binaryDataArray entries per spectrum beyond the
+      mandatory m/z and intensity pair — most notably ion mobility arrays such as
+      @c MS:1003006 "mean inverse reduced ion mobility array". Values are returned
+      as @c float because OpenMS stores auxiliary spectrum data in
+      @p MSSpectrum::FloatDataArray.
+
+      @param[in] array_name Array name used in error messages (e.g. the CV term name).
+
+      @note zlib-compressed external arrays (MS:1000574) are not decoded; callers
+      must reject them before invoking this method. @c IMS:1000104 is then
+      required to know how many compressed bytes to read.
+
+      @throws Exception::ParseError if seek or read fails.
+    */
+    static void readAuxArray(FILE* ibd,
+                             uint64_t offset,
+                             uint64_t count,
+                             ImzMLSpectrumIndex::DataType dt,
+                             std::vector<float>& out,
+                             const std::string& ibd_path,
+                             const std::string& array_name);
 
     /**
       @brief Write a float32 array to the companion .ibd file (little-endian).

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLHandlerHelper.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLHandlerHelper.h
@@ -184,6 +184,12 @@ namespace OpenMS
       as @c float because OpenMS stores auxiliary spectrum data in
       @p MSSpectrum::FloatDataArray.
 
+      @param[in] ibd        Open binary file handle.
+      @param[in] offset     Byte offset (IMS:1000102).
+      @param[in] count      Element count (IMS:1000103).
+      @param[in] dt         Scalar type of stored values.
+      @param[out] out       Decoded values as float (FloatDataArray storage).
+      @param[in] ibd_path   Path used in error messages.
       @param[in] array_name Array name used in error messages (e.g. the CV term name).
 
       @note zlib-compressed external arrays (MS:1000574) are not decoded; callers

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLHandlerHelper.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLHandlerHelper.h
@@ -88,8 +88,9 @@ namespace OpenMS
     coordinates and zlib-compression flags (@c MS:1000574).  Built during
     ImzMLHandler parsing and stored inside OnDiscImzMLExperiment so that
     random-access spectrum decoding requires only a single fseek + fread
-    per call. Compressed m/z, intensity, and auxiliary arrays are rejected
-    at decode time (inflate of external arrays is not supported).
+    per call. Compressed m/z, intensity, and auxiliary arrays (any child of
+    @c MS:1000572 other than uncompressed @c MS:1000576) are rejected at
+    decode time (inflate / numpress of external arrays is not supported).
 
     Optional @p aux entries describe additional external arrays (ion mobility
     and other @c FloatDataArray values). Both in-memory @p ImzMLFile::load and
@@ -114,11 +115,12 @@ namespace OpenMS
     {
       std::string name;                 ///< Ontology / free-text array name (FloatDataArray::getName)
       std::string accession;            ///< MS accession (e.g. MS:1003006), may be empty
+      std::string unit_accession;       ///< unitAccession on the array-identity cvParam (may be empty)
       uint64_t offset {0};              ///< IMS:1000102
       uint64_t length {0};              ///< IMS:1000103 element count
       uint64_t encoded_bytes {0};       ///< IMS:1000104 byte length on disk
       DataType type {DataType::UNKNOWN};
-      bool compressed {false};          ///< MS:1000574 (unsupported for decode)
+      bool compressed {false};          ///< Child of MS:1000572 other than MS:1000576 (unsupported)
     };
 
     int32_t  index      {0};               ///< 0-based document order
@@ -128,11 +130,11 @@ namespace OpenMS
     uint64_t mz_offset  {0};              ///< Byte offset of m/z array (IMS:1000102)
     uint64_t mz_length  {0};              ///< Element count             (IMS:1000103)
     DataType mz_type    {DataType::UNKNOWN};
-    bool mz_compressed {false};           ///< MS:1000574 on m/z array (unsupported for decode)
+    bool mz_compressed {false};           ///< Compressed (not MS:1000576) on m/z array
     uint64_t int_offset {0};              ///< Byte offset of intensity array
     uint64_t int_length {0};              ///< Element count
     DataType int_type   {DataType::UNKNOWN};
-    bool int_compressed {false};          ///< MS:1000574 on intensity array (unsupported for decode)
+    bool int_compressed {false};          ///< Compressed (not MS:1000576) on intensity array
     std::vector<AuxArray> aux;            ///< Extra external arrays (IM, …) in document order
   };
 
@@ -192,9 +194,10 @@ namespace OpenMS
       @param[in] ibd_path   Path used in error messages.
       @param[in] array_name Array name used in error messages (e.g. the CV term name).
 
-      @note zlib-compressed external arrays (MS:1000574) are not decoded; callers
-      must reject them before invoking this method. @c IMS:1000104 is then
-      required to know how many compressed bytes to read.
+      @note Compressed external arrays (any child of MS:1000572 other than
+      uncompressed MS:1000576) are not decoded; callers must reject them before
+      invoking this method. @c IMS:1000104 is then required to know how many
+      compressed bytes to read.
 
       @throws Exception::ParseError if seek or read fails.
     */

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLWriter.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLWriter.h
@@ -44,6 +44,9 @@ namespace Internal
       Scope of that path:
       - @c FloatDataArray only (not integer/string data arrays)
       - unnamed arrays are skipped with a warning
+      - arrays named after the peak CV terms (@c MS:1000514 "m/z array",
+        @c MS:1000515 "intensity array") are skipped with a warning: such an array
+        would be read back as the spectrum's peak metadata
       - arrays must have the same length as the spectrum peaks (others are skipped)
       - always 32-bit float, uncompressed (@c MS:1000576 on the array and on the
         m/z and intensity @c referenceableParamGroup entries)

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLWriter.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLWriter.h
@@ -43,8 +43,10 @@ namespace Internal
       binary arrays after m/z and intensity (standard imzML multi-array layout).
       Scope of that path:
       - @c FloatDataArray only (not integer/string data arrays)
+      - unnamed arrays are skipped with a warning
       - arrays must have the same length as the spectrum peaks (others are skipped)
-      - always 32-bit float, uncompressed (@c MS:1000576)
+      - always 32-bit float, uncompressed (@c MS:1000576 on the array and on the
+        m/z and intensity @c referenceableParamGroup entries)
       - PSI-MS accession resolved via the ontology (children of @c MS:1000513).
         If the term declares exactly one allowed unit, that unit is written
         (accession, name, cvRef). Terms with several allowed units get no unit

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLWriter.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLWriter.h
@@ -36,10 +36,24 @@ namespace Internal
       MetaValues when present.
 
       Export writes external binary arrays with a 16-byte UUID header in the
-      @c .ibd file. Binary precision follows @p PeakFileOptions (@p getMz32Bit,
-      @p getIntensity32Bit). @p PeakFileOptions spectrum/peak filters (MS level,
-      RT, precursor m/z, m/z and intensity ranges, metadata-only, sort-by-m/z)
-      are applied to a temporary copy before export.
+      @c .ibd file. Binary precision for m/z and intensity follows
+      @p PeakFileOptions (@p getMz32Bit, @p getIntensity32Bit).
+
+      Per-spectrum @c FloatDataArray values are exported as additional external
+      binary arrays after m/z and intensity (standard imzML multi-array layout).
+      Scope of that path:
+      - @c FloatDataArray only (not integer/string data arrays)
+      - arrays must have the same length as the spectrum peaks (others are skipped)
+      - always 32-bit float, uncompressed (@c MS:1000576)
+      - PSI-MS accession resolved via the ontology (children of @c MS:1000513),
+        with unit CVs when the term declares them (e.g. @c MS:1002814 for 1/K0);
+        unknown names become @c MS:1000786 "non-standard data array"
+
+      Viewers can rely on @c MSSpectrum::containsIMData() after load for IM arrays.
+
+      @p PeakFileOptions spectrum/peak filters (MS level, RT, precursor m/z,
+      m/z and intensity ranges, metadata-only, sort-by-m/z) are applied to a
+      temporary copy before export.
 
       @param[in] imzml_path Path to the output @c .imzML file.
       @param[in] exp        Experiment to store (must contain at least one spectrum).

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLWriter.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ImzMLWriter.h
@@ -45,9 +45,11 @@ namespace Internal
       - @c FloatDataArray only (not integer/string data arrays)
       - arrays must have the same length as the spectrum peaks (others are skipped)
       - always 32-bit float, uncompressed (@c MS:1000576)
-      - PSI-MS accession resolved via the ontology (children of @c MS:1000513),
-        with unit CVs when the term declares them (e.g. @c MS:1002814 for 1/K0);
-        unknown names become @c MS:1000786 "non-standard data array"
+      - PSI-MS accession resolved via the ontology (children of @c MS:1000513).
+        If the term declares exactly one allowed unit, that unit is written
+        (accession, name, cvRef). Terms with several allowed units get no unit
+        attributes (no arbitrary choice). Unknown names become @c MS:1000786
+        "non-standard data array"
 
       Viewers can rely on @c MSSpectrum::containsIMData() after load for IM arrays.
 

--- a/src/openms/include/OpenMS/FORMAT/ImzMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ImzMLFile.h
@@ -40,7 +40,8 @@ namespace OpenMS
     After load, spectra that carry per-peak ion mobility expose it via
     @p MSSpectrum::containsIMData() / @p getFloatDataArrays() — the same
     contract used by mzML ion-mobility data and by viewers. Aux arrays must
-    match the peak count; mismatched lengths are skipped with a warning.
+    match the peak count; mismatched lengths are skipped with a warning, as are
+    aux arrays without a supported binary data type.
 
     The @c .ibd path is derived from the @c .imzML path (same basename,
     extension replaced with @c .ibd, case-insensitive).

--- a/src/openms/include/OpenMS/FORMAT/ImzMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ImzMLFile.h
@@ -34,7 +34,13 @@ namespace OpenMS
     Data are split across two files on disk:
 
     - @c .imzML — XML metadata (mzML 1.1.0 schema + IMS CV terms)
-    - @c .ibd   — external m/z and intensity arrays
+    - @c .ibd   — external m/z, intensity, and optional auxiliary arrays
+      (e.g. PSI-MS @c MS:1003006 ion mobility → @c FloatDataArray)
+
+    After load, spectra that carry per-peak ion mobility expose it via
+    @p MSSpectrum::containsIMData() / @p getFloatDataArrays() — the same
+    contract used by mzML ion-mobility data and by viewers. Aux arrays must
+    match the peak count; mismatched lengths are skipped with a warning.
 
     The @c .ibd path is derived from the @c .imzML path (same basename,
     extension replaced with @c .ibd, case-insensitive).

--- a/src/openms/include/OpenMS/KERNEL/OnDiscImzMLExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/OnDiscImzMLExperiment.h
@@ -57,6 +57,8 @@ namespace OpenMS
     external arrays (e.g. @c MS:1003006 ion mobility) as @c FloatDataArray
     entries — the same contract as in-memory @p ImzMLFile::load — so viewers
     can call @c containsIMData() / rasterize without a separate code path.
+    Auxiliary arrays whose length differs from the peak count, or which declare no
+    supported binary data type, are skipped with a warning in both loaders.
 
     @note This class is not thread-safe.  If concurrent reads are needed,
     construct one instance per thread.

--- a/src/openms/include/OpenMS/KERNEL/OnDiscImzMLExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/OnDiscImzMLExperiment.h
@@ -146,6 +146,8 @@ namespace OpenMS
       @param i  0-based spectrum index.
       @throws Exception::IndexOverflow if @p i >= getNrSpectra().
       @throws Exception::FileNotFound  if the .ibd is not open.
+      @throws Exception::ParseError    if m/z or intensity arrays are zlib-compressed
+                                       (@c MS:1000574), or if array lengths mismatch.
     */
     MSSpectrum getSpectrum(std::size_t i) const;
 

--- a/src/openms/include/OpenMS/KERNEL/OnDiscImzMLExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/OnDiscImzMLExperiment.h
@@ -146,8 +146,9 @@ namespace OpenMS
       @param i  0-based spectrum index.
       @throws Exception::IndexOverflow if @p i >= getNrSpectra().
       @throws Exception::FileNotFound  if the .ibd is not open.
-      @throws Exception::ParseError    if m/z or intensity arrays are zlib-compressed
-                                       (@c MS:1000574), or if array lengths mismatch.
+      @throws Exception::ParseError    if m/z, intensity, or auxiliary arrays are
+                                       zlib-compressed (@c MS:1000574), or if m/z
+                                       and intensity array lengths mismatch.
     */
     MSSpectrum getSpectrum(std::size_t i) const;
 

--- a/src/openms/include/OpenMS/KERNEL/OnDiscImzMLExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/OnDiscImzMLExperiment.h
@@ -147,8 +147,9 @@ namespace OpenMS
       @throws Exception::IndexOverflow if @p i >= getNrSpectra().
       @throws Exception::FileNotFound  if the .ibd is not open.
       @throws Exception::ParseError    if m/z, intensity, or auxiliary arrays are
-                                       zlib-compressed (@c MS:1000574), or if m/z
-                                       and intensity array lengths mismatch.
+                                       compressed (@c MS:1000572 other than
+                                       @c MS:1000576), or if m/z and intensity
+                                       array lengths mismatch.
     */
     MSSpectrum getSpectrum(std::size_t i) const;
 
@@ -181,10 +182,12 @@ namespace OpenMS
              intensities inside [mz - dm, mz + dm], with dm = mz * tolerance_ppm * 1e-6.
 
       This is the on-disc counterpart of @p MSImagingExperiment::extractIonImage:
-      it walks the shared 2D geometry and decodes each pixel's spectrum from the
-      .ibd on demand (one fseek + fread per pixel), so the full dataset never needs
-      to be held in memory. This makes it suitable for visualizing single-mass ion
-      images of large datasets.
+      it walks the shared 2D geometry and decodes each pixel's peaks from the
+      .ibd on demand, so the full dataset never needs to be held in memory. This
+      makes it suitable for visualizing single-mass ion images of large datasets.
+      Only m/z and intensity are decoded — auxiliary arrays do not contribute to
+      the summed intensity, so a compressed auxiliary array is not reported here
+      (unlike getSpectrum()).
 
       Pixels absent from the geometry stay invalid in the returned image. Pixels with
       a spectrum but no peaks in the window are marked valid with intensity 0. The

--- a/src/openms/include/OpenMS/KERNEL/OnDiscImzMLExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/OnDiscImzMLExperiment.h
@@ -53,6 +53,11 @@ namespace OpenMS
     @p ImzMLFile::loadSpectraIndex() during @p open() — no peak arrays
     are decoded until @p getSpectrum() is called.
 
+    @note @p getSpectrum() returns m/z, intensity, and any indexed auxiliary
+    external arrays (e.g. @c MS:1003006 ion mobility) as @c FloatDataArray
+    entries — the same contract as in-memory @p ImzMLFile::load — so viewers
+    can call @c containsIMData() / rasterize without a separate code path.
+
     @note This class is not thread-safe.  If concurrent reads are needed,
     construct one instance per thread.
 

--- a/src/openms/source/FORMAT/HANDLERS/ImzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ImzMLHandler.cpp
@@ -260,7 +260,7 @@ public:
           {
             continue;
           }
-          if (!s.empty() && values.size() != s.size())
+          if (values.size() != s.size())
           {
             OPENMS_LOG_WARN << "Skipping auxiliary array '" << aux.name << "' at pixel ("
                             << ims->x << "," << ims->y << "," << ims->z

--- a/src/openms/source/FORMAT/HANDLERS/ImzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ImzMLHandler.cpp
@@ -322,12 +322,19 @@ public:
       // containsIMData() matches OnDiscImzMLExperiment.
       pruneEmptyDataArrays_(s);
 
-      // MzMLHandler::populateSpectraWithData_() defaults UNKNOWN → IM_PROFILE before
-      // consumeSpectrum(), but that runs before this late .ibd aux fill. Re-apply the
-      // same default now that containsIMData() can see the materialized IM array.
-      if (s.containsIMData() && s.getIMPeakType() == IMPeakType::UNKNOWN)
+      // MzMLHandler::populateSpectraWithData_() runs before this late .ibd aux fill:
+      // it defaults UNKNOWN → IM_PROFILE from a still-empty named IM array, which we
+      // may have just pruned. Sync the peak type with the arrays that actually remain.
+      if (s.containsIMData())
       {
-        s.setIMPeakType(IMPeakType::IM_PROFILE);
+        if (s.getIMPeakType() == IMPeakType::UNKNOWN)
+        {
+          s.setIMPeakType(IMPeakType::IM_PROFILE);
+        }
+      }
+      else
+      {
+        s.setIMPeakType(IMPeakType::UNKNOWN);
       }
 
       // MzMLHandler sorted before consumeSpectrum(), which is a no-op for external

--- a/src/openms/source/FORMAT/HANDLERS/ImzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ImzMLHandler.cpp
@@ -129,8 +129,9 @@ namespace
       "(need uncompressed MS:1000576). Re-export without compression.");
   }
 
-  /// Drop empty Float/IntegerDataArrays left by MzMLHandler for skipped, zero-length,
-  /// integer-typed, or inline aux arrays. On-disc never materializes those ghosts.
+  /// Drop empty Float/Integer/StringDataArrays left by MzMLHandler for skipped,
+  /// zero-length, untyped, integer-typed, or inline aux arrays. On-disc never
+  /// materializes those ghosts.
   void pruneEmptyDataArrays_(MSSpectrum& s)
   {
     auto prune = [](auto& arrays) {
@@ -140,6 +141,7 @@ namespace
     };
     prune(s.getFloatDataArrays());
     prune(s.getIntegerDataArrays());
+    prune(s.getStringDataArrays());
   }
 } // namespace
 
@@ -282,6 +284,14 @@ public:
                             << ims->x << "," << ims->y << "," << ims->z
                             << "): length " << aux.count << " != peak count " << s.size()
                             << " (viewers require equal length for ion mobility)\n";
+            continue;
+          }
+          if (aux.dt == ImzMLSpectrumIndex::DataType::UNKNOWN)
+          { // no MS:1000521/1000523/1000519/1000522 on this array: skip it rather than
+            // abort the load, matching the warn-and-skip policy for other bad aux arrays
+            OPENMS_LOG_WARN << "Skipping auxiliary array '" << aux.name << "' at pixel ("
+                            << ims->x << "," << ims->y << "," << ims->z
+                            << "): missing or unsupported binary data type\n";
             continue;
           }
           std::vector<float> values;

--- a/src/openms/source/FORMAT/HANDLERS/ImzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ImzMLHandler.cpp
@@ -11,6 +11,7 @@
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
+#include <OpenMS/IONMOBILITY/IMTypes.h>
 
 #include <xercesc/util/XMLString.hpp>
 
@@ -280,6 +281,14 @@ public:
         }
       }
 
+      // MzMLHandler::populateSpectraWithData_() defaults UNKNOWN → IM_PROFILE before
+      // consumeSpectrum(), but that runs before this late .ibd aux fill. Re-apply the
+      // same default now that containsIMData() can see the materialized IM array.
+      if (s.containsIMData() && s.getIMPeakType() == IMPeakType::UNKNOWN)
+      {
+        s.setIMPeakType(IMPeakType::IM_PROFILE);
+      }
+
       // Build full spectrum index entry (includes aux so OnDisc can decode IM lazily).
       ImzMLSpectrumIndex entry;
       entry.index      = idx;
@@ -289,9 +298,11 @@ public:
       entry.mz_offset  = ims->mz_meta.offset;
       entry.mz_length  = ims->mz_meta.count;
       entry.mz_type    = ims->mz_meta.dt;
+      entry.mz_compressed = ims->mz_meta.compressed;
       entry.int_offset = ims->int_meta.offset;
       entry.int_length = ims->int_meta.count;
       entry.int_type   = ims->int_meta.dt;
+      entry.int_compressed = ims->int_meta.compressed;
       entry.aux.reserve(ims->aux_meta.size());
       for (const auto& aux : ims->aux_meta)
       {

--- a/src/openms/source/FORMAT/HANDLERS/ImzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ImzMLHandler.cpp
@@ -14,6 +14,7 @@
 
 #include <xercesc/util/XMLString.hpp>
 
+#include <algorithm>
 #include <cstring>
 #include <limits>
 #include <stdexcept>
@@ -174,6 +175,12 @@ public:
         std::vector<double> mz_vec;
         std::vector<float>  int_vec;
         const std::string& ibd_path = handler_.meta_.ibd_file_path;
+        if (ims->mz_meta.compressed || ims->int_meta.compressed)
+        {
+          throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, ibd_path,
+            "zlib-compressed external m/z or intensity arrays are not supported "
+            "(need IMS:1000104 + inflate). Re-export without compression.");
+        }
         if (ims->mz_meta.is_ext)
         {
           ImzMLBinaryIO::readMzArray(handler_.ibd_, ims->mz_meta.offset, ims->mz_meta.count,
@@ -222,7 +229,58 @@ public:
           handler_.meta_.int_data_type = dtStr_(ims->int_meta.dt);
       }
 
-      // Build full spectrum index entry
+      // Fill auxiliary arrays (ion mobility, …) from the .ibd. MzMLHandler has already
+      // created an empty FloatDataArray per auxiliary binaryDataArray, named from the
+      // PSI-MS ontology (or MS:1000786 @value), so match on that name and fill data.
+      // Length must equal the peak count so containsIMData()/viewers can use the array.
+      if (handler_.ibd_ && handler_.decode_ibd_ && !ims->aux_meta.empty())
+      {
+        const std::string& ibd_path = handler_.meta_.ibd_file_path;
+        auto& float_arrays = s.getFloatDataArrays();
+        for (const auto& aux : ims->aux_meta)
+        {
+          if (aux.name.empty())
+          {
+            OPENMS_LOG_WARN << "Skipping external auxiliary array without MS:1000513 / MS:1000786 identity at pixel ("
+                            << ims->x << "," << ims->y << "," << ims->z << ")\n";
+            continue;
+          }
+          if (aux.compressed)
+          {
+            throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, ibd_path,
+              "zlib-compressed external auxiliary array '" + aux.name
+              + "' is not supported (IMS:1000104 encoded length="
+              + StringConversions::toString(aux.encoded_bytes) + "). "
+              "Re-export without compression or use an in-memory converter that decompresses.");
+          }
+          std::vector<float> values;
+          ImzMLBinaryIO::readAuxArray(handler_.ibd_, aux.offset, aux.count, aux.dt, values, ibd_path, aux.name);
+          if (values.empty())
+          {
+            continue;
+          }
+          if (!s.empty() && values.size() != s.size())
+          {
+            OPENMS_LOG_WARN << "Skipping auxiliary array '" << aux.name << "' at pixel ("
+                            << ims->x << "," << ims->y << "," << ims->z
+                            << "): length " << values.size() << " != peak count " << s.size()
+                            << " (viewers require equal length for ion mobility)\n";
+            continue;
+          }
+          // Only consider still-empty arrays so repeated array names map 1:1 in order.
+          auto it = std::find_if(float_arrays.begin(), float_arrays.end(),
+                                 [&aux](const auto& a) { return a.empty() && a.getName() == aux.name; });
+          if (it == float_arrays.end())
+          {
+            float_arrays.emplace_back();
+            it = std::prev(float_arrays.end());
+            it->setName(aux.name);
+          }
+          it->assign(values.begin(), values.end());
+        }
+      }
+
+      // Build full spectrum index entry (includes aux so OnDisc can decode IM lazily).
       ImzMLSpectrumIndex entry;
       entry.index      = idx;
       entry.x          = ims->x;
@@ -234,6 +292,23 @@ public:
       entry.int_offset = ims->int_meta.offset;
       entry.int_length = ims->int_meta.count;
       entry.int_type   = ims->int_meta.dt;
+      entry.aux.reserve(ims->aux_meta.size());
+      for (const auto& aux : ims->aux_meta)
+      {
+        if (aux.name.empty())
+        {
+          continue;
+        }
+        ImzMLSpectrumIndex::AuxArray a;
+        a.name = aux.name;
+        a.accession = aux.accession;
+        a.offset = aux.offset;
+        a.length = aux.count;
+        a.encoded_bytes = aux.encoded_bytes;
+        a.type = aux.dt;
+        a.compressed = aux.compressed;
+        entry.aux.push_back(std::move(a));
+      }
       handler_.index_.push_back(entry);
     }
 
@@ -324,6 +399,7 @@ void ImzMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& at
     cur_y_seen_ = false;
     cur_mz_meta_.reset();
     cur_int_meta_.reset();
+    cur_aux_metas_.clear();
   }
   if (tag == "scan"            && in_spectrum_) in_scan_ = true;
   if (tag == "binaryDataArray" && in_spectrum_)
@@ -350,14 +426,15 @@ void ImzMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& at
   // Intercept <cvParam> before MzMLHandler: capture IMS:* terms
   if (tag == "cvParam")
   {
-    std::string acc_om, val_om;
+    std::string acc_om, name_om, val_om;
     optionalAttributeAsString_(acc_om, attrs, "accession");
+    optionalAttributeAsString_(name_om, attrs, "name");
     optionalAttributeAsString_(val_om, attrs, "value");
 
     if (in_ref_group_)
-      ref_groups_[cur_ref_id_].emplace_back(acc_om, val_om);
+      ref_groups_[cur_ref_id_].push_back(CvEntry{acc_om, name_om, val_om});
     else
-      handleIMSCvParam_(acc_om, val_om);
+      handleIMSCvParam_(acc_om, name_om, val_om);
     // Fall through: MzMLHandler still processes MS:* terms below
   }
 
@@ -372,6 +449,10 @@ void ImzMLHandler::onEndElement(const char16_t* qname)
   {
     if      (cur_array_.is_mz)  cur_mz_meta_  = cur_array_;
     else if (cur_array_.is_int) cur_int_meta_ = cur_array_;
+    // Auxiliary external array (ion mobility, SNR, …). MzMLHandler creates a
+    // correspondingly named — but empty — FloatDataArray from the same CV term;
+    // ImzMLInterceptConsumer fills it from the .ibd.
+    else if (cur_array_.is_ext) cur_aux_metas_.push_back(cur_array_);
 
     // For external (.ibd) arrays the inline <binary> is an empty placeholder, but the
     // base MzMLHandler captured this array's expected length from defaultArrayLength
@@ -418,6 +499,7 @@ void ImzMLHandler::onEndElement(const char16_t* qname)
       snap.z        = cur_z_;
       snap.mz_meta  = cur_mz_meta_;
       snap.int_meta = cur_int_meta_;
+      snap.aux_meta = cur_aux_metas_;
       spec_ims_.push_back(snap);
     }
 
@@ -454,6 +536,7 @@ void ImzMLHandler::onEndElement(const char16_t* qname)
     cur_z_ = 1;
     cur_mz_meta_.reset();
     cur_int_meta_.reset();
+    cur_aux_metas_.clear();
   }
 }
 
@@ -461,7 +544,7 @@ void ImzMLHandler::onEndElement(const char16_t* qname)
 // IMS CV dispatch
 // ===========================================================================
 
-void ImzMLHandler::handleIMSCvParam_(const std::string& acc, const std::string& val)
+void ImzMLHandler::handleIMSCvParam_(const std::string& acc, const std::string& /*name*/, const std::string& val)
 {
   // Pixel coordinates (inside <scan> inside <spectrum>)
   if (in_scan_ && in_spectrum_)
@@ -484,6 +567,28 @@ void ImzMLHandler::handleIMSCvParam_(const std::string& acc, const std::string& 
     if (acc == "IMS:1000101"){ cur_array_.is_ext = true;    return; }
     if (acc == "IMS:1000102") { cur_array_.offset = parseImsUInt64_(file_, acc, val); return; }
     if (acc == "IMS:1000103") { cur_array_.count  = parseImsUInt64_(file_, acc, val); return; }
+    if (acc == "IMS:1000104") { cur_array_.encoded_bytes = parseImsUInt64_(file_, acc, val); return; }
+    if (acc == "MS:1000576") { cur_array_.compressed = false; return; }  // no compression
+    if (acc == "MS:1000574") { cur_array_.compressed = true;  return; }  // zlib compression
+    // Array identity: only MS:1000786 / children of MS:1000513 (PSI binary data array).
+    // Match MzMLHandler naming so FloatDataArray lookup uses the ontology name, not XML @name.
+    if (acc == "MS:1000786")
+    {
+      cur_array_.accession = acc;
+      if (!val.empty())
+      {
+        cur_array_.name = val;
+      }
+      return;
+    }
+    if (cv_.exists(acc) && cv_.isChildOf(acc, "MS:1000513"))
+    {
+      cur_array_.accession = acc;
+      cur_array_.name = cv_.getTerm(acc).name;
+      return;
+    }
+    // Ignore other cvParams here (units, etc.) so they cannot overwrite the array name.
+    return;
   }
 
   // Dataset-level imaging metadata
@@ -514,8 +619,8 @@ void ImzMLHandler::applyRefGroup_(const std::string& id)
 {
   auto it = ref_groups_.find(id);
   if (it == ref_groups_.end()) return;
-  for (const auto& kv : it->second)
-    handleIMSCvParam_(kv.first, kv.second);
+  for (const auto& cv : it->second)
+    handleIMSCvParam_(cv.accession, cv.name, cv.value);
 }
 
 } // namespace Internal

--- a/src/openms/source/FORMAT/HANDLERS/ImzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ImzMLHandler.cpp
@@ -12,6 +12,7 @@
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/IONMOBILITY/IMTypes.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
 
 #include <xercesc/util/XMLString.hpp>
 
@@ -120,6 +121,26 @@ namespace
       throwImsParseError_(file, acc, val, "not a valid floating-point number");
     }
   }
+
+  [[noreturn]] void throwCompressedExternalError_(const std::string& ibd_path, const std::string& what)
+  {
+    throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, ibd_path,
+      "Compressed external " + what + " are not supported "
+      "(need uncompressed MS:1000576). Re-export without compression.");
+  }
+
+  /// Drop empty Float/IntegerDataArrays left by MzMLHandler for skipped, zero-length,
+  /// integer-typed, or inline aux arrays. On-disc never materializes those ghosts.
+  void pruneEmptyDataArrays_(MSSpectrum& s)
+  {
+    auto prune = [](auto& arrays) {
+      arrays.erase(std::remove_if(arrays.begin(), arrays.end(),
+                                  [](const auto& a) { return a.empty(); }),
+                   arrays.end());
+    };
+    prune(s.getFloatDataArrays());
+    prune(s.getIntegerDataArrays());
+  }
 } // namespace
 
 // ===========================================================================
@@ -178,9 +199,7 @@ public:
         const std::string& ibd_path = handler_.meta_.ibd_file_path;
         if (ims->mz_meta.compressed || ims->int_meta.compressed)
         {
-          throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, ibd_path,
-            "zlib-compressed external m/z or intensity arrays are not supported "
-            "(need IMS:1000104 + inflate). Re-export without compression.");
+          throwCompressedExternalError_(ibd_path, "m/z or intensity arrays");
         }
         if (ims->mz_meta.is_ext)
         {
@@ -231,9 +250,8 @@ public:
       }
 
       // Fill auxiliary arrays (ion mobility, …) from the .ibd. MzMLHandler has already
-      // created an empty FloatDataArray per auxiliary binaryDataArray, named from the
-      // PSI-MS ontology (or MS:1000786 @value), so match on that name and fill data.
-      // Length must equal the peak count so containsIMData()/viewers can use the array.
+      // created an empty FloatDataArray (or IntegerDataArray) per auxiliary binaryDataArray.
+      // Check declared length before reading so a single bad IMS:1000103 cannot abort the load.
       if (handler_.ibd_ && handler_.decode_ibd_ && !ims->aux_meta.empty())
       {
         const std::string& ibd_path = handler_.meta_.ibd_file_path;
@@ -249,23 +267,27 @@ public:
           if (aux.compressed)
           {
             throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, ibd_path,
-              "zlib-compressed external auxiliary array '" + aux.name
+              "Compressed external auxiliary array '" + aux.name
               + "' is not supported (IMS:1000104 encoded length="
               + StringConversions::toString(aux.encoded_bytes) + "). "
-              "Re-export without compression or use an in-memory converter that decompresses.");
+              "Re-export without compression.");
           }
-          std::vector<float> values;
-          ImzMLBinaryIO::readAuxArray(handler_.ibd_, aux.offset, aux.count, aux.dt, values, ibd_path, aux.name);
-          if (values.empty())
+          if (aux.count == 0)
           {
             continue;
           }
-          if (values.size() != s.size())
+          if (aux.count != s.size())
           {
             OPENMS_LOG_WARN << "Skipping auxiliary array '" << aux.name << "' at pixel ("
                             << ims->x << "," << ims->y << "," << ims->z
-                            << "): length " << values.size() << " != peak count " << s.size()
+                            << "): length " << aux.count << " != peak count " << s.size()
                             << " (viewers require equal length for ion mobility)\n";
+            continue;
+          }
+          std::vector<float> values;
+          ImzMLBinaryIO::readAuxArray(handler_.ibd_, aux.offset, aux.count, aux.dt, values, ibd_path, aux.name);
+          if (values.empty() || values.size() != s.size())
+          {
             continue;
           }
           // Only consider still-empty arrays so repeated array names map 1:1 in order.
@@ -276,10 +298,29 @@ public:
             float_arrays.emplace_back();
             it = std::prev(float_arrays.end());
             it->setName(aux.name);
+            if (!aux.unit_accession.empty())
+            {
+              it->setMetaValue("unit_accession", aux.unit_accession);
+            }
           }
           it->assign(values.begin(), values.end());
         }
       }
+
+      if ((ims->mz_meta.is_ext || ims->int_meta.is_ext) && !ims->inline_aux_names.empty())
+      {
+        for (const std::string& name : ims->inline_aux_names)
+        {
+          OPENMS_LOG_WARN << "Skipping inline auxiliary array '" << name
+                          << "' at pixel (" << ims->x << "," << ims->y << "," << ims->z
+                          << "): peak data is stored in the .ibd, so inline aux payloads are not decoded\n";
+        }
+      }
+
+      // MzMLHandler pre-creates empty named arrays for every aux binaryDataArray.
+      // Drop leftovers (zero-length, length mismatch, integer-typed, inline) so
+      // containsIMData() matches OnDiscImzMLExperiment.
+      pruneEmptyDataArrays_(s);
 
       // MzMLHandler::populateSpectraWithData_() defaults UNKNOWN → IM_PROFILE before
       // consumeSpectrum(), but that runs before this late .ibd aux fill. Re-apply the
@@ -287,6 +328,14 @@ public:
       if (s.containsIMData() && s.getIMPeakType() == IMPeakType::UNKNOWN)
       {
         s.setIMPeakType(IMPeakType::IM_PROFILE);
+      }
+
+      // MzMLHandler sorted before consumeSpectrum(), which is a no-op for external
+      // arrays (peaks are overwritten from the .ibd). Re-sort here so MZBegin/MZEnd
+      // ion-image lookup matches OnDiscImzMLExperiment and the mzML path.
+      if (handler_.getOptions().getSortSpectraByMZ() && !s.isSorted())
+      {
+        s.sortByPosition();
       }
 
       // Build full spectrum index entry (includes aux so OnDisc can decode IM lazily).
@@ -313,6 +362,7 @@ public:
         ImzMLSpectrumIndex::AuxArray a;
         a.name = aux.name;
         a.accession = aux.accession;
+        a.unit_accession = aux.unit_accession;
         a.offset = aux.offset;
         a.length = aux.count;
         a.encoded_bytes = aux.encoded_bytes;
@@ -411,6 +461,7 @@ void ImzMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& at
     cur_mz_meta_.reset();
     cur_int_meta_.reset();
     cur_aux_metas_.clear();
+    cur_inline_aux_names_.clear();
   }
   if (tag == "scan"            && in_spectrum_) in_scan_ = true;
   if (tag == "binaryDataArray" && in_spectrum_)
@@ -437,15 +488,16 @@ void ImzMLHandler::onStartElement(const char16_t* qname, const XMLAttributes& at
   // Intercept <cvParam> before MzMLHandler: capture IMS:* terms
   if (tag == "cvParam")
   {
-    std::string acc_om, name_om, val_om;
+    std::string acc_om, name_om, val_om, unit_om;
     optionalAttributeAsString_(acc_om, attrs, "accession");
     optionalAttributeAsString_(name_om, attrs, "name");
     optionalAttributeAsString_(val_om, attrs, "value");
+    optionalAttributeAsString_(unit_om, attrs, "unitAccession");
 
     if (in_ref_group_)
-      ref_groups_[cur_ref_id_].push_back(CvEntry{acc_om, name_om, val_om});
+      ref_groups_[cur_ref_id_].push_back(CvEntry{acc_om, name_om, val_om, unit_om});
     else
-      handleIMSCvParam_(acc_om, name_om, val_om);
+      handleIMSCvParam_(acc_om, name_om, val_om, unit_om);
     // Fall through: MzMLHandler still processes MS:* terms below
   }
 
@@ -464,6 +516,10 @@ void ImzMLHandler::onEndElement(const char16_t* qname)
     // correspondingly named — but empty — FloatDataArray from the same CV term;
     // ImzMLInterceptConsumer fills it from the .ibd.
     else if (cur_array_.is_ext) cur_aux_metas_.push_back(cur_array_);
+    else
+    {
+      cur_inline_aux_names_.push_back(cur_array_.name.empty() ? cur_array_.accession : cur_array_.name);
+    }
 
     // For external (.ibd) arrays the inline <binary> is an empty placeholder, but the
     // base MzMLHandler captured this array's expected length from defaultArrayLength
@@ -511,6 +567,7 @@ void ImzMLHandler::onEndElement(const char16_t* qname)
       snap.mz_meta  = cur_mz_meta_;
       snap.int_meta = cur_int_meta_;
       snap.aux_meta = cur_aux_metas_;
+      snap.inline_aux_names = cur_inline_aux_names_;
       spec_ims_.push_back(snap);
     }
 
@@ -548,6 +605,7 @@ void ImzMLHandler::onEndElement(const char16_t* qname)
     cur_mz_meta_.reset();
     cur_int_meta_.reset();
     cur_aux_metas_.clear();
+    cur_inline_aux_names_.clear();
   }
 }
 
@@ -555,7 +613,8 @@ void ImzMLHandler::onEndElement(const char16_t* qname)
 // IMS CV dispatch
 // ===========================================================================
 
-void ImzMLHandler::handleIMSCvParam_(const std::string& acc, const std::string& /*name*/, const std::string& val)
+void ImzMLHandler::handleIMSCvParam_(const std::string& acc, const std::string& /*name*/, const std::string& val,
+                                     const std::string& unit_accession)
 {
   // Pixel coordinates (inside <scan> inside <spectrum>)
   if (in_scan_ && in_spectrum_)
@@ -580,7 +639,12 @@ void ImzMLHandler::handleIMSCvParam_(const std::string& acc, const std::string& 
     if (acc == "IMS:1000103") { cur_array_.count  = parseImsUInt64_(file_, acc, val); return; }
     if (acc == "IMS:1000104") { cur_array_.encoded_bytes = parseImsUInt64_(file_, acc, val); return; }
     if (acc == "MS:1000576") { cur_array_.compressed = false; return; }  // no compression
-    if (acc == "MS:1000574") { cur_array_.compressed = true;  return; }  // zlib compression
+    // Any other child of MS:1000572 (zlib, numpress, numpress+zlib, …) is compressed.
+    if (cv_.exists(acc) && cv_.isChildOf(acc, "MS:1000572"))
+    {
+      cur_array_.compressed = true;
+      return;
+    }
     // Array identity: only MS:1000786 / children of MS:1000513 (PSI binary data array).
     // Match MzMLHandler naming so FloatDataArray lookup uses the ontology name, not XML @name.
     if (acc == "MS:1000786")
@@ -590,12 +654,20 @@ void ImzMLHandler::handleIMSCvParam_(const std::string& acc, const std::string& 
       {
         cur_array_.name = val;
       }
+      if (!unit_accession.empty())
+      {
+        cur_array_.unit_accession = unit_accession;
+      }
       return;
     }
     if (cv_.exists(acc) && cv_.isChildOf(acc, "MS:1000513"))
     {
       cur_array_.accession = acc;
       cur_array_.name = cv_.getTerm(acc).name;
+      if (!unit_accession.empty())
+      {
+        cur_array_.unit_accession = unit_accession;
+      }
       return;
     }
     // Ignore other cvParams here (units, etc.) so they cannot overwrite the array name.
@@ -631,7 +703,7 @@ void ImzMLHandler::applyRefGroup_(const std::string& id)
   auto it = ref_groups_.find(id);
   if (it == ref_groups_.end()) return;
   for (const auto& cv : it->second)
-    handleIMSCvParam_(cv.accession, cv.name, cv.value);
+    handleIMSCvParam_(cv.accession, cv.name, cv.value, cv.unit_accession);
 }
 
 } // namespace Internal

--- a/src/openms/source/FORMAT/HANDLERS/ImzMLHandlerHelper.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ImzMLHandlerHelper.cpp
@@ -186,6 +186,86 @@ void ImzMLBinaryIO::readMzArray(FILE* ibd,
   }
 }
 
+namespace
+{
+  /// Shared float-typed .ibd array reader. @p context names the array in error messages.
+  void readFloatVector_(FILE* ibd,
+                        const uint64_t offset,
+                        const uint64_t count,
+                        const ImzMLSpectrumIndex::DataType dt,
+                        std::vector<float>& out,
+                        const std::string& ibd_path,
+                        const std::string& context)
+  {
+    out.clear();
+    if (!ibd || count == 0)
+    {
+      return;
+    }
+
+    validateCount_(count, ibd_path, context.c_str());
+
+    seekIbd_(ibd, offset, ibd_path, context.c_str());
+
+    out.resize(count);
+
+    switch (dt)
+    {
+      case ImzMLSpectrumIndex::DataType::FLOAT32:
+        if (fread(out.data(), 4, count, ibd) != count)
+        {
+          throwReadError_(ibd_path, "failed to read float32 " + context + " from .ibd");
+        }
+        decodeLittleEndian_(out.data(), count);
+        break;
+      case ImzMLSpectrumIndex::DataType::FLOAT64:
+      {
+        std::vector<double> tmp(count);
+        if (fread(tmp.data(), 8, count, ibd) != count)
+        {
+          throwReadError_(ibd_path, "failed to read float64 " + context + " from .ibd");
+        }
+        decodeLittleEndian_(tmp.data(), count);
+        for (Size i = 0; i < count; ++i)
+        {
+          out[i] = static_cast<float>(tmp[i]);
+        }
+        break;
+      }
+      case ImzMLSpectrumIndex::DataType::INT32:
+      {
+        std::vector<int32_t> tmp(count);
+        if (fread(tmp.data(), 4, count, ibd) != count)
+        {
+          throwReadError_(ibd_path, "failed to read int32 " + context + " from .ibd");
+        }
+        decodeLittleEndian_(tmp.data(), count);
+        for (Size i = 0; i < count; ++i)
+        {
+          out[i] = static_cast<float>(tmp[i]);
+        }
+        break;
+      }
+      case ImzMLSpectrumIndex::DataType::INT64:
+      {
+        std::vector<int64_t> tmp(count);
+        if (fread(tmp.data(), 8, count, ibd) != count)
+        {
+          throwReadError_(ibd_path, "failed to read int64 " + context + " from .ibd");
+        }
+        decodeLittleEndian_(tmp.data(), count);
+        for (Size i = 0; i < count; ++i)
+        {
+          out[i] = static_cast<float>(tmp[i]);
+        }
+        break;
+      }
+      default:
+        throwReadError_(ibd_path, "unsupported " + context + " data type in .ibd");
+    }
+  }
+} // namespace
+
 void ImzMLBinaryIO::readIntArray(FILE* ibd,
                                  const uint64_t offset,
                                  const uint64_t count,
@@ -193,72 +273,19 @@ void ImzMLBinaryIO::readIntArray(FILE* ibd,
                                  std::vector<float>& out,
                                  const std::string& ibd_path)
 {
-  out.clear();
-  if (!ibd || count == 0)
-  {
-    return;
-  }
+  readFloatVector_(ibd, offset, count, dt, out, ibd_path, "intensity array");
+}
 
-  validateCount_(count, ibd_path, "intensity array");
-
-  seekIbd_(ibd, offset, ibd_path, "intensity array");
-
-  out.resize(count);
-
-  switch (dt)
-  {
-    case ImzMLSpectrumIndex::DataType::FLOAT32:
-      if (fread(out.data(), 4, count, ibd) != count)
-      {
-        throwReadError_(ibd_path, "failed to read float32 intensity array from .ibd");
-      }
-      decodeLittleEndian_(out.data(), count);
-      break;
-    case ImzMLSpectrumIndex::DataType::FLOAT64:
-    {
-      std::vector<double> tmp(count);
-      if (fread(tmp.data(), 8, count, ibd) != count)
-      {
-        throwReadError_(ibd_path, "failed to read float64 intensity array from .ibd");
-      }
-      decodeLittleEndian_(tmp.data(), count);
-      for (Size i = 0; i < count; ++i)
-      {
-        out[i] = static_cast<float>(tmp[i]);
-      }
-      break;
-    }
-    case ImzMLSpectrumIndex::DataType::INT32:
-    {
-      std::vector<int32_t> tmp(count);
-      if (fread(tmp.data(), 4, count, ibd) != count)
-      {
-        throwReadError_(ibd_path, "failed to read int32 intensity array from .ibd");
-      }
-      decodeLittleEndian_(tmp.data(), count);
-      for (Size i = 0; i < count; ++i)
-      {
-        out[i] = static_cast<float>(tmp[i]);
-      }
-      break;
-    }
-    case ImzMLSpectrumIndex::DataType::INT64:
-    {
-      std::vector<int64_t> tmp(count);
-      if (fread(tmp.data(), 8, count, ibd) != count)
-      {
-        throwReadError_(ibd_path, "failed to read int64 intensity array from .ibd");
-      }
-      decodeLittleEndian_(tmp.data(), count);
-      for (Size i = 0; i < count; ++i)
-      {
-        out[i] = static_cast<float>(tmp[i]);
-      }
-      break;
-    }
-    default:
-      throwReadError_(ibd_path, "unsupported intensity array data type in .ibd");
-  }
+void ImzMLBinaryIO::readAuxArray(FILE* ibd,
+                                 const uint64_t offset,
+                                 const uint64_t count,
+                                 const ImzMLSpectrumIndex::DataType dt,
+                                 std::vector<float>& out,
+                                 const std::string& ibd_path,
+                                 const std::string& array_name)
+{
+  readFloatVector_(ibd, offset, count, dt, out, ibd_path,
+                   array_name.empty() ? std::string("auxiliary array") : array_name);
 }
 
 void ImzMLBinaryIO::writeFloat32Array(FILE* ibd,

--- a/src/openms/source/FORMAT/HANDLERS/ImzMLWriter.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ImzMLWriter.cpp
@@ -28,6 +28,7 @@
 #include <iomanip>
 #include <random>
 #include <sstream>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -73,10 +74,28 @@ namespace
     std::vector<AuxArrayWritePlan> aux;
   };
 
-  /// Map FloatDataArray names to PSI-MS binary-array CV terms (same strategy as MzMLHandler).
-  void resolveFloatArrayCv_(const std::string& array_name, std::string& accession, std::string& cv_name, bool& non_standard, std::string& unit_attrs)
+  /// PSI-MS identity of a FloatDataArray name, as written to the imzML XML.
+  struct ResolvedArrayCv
   {
-    unit_attrs.clear();
+    std::string accession;  ///< MS CV accession (or MS:1000786 for non-standard)
+    std::string cv_name;    ///< CV term name written to XML
+    std::string unit_attrs; ///< Optional unitAccession/unitName/unitCvRef attributes
+    bool non_standard {false};
+  };
+
+  /// Keyed by FloatDataArray name: the same names repeat for every spectrum, while
+  /// resolving one walks the whole MS:1000513 subtree.
+  using ArrayCvCache = std::unordered_map<std::string, ResolvedArrayCv>;
+
+  /// Map a FloatDataArray name to a PSI-MS binary-array CV term (same strategy as MzMLHandler).
+  const ResolvedArrayCv& resolveFloatArrayCv_(const std::string& array_name, ArrayCvCache& cache)
+  {
+    const auto cached = cache.find(array_name);
+    if (cached != cache.end())
+    {
+      return cached->second;
+    }
+
     const ControlledVocabulary& cv = ControlledVocabulary::getPSIMSCV();
     ControlledVocabulary::CVTerm match;
     auto searcher = [&match, &array_name, &cv](const std::string& child_id) {
@@ -89,11 +108,12 @@ namespace
       return false;
     };
     cv.iterateAllChildren("MS:1000513", searcher);
+
+    ResolvedArrayCv resolved;
     if (!match.id.empty())
     {
-      accession = match.id;
-      cv_name = match.name;
-      non_standard = false;
+      resolved.accession = match.id;
+      resolved.cv_name = match.name;
       // Write a unit only when the CV term allows exactly one. Several allowed
       // units (e.g. raw ion mobility array) are left unset rather than guessed.
       if (match.units.size() == 1)
@@ -102,16 +122,19 @@ namespace
         if (cv.exists(unit_id))
         {
           const ControlledVocabulary::CVTerm& unit_term = cv.getTerm(unit_id);
-          unit_attrs = "unitCvRef=\"" + StringUtils::prefix(unit_id, 2)
-                       + "\" unitAccession=\"" + unit_id
-                       + "\" unitName=\"" + XMLHandler::writeXMLEscape(unit_term.name) + "\"";
+          resolved.unit_attrs = "unitCvRef=\"" + StringUtils::prefix(unit_id, 2)
+                                + "\" unitAccession=\"" + unit_id
+                                + "\" unitName=\"" + XMLHandler::writeXMLEscape(unit_term.name) + "\"";
         }
       }
-      return;
     }
-    accession = "MS:1000786";
-    cv_name = "non-standard data array";
-    non_standard = true;
+    else
+    {
+      resolved.accession = "MS:1000786";
+      resolved.cv_name = "non-standard data array";
+      resolved.non_standard = true;
+    }
+    return cache.emplace(array_name, std::move(resolved)).first->second;
   }
 
   std::vector<float> floatDataArrayAsFloat_(const OpenMS::DataArrays::FloatDataArray& fda)
@@ -378,7 +401,8 @@ namespace
                                       const MSSpectrum& spec,
                                       SpectrumWritePlan& plan,
                                       uint64_t& offset,
-                                      const std::string& ibd_path)
+                                      const std::string& ibd_path,
+                                      ArrayCvCache& cv_cache)
   {
     plan.aux.clear();
     plan.aux.reserve(spec.getFloatDataArrays().size());
@@ -386,6 +410,11 @@ namespace
     {
       if (fda.empty())
       {
+        continue;
+      }
+      if (fda.getName().empty())
+      {
+        OPENMS_LOG_WARN << "Skipping unnamed FloatDataArray on imzML export\n";
         continue;
       }
       // Per-peak contract: aux length must match peak count (including both empty).
@@ -398,7 +427,11 @@ namespace
       }
       AuxArrayWritePlan aux;
       aux.array_name = fda.getName();
-      resolveFloatArrayCv_(aux.array_name, aux.accession, aux.cv_name, aux.non_standard, aux.unit_attrs);
+      const ResolvedArrayCv& resolved = resolveFloatArrayCv_(aux.array_name, cv_cache);
+      aux.accession = resolved.accession;
+      aux.cv_name = resolved.cv_name;
+      aux.unit_attrs = resolved.unit_attrs;
+      aux.non_standard = resolved.non_standard;
       aux.offset = offset;
       aux.count = fda.size();
       aux.encoded = aux.count * 4ULL; // FloatDataArray is always float32 on write
@@ -1104,6 +1137,8 @@ namespace
     os << "\n\t\t\t";
     writeCvParam_(os, "MS", mz_precision_acc, mz_precision_name);
     os << "\n\t\t\t";
+    writeCvParam_(os, "MS", "MS:1000576", "no compression");
+    os << "\n\t\t\t";
     writeCvParam_(os, "IMS", "IMS:1000101", "external data", "true");
     os << "\n";
     os << "\t\t</referenceableParamGroup>\n";
@@ -1112,6 +1147,8 @@ namespace
     writeCvParam_(os, "MS", "MS:1000515", "intensity array");
     os << "\n\t\t\t";
     writeCvParam_(os, "MS", int_precision_acc, int_precision_name);
+    os << "\n\t\t\t";
+    writeCvParam_(os, "MS", "MS:1000576", "no compression");
     os << "\n\t\t\t";
     writeCvParam_(os, "IMS", "IMS:1000101", "external data", "true");
     os << "\n";
@@ -1298,6 +1335,7 @@ void ImzMLWriter::store(const std::string& imzml_path,
     ensureUuidBytes_(meta, uuid_bytes);
     writeIbdUuidHeader_(ibd.get(), uuid_bytes, ibd_path);
 
+    ArrayCvCache cv_cache;
     if (continuous)
     {
       Size ref = 0;
@@ -1328,7 +1366,7 @@ void ImzMLWriter::store(const std::string& imzml_path,
         const std::vector<float> intensities = intensitiesAsFloat_(work[i]);
         writeIntArray_(ibd.get(), intensities, int_32_bit, ibd_path);
         current += plans[i].int_encoded;
-        appendAndWriteFloatDataArrays_(ibd.get(), work[i], plans[i], current, ibd_path);
+        appendAndWriteFloatDataArrays_(ibd.get(), work[i], plans[i], current, ibd_path, cv_cache);
       }
     }
     else
@@ -1349,7 +1387,7 @@ void ImzMLWriter::store(const std::string& imzml_path,
         writeMzArray_(ibd.get(), mzAsDouble_(work[i]), mz_32_bit, ibd_path);
         const std::vector<float> intensities = intensitiesAsFloat_(work[i]);
         writeIntArray_(ibd.get(), intensities, int_32_bit, ibd_path);
-        appendAndWriteFloatDataArrays_(ibd.get(), work[i], plans[i], offset, ibd_path);
+        appendAndWriteFloatDataArrays_(ibd.get(), work[i], plans[i], offset, ibd_path, cv_cache);
       }
     }
 

--- a/src/openms/source/FORMAT/HANDLERS/ImzMLWriter.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ImzMLWriter.cpp
@@ -425,9 +425,19 @@ namespace
                         << " != spectrum peak count " << spec.size() << "\n";
         continue;
       }
+      const ResolvedArrayCv& resolved = resolveFloatArrayCv_(fda.getName(), cv_cache);
+      // MS:1000514 / MS:1000515 are children of MS:1000513, so an array named after the
+      // peak CV terms resolves to their accession. Written out, it becomes a second
+      // m/z (or intensity) binaryDataArray whose offset and type replace the real peak
+      // metadata on read (last cvParam wins), silently corrupting the spectrum.
+      if (resolved.accession == "MS:1000514" || resolved.accession == "MS:1000515")
+      {
+        OPENMS_LOG_WARN << "Skipping FloatDataArray '" << fda.getName()
+                        << "' on imzML export: the name is reserved for the peak arrays\n";
+        continue;
+      }
       AuxArrayWritePlan aux;
       aux.array_name = fda.getName();
-      const ResolvedArrayCv& resolved = resolveFloatArrayCv_(aux.array_name, cv_cache);
       aux.accession = resolved.accession;
       aux.cv_name = resolved.cv_name;
       aux.unit_attrs = resolved.unit_attrs;

--- a/src/openms/source/FORMAT/HANDLERS/ImzMLWriter.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ImzMLWriter.cpp
@@ -9,8 +9,10 @@
 #include <OpenMS/FORMAT/HANDLERS/ImzMLWriter.h>
 
 #include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/VersionInfo.h>
 #include <OpenMS/DATASTRUCTURES/DRange.h>
+#include <OpenMS/FORMAT/ControlledVocabulary.h>
 #include <OpenMS/FORMAT/HANDLERS/ImzMLHandlerHelper.h>
 #include <OpenMS/FORMAT/HANDLERS/XMLHandler.h>
 #include <OpenMS/FORMAT/OPTIONS/PeakFileOptions.h>
@@ -46,6 +48,18 @@ namespace
     uint32_t z {1};
   };
 
+  struct AuxArrayWritePlan
+  {
+    std::string accession; ///< MS CV accession (or MS:1000786 for non-standard)
+    std::string cv_name;   ///< CV term name written to XML
+    std::string array_name; ///< Original FloatDataArray::getName() (value for MS:1000786)
+    std::string unit_attrs; ///< Optional unitAccession/unitName/unitCvRef attributes
+    bool non_standard {false};
+    uint64_t offset {0};
+    uint64_t count {0};
+    uint64_t encoded {0};
+  };
+
   struct SpectrumWritePlan
   {
     PixelCoord pixel;
@@ -56,7 +70,53 @@ namespace
     uint64_t int_count {0};
     uint64_t int_encoded {0};
     bool share_mz {false};
+    std::vector<AuxArrayWritePlan> aux;
   };
+
+  /// Map FloatDataArray names to PSI-MS binary-array CV terms (same strategy as MzMLHandler).
+  void resolveFloatArrayCv_(const std::string& array_name, std::string& accession, std::string& cv_name, bool& non_standard, std::string& unit_attrs)
+  {
+    unit_attrs.clear();
+    const ControlledVocabulary& cv = ControlledVocabulary::getPSIMSCV();
+    ControlledVocabulary::CVTerm match;
+    auto searcher = [&match, &array_name, &cv](const std::string& child_id) {
+      const ControlledVocabulary::CVTerm& current = cv.getTerm(child_id);
+      if (current.name == array_name)
+      {
+        match = current;
+        return true;
+      }
+      return false;
+    };
+    cv.iterateAllChildren("MS:1000513", searcher);
+    if (!match.id.empty())
+    {
+      accession = match.id;
+      cv_name = match.name;
+      non_standard = false;
+      if (match.units.contains("MS:1002814"))
+      {
+        unit_attrs = "unitCvRef=\"MS\" unitAccession=\"MS:1002814\" unitName=\"volt-second per square centimeter\"";
+      }
+      else if (match.units.contains("UO:0000028"))
+      {
+        unit_attrs = "unitCvRef=\"UO\" unitAccession=\"UO:0000028\" unitName=\"millisecond\"";
+      }
+      else if (match.units.contains("UO:0000324"))
+      {
+        unit_attrs = "unitCvRef=\"UO\" unitAccession=\"UO:0000324\" unitName=\"square angstrom\"";
+      }
+      return;
+    }
+    accession = "MS:1000786";
+    cv_name = "non-standard data array";
+    non_standard = true;
+  }
+
+  std::vector<float> floatDataArrayAsFloat_(const OpenMS::DataArrays::FloatDataArray& fda)
+  {
+    return std::vector<float>(fda.begin(), fda.end());
+  }
 
   std::string inferIbdPath_(const std::string& imzml_path)
   {
@@ -311,6 +371,41 @@ namespace
   uint64_t elementByteSize_(const bool use_32_bit)
   {
     return use_32_bit ? 4ULL : 8ULL;
+  }
+
+  void appendAndWriteFloatDataArrays_(FILE* ibd,
+                                      const MSSpectrum& spec,
+                                      SpectrumWritePlan& plan,
+                                      uint64_t& offset,
+                                      const std::string& ibd_path)
+  {
+    plan.aux.clear();
+    plan.aux.reserve(spec.getFloatDataArrays().size());
+    for (const auto& fda : spec.getFloatDataArrays())
+    {
+      if (fda.empty())
+      {
+        continue;
+      }
+      // Per-peak contract: aux length must match peak count (including both empty).
+      if (fda.size() != spec.size())
+      {
+        OPENMS_LOG_WARN << "Skipping FloatDataArray '" << fda.getName()
+                        << "' on imzML export: length " << fda.size()
+                        << " != spectrum peak count " << spec.size() << "\n";
+        continue;
+      }
+      AuxArrayWritePlan aux;
+      aux.array_name = fda.getName();
+      resolveFloatArrayCv_(aux.array_name, aux.accession, aux.cv_name, aux.non_standard, aux.unit_attrs);
+      aux.offset = offset;
+      aux.count = fda.size();
+      aux.encoded = aux.count * 4ULL; // FloatDataArray is always float32 on write
+      const std::vector<float> values = floatDataArrayAsFloat_(fda);
+      ImzMLBinaryIO::writeFloat32Array(ibd, values.data(), values.size(), ibd_path);
+      offset += aux.encoded;
+      plan.aux.push_back(std::move(aux));
+    }
   }
 
   void writeMzArray_(FILE* ibd,
@@ -898,6 +993,40 @@ namespace
     os << pad << "</binaryDataArray>\n";
   }
 
+  /// Write an auxiliary FloatDataArray (e.g. ion mobility) as an external binaryDataArray.
+  /// Uses inline CV terms (no referenceableParamGroup) so arbitrary array names round-trip.
+  void writeExternalAuxBinaryArray_(std::ostream& os,
+                                    const AuxArrayWritePlan& aux,
+                                    int indent)
+  {
+    const std::string pad(indent, '\t');
+    os << pad << "<binaryDataArray encodedLength=\"0\">\n";
+    os << pad << "\t";
+    writeCvParam_(os, "MS", "MS:1000576", "no compression");
+    os << "\n" << pad << "\t";
+    writeCvParam_(os, "MS", "MS:1000521", "32-bit float");
+    os << "\n" << pad << "\t";
+    writeCvParam_(os, "IMS", "IMS:1000101", "external data", "true");
+    os << "\n" << pad << "\t";
+    if (aux.non_standard)
+    {
+      writeCvParam_(os, "MS", aux.accession, aux.cv_name, aux.array_name, aux.unit_attrs);
+    }
+    else
+    {
+      writeCvParam_(os, "MS", aux.accession, aux.cv_name, "", aux.unit_attrs);
+    }
+    os << "\n" << pad << "\t";
+    writeCvParam_(os, "IMS", "IMS:1000102", "external offset", OpenMS::StringConversions::toString(aux.offset));
+    os << "\n" << pad << "\t";
+    writeCvParam_(os, "IMS", "IMS:1000103", "external array length", OpenMS::StringConversions::toString(aux.count));
+    os << "\n" << pad << "\t";
+    writeCvParam_(os, "IMS", "IMS:1000104", "external encoded length", OpenMS::StringConversions::toString(aux.encoded));
+    os << "\n";
+    os << pad << "\t<binary/>\n";
+    os << pad << "</binaryDataArray>\n";
+  }
+
   void writeImzMLXml_(const std::string& imzml_path,
                       const MSExperiment& exp,
                       const ImzMLMeta& meta,
@@ -1097,9 +1226,13 @@ namespace
       os << "\n";
       os << "\t\t\t\t\t</scan>\n";
       os << "\t\t\t\t</scanList>\n";
-      os << "\t\t\t\t<binaryDataArrayList count=\"2\">\n";
+      os << "\t\t\t\t<binaryDataArrayList count=\"" << (2 + plan.aux.size()) << "\">\n";
       writeExternalBinaryArray_(os, "mzArray", plan.mz_offset, plan.mz_count, plan.mz_encoded, 4);
       writeExternalBinaryArray_(os, "intensityArray", plan.int_offset, plan.int_count, plan.int_encoded, 4);
+      for (const auto& aux : plan.aux)
+      {
+        writeExternalAuxBinaryArray_(os, aux, 4);
+      }
       os << "\t\t\t\t</binaryDataArrayList>\n";
       os << "\t\t\t</spectrum>\n";
     }
@@ -1194,6 +1327,7 @@ void ImzMLWriter::store(const std::string& imzml_path,
         const std::vector<float> intensities = intensitiesAsFloat_(work[i]);
         writeIntArray_(ibd.get(), intensities, int_32_bit, ibd_path);
         current += plans[i].int_encoded;
+        appendAndWriteFloatDataArrays_(ibd.get(), work[i], plans[i], current, ibd_path);
       }
     }
     else
@@ -1214,6 +1348,7 @@ void ImzMLWriter::store(const std::string& imzml_path,
         writeMzArray_(ibd.get(), mzAsDouble_(work[i]), mz_32_bit, ibd_path);
         const std::vector<float> intensities = intensitiesAsFloat_(work[i]);
         writeIntArray_(ibd.get(), intensities, int_32_bit, ibd_path);
+        appendAndWriteFloatDataArrays_(ibd.get(), work[i], plans[i], offset, ibd_path);
       }
     }
 

--- a/src/openms/source/FORMAT/HANDLERS/ImzMLWriter.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ImzMLWriter.cpp
@@ -94,17 +94,18 @@ namespace
       accession = match.id;
       cv_name = match.name;
       non_standard = false;
-      if (match.units.contains("MS:1002814"))
+      // Write a unit only when the CV term allows exactly one. Several allowed
+      // units (e.g. raw ion mobility array) are left unset rather than guessed.
+      if (match.units.size() == 1)
       {
-        unit_attrs = "unitCvRef=\"MS\" unitAccession=\"MS:1002814\" unitName=\"volt-second per square centimeter\"";
-      }
-      else if (match.units.contains("UO:0000028"))
-      {
-        unit_attrs = "unitCvRef=\"UO\" unitAccession=\"UO:0000028\" unitName=\"millisecond\"";
-      }
-      else if (match.units.contains("UO:0000324"))
-      {
-        unit_attrs = "unitCvRef=\"UO\" unitAccession=\"UO:0000324\" unitName=\"square angstrom\"";
+        const std::string unit_id = *match.units.begin();
+        if (cv.exists(unit_id))
+        {
+          const ControlledVocabulary::CVTerm& unit_term = cv.getTerm(unit_id);
+          unit_attrs = "unitCvRef=\"" + StringUtils::prefix(unit_id, 2)
+                       + "\" unitAccession=\"" + unit_id
+                       + "\" unitName=\"" + XMLHandler::writeXMLEscape(unit_term.name) + "\"";
+        }
       }
       return;
     }

--- a/src/openms/source/IONMOBILITY/IMDataConverter.cpp
+++ b/src/openms/source/IONMOBILITY/IMDataConverter.cpp
@@ -330,24 +330,10 @@ namespace OpenMS
   bool IMDataConverter::getIMUnit(const DataArrays::FloatDataArray& fda, DriftTimeUnit& unit)
   {
     const auto& cv = ControlledVocabulary::getPSIMSCV();
-    if (StringUtils::hasPrefix(fda.getName(), Constants::UserParam::ION_MOBILITY) ||
-        StringUtils::hasPrefix(fda.getName(), Constants::UserParam::INVERSE_REDUCED_ION_MOBILITY) ||
-        StringUtils::hasPrefix(fda.getName(), Constants::UserParam::MEAN_INVERSE_REDUCED_ION_MOBILITY_ARRAY))
-    { // fallback for non-standard IM arrays (as created by Mobi-DIK, "Ion Mobility Centroid" from PeakPickerIM, "inverse reduced ion mobility" from MSConvert, or "mean inverse reduced ion mobility array" from Bruker)
-      if (StringUtils::hasSubstring(fda.getName(), "MS:1002815") || StringUtils::hasSubstring(fda.getName(), "MS:1003006"))
-      {
-        unit = DriftTimeUnit::VSSC;
-      }
-      else if (StringUtils::hasSubstring(fda.getName(), "MS:1002954"))
-      {
-        unit = DriftTimeUnit::CCS;
-      }
-      else
-      {
-        unit = DriftTimeUnit::MILLISECOND;
-      }
-      return true;
-    }
+
+    // Prefer PSI-MS ontology lookup so official names (e.g. MS:1003006
+    // "mean inverse reduced ion mobility array") get the CV unit (1/K0 = VSSC),
+    // not the UserParam fallback that defaulted them to milliseconds.
     try
     {
       const auto& cv_term = cv.getTermByName(fda.getName()); // may throw if term is unknown
@@ -376,6 +362,32 @@ namespace OpenMS
     }
     catch (...)
     {
+    }
+
+    // Fallbacks for non-standard / vendor UserParam names
+    // (Mobi-DIK "Ion Mobility", MSConvert "inverse reduced ion mobility", …).
+    if (StringUtils::hasPrefix(fda.getName(), Constants::UserParam::MEAN_INVERSE_REDUCED_ION_MOBILITY_ARRAY) ||
+        StringUtils::hasPrefix(fda.getName(), Constants::UserParam::INVERSE_REDUCED_ION_MOBILITY))
+    {
+      // These names denote 1/K0 (Vs/cm^2), not drift time in ms.
+      unit = DriftTimeUnit::VSSC;
+      return true;
+    }
+    if (StringUtils::hasPrefix(fda.getName(), Constants::UserParam::ION_MOBILITY))
+    {
+      if (StringUtils::hasSubstring(fda.getName(), "MS:1002815") || StringUtils::hasSubstring(fda.getName(), "MS:1003006"))
+      {
+        unit = DriftTimeUnit::VSSC;
+      }
+      else if (StringUtils::hasSubstring(fda.getName(), "MS:1002954"))
+      {
+        unit = DriftTimeUnit::CCS;
+      }
+      else
+      {
+        unit = DriftTimeUnit::MILLISECOND;
+      }
+      return true;
     }
     return false;
   }

--- a/src/openms/source/IONMOBILITY/IMDataConverter.cpp
+++ b/src/openms/source/IONMOBILITY/IMDataConverter.cpp
@@ -334,34 +334,29 @@ namespace OpenMS
     // Prefer PSI-MS ontology lookup so official names (e.g. MS:1003006
     // "mean inverse reduced ion mobility array") get the CV unit (1/K0 = VSSC),
     // not the UserParam fallback that defaulted them to milliseconds.
-    try
+    // Unknown names yield nullptr, so non-CV arrays cost no exception here —
+    // this runs for every float array of every spectrum/pixel.
+    const ControlledVocabulary::CVTerm* cv_term = cv.checkAndGetTermByName(fda.getName());
+    if (cv_term != nullptr && cv.isChildOf(cv_term->id, "MS:1002893")) // child of generic 'ion mobility array'?
     {
-      const auto& cv_term = cv.getTermByName(fda.getName()); // may throw if term is unknown
-
-      if (cv.isChildOf(cv_term.id, "MS:1002893")) // is child of generic 'ion mobility array'?
-      {
-        if (cv_term.units.contains("MS:1002814"))
-        { // MS:1002814 ! volt-second per square centimeter
-          unit = DriftTimeUnit::VSSC;
-        }
-        else if (cv_term.units.contains("UO:0000028"))
-        { // UO:0000028 ! millisecond
-          unit = DriftTimeUnit::MILLISECOND;
-        }
-        else if (cv_term.units.contains("UO:0000324"))
-        { // UO:0000324 ! square angstrom (CCS)
-          unit = DriftTimeUnit::CCS;
-        }
-        else
-        { // fallback
-          OPENMS_LOG_WARN << "Warning: FloatDataArray for IonMobility data '" << cv_term.id << " " << cv_term.name << "' does not contain proper units!" << std::endl;
-          unit = DriftTimeUnit::NONE;
-        }
-        return true;
+      if (cv_term->units.contains("MS:1002814"))
+      { // MS:1002814 ! volt-second per square centimeter
+        unit = DriftTimeUnit::VSSC;
       }
-    }
-    catch (...)
-    {
+      else if (cv_term->units.contains("UO:0000028"))
+      { // UO:0000028 ! millisecond
+        unit = DriftTimeUnit::MILLISECOND;
+      }
+      else if (cv_term->units.contains("UO:0000324"))
+      { // UO:0000324 ! square angstrom (CCS)
+        unit = DriftTimeUnit::CCS;
+      }
+      else
+      { // fallback
+        OPENMS_LOG_WARN << "Warning: FloatDataArray for IonMobility data '" << cv_term->id << " " << cv_term->name << "' does not contain proper units!" << std::endl;
+        unit = DriftTimeUnit::NONE;
+      }
+      return true;
     }
 
     // Fallbacks for non-standard / vendor UserParam names

--- a/src/openms/source/KERNEL/OnDiscImzMLExperiment.cpp
+++ b/src/openms/source/KERNEL/OnDiscImzMLExperiment.cpp
@@ -130,6 +130,14 @@ struct OnDiscImzMLExperiment::Impl
                         << "): length " << aux.length << " != peak count " << n << "\n";
         continue;
       }
+      if (aux.type == ImzMLSpectrumIndex::DataType::UNKNOWN)
+      { // no MS:1000521/1000523/1000519/1000522 on this array: skip it rather than
+        // abort the read, matching the warn-and-skip policy for other bad aux arrays
+        OPENMS_LOG_WARN << "Skipping auxiliary array '" << aux.name << "' at pixel ("
+                        << e.x << "," << e.y << "," << e.z
+                        << "): missing or unsupported binary data type\n";
+        continue;
+      }
       std::vector<float> values;
       ImzMLBinaryIO::readAuxArray(ibd_, aux.offset, aux.length, aux.type, values, ibd_path_, aux.name);
       if (values.empty())

--- a/src/openms/source/KERNEL/OnDiscImzMLExperiment.cpp
+++ b/src/openms/source/KERNEL/OnDiscImzMLExperiment.cpp
@@ -14,6 +14,7 @@
 #include <OpenMS/IMAGING/IonImageExtraction.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/IONMOBILITY/IMTypes.h>
 
 #include <cmath>
 #include <cstdio>
@@ -62,6 +63,13 @@ struct OnDiscImzMLExperiment::Impl
     s.setMetaValue("imzml:x", static_cast<Int>(e.x));
     s.setMetaValue("imzml:y", static_cast<Int>(e.y));
     s.setMetaValue("imzml:z", static_cast<Int>(e.z));
+
+    if (e.mz_compressed || e.int_compressed)
+    {
+      throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, ibd_path_,
+        "zlib-compressed external m/z or intensity arrays are not supported "
+        "(need IMS:1000104 + inflate). Re-export without compression.");
+    }
 
     std::vector<double> mz_vec = readMz_(e);
     std::vector<float> int_vec = readInt_(e);
@@ -118,6 +126,13 @@ struct OnDiscImzMLExperiment::Impl
       auto& fda = s.getFloatDataArrays().emplace_back();
       fda.setName(aux.name);
       fda.assign(values.begin(), values.end());
+    }
+
+    // Same default as MzMLHandler / ImzMLInterceptConsumer: per-peak IM from the
+    // .ibd is profile data unless a later centroiding step marks it otherwise.
+    if (s.containsIMData() && s.getIMPeakType() == IMPeakType::UNKNOWN)
+    {
+      s.setIMPeakType(IMPeakType::IM_PROFILE);
     }
 
     s.sortByPosition();

--- a/src/openms/source/KERNEL/OnDiscImzMLExperiment.cpp
+++ b/src/openms/source/KERNEL/OnDiscImzMLExperiment.cpp
@@ -56,19 +56,16 @@ struct OnDiscImzMLExperiment::Impl
     ImzMLFile::buildImagingGeometry(index_, meta_, geometry_);
   }
 
-  MSSpectrum decodeSpectrum(std::size_t i) const
+  // Decode m/z and intensity into 's'. Deliberately does not sort: callers attach
+  // auxiliary arrays first and sort afterwards, so FloatDataArrays stay aligned
+  // with peak order.
+  void decodePeaksInto_(const ImzMLSpectrumIndex& e, MSSpectrum& s) const
   {
-    const ImzMLSpectrumIndex& e = index_[i];
-    MSSpectrum s;
-    s.setMetaValue("imzml:x", static_cast<Int>(e.x));
-    s.setMetaValue("imzml:y", static_cast<Int>(e.y));
-    s.setMetaValue("imzml:z", static_cast<Int>(e.z));
-
     if (e.mz_compressed || e.int_compressed)
     {
       throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, ibd_path_,
-        "zlib-compressed external m/z or intensity arrays are not supported "
-        "(need IMS:1000104 + inflate). Re-export without compression.");
+        "Compressed external m/z or intensity arrays are not supported "
+        "(need uncompressed MS:1000576). Re-export without compression.");
     }
 
     std::vector<double> mz_vec = readMz_(e);
@@ -94,6 +91,18 @@ struct OnDiscImzMLExperiment::Impl
       s[k].setMZ(mz_vec[k]);
       s[k].setIntensity(int_vec[k]);
     }
+  }
+
+  MSSpectrum decodeSpectrum(std::size_t i) const
+  {
+    const ImzMLSpectrumIndex& e = index_[i];
+    MSSpectrum s;
+    s.setMetaValue("imzml:x", static_cast<Int>(e.x));
+    s.setMetaValue("imzml:y", static_cast<Int>(e.y));
+    s.setMetaValue("imzml:z", static_cast<Int>(e.z));
+
+    decodePeaksInto_(e, s);
+    const std::size_t n = s.size();
 
     // Attach auxiliary external arrays (ion mobility, …) before sortByPosition
     // so FloatDataArrays stay aligned with peak order.
@@ -106,7 +115,7 @@ struct OnDiscImzMLExperiment::Impl
       if (aux.compressed)
       {
         throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, ibd_path_,
-          "zlib-compressed external auxiliary array '" + aux.name
+          "Compressed external auxiliary array '" + aux.name
           + "' is not supported (IMS:1000104 encoded length="
           + StringConversions::toString(aux.encoded_bytes) + ")");
       }
@@ -129,6 +138,10 @@ struct OnDiscImzMLExperiment::Impl
       }
       auto& fda = s.getFloatDataArrays().emplace_back();
       fda.setName(aux.name);
+      if (!aux.unit_accession.empty())
+      {
+        fda.setMetaValue("unit_accession", aux.unit_accession);
+      }
       fda.assign(values.begin(), values.end());
     }
 
@@ -139,6 +152,17 @@ struct OnDiscImzMLExperiment::Impl
       s.setIMPeakType(IMPeakType::IM_PROFILE);
     }
 
+    s.sortByPosition();
+    return s;
+  }
+
+  // Ion image extraction only sums intensities inside an m/z window (via
+  // MZBegin/MZEnd), so skip the auxiliary array reads and the pixel MetaValues
+  // that decodeSpectrum() has to produce.
+  MSSpectrum decodePeaks(std::size_t i) const
+  {
+    MSSpectrum s;
+    decodePeaksInto_(index_[i], s);
     s.sortByPosition();
     return s;
   }
@@ -287,7 +311,7 @@ IonImage OnDiscImzMLExperiment::extractIonImage(double mz, double tolerance_ppm)
   std::vector<Size> all(pimpl_->geometry_.getNumberOfPixels());
   std::iota(all.begin(), all.end(), Size(0));
   return Internal::extractIonImage(pimpl_->geometry_, mz, tolerance_ppm, all, pimpl_->index_.size(),
-                                   [this](Size i) -> MSSpectrum { return pimpl_->decodeSpectrum(i); });
+                                   [this](Size i) -> MSSpectrum { return pimpl_->decodePeaks(i); });
 }
 
 IonImage OnDiscImzMLExperiment::extractIonImage(double mz, double tolerance_ppm, Size region_id) const
@@ -298,7 +322,7 @@ IonImage OnDiscImzMLExperiment::extractIonImage(double mz, double tolerance_ppm,
   // getRegionPixels throws Exception::ElementNotFound for an unknown region_id.
   const std::vector<Size> region = pimpl_->geometry_.getRegionPixels(region_id);
   return Internal::extractIonImage(pimpl_->geometry_, mz, tolerance_ppm, region, pimpl_->index_.size(),
-                                   [this](Size i) -> MSSpectrum { return pimpl_->decodeSpectrum(i); });
+                                   [this](Size i) -> MSSpectrum { return pimpl_->decodePeaks(i); });
 }
 
 const MSImagingGeometry& OnDiscImzMLExperiment::getGeometry() const

--- a/src/openms/source/KERNEL/OnDiscImzMLExperiment.cpp
+++ b/src/openms/source/KERNEL/OnDiscImzMLExperiment.cpp
@@ -99,7 +99,7 @@ struct OnDiscImzMLExperiment::Impl
     // so FloatDataArrays stay aligned with peak order.
     for (const ImzMLSpectrumIndex::AuxArray& aux : e.aux)
     {
-      if (aux.name.empty() || aux.length == 0)
+      if (aux.name.empty())
       {
         continue;
       }
@@ -110,7 +110,11 @@ struct OnDiscImzMLExperiment::Impl
           + "' is not supported (IMS:1000104 encoded length="
           + StringConversions::toString(aux.encoded_bytes) + ")");
       }
-      if (n > 0 && aux.length != n)
+      if (aux.length == 0)
+      {
+        continue;
+      }
+      if (aux.length != n)
       {
         OPENMS_LOG_WARN << "Skipping auxiliary array '" << aux.name << "' at pixel ("
                         << e.x << "," << e.y << "," << e.z

--- a/src/openms/source/KERNEL/OnDiscImzMLExperiment.cpp
+++ b/src/openms/source/KERNEL/OnDiscImzMLExperiment.cpp
@@ -13,6 +13,7 @@
 #include <OpenMS/IMAGING/IonImage.h>
 #include <OpenMS/IMAGING/IonImageExtraction.h>
 #include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/LogStream.h>
 
 #include <cmath>
 #include <cstdio>
@@ -85,6 +86,40 @@ struct OnDiscImzMLExperiment::Impl
       s[k].setMZ(mz_vec[k]);
       s[k].setIntensity(int_vec[k]);
     }
+
+    // Attach auxiliary external arrays (ion mobility, …) before sortByPosition
+    // so FloatDataArrays stay aligned with peak order.
+    for (const ImzMLSpectrumIndex::AuxArray& aux : e.aux)
+    {
+      if (aux.name.empty() || aux.length == 0)
+      {
+        continue;
+      }
+      if (aux.compressed)
+      {
+        throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, ibd_path_,
+          "zlib-compressed external auxiliary array '" + aux.name
+          + "' is not supported (IMS:1000104 encoded length="
+          + StringConversions::toString(aux.encoded_bytes) + ")");
+      }
+      if (n > 0 && aux.length != n)
+      {
+        OPENMS_LOG_WARN << "Skipping auxiliary array '" << aux.name << "' at pixel ("
+                        << e.x << "," << e.y << "," << e.z
+                        << "): length " << aux.length << " != peak count " << n << "\n";
+        continue;
+      }
+      std::vector<float> values;
+      ImzMLBinaryIO::readAuxArray(ibd_, aux.offset, aux.length, aux.type, values, ibd_path_, aux.name);
+      if (values.empty())
+      {
+        continue;
+      }
+      auto& fda = s.getFloatDataArrays().emplace_back();
+      fda.setName(aux.name);
+      fda.assign(values.begin(), values.end());
+    }
+
     s.sortByPosition();
     return s;
   }

--- a/src/pyOpenMS/bindings/bind_format.cpp
+++ b/src/pyOpenMS/bindings/bind_format.cpp
@@ -803,9 +803,11 @@ by isobar to load quantification results
         .def_ro("mz_offset", &OpenMS::ImzMLSpectrumIndex::mz_offset)
         .def_ro("mz_length", &OpenMS::ImzMLSpectrumIndex::mz_length)
         .def_ro("mz_type", &OpenMS::ImzMLSpectrumIndex::mz_type)
+        .def_ro("mz_compressed", &OpenMS::ImzMLSpectrumIndex::mz_compressed)
         .def_ro("int_offset", &OpenMS::ImzMLSpectrumIndex::int_offset)
         .def_ro("int_length", &OpenMS::ImzMLSpectrumIndex::int_length)
         .def_ro("int_type", &OpenMS::ImzMLSpectrumIndex::int_type)
+        .def_ro("int_compressed", &OpenMS::ImzMLSpectrumIndex::int_compressed)
         .def_ro("aux", &OpenMS::ImzMLSpectrumIndex::aux);
 
     // -----------------------------------------------------------------------

--- a/src/pyOpenMS/bindings/bind_format.cpp
+++ b/src/pyOpenMS/bindings/bind_format.cpp
@@ -787,6 +787,7 @@ by isobar to load quantification results
         .def(nb::init<>())
         .def_ro("name", &OpenMS::ImzMLSpectrumIndex::AuxArray::name)
         .def_ro("accession", &OpenMS::ImzMLSpectrumIndex::AuxArray::accession)
+        .def_ro("unit_accession", &OpenMS::ImzMLSpectrumIndex::AuxArray::unit_accession)
         .def_ro("offset", &OpenMS::ImzMLSpectrumIndex::AuxArray::offset)
         .def_ro("length", &OpenMS::ImzMLSpectrumIndex::AuxArray::length)
         .def_ro("encoded_bytes", &OpenMS::ImzMLSpectrumIndex::AuxArray::encoded_bytes)

--- a/src/pyOpenMS/bindings/bind_format.cpp
+++ b/src/pyOpenMS/bindings/bind_format.cpp
@@ -782,8 +782,19 @@ by isobar to load quantification results
         .def_ro("line_scan_direction", &OpenMS::ImzMLMeta::line_scan_direction)
         .def_ro("polarity", &OpenMS::ImzMLMeta::polarity);
 
+    nb::class_<OpenMS::ImzMLSpectrumIndex::AuxArray>(m, "ImzMLAuxArrayIndex",
+        "Index entry for one auxiliary (non-m/z/intensity) external .ibd array, e.g. ion mobility")
+        .def(nb::init<>())
+        .def_ro("name", &OpenMS::ImzMLSpectrumIndex::AuxArray::name)
+        .def_ro("accession", &OpenMS::ImzMLSpectrumIndex::AuxArray::accession)
+        .def_ro("offset", &OpenMS::ImzMLSpectrumIndex::AuxArray::offset)
+        .def_ro("length", &OpenMS::ImzMLSpectrumIndex::AuxArray::length)
+        .def_ro("encoded_bytes", &OpenMS::ImzMLSpectrumIndex::AuxArray::encoded_bytes)
+        .def_ro("type", &OpenMS::ImzMLSpectrumIndex::AuxArray::type)
+        .def_ro("compressed", &OpenMS::ImzMLSpectrumIndex::AuxArray::compressed);
+
     nb::class_<OpenMS::ImzMLSpectrumIndex>(m, "ImzMLSpectrumIndex",
-        "Per-spectrum .ibd byte-offset index entry for on-disc imzML access")
+        "Per-spectrum .ibd byte-offset index entry for on-disc imzML access (includes optional aux/IM arrays)")
         .def(nb::init<>())
         .def_ro("index", &OpenMS::ImzMLSpectrumIndex::index)
         .def_ro("x", &OpenMS::ImzMLSpectrumIndex::x)
@@ -794,7 +805,8 @@ by isobar to load quantification results
         .def_ro("mz_type", &OpenMS::ImzMLSpectrumIndex::mz_type)
         .def_ro("int_offset", &OpenMS::ImzMLSpectrumIndex::int_offset)
         .def_ro("int_length", &OpenMS::ImzMLSpectrumIndex::int_length)
-        .def_ro("int_type", &OpenMS::ImzMLSpectrumIndex::int_type);
+        .def_ro("int_type", &OpenMS::ImzMLSpectrumIndex::int_type)
+        .def_ro("aux", &OpenMS::ImzMLSpectrumIndex::aux);
 
     // -----------------------------------------------------------------------
     // ImzMLFile

--- a/src/pyOpenMS/tests/unittests/test_ImzMLFile.py
+++ b/src/pyOpenMS/tests/unittests/test_ImzMLFile.py
@@ -447,6 +447,79 @@ class TestImzMLFile(unittest.TestCase):
             if os.path.isfile(ibd_path):
                 os.remove(ibd_path)
 
+    def test_store_load_ion_mobility_float_data_array(self):
+        """Per-peak IM FloatDataArray (MS:1003006) round-trips for in-memory and OnDisc load."""
+        import tempfile
+
+        exp = pyopenms.MSExperiment()
+        spec = self._make_pixel_spectrum(1, 1, 100.0, 10.0)
+        p2 = pyopenms.Peak1D()
+        p2.setMZ(200.0)
+        p2.setIntensity(20.0)
+        spec.push_back(p2)
+
+        im = pyopenms.FloatDataArray()
+        im.setName("mean inverse reduced ion mobility array")
+        im.push_back(0.85)
+        im.push_back(1.15)
+        custom = pyopenms.FloatDataArray()
+        custom.setName("my custom SNR")
+        custom.push_back(3.0)
+        custom.push_back(4.5)
+        spec.setFloatDataArrays([im, custom])
+        exp.addSpectrum(spec)
+        exp.setMetaValue("imzml:imaging_mode", "processed")
+
+        with tempfile.NamedTemporaryFile(suffix=".imzML", delete=False) as tmp:
+            out_path = tmp.name
+        try:
+            pyopenms.ImzMLFile().store(out_path, exp)
+
+            img = pyopenms.MSImagingExperiment()
+            pyopenms.ImzMLFile().load(out_path, img)
+            loaded = img.getMSExperiment().getSpectrum(0)
+            self.assertTrue(loaded.containsIMData())
+            self.assertEqual(len(loaded.getFloatDataArrays()), 2)
+            loaded_by_name = {a.getName(): a for a in loaded.getFloatDataArrays()}
+            self.assertIn("mean inverse reduced ion mobility array", loaded_by_name)
+            self.assertIn("my custom SNR", loaded_by_name)
+            im_idx, unit = loaded.getIMData()
+            self.assertEqual(unit, pyopenms.DriftTimeUnit.VSSC)
+            self.assertEqual(len(loaded.getFloatDataArrays()[im_idx]), 2)
+            self.assertAlmostEqual(loaded.getFloatDataArrays()[im_idx][0], 0.85, places=5)
+            self.assertAlmostEqual(loaded.getFloatDataArrays()[im_idx][1], 1.15, places=5)
+            custom = loaded_by_name["my custom SNR"]
+            self.assertEqual(len(custom), 2)
+            self.assertAlmostEqual(custom[0], 3.0, places=5)
+            self.assertAlmostEqual(custom[1], 4.5, places=5)
+
+            od = pyopenms.OnDiscImzMLExperiment()
+            od.open(out_path)
+            try:
+                self.assertEqual(len(od.getIndex(0).aux), 2)
+                od_spec = od.getSpectrum(0)
+                self.assertTrue(od_spec.containsIMData())
+                self.assertEqual(len(od_spec.getFloatDataArrays()), 2)
+                od_by_name = {a.getName(): a for a in od_spec.getFloatDataArrays()}
+                self.assertIn("mean inverse reduced ion mobility array", od_by_name)
+                self.assertIn("my custom SNR", od_by_name)
+                od_im_idx, od_unit = od_spec.getIMData()
+                self.assertEqual(od_unit, pyopenms.DriftTimeUnit.VSSC)
+                self.assertEqual(len(od_spec.getFloatDataArrays()[od_im_idx]), 2)
+                self.assertAlmostEqual(od_spec.getFloatDataArrays()[od_im_idx][0], 0.85, places=5)
+                self.assertAlmostEqual(od_spec.getFloatDataArrays()[od_im_idx][1], 1.15, places=5)
+                od_custom = od_by_name["my custom SNR"]
+                self.assertEqual(len(od_custom), 2)
+                self.assertAlmostEqual(od_custom[0], 3.0, places=5)
+                self.assertAlmostEqual(od_custom[1], 4.5, places=5)
+            finally:
+                od.close()
+        finally:
+            os.remove(out_path)
+            ibd_path = out_path[:-6] + ".ibd" if out_path.lower().endswith(".imzml") else out_path + ".ibd"
+            if os.path.isfile(ibd_path):
+                os.remove(ibd_path)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/pyOpenMS/tests/unittests/test_ImzMLFile.py
+++ b/src/pyOpenMS/tests/unittests/test_ImzMLFile.py
@@ -479,6 +479,7 @@ class TestImzMLFile(unittest.TestCase):
             pyopenms.ImzMLFile().load(out_path, img)
             loaded = img.getMSExperiment().getSpectrum(0)
             self.assertTrue(loaded.containsIMData())
+            self.assertEqual(loaded.getIMPeakType(), pyopenms.IMPeakType.IM_PROFILE)
             self.assertEqual(len(loaded.getFloatDataArrays()), 2)
             loaded_by_name = {a.getName(): a for a in loaded.getFloatDataArrays()}
             self.assertIn("mean inverse reduced ion mobility array", loaded_by_name)
@@ -497,8 +498,11 @@ class TestImzMLFile(unittest.TestCase):
             od.open(out_path)
             try:
                 self.assertEqual(len(od.getIndex(0).aux), 2)
+                self.assertFalse(od.getIndex(0).mz_compressed)
+                self.assertFalse(od.getIndex(0).int_compressed)
                 od_spec = od.getSpectrum(0)
                 self.assertTrue(od_spec.containsIMData())
+                self.assertEqual(od_spec.getIMPeakType(), pyopenms.IMPeakType.IM_PROFILE)
                 self.assertEqual(len(od_spec.getFloatDataArrays()), 2)
                 od_by_name = {a.getName(): a for a in od_spec.getFloatDataArrays()}
                 self.assertIn("mean inverse reduced ion mobility array", od_by_name)

--- a/src/tests/class_tests/openms/source/IMDataConverter_test.cpp
+++ b/src/tests/class_tests/openms/source/IMDataConverter_test.cpp
@@ -89,6 +89,12 @@ START_SECTION(static void setIMUnit(DataArrays::FloatDataArray& fda, const Drift
 	IMDataConverter::setIMUnit(fda, DriftTimeUnit::VSSC);
   TEST_EQUAL(IMDataConverter::getIMUnit(fda, unit), true)
   TEST_EQUAL(DriftTimeUnit::VSSC == unit, true)
+
+  // Official PSI name for imzML/mzML (MS:1003006) must map to 1/K0 (VSSC),
+  // not milliseconds (regression: UserParam prefix used to force ms).
+  fda.setName("mean inverse reduced ion mobility array");
+  TEST_EQUAL(IMDataConverter::getIMUnit(fda, unit), true)
+  TEST_EQUAL(DriftTimeUnit::VSSC == unit, true)
 END_SECTION
 
 START_SECTION(static bool getIMUnit(const DataArrays::FloatDataArray& fda, DriftTimeUnit& unit))

--- a/src/tests/class_tests/openms/source/ImzMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ImzMLFile_test.cpp
@@ -26,6 +26,7 @@
 #include <OpenMS/DATASTRUCTURES/DRange.h>
 
 #include <fstream>
+#include <iterator>
 #include <cstdio>
 #include <sstream>
 
@@ -193,6 +194,50 @@ namespace
     xml << "    </spectrumList>\n"
         << "  </run>\n"
         << "</mzML>\n";
+  }
+
+  /// Insert MS:1000574 into the mzArray and intensityArray referenceableParamGroups
+  /// of a stored imzML so loaders see zlib-compressed external m/z / intensity.
+  bool injectZlibCompressionOnMzIntGroups_(const std::string& imzml_path)
+  {
+    std::ifstream in(imzml_path.c_str());
+    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    in.close();
+    const std::string zlib = "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000574\" name=\"zlib compression\"/>\n";
+    auto inject = [&](const std::string& id) -> bool {
+      const std::string open = "<referenceableParamGroup id=\"" + id + "\">";
+      const std::string::size_type start = content.find(open);
+      if (start == std::string::npos)
+      {
+        return false;
+      }
+      const std::string::size_type end = content.find("</referenceableParamGroup>", start);
+      if (end == std::string::npos)
+      {
+        return false;
+      }
+      content.insert(end, zlib);
+      return true;
+    };
+    // intensity first so the mz group's insert offset stays valid
+    if (!inject("intensityArray") || !inject("mzArray"))
+    {
+      return false;
+    }
+    std::ofstream out(imzml_path.c_str(), std::ios::trunc);
+    out << content;
+    return out.good();
+  }
+
+  std::string ibdPathFor_(const std::string& imzml_path)
+  {
+    std::string lower = imzml_path;
+    StringUtils::toLower(lower);
+    if (StringUtils::hasSuffix(lower, ".imzml"))
+    {
+      return imzml_path.substr(0, imzml_path.size() - 6) + ".ibd";
+    }
+    return imzml_path + ".ibd";
   }
 } // namespace
 
@@ -695,8 +740,9 @@ START_SECTION(void store round-trip FloatDataArray ion mobility and non-standard
   TEST_REAL_SIMILAR(fda[custom_idx][0], 3.0)
   TEST_REAL_SIMILAR(fda[custom_idx][1], 4.5)
 
-  // Viewer contract: containsIMData() + correct 1/K0 unit for the PSI IM array.
+  // Viewer contract: containsIMData() + IM_PROFILE + correct 1/K0 unit for the PSI IM array.
   TEST_TRUE(reloaded[0].containsIMData())
+  TEST_TRUE(reloaded[0].getIMPeakType() == IMPeakType::IM_PROFILE)
   DriftTimeUnit im_unit = DriftTimeUnit::NONE;
   TEST_TRUE(IMDataConverter::getIMUnit(fda[im_idx], im_unit))
   TEST_TRUE(im_unit == DriftTimeUnit::VSSC)
@@ -706,8 +752,11 @@ START_SECTION(void store round-trip FloatDataArray ion mobility and non-standard
   od.open(tmp_imzml);
   TEST_EQUAL(od.getNrSpectra(), 1)
   TEST_EQUAL(od.getIndex(0).aux.size(), 2)
+  TEST_FALSE(od.getIndex(0).mz_compressed)
+  TEST_FALSE(od.getIndex(0).int_compressed)
   MSSpectrum od_spec = od.getSpectrum(0);
   TEST_TRUE(od_spec.containsIMData())
+  TEST_TRUE(od_spec.getIMPeakType() == IMPeakType::IM_PROFILE)
   TEST_EQUAL(od_spec.getFloatDataArrays().size(), 2)
   const auto& od_fda = od_spec.getFloatDataArrays();
   Size od_im_idx = od_fda.size();
@@ -802,6 +851,31 @@ START_SECTION(void buildImagingGeometry rejects duplicate pixels)
 
   MSImagingGeometry geom;
   TEST_EXCEPTION(Exception::InvalidValue, ImzMLFile::buildImagingGeometry(exp, geom))
+}
+END_SECTION
+
+
+START_SECTION(void load and OnDisc reject zlib-compressed external m/z and intensity)
+{
+  MSExperiment exp;
+  exp.addSpectrum(makePixelSpectrum_(1, 1, 100.0, 1000.0));
+
+  ImzMLFile f;
+  std::string tmp_imzml;
+  NEW_TMP_FILE_EXT(tmp_imzml, ".imzML");
+  f.store(tmp_imzml, exp);
+  TEST_TRUE(injectZlibCompressionOnMzIntGroups_(tmp_imzml))
+
+  MSImagingExperiment img;
+  TEST_EXCEPTION(Exception::ParseError, f.load(tmp_imzml, img))
+
+  OnDiscImzMLExperiment od;
+  od.open(tmp_imzml);
+  TEST_TRUE(od.getIndex(0).mz_compressed)
+  TEST_TRUE(od.getIndex(0).int_compressed)
+  TEST_EXCEPTION(Exception::ParseError, od.getSpectrum(0))
+
+  remove(ibdPathFor_(tmp_imzml).c_str());
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ImzMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ImzMLFile_test.cpp
@@ -196,14 +196,15 @@ namespace
         << "</mzML>\n";
   }
 
-  /// Insert MS:1000574 into the mzArray and intensityArray referenceableParamGroups
-  /// of a stored imzML so loaders see zlib-compressed external m/z / intensity.
-  bool injectZlibCompressionOnMzIntGroups_(const std::string& imzml_path)
+  /// Insert a compression cvParam into the mzArray and intensityArray groups.
+  bool injectCompressionOnMzIntGroups_(const std::string& imzml_path,
+                                       const std::string& accession,
+                                       const std::string& name)
   {
     std::ifstream in(imzml_path.c_str());
     std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
     in.close();
-    const std::string zlib = "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000574\" name=\"zlib compression\"/>\n";
+    const std::string line = "\t\t\t<cvParam cvRef=\"MS\" accession=\"" + accession + "\" name=\"" + name + "\"/>\n";
     auto inject = [&](const std::string& id) -> bool {
       const std::string open = "<referenceableParamGroup id=\"" + id + "\">";
       const std::string::size_type start = content.find(open);
@@ -216,14 +217,87 @@ namespace
       {
         return false;
       }
-      content.insert(end, zlib);
+      content.insert(end, line);
       return true;
     };
-    // intensity first so the mz group's insert offset stays valid
     if (!inject("intensityArray") || !inject("mzArray"))
     {
       return false;
     }
+    std::ofstream out(imzml_path.c_str(), std::ios::trunc);
+    out << content;
+    return out.good();
+  }
+
+  /// Insert MS:1000574 into the mzArray and intensityArray referenceableParamGroups
+  /// of a stored imzML so loaders see zlib-compressed external m/z / intensity.
+  bool injectZlibCompressionOnMzIntGroups_(const std::string& imzml_path)
+  {
+    return injectCompressionOnMzIntGroups_(imzml_path, "MS:1000574", "zlib compression");
+  }
+
+  bool mutateNamedBinaryDataArray_(const std::string& imzml_path,
+                                   const std::string& accession,
+                                   const std::string& from,
+                                   const std::string& to)
+  {
+    std::ifstream in(imzml_path.c_str());
+    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    in.close();
+    const std::string::size_type acc_pos = content.find(accession);
+    if (acc_pos == std::string::npos)
+    {
+      return false;
+    }
+    const std::string::size_type bda_start = content.rfind("<binaryDataArray", acc_pos);
+    const std::string::size_type bda_end = content.find("</binaryDataArray>", acc_pos);
+    if (bda_start == std::string::npos || bda_end == std::string::npos)
+    {
+      return false;
+    }
+    std::string block = content.substr(bda_start, bda_end - bda_start);
+    const std::string::size_type at = block.find(from);
+    if (at == std::string::npos)
+    {
+      return false;
+    }
+    block.replace(at, from.size(), to);
+    content.replace(bda_start, bda_end - bda_start, block);
+    std::ofstream out(imzml_path.c_str(), std::ios::trunc);
+    out << content;
+    return out.good();
+  }
+
+  bool setNamedAuxImsLength_(const std::string& imzml_path, const std::string& accession, const std::string& new_len)
+  {
+    std::ifstream in(imzml_path.c_str());
+    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    in.close();
+    const std::string::size_type acc_pos = content.find(accession);
+    if (acc_pos == std::string::npos)
+    {
+      return false;
+    }
+    const std::string::size_type bda_start = content.rfind("<binaryDataArray", acc_pos);
+    const std::string::size_type bda_end = content.find("</binaryDataArray>", acc_pos);
+    if (bda_start == std::string::npos || bda_end == std::string::npos)
+    {
+      return false;
+    }
+    std::string block = content.substr(bda_start, bda_end - bda_start);
+    const std::string::size_type len_acc = block.find("accession=\"IMS:1000103\"");
+    if (len_acc == std::string::npos)
+    {
+      return false;
+    }
+    const std::string::size_type value_pos = block.find("value=\"", len_acc);
+    const std::string::size_type value_end = (value_pos == std::string::npos) ? std::string::npos : block.find('"', value_pos + 7);
+    if (value_pos == std::string::npos || value_end == std::string::npos)
+    {
+      return false;
+    }
+    block.replace(value_pos, value_end - value_pos, "value=\"" + new_len);
+    content.replace(bda_start, bda_end - bda_start, block);
     std::ofstream out(imzml_path.c_str(), std::ios::trunc);
     out << content;
     return out.good();
@@ -792,6 +866,8 @@ START_SECTION(void store round-trip FloatDataArray ion mobility and non-standard
   DriftTimeUnit im_unit = DriftTimeUnit::NONE;
   TEST_TRUE(IMDataConverter::getIMUnit(fda[im_idx], im_unit))
   TEST_TRUE(im_unit == DriftTimeUnit::VSSC)
+  TEST_TRUE(fda[im_idx].metaValueExists("unit_accession"))
+  TEST_EQUAL(OpenMS::StringConversions::toString(fda[im_idx].getMetaValue("unit_accession")), std::string("MS:1002814"))
 
   // On-disc path must expose the same IM + custom FloatDataArrays (index + lazy decode).
   OnDiscImzMLExperiment od;
@@ -826,6 +902,18 @@ START_SECTION(void store round-trip FloatDataArray ion mobility and non-standard
   TEST_EQUAL(od_fda[od_custom_idx].size(), 2)
   TEST_REAL_SIMILAR(od_fda[od_custom_idx][0], 3.0)
   TEST_REAL_SIMILAR(od_fda[od_custom_idx][1], 4.5)
+  TEST_TRUE(od_fda[od_im_idx].metaValueExists("unit_accession"))
+  TEST_EQUAL(OpenMS::StringConversions::toString(od_fda[od_im_idx].getMetaValue("unit_accession")), std::string("MS:1002814"))
+  bool found_im_unit = false;
+  for (const auto& a : od.getIndex(0).aux)
+  {
+    if (a.name == "mean inverse reduced ion mobility array")
+    {
+      TEST_EQUAL(a.unit_accession, std::string("MS:1002814"))
+      found_im_unit = true;
+    }
+  }
+  TEST_TRUE(found_im_unit)
 }
 END_SECTION
 
@@ -1183,6 +1271,278 @@ START_SECTION(IonImage extractIonImage(double mz, double tolerance_ppm, Size reg
 
   // Unknown region id must throw.
   TEST_EXCEPTION(Exception::ElementNotFound, od.extractIonImage(mz, tol_ppm, 99))
+}
+END_SECTION
+
+
+START_SECTION(void load sorts external peaks when getSortSpectraByMZ is true)
+{
+  MSSpectrum s;
+  s.setMetaValue("imzml:x", 1);
+  s.setMetaValue("imzml:y", 1);
+  s.setMetaValue("imzml:z", 1);
+  s.push_back(Peak1D(131.0, 1310.0f));
+  s.push_back(Peak1D(121.0, 1210.0f));
+  MSSpectrum::FloatDataArray im;
+  im.setName("mean inverse reduced ion mobility array");
+  im.push_back(1.31f);
+  im.push_back(1.21f);
+  s.getFloatDataArrays().push_back(im);
+  MSExperiment original;
+  original.addSpectrum(s);
+  original.setMetaValue("imzml:imaging_mode", "processed");
+
+  ImzMLFile f;
+  PeakFileOptions store_opts;
+  store_opts.setSortSpectraByMZ(false);
+  f.setOptions(store_opts);
+  std::string tmp_imzml;
+  NEW_TMP_FILE_EXT(tmp_imzml, ".imzML");
+  f.store(tmp_imzml, original);
+
+  MSImagingExperiment img;
+  ImzMLFile loader;
+  loader.load(tmp_imzml, img);
+  const MSSpectrum& mem = img.getMSExperiment()[0];
+  TEST_TRUE(mem.isSorted())
+  TEST_REAL_SIMILAR(mem[0].getMZ(), 121.0)
+  TEST_REAL_SIMILAR(mem[1].getMZ(), 131.0)
+  TEST_EQUAL(mem.getFloatDataArrays().size(), 1)
+  TEST_REAL_SIMILAR(mem.getFloatDataArrays()[0][0], 1.21)
+  TEST_REAL_SIMILAR(mem.getFloatDataArrays()[0][1], 1.31)
+
+  OnDiscImzMLExperiment od;
+  od.open(tmp_imzml);
+  const MSSpectrum disc = od.getSpectrum(0);
+  TEST_TRUE(disc.isSorted())
+  TEST_REAL_SIMILAR(disc[0].getMZ(), 121.0)
+  TEST_REAL_SIMILAR(disc[1].getMZ(), 131.0)
+
+  const IonImage mem_img = img.extractIonImage(131.0, 10.0);
+  const IonImage disc_img = od.extractIonImage(131.0, 10.0);
+  TEST_REAL_SIMILAR(mem_img.getIntensity(0, 0), 1310.0)
+  TEST_REAL_SIMILAR(disc_img.getIntensity(0, 0), 1310.0)
+  od.close();
+  remove(ibdPathFor_(tmp_imzml).c_str());
+}
+END_SECTION
+
+
+START_SECTION(void load and OnDisc reject numpress-compressed external m/z)
+{
+  MSExperiment exp;
+  exp.addSpectrum(makePixelSpectrum_(1, 1, 100.0, 1000.0f));
+  ImzMLFile f;
+  std::string tmp_imzml;
+  NEW_TMP_FILE_EXT(tmp_imzml, ".imzML");
+  f.store(tmp_imzml, exp);
+  TEST_TRUE(injectCompressionOnMzIntGroups_(tmp_imzml, "MS:1002312", "MS-Numpress linear prediction compression"))
+
+  MSImagingExperiment img;
+  TEST_EXCEPTION(Exception::ParseError, f.load(tmp_imzml, img))
+
+  OnDiscImzMLExperiment od;
+  od.open(tmp_imzml);
+  TEST_TRUE(od.getIndex(0).mz_compressed)
+  TEST_EXCEPTION(Exception::ParseError, od.getSpectrum(0))
+  od.close();
+  remove(ibdPathFor_(tmp_imzml).c_str());
+}
+END_SECTION
+
+
+START_SECTION(void load skips one bad aux length and still returns all spectra)
+{
+  MSExperiment original;
+  for (Int x = 1; x <= 4; ++x)
+  {
+    MSSpectrum s = makePixelSpectrum_(x, 1, 100.0 + x, 10.0f * x);
+    MSSpectrum::FloatDataArray im;
+    im.setName("mean inverse reduced ion mobility array");
+    im.push_back(0.8f + 0.01f * x);
+    s.getFloatDataArrays().push_back(im);
+    original.addSpectrum(s);
+  }
+  original.setMetaValue("imzml:imaging_mode", "processed");
+
+  ImzMLFile f;
+  std::string tmp_imzml;
+  NEW_TMP_FILE_EXT(tmp_imzml, ".imzML");
+  f.store(tmp_imzml, original);
+  TEST_TRUE(setNamedAuxImsLength_(tmp_imzml, "MS:1003006", "999999"))
+
+  MSExperiment mem = loadImzMLExperiment_(tmp_imzml);
+  TEST_EQUAL(mem.getNrSpectra(), 4)
+  TEST_FALSE(mem[0].containsIMData())
+  TEST_EQUAL(mem[0].getFloatDataArrays().size(), 0)
+  TEST_TRUE(mem[1].containsIMData())
+  TEST_TRUE(mem[2].containsIMData())
+  TEST_TRUE(mem[3].containsIMData())
+
+  OnDiscImzMLExperiment od;
+  od.open(tmp_imzml);
+  TEST_EQUAL(od.getNrSpectra(), 4)
+  TEST_FALSE(od.getSpectrum(0).containsIMData())
+  TEST_TRUE(od.getSpectrum(1).containsIMData())
+  od.close();
+  remove(ibdPathFor_(tmp_imzml).c_str());
+}
+END_SECTION
+
+
+START_SECTION(void load and OnDisc drop zero-length aux without a ghost IM array)
+{
+  MSExperiment original;
+  MSSpectrum s = makePixelSpectrum_(1, 1, 100.0, 10.0f);
+  MSSpectrum::FloatDataArray im;
+  im.setName("mean inverse reduced ion mobility array");
+  im.push_back(0.85f);
+  s.getFloatDataArrays().push_back(im);
+  original.addSpectrum(s);
+  original.setMetaValue("imzml:imaging_mode", "processed");
+
+  ImzMLFile f;
+  std::string tmp_imzml;
+  NEW_TMP_FILE_EXT(tmp_imzml, ".imzML");
+  f.store(tmp_imzml, original);
+  TEST_TRUE(setNamedAuxImsLength_(tmp_imzml, "MS:1003006", "0"))
+
+  MSExperiment mem = loadImzMLExperiment_(tmp_imzml);
+  TEST_EQUAL(mem[0].getFloatDataArrays().size(), 0)
+  TEST_FALSE(mem[0].containsIMData())
+  TEST_TRUE(mem[0].getIMPeakType() == IMPeakType::UNKNOWN)
+
+  OnDiscImzMLExperiment od;
+  od.open(tmp_imzml);
+  const MSSpectrum disc = od.getSpectrum(0);
+  TEST_EQUAL(disc.getFloatDataArrays().size(), 0)
+  TEST_FALSE(disc.containsIMData())
+  TEST_TRUE(disc.getIMPeakType() == IMPeakType::UNKNOWN)
+  od.close();
+  remove(ibdPathFor_(tmp_imzml).c_str());
+}
+END_SECTION
+
+
+START_SECTION(void store skips unnamed FloatDataArray)
+{
+  MSExperiment original;
+  MSSpectrum s = makePixelSpectrum_(1, 1, 100.0, 10.0f);
+  MSSpectrum::FloatDataArray unnamed;
+  unnamed.push_back(1.0f);
+  s.getFloatDataArrays().push_back(unnamed);
+  original.addSpectrum(s);
+
+  ImzMLFile f;
+  std::string tmp_imzml;
+  NEW_TMP_FILE_EXT(tmp_imzml, ".imzML");
+  f.store(tmp_imzml, original);
+
+  std::ifstream xml(tmp_imzml.c_str());
+  std::string content((std::istreambuf_iterator<char>(xml)), std::istreambuf_iterator<char>());
+  TEST_TRUE(content.find("binaryDataArrayList count=\"2\"") != std::string::npos)
+  TEST_TRUE(content.find("MS:1000786") == std::string::npos)
+
+  MSExperiment mem = loadImzMLExperiment_(tmp_imzml);
+  TEST_EQUAL(mem[0].getFloatDataArrays().size(), 0)
+  OnDiscImzMLExperiment od;
+  od.open(tmp_imzml);
+  TEST_EQUAL(od.getIndex(0).aux.size(), 0)
+  od.close();
+  remove(ibdPathFor_(tmp_imzml).c_str());
+}
+END_SECTION
+
+
+START_SECTION(void load drops phantom IntegerDataArray for integer-typed aux)
+{
+  MSExperiment original;
+  MSSpectrum s = makePixelSpectrum_(1, 1, 100.0, 10.0f);
+  MSSpectrum::FloatDataArray im;
+  im.setName("mean inverse reduced ion mobility array");
+  im.push_back(0.85f);
+  s.getFloatDataArrays().push_back(im);
+  original.addSpectrum(s);
+  original.setMetaValue("imzml:imaging_mode", "processed");
+
+  ImzMLFile f;
+  std::string tmp_imzml;
+  NEW_TMP_FILE_EXT(tmp_imzml, ".imzML");
+  f.store(tmp_imzml, original);
+  TEST_TRUE(mutateNamedBinaryDataArray_(tmp_imzml, "MS:1003006",
+                                        "accession=\"MS:1000521\" name=\"32-bit float\"",
+                                        "accession=\"MS:1000519\" name=\"32-bit integer\""))
+
+  MSExperiment mem = loadImzMLExperiment_(tmp_imzml);
+  TEST_EQUAL(mem[0].getIntegerDataArrays().size(), 0)
+  TEST_EQUAL(mem[0].getFloatDataArrays().size(), 1)
+  OnDiscImzMLExperiment od;
+  od.open(tmp_imzml);
+  TEST_EQUAL(od.getSpectrum(0).getIntegerDataArrays().size(), 0)
+  TEST_EQUAL(od.getSpectrum(0).getFloatDataArrays().size(), 1)
+  od.close();
+  remove(ibdPathFor_(tmp_imzml).c_str());
+}
+END_SECTION
+
+
+START_SECTION(void load and OnDisc drop inline aux when peaks are external)
+{
+  MSExperiment original;
+  MSSpectrum s = makePixelSpectrum_(1, 1, 100.0, 10.0f);
+  MSSpectrum::FloatDataArray im;
+  im.setName("mean inverse reduced ion mobility array");
+  im.push_back(0.85f);
+  s.getFloatDataArrays().push_back(im);
+  original.addSpectrum(s);
+  original.setMetaValue("imzml:imaging_mode", "processed");
+
+  ImzMLFile f;
+  std::string tmp_imzml;
+  NEW_TMP_FILE_EXT(tmp_imzml, ".imzML");
+  f.store(tmp_imzml, original);
+  TEST_TRUE(mutateNamedBinaryDataArray_(tmp_imzml, "MS:1003006",
+                                        "accession=\"IMS:1000101\"",
+                                        "accession=\"IMS:1000000\""))
+
+  MSExperiment mem = loadImzMLExperiment_(tmp_imzml);
+  TEST_EQUAL(mem[0].getFloatDataArrays().size(), 0)
+  TEST_FALSE(mem[0].containsIMData())
+  OnDiscImzMLExperiment od;
+  od.open(tmp_imzml);
+  TEST_EQUAL(od.getIndex(0).aux.size(), 0)
+  TEST_EQUAL(od.getSpectrum(0).getFloatDataArrays().size(), 0)
+  od.close();
+  remove(ibdPathFor_(tmp_imzml).c_str());
+}
+END_SECTION
+
+
+START_SECTION(void store writes MS:1000576 on mz and intensity referenceableParamGroups)
+{
+  MSExperiment original;
+  original.addSpectrum(makePixelSpectrum_(1, 1, 100.0, 10.0f));
+  ImzMLFile f;
+  std::string tmp_imzml;
+  NEW_TMP_FILE_EXT(tmp_imzml, ".imzML");
+  f.store(tmp_imzml, original);
+
+  std::ifstream xml(tmp_imzml.c_str());
+  std::string content((std::istreambuf_iterator<char>(xml)), std::istreambuf_iterator<char>());
+  auto group_has_no_compression = [&](const std::string& id) {
+    const std::string open = "<referenceableParamGroup id=\"" + id + "\">";
+    const std::string::size_type start = content.find(open);
+    const std::string::size_type end = content.find("</referenceableParamGroup>", start);
+    if (start == std::string::npos || end == std::string::npos)
+    {
+      return false;
+    }
+    const std::string group = content.substr(start, end - start);
+    return group.find("MS:1000576") != std::string::npos;
+  };
+  TEST_TRUE(group_has_no_compression("mzArray"))
+  TEST_TRUE(group_has_no_compression("intensityArray"))
+  remove(ibdPathFor_(tmp_imzml).c_str());
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ImzMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ImzMLFile_test.cpp
@@ -11,6 +11,8 @@
 
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/FORMAT/ImzMLFile.h>
+#include <OpenMS/IONMOBILITY/IMDataConverter.h>
+#include <OpenMS/IONMOBILITY/IMTypes.h>
 #include <OpenMS/KERNEL/OnDiscImzMLExperiment.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
@@ -622,6 +624,113 @@ START_SECTION(void store round-trip processed imzML)
     TEST_REAL_SIMILAR(reloaded[0][0].getMZ(), original[0][0].getMZ())
   }
   TEST_EQUAL(reloaded.getMetaValue("imzml:imaging_mode"), "processed")
+}
+END_SECTION
+
+
+START_SECTION(void store round-trip FloatDataArray ion mobility and non-standard)
+{
+  // PSI MS:1003006 ion mobility plus a free-text MS:1000786 array.
+  MSExperiment original;
+  MSSpectrum s = makePixelSpectrum_(1, 1, 100.0, 10.0f);
+  s.push_back(Peak1D(200.0, 20.0f));
+
+  MSSpectrum::FloatDataArray im;
+  im.setName("mean inverse reduced ion mobility array");
+  im.push_back(0.85f);
+  im.push_back(1.15f);
+  s.getFloatDataArrays().push_back(im);
+
+  MSSpectrum::FloatDataArray custom;
+  custom.setName("my custom SNR");
+  custom.push_back(3.0f);
+  custom.push_back(4.5f);
+  s.getFloatDataArrays().push_back(custom);
+
+  original.addSpectrum(s);
+  original.setMetaValue("imzml:imaging_mode", "processed");
+
+  ImzMLFile f;
+  std::string tmp_imzml;
+  NEW_TMP_FILE_EXT(tmp_imzml, ".imzML");
+  f.store(tmp_imzml, original);
+
+  // Writer must emit the ontology accession for IM and MS:1000786 for the custom name.
+  {
+    std::ifstream xml(tmp_imzml.c_str());
+    std::string content((std::istreambuf_iterator<char>(xml)), std::istreambuf_iterator<char>());
+    TEST_TRUE(content.find("MS:1003006") != std::string::npos)
+    TEST_TRUE(content.find("mean inverse reduced ion mobility array") != std::string::npos)
+    TEST_TRUE(content.find("MS:1002814") != std::string::npos) // 1/K0 unit on IM array
+    TEST_TRUE(content.find("MS:1000786") != std::string::npos)
+    TEST_TRUE(content.find("my custom SNR") != std::string::npos)
+    TEST_TRUE(content.find("binaryDataArrayList count=\"4\"") != std::string::npos)
+  }
+
+  MSExperiment reloaded = loadImzMLExperiment_(tmp_imzml);
+  TEST_EQUAL(reloaded.getNrSpectra(), 1)
+  TEST_EQUAL(reloaded[0].size(), 2)
+  TEST_EQUAL(reloaded[0].getFloatDataArrays().size(), 2)
+
+  const auto& fda = reloaded[0].getFloatDataArrays();
+  Size im_idx = fda.size();
+  Size custom_idx = fda.size();
+  for (Size i = 0; i < fda.size(); ++i)
+  {
+    if (fda[i].getName() == "mean inverse reduced ion mobility array")
+    {
+      im_idx = i;
+    }
+    if (fda[i].getName() == "my custom SNR")
+    {
+      custom_idx = i;
+    }
+  }
+  TEST_NOT_EQUAL(im_idx, fda.size())
+  TEST_NOT_EQUAL(custom_idx, fda.size())
+  TEST_EQUAL(fda[im_idx].size(), 2)
+  TEST_REAL_SIMILAR(fda[im_idx][0], 0.85)
+  TEST_REAL_SIMILAR(fda[im_idx][1], 1.15)
+  TEST_EQUAL(fda[custom_idx].size(), 2)
+  TEST_REAL_SIMILAR(fda[custom_idx][0], 3.0)
+  TEST_REAL_SIMILAR(fda[custom_idx][1], 4.5)
+
+  // Viewer contract: containsIMData() + correct 1/K0 unit for the PSI IM array.
+  TEST_TRUE(reloaded[0].containsIMData())
+  DriftTimeUnit im_unit = DriftTimeUnit::NONE;
+  TEST_TRUE(IMDataConverter::getIMUnit(fda[im_idx], im_unit))
+  TEST_TRUE(im_unit == DriftTimeUnit::VSSC)
+
+  // On-disc path must expose the same IM + custom FloatDataArrays (index + lazy decode).
+  OnDiscImzMLExperiment od;
+  od.open(tmp_imzml);
+  TEST_EQUAL(od.getNrSpectra(), 1)
+  TEST_EQUAL(od.getIndex(0).aux.size(), 2)
+  MSSpectrum od_spec = od.getSpectrum(0);
+  TEST_TRUE(od_spec.containsIMData())
+  TEST_EQUAL(od_spec.getFloatDataArrays().size(), 2)
+  const auto& od_fda = od_spec.getFloatDataArrays();
+  Size od_im_idx = od_fda.size();
+  Size od_custom_idx = od_fda.size();
+  for (Size i = 0; i < od_fda.size(); ++i)
+  {
+    if (od_fda[i].getName() == "mean inverse reduced ion mobility array")
+    {
+      od_im_idx = i;
+    }
+    if (od_fda[i].getName() == "my custom SNR")
+    {
+      od_custom_idx = i;
+    }
+  }
+  TEST_NOT_EQUAL(od_im_idx, od_fda.size())
+  TEST_NOT_EQUAL(od_custom_idx, od_fda.size())
+  TEST_EQUAL(od_fda[od_im_idx].size(), 2)
+  TEST_REAL_SIMILAR(od_fda[od_im_idx][0], 0.85)
+  TEST_REAL_SIMILAR(od_fda[od_im_idx][1], 1.15)
+  TEST_EQUAL(od_fda[od_custom_idx].size(), 2)
+  TEST_REAL_SIMILAR(od_fda[od_custom_idx][0], 3.0)
+  TEST_REAL_SIMILAR(od_fda[od_custom_idx][1], 4.5)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ImzMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ImzMLFile_test.cpp
@@ -229,6 +229,52 @@ namespace
     return out.good();
   }
 
+  /// Mark the binaryDataArray that carries @p accession as zlib-compressed with
+  /// IMS:1000103 length 0, so OnDisc must reject it even though there is no payload.
+  bool makeNamedAuxCompressedAndEmpty_(const std::string& imzml_path, const std::string& accession)
+  {
+    std::ifstream in(imzml_path.c_str());
+    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    in.close();
+    const std::string::size_type acc_pos = content.find(accession);
+    if (acc_pos == std::string::npos)
+    {
+      return false;
+    }
+    const std::string::size_type bda_start = content.rfind("<binaryDataArray", acc_pos);
+    const std::string::size_type bda_end = content.find("</binaryDataArray>", acc_pos);
+    if (bda_start == std::string::npos || bda_end == std::string::npos)
+    {
+      return false;
+    }
+    std::string block = content.substr(bda_start, bda_end - bda_start);
+    const std::string no_comp = "accession=\"MS:1000576\" name=\"no compression\"";
+    const std::string zlib = "accession=\"MS:1000574\" name=\"zlib compression\"";
+    const std::string::size_type nc = block.find(no_comp);
+    if (nc == std::string::npos)
+    {
+      return false;
+    }
+    block.replace(nc, no_comp.size(), zlib);
+
+    const std::string::size_type len_acc = block.find("accession=\"IMS:1000103\"");
+    if (len_acc == std::string::npos)
+    {
+      return false;
+    }
+    const std::string::size_type value_pos = block.find("value=\"", len_acc);
+    const std::string::size_type value_end = (value_pos == std::string::npos) ? std::string::npos : block.find('"', value_pos + 7);
+    if (value_pos == std::string::npos || value_end == std::string::npos)
+    {
+      return false;
+    }
+    block.replace(value_pos, value_end - value_pos, "value=\"0");
+    content.replace(bda_start, bda_end - bda_start, block);
+    std::ofstream out(imzml_path.c_str(), std::ios::trunc);
+    out << content;
+    return out.good();
+  }
+
   std::string ibdPathFor_(const std::string& imzml_path)
   {
     std::string lower = imzml_path;
@@ -874,7 +920,79 @@ START_SECTION(void load and OnDisc reject zlib-compressed external m/z and inten
   TEST_TRUE(od.getIndex(0).mz_compressed)
   TEST_TRUE(od.getIndex(0).int_compressed)
   TEST_EXCEPTION(Exception::ParseError, od.getSpectrum(0))
+  od.close();
 
+  remove(ibdPathFor_(tmp_imzml).c_str());
+}
+END_SECTION
+
+
+START_SECTION(void store writes a single allowed unit for PSI-MS aux arrays)
+{
+  MSExperiment original;
+  MSSpectrum s = makePixelSpectrum_(1, 1, 100.0, 10.0f);
+
+  MSSpectrum::FloatDataArray pressure;
+  pressure.setName("pressure array");
+  pressure.push_back(101325.0f);
+  s.getFloatDataArrays().push_back(pressure);
+
+  // Two allowed units (ms and s): writer must not pick one arbitrarily.
+  MSSpectrum::FloatDataArray raw_im;
+  raw_im.setName("raw ion mobility array");
+  raw_im.push_back(12.5f);
+  s.getFloatDataArrays().push_back(raw_im);
+
+  original.addSpectrum(s);
+
+  ImzMLFile f;
+  std::string tmp_imzml;
+  NEW_TMP_FILE_EXT(tmp_imzml, ".imzML");
+  f.store(tmp_imzml, original);
+
+  std::ifstream xml(tmp_imzml.c_str());
+  std::string content((std::istreambuf_iterator<char>(xml)), std::istreambuf_iterator<char>());
+  TEST_TRUE(content.find("MS:1000821") != std::string::npos)
+  TEST_TRUE(content.find("pressure array") != std::string::npos)
+  TEST_TRUE(content.find("unitAccession=\"UO:0000110\"") != std::string::npos)
+  TEST_TRUE(content.find("unitName=\"pascal\"") != std::string::npos)
+  TEST_TRUE(content.find("unitCvRef=\"UO\"") != std::string::npos)
+
+  const std::string::size_type raw_pos = content.find("MS:1003007");
+  TEST_NOT_EQUAL(raw_pos, std::string::npos)
+  const std::string::size_type tag_start = content.rfind("<cvParam", raw_pos);
+  const std::string::size_type tag_end = content.find("/>", raw_pos);
+  TEST_NOT_EQUAL(tag_start, std::string::npos)
+  TEST_NOT_EQUAL(tag_end, std::string::npos)
+  const std::string raw_tag = content.substr(tag_start, tag_end - tag_start);
+  TEST_TRUE(raw_tag.find("unitAccession") == std::string::npos)
+}
+END_SECTION
+
+
+START_SECTION(OnDiscImzMLExperiment rejects compressed zero-length aux arrays)
+{
+  MSExperiment exp;
+  MSSpectrum s = makePixelSpectrum_(1, 1, 100.0, 10.0f);
+  MSSpectrum::FloatDataArray im;
+  im.setName("mean inverse reduced ion mobility array");
+  im.push_back(0.85f);
+  s.getFloatDataArrays().push_back(im);
+  exp.addSpectrum(s);
+
+  ImzMLFile f;
+  std::string tmp_imzml;
+  NEW_TMP_FILE_EXT(tmp_imzml, ".imzML");
+  f.store(tmp_imzml, exp);
+  TEST_TRUE(makeNamedAuxCompressedAndEmpty_(tmp_imzml, "MS:1003006"))
+
+  OnDiscImzMLExperiment od;
+  od.open(tmp_imzml);
+  TEST_EQUAL(od.getIndex(0).aux.size(), 1)
+  TEST_TRUE(od.getIndex(0).aux[0].compressed)
+  TEST_EQUAL(od.getIndex(0).aux[0].length, 0)
+  TEST_EXCEPTION(Exception::ParseError, od.getSpectrum(0))
+  od.close();
   remove(ibdPathFor_(tmp_imzml).c_str());
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/ImzMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ImzMLFile_test.cpp
@@ -1546,4 +1546,100 @@ START_SECTION(void store writes MS:1000576 on mz and intensity referenceablePara
 }
 END_SECTION
 
+
+START_SECTION(void store skips FloatDataArrays named after the peak arrays)
+{
+  // "m/z array" / "intensity array" resolve to MS:1000514 / MS:1000515, so writing them
+  // as aux arrays would overwrite the real peak metadata on read (last cvParam wins).
+  MSExperiment original;
+  MSSpectrum s = makePixelSpectrum_(1, 1, 100.0, 10.0f);
+  s.push_back(Peak1D(200.0, 20.0f));
+
+  MSSpectrum::FloatDataArray shadow_mz;
+  shadow_mz.setName("m/z array");
+  shadow_mz.push_back(999.0f);
+  shadow_mz.push_back(998.0f);
+  s.getFloatDataArrays().push_back(shadow_mz);
+
+  MSSpectrum::FloatDataArray shadow_int;
+  shadow_int.setName("intensity array");
+  shadow_int.push_back(1.0f);
+  shadow_int.push_back(2.0f);
+  s.getFloatDataArrays().push_back(shadow_int);
+
+  original.addSpectrum(s);
+  original.setMetaValue("imzml:imaging_mode", "processed");
+
+  ImzMLFile f;
+  std::string tmp_imzml;
+  NEW_TMP_FILE_EXT(tmp_imzml, ".imzML");
+  f.store(tmp_imzml, original);
+
+  std::ifstream xml(tmp_imzml.c_str());
+  std::string content((std::istreambuf_iterator<char>(xml)), std::istreambuf_iterator<char>());
+  TEST_TRUE(content.find("binaryDataArrayList count=\"2\"") != std::string::npos)
+
+  MSExperiment mem = loadImzMLExperiment_(tmp_imzml);
+  TEST_EQUAL(mem.getNrSpectra(), 1)
+  TEST_EQUAL(mem[0].size(), 2)
+  TEST_REAL_SIMILAR(mem[0][0].getMZ(), 100.0)
+  TEST_REAL_SIMILAR(mem[0][1].getMZ(), 200.0)
+  TEST_REAL_SIMILAR(mem[0][0].getIntensity(), 10.0)
+  TEST_REAL_SIMILAR(mem[0][1].getIntensity(), 20.0)
+  TEST_EQUAL(mem[0].getFloatDataArrays().size(), 0)
+
+  OnDiscImzMLExperiment od;
+  od.open(tmp_imzml);
+  TEST_EQUAL(od.getIndex(0).aux.size(), 0)
+  const MSSpectrum disc = od.getSpectrum(0);
+  TEST_EQUAL(disc.size(), 2)
+  TEST_REAL_SIMILAR(disc[0].getMZ(), 100.0)
+  TEST_REAL_SIMILAR(disc[1].getMZ(), 200.0)
+  od.close();
+  remove(ibdPathFor_(tmp_imzml).c_str());
+}
+END_SECTION
+
+
+START_SECTION(void load and OnDisc skip aux array without a supported binary data type)
+{
+  MSExperiment original;
+  MSSpectrum s = makePixelSpectrum_(1, 1, 100.0, 10.0f);
+  MSSpectrum::FloatDataArray im;
+  im.setName("mean inverse reduced ion mobility array");
+  im.push_back(0.85f);
+  s.getFloatDataArrays().push_back(im);
+  original.addSpectrum(s);
+  original.setMetaValue("imzml:imaging_mode", "processed");
+
+  ImzMLFile f;
+  std::string tmp_imzml;
+  NEW_TMP_FILE_EXT(tmp_imzml, ".imzML");
+  f.store(tmp_imzml, original);
+  // MS:1000520 (obsolete '16-bit float') is not a type either loader can decode
+  TEST_TRUE(mutateNamedBinaryDataArray_(tmp_imzml, "MS:1003006",
+                                        "accession=\"MS:1000521\" name=\"32-bit float\"",
+                                        "accession=\"MS:1000520\" name=\"16-bit float\""))
+
+  // One undecodable aux array must not abort the load: peaks still come through.
+  MSExperiment mem = loadImzMLExperiment_(tmp_imzml);
+  TEST_EQUAL(mem.getNrSpectra(), 1)
+  TEST_EQUAL(mem[0].size(), 1)
+  TEST_REAL_SIMILAR(mem[0][0].getMZ(), 100.0)
+  TEST_EQUAL(mem[0].getFloatDataArrays().size(), 0)
+  TEST_FALSE(mem[0].containsIMData())
+
+  OnDiscImzMLExperiment od;
+  od.open(tmp_imzml);
+  TEST_EQUAL(od.getIndex(0).aux.size(), 1)
+  TEST_TRUE(od.getIndex(0).aux[0].type == ImzMLSpectrumIndex::DataType::UNKNOWN)
+  const MSSpectrum disc = od.getSpectrum(0);
+  TEST_EQUAL(disc.size(), 1)
+  TEST_EQUAL(disc.getFloatDataArrays().size(), 0)
+  TEST_FALSE(disc.containsIMData())
+  od.close();
+  remove(ibdPathFor_(tmp_imzml).c_str());
+}
+END_SECTION
+
 END_TEST


### PR DESCRIPTION
## Summary

imzML used to keep only m/z and intensity. Extra per peak arrays such as ion mobility (`MS:1003006`) were dropped on write and never filled from the `.ibd` on read. Tools that call `containsIMData()` therefore treated those spectra as having no IM.

This PR reads and writes those extra `FloatDataArray`s as external `.ibd` arrays so imaging data matches the usual mzML IM contract.

### Write

After m/z and intensity, each `FloatDataArray` is stored as another external array. Known PSI MS names (children of `MS:1000513`) keep their accession and units (for example `MS:1002814` for 1/K0). Other names become `MS:1000786`. Only float arrays of the same length as the peaks are written, always uncompressed 32 bit float.

### Read

The handler records each aux array (name, offset, length, type, zlib flag) and fills it from the `.ibd`. `OnDiscImzMLExperiment` does the same lazily in `getSpectrum()`, so `containsIMData()` works without loading the whole file. Length mismatches are skipped with a warning. zlib compressed aux arrays raise `ParseError`.

### IM peak type and units

After the `.ibd` fill, both loaders set `getIMPeakType()` to `IM_PROFILE` when IM data is present and the type is still `UNKNOWN`, same as mzML. `IM_CENTROIDED` is left as is. `getIMUnit()` looks up the PSI MS ontology first so `MS:1003006` is 1/K0 (`VSSC`), not milliseconds.

### Compressed m/z and intensity

The in memory loader already refused zlib compressed m/z and intensity (`MS:1000574`). The on disc path did not. The index now stores `mz_compressed` and `int_compressed`. Opening the file still works; `getSpectrum()` raises `ParseError`. pyOpenMS exposes those flags as read only.

### Tests

C++ and pyOpenMS cover IM round trip (in memory and on disc), `IM_PROFILE`, and zlib rejection for m/z and intensity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reading and writing auxiliary per-peak data, including ion-mobility and custom floating-point arrays, in imzML files.
  * Auxiliary data is available through in-memory and on-disc readers, Python bindings, and metadata.
  * Improved ion-mobility unit recognition and preservation across round trips.

* **Bug Fixes**
  * Added validation and clear errors for unsupported compression and mismatched array lengths.
  * Improved handling of empty, unnamed, incompatible, and unsupported auxiliary arrays.

* **Tests**
  * Added coverage for auxiliary data round trips, metadata, ion-mobility handling, sorting, and compression rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->