### PR TITLE
[FIX,FORMAT] #9864 pg: let a quantified group have no quantity in a cell

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/ProteinGroupArrowExport.h
+++ b/src/openms/include/OpenMS/FORMAT/ProteinGroupArrowExport.h
@@ -54,8 +54,8 @@ public:
   /**
     @brief Export protein group data to Apache Arrow Table
 
-    Exports indistinguishable protein groups following the active QPX 1.1 pg schema. One row is
-    emitted per protein group, experimental-design @c fraction_group, and label. @c grouped_runs
+    Exports indistinguishable protein groups following the active QPX 1.1 pg schema. At most one
+    row is emitted per protein group, experimental-design @c fraction_group, and label. @c grouped_runs
     lists that fraction group's raw files, while scalar @c label and @c intensity carry one
     quantity. The row's identity is derived from @c pg_accessions, @c grouped_runs and @c label --
     the FULL group membership, not @c anchor_protein, which is a display representative and is not

--- a/src/openms/include/OpenMS/FORMAT/ProteinGroupArrowExport.h
+++ b/src/openms/include/OpenMS/FORMAT/ProteinGroupArrowExport.h
@@ -79,6 +79,11 @@ public:
     identification-only, so its label is known, and a null says "not measured" where a @c 0.0 would
     be indistinguishable from a measurement of zero.
 
+    That row is emitted only where the group has identification evidence in the quantification
+    unit, because a labelled null asserts "identified here, but not quantified for this label". A
+    cell with neither a quantity nor evidence is omitted entirely: a row there would claim an
+    observation that was never made.
+
     @param[in] cmap The ConsensusMap with annotated protein group quantification
     @param[in] design The experimental design that was used to quantify @p cmap. It defines the
                fraction-group/label keys and their grouped runs. Every key a protein group carries

--- a/src/openms/include/OpenMS/FORMAT/ProteinGroupArrowExport.h
+++ b/src/openms/include/OpenMS/FORMAT/ProteinGroupArrowExport.h
@@ -57,7 +57,9 @@ public:
     Exports indistinguishable protein groups following the active QPX 1.1 pg schema. One row is
     emitted per protein group, experimental-design @c fraction_group, and label. @c grouped_runs
     lists that fraction group's raw files, while scalar @c label and @c intensity carry one
-    quantity. Together with @c anchor_protein these columns form the primary key.
+    quantity. The row's identity is derived from @c pg_accessions, @c grouped_runs and @c label --
+    the FULL group membership, not @c anchor_protein, which is a display representative and is not
+    unique across groups that share a leading protein.
 
     A fraction group must be <b>rectangular</b>: every label it publishes has to exist in every one
     of its runs, which makes "(any file in grouped_runs, label) -> run.samples[]" resolvable.
@@ -72,10 +74,16 @@ public:
     Groups without quantification are melted onto the fraction groups in which a member accession
     has peptide evidence, with null @c label and @c intensity.
 
+    A quantified group may still have no quantity for an individual cell, because it was never
+    measured there. Such a cell keeps its @c label and takes a null @c intensity: the group is not
+    identification-only, so its label is known, and a null says "not measured" where a @c 0.0 would
+    be indistinguishable from a measurement of zero.
+
     @param[in] cmap The ConsensusMap with annotated protein group quantification
     @param[in] design The experimental design that was used to quantify @p cmap. It defines the
-               exact fraction-group/label keys and their grouped runs. The exporter checks those
-               keys against every quantified protein group.
+               fraction-group/label keys and their grouped runs. Every key a protein group carries
+               must be one of them; a group carrying fewer is quantified in fewer cells, which is
+               not an error.
     @return Shared pointer to Arrow Table, or nullptr on error
   */
   static std::shared_ptr<arrow::Table> exportToArrow(const ConsensusMap& cmap,

--- a/src/openms/include/OpenMS/FORMAT/ProteinGroupArrowExport_impl.h
+++ b/src/openms/include/OpenMS/FORMAT/ProteinGroupArrowExport_impl.h
@@ -358,7 +358,8 @@ inline FractionGroupAbundanceData fractionGroupAbundances(
   @param[in] quantities Parsed fraction-group/label abundance arrays
   @param[in] design_samples Number of samples in the experimental design
   @param[in] units Quantification units derived from the design and ConsensusMap headers
-  @param[in] expected_quantity_keys Fraction-group/label keys required by @p units
+  @param[in] expected_quantity_keys Fraction-group/label keys permitted by @p units. A group may
+             carry fewer (a cell it was never measured in); it may not carry a key not in this set.
   @return An empty string when exportable, otherwise a diagnostic describing the first violation
 */
 inline std::string validateQuantificationAnnotations(
@@ -397,19 +398,27 @@ inline std::string validateQuantificationAnnotations(
     return "carries fraction-group abundances, but the experimental design yields no matching "
            "quantification unit";
   }
-  if (quantities.values.size() != expected_quantity_keys.size())
+  if (quantities.values.empty())
   {
-    return "carries " + std::to_string(quantities.values.size())
-         + " fraction-group/label quantities but the experimental design requires "
-         + std::to_string(expected_quantity_keys.size())
-         + ", so the annotations and design do not describe the same quantification";
+    return "carries fraction-group abundance arrays with no entries at all, so it claims to be "
+           "quantified without saying where";
   }
-  for (const auto& key : expected_quantity_keys)
+  // A subset, not an exact match: a group may legitimately have no quantity for a cell it was
+  // never measured in, and the exporter writes that as a null intensity rather than inventing a
+  // value. The direction that still has to hold is the other one -- a key the design cannot name
+  // means these annotations were produced by a different design. PeptideAndProteinQuant relies on
+  // exactly that when it restricts its cell set to header-backed cells: "otherwise every absent
+  // design file would add an invented zero-valued quantity that the exporter correctly refuses as
+  // an extra key".
+  for (const auto& [key, value] : quantities.values)
   {
-    if (!quantities.values.count(key))
+    (void)value;
+    if (expected_quantity_keys.count(key) == 0)
     {
-      return "has no quantity for fraction group " + std::to_string(key.first)
-           + ", label " + std::to_string(key.second);
+      return "carries a quantity for fraction group " + std::to_string(key.first)
+           + ", label " + std::to_string(key.second)
+           + ", which the experimental design does not describe, so the annotations and design "
+             "do not describe the same quantification";
     }
   }
   return {};

--- a/src/openms/include/OpenMS/FORMAT/ProteinGroupArrowExport_impl.h
+++ b/src/openms/include/OpenMS/FORMAT/ProteinGroupArrowExport_impl.h
@@ -404,8 +404,9 @@ inline std::string validateQuantificationAnnotations(
            "quantified without saying where";
   }
   // A subset, not an exact match: a group may legitimately have no quantity for a cell it was
-  // never measured in, and the exporter writes that as a null intensity rather than inventing a
-  // value. The direction that still has to hold is the other one -- a key the design cannot name
+  // never measured in. The exporter writes such a cell as a null intensity where the group has
+  // identification evidence in that unit, and omits it entirely where it has none -- either way,
+  // no value is invented. The direction that still has to hold is the other one -- a key the design cannot name
   // means these annotations were produced by a different design. PeptideAndProteinQuant relies on
   // exactly that when it restricts its cell set to header-backed cells: "otherwise every absent
   // design file would add an invented zero-valued quantity that the exporter correctly refuses as

--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -306,8 +306,9 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
                     << "'. They contributed no quantification." << std::endl;
   }
 
-  // Quantified groups emit one row per (fraction_group, label). Identification-only groups emit
-  // one row per evidence unit, which is bounded well enough by the same minimum reservation.
+  // Quantified groups emit at most one row per (fraction_group, label) -- a cell with neither a
+  // quantity nor evidence is omitted, so this reservation is an upper bound. Identification-only
+  // groups emit one row per evidence unit, bounded well enough by the same minimum reservation.
   Size quantities_per_group = 0;
   for (const auto& unit : units.units()) { quantities_per_group += unit.channels.size(); }
   const Size estimated_rows = groups.size() * std::max<Size>(quantities_per_group, 1);
@@ -524,7 +525,8 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
     if (intensity.has_value()) { (void)intensity_builder.Append(*intensity); }
     else                       { (void)intensity_builder.AppendNull(); }
 
-    // additional_intensities - empty for quantified rows, null for identification-only rows.
+    // additional_intensities - empty for labelled rows (quantified or labelled-null alike),
+    // null for identification-only rows.
     if (label.has_value()) { (void)additional_intensities_builder.Append(); }
     else                   { (void)additional_intensities_builder.AppendNull(); }
 
@@ -731,7 +733,8 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
     const bool quantified = quantities.present;
     if (quantified)
     {
-      // One scalar row per label in each fraction group, matching the active QPX 1.1 primary key.
+      // At most one scalar row per label in each fraction group, matching the active QPX 1.1
+      // primary key.
       //
       // A cell with a quantity is always written -- the quantity is its own evidence -- so a dense
       // annotation, which is what PeptideAndProteinQuant produces, takes this path for every cell
@@ -742,6 +745,12 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
       // for a unit the group was never observed in would assert an observation that was never made.
       // That is the same rule, computed from the same evidence set, as the identification-only
       // branch below -- which already refuses to fan out across units it has no evidence for.
+      //
+      // One deliberate asymmetry with that branch, unchanged from before this gate existed:
+      // evidence in a run outside every design unit enables nothing here. The else branch melts
+      // such a run into its own singleton unit, but a quantified group has no channel vocabulary
+      // for a run the design does not describe, so its evidence there is not representable and is
+      // dropped without a diagnostic.
       const std::set<std::string> evidence = evidenceRuns(acc_runs, group);
       for (const auto& unit : units.units())
       {

--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -334,7 +334,8 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
   auto gg_names_vb = std::make_shared<arrow::StringBuilder>();
   arrow::ListBuilder gg_names_builder(arrow::default_memory_pool(), gg_names_vb);
 
-  // -- scalar quantity columns; nullable for identification-only evidence rows --
+  // -- scalar quantity columns; independently nullable. Both null on an identification-only row,
+  //    and a label with a null intensity on a cell the group was never measured in. --
   arrow::StringBuilder label_builder;
   arrow::FloatBuilder intensity_builder;
 
@@ -514,17 +515,14 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
     // pg_qvalue - not per-run in OpenMS
     (void)pg_qvalue_builder.AppendNull();
 
-    // label/intensity are both null for a row backed only by identification evidence.
-    if (!label.has_value())
-    {
-      (void)label_builder.AppendNull();
-      (void)intensity_builder.AppendNull();
-    }
-    else
-    {
-      (void)label_builder.Append(*label);
-      (void)intensity_builder.Append(*intensity);
-    }
+    // label and intensity are independent. Both null for a row backed only by identification
+    // evidence; a label with a null intensity where the group has evidence in this quantification
+    // unit but no quantity for this label. Writing 0.0 there instead would be indistinguishable
+    // from a measurement of zero.
+    if (label.has_value()) { (void)label_builder.Append(*label); }
+    else                   { (void)label_builder.AppendNull(); }
+    if (intensity.has_value()) { (void)intensity_builder.Append(*intensity); }
+    else                       { (void)intensity_builder.AppendNull(); }
 
     // additional_intensities - empty for quantified rows, null for identification-only rows.
     if (label.has_value()) { (void)additional_intensities_builder.Append(); }
@@ -734,12 +732,34 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
     if (quantified)
     {
       // One scalar row per label in each fraction group, matching the active QPX 1.1 primary key.
+      //
+      // A cell with a quantity is always written -- the quantity is its own evidence -- so a dense
+      // annotation, which is what PeptideAndProteinQuant produces, takes this path for every cell
+      // and is unaffected by anything below.
+      //
+      // A cell with NO quantity is only written where the group was actually seen. A null intensity
+      // beside a label says "identified in this unit, not quantified for this label"; emitting one
+      // for a unit the group was never observed in would assert an observation that was never made.
+      // That is the same rule, computed from the same evidence set, as the identification-only
+      // branch below -- which already refuses to fan out across units it has no evidence for.
+      const std::set<std::string> evidence = evidenceRuns(acc_runs, group);
       for (const auto& unit : units.units())
       {
+        const bool seen_in_unit = std::any_of(unit.runs.begin(), unit.runs.end(),
+                                              [&evidence](const std::string& run)
+                                              { return evidence.count(run) != 0; });
         for (const auto& channel : unit.channels)
         {
           const auto value = quantities.values.find({unit.fraction_group, channel.label});
-          emitRow(group, unit.runs, channel.qpx_label, value->second);
+          if (value == quantities.values.end())
+          {
+            if (!seen_in_unit) { continue; }
+            emitRow(group, unit.runs, channel.qpx_label, std::nullopt);
+          }
+          else
+          {
+            emitRow(group, unit.runs, channel.qpx_label, std::optional<float>(value->second));
+          }
         }
       }
     }

--- a/src/openms/source/FORMAT/QPXValueValidation.cpp
+++ b/src/openms/source/FORMAT/QPXValueValidation.cpp
@@ -645,10 +645,17 @@ namespace OpenMS
 
         const bool has_label = !label->IsNull(row);
         const bool has_intensity = !intensity->IsNull(row);
-        if (has_label != has_intensity)
+        // Only one direction of the old "both or neither" rule survives. A label with a null
+        // intensity is legal: the group has evidence in this quantification unit but no quantity
+        // for this label, which the QPX schema expresses with a null (both fields are nullable)
+        // and which is what an absent measurement means. An intensity with no label is not: the
+        // label is what joins the value to a sample and is a component of the pg_id identity, so
+        // an unlabelled value cannot be attributed to anything.
+        if (has_intensity && !has_label)
         {
           addError(result, "row " + std::to_string(row)
-                           + " must set label and intensity together, or leave both null");
+                           + " has an intensity but no label, so the value cannot be joined to a "
+                             "sample");
         }
         std::optional<std::string> label_value;
         if (has_label)

--- a/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
@@ -783,6 +783,82 @@ START_SECTION(([EXTRA] isobaric feature rows keep consensus coordinates and list
 }
 END_SECTION
 
+START_SECTION(([EXTRA] an undetected reporter channel is written as an explicit 0.0, unlike in the pg view))
+{
+  // CHARACTERISATION of current behaviour, not an endorsement of it.
+  //
+  // IsobaricChannelExtractor resets every channel to 0 before searching the MS2 for its reporter
+  // and inserts the channel handle even when no peak is found, so a channel that was never
+  // detected arrives here as a stored 0.0. This exporter writes every handle it is given,
+  // including those, so an undetected channel becomes an entry whose intensity is exactly 0.0 --
+  // indistinguishable from a reporter that was measured at zero.
+  //
+  // The pg view takes the opposite position on the same measurement: PeptideAndProteinQuant drops
+  // non-positive abundances before aggregating, so a channel whose reporters were all undetected
+  // ends up with no quantity and is written with a NULL intensity. The two views therefore
+  // disagree about what "not measured" looks like, and because the QPX feature->pg softlink joins
+  // on the label, a feature can associate a channel that pg reports as absent.
+  //
+  // The feature view cannot resolve this the way pg did: QPXFeatureSchema declares
+  // intensities[].intensity non-nullable, so absence can only be expressed by OMITTING the entry
+  // -- which is what the QPX reference converter does (it skips inten <= 0). That moves real
+  // output, and no reference pins any value in this view, so it is deliberately not changed here.
+  // This section pins the status quo so that when the policy is unified the diff is visible
+  // somewhere instead of landing silently green.
+  ConsensusMap cmap;
+  const std::vector<std::string> channels = {"126", "127N", "127C"};
+  for (Size c = 0; c < channels.size(); ++c)
+  {
+    ConsensusMap::ColumnHeader ch;
+    ch.filename = "/data/tmt_run.mzML";
+    ch.label = "tmt10plex_" + channels[c];
+    ch.setMetaValue("channel_name", channels[c]);
+    ch.setMetaValue("channel_id", static_cast<int>(c));
+    cmap.getColumnHeaders()[c] = ch;
+  }
+
+  ConsensusFeature cf;
+  cf.setMZ(700.5);
+  cf.setRT(300.0);
+  cf.setCharge(2);
+  const float reporter[3] = {100.0f, 0.0f, 300.0f};   // 127N was never detected
+  for (Size c = 0; c < channels.size(); ++c)
+  {
+    BaseFeature b;
+    b.setIntensity(reporter[c]);
+    b.setMZ(126.0 + c);
+    b.setRT(301.0);
+    cf.insert(c, b);
+  }
+  cmap.push_back(cf);
+
+  auto t = ConsensusMapArrowExport::exportToArrow(cmap);
+  TEST_NOT_EQUAL(t, nullptr)
+
+  if (t != nullptr)
+  {
+    TEST_EQUAL(t->num_rows(), 1)
+    auto int_col = std::static_pointer_cast<arrow::ListArray>(t->GetColumnByName("intensities")->chunk(0));
+    auto st  = std::static_pointer_cast<arrow::StructArray>(int_col->values());
+    auto lab = std::static_pointer_cast<arrow::StringArray>(st->field(0));
+    auto val = std::static_pointer_cast<arrow::FloatArray>(st->field(1));
+
+    // The undetected channel is NOT dropped: all three labels are present.
+    TEST_EQUAL(int_col->value_length(0), 3)
+    TEST_STRING_EQUAL(lab->GetString(0), "TMT126")
+    TEST_STRING_EQUAL(lab->GetString(1), "TMT127N")
+    TEST_STRING_EQUAL(lab->GetString(2), "TMT127C")
+
+    // ... and it carries a stored 0.0 rather than being absent. This is the assertion that has to
+    // change if the feature view ever adopts the pg view's notion of "not measured".
+    TEST_FALSE(val->IsNull(1))
+    TEST_REAL_SIMILAR(val->Value(0), 100.0f)
+    TEST_REAL_SIMILAR(val->Value(1), 0.0f)
+    TEST_REAL_SIMILAR(val->Value(2), 300.0f)
+  }
+}
+END_SECTION
+
 START_SECTION(([EXTRA] SILAC feature labels use the canonical QPX two-plex vocabulary))
 {
   ConsensusMap cmap;

--- a/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapArrowExport_test.cpp
@@ -793,11 +793,13 @@ START_SECTION(([EXTRA] an undetected reporter channel is written as an explicit 
   // including those, so an undetected channel becomes an entry whose intensity is exactly 0.0 --
   // indistinguishable from a reporter that was measured at zero.
   //
-  // The pg view takes the opposite position on the same measurement: PeptideAndProteinQuant drops
-  // non-positive abundances before aggregating, so a channel whose reporters were all undetected
-  // ends up with no quantity and is written with a NULL intensity. The two views therefore
-  // disagree about what "not measured" looks like, and because the QPX feature->pg softlink joins
-  // on the label, a feature can associate a channel that pg reports as absent.
+  // The pg view CAN now take the opposite position on the same measurement: a labelled cell with
+  // no quantity is written with a NULL intensity. Today that shape is still latent --
+  // PeptideAndProteinQuant drops non-positive abundances before aggregating, but its annotation
+  // step then re-densifies every design cell with 0.0, so in-tree pg output writes the same 0.0
+  // this view does. Once the producer stops densifying, the two views WILL disagree about what
+  // "not measured" looks like, and because the QPX feature->pg softlink joins on the label, a
+  // feature would associate a channel that pg reports as absent.
   //
   // The feature view cannot resolve this the way pg did: QPXFeatureSchema declares
   // intensities[].intensity non-nullable, so absence can only be expressed by OMITTING the entry

--- a/src/tests/class_tests/openms/source/ProteinGroupArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteinGroupArrowExport_test.cpp
@@ -1559,8 +1559,10 @@ START_SECTION(([EXTRA] ConsensusMap overload - isobaric: an undetected reporter 
   // and inserts the channel handle even when no peak is found, so an undetected reporter arrives
   // at quantification as a stored 0.0. PeptideAndProteinQuant filters those out before aggregating
   // (only 'abundance > 0.0' contributes), so a channel whose reporters were all undetected ends up
-  // with no key -- and has to be written as null, because aggregating the resulting empty list
-  // returns 0.0, which is indistinguishable from a real measurement of zero.
+  // with no key in its internal result map. Today its annotation step then re-densifies that map,
+  // seeding the missing cell with 0.0 -- indistinguishable from a real measurement of zero -- so
+  // in-tree output does not yet contain the sparse shape; this section builds it by hand. Once the
+  // producer stops densifying, this is the row a dead channel becomes.
   const std::string path = "/d/plex.mzML";
   ConsensusMap cmap;
   cmap.setExperimentType("labeled_MS2");
@@ -1691,8 +1693,22 @@ START_SECTION(([EXTRA] ConsensusMap overload - the relaxed annotation check stil
 
   const ExperimentalDesign design = ExperimentalDesign::fromConsensusMap(cmap);
 
-  // The one design cell, quantified: exportable.
-  TEST_NOT_EQUAL(ProteinGroupArrowExport::exportToArrow(mapWith({{1, 1, 500.0f}}), design), nullptr)
+  // The one design cell, quantified: exportable, and the value row is actually there. The group
+  // has no identification evidence anywhere, so this also pins that the evidence gate never
+  // withholds a cell that carries a quantity -- a nullptr check alone would be satisfied by an
+  // empty table.
+  {
+    auto t = ProteinGroupArrowExport::exportToArrow(mapWith({{1, 1, 500.0f}}), design);
+    TEST_NOT_EQUAL(t, nullptr)
+    if (t != nullptr)
+    {
+      TEST_EQUAL(t->num_rows(), 1)
+      const auto cell = cellOf(t, 0);
+      TEST_TRUE(cell.first.has_value())
+      TEST_TRUE(cell.second.has_value())
+      if (cell.second.has_value()) { TEST_REAL_SIMILAR(*cell.second, 500.0f) }
+    }
+  }
 
   // A key the design cannot name. This is the direction the subset check keeps, and the one
   // PeptideAndProteinQuant relies on when it restricts its cell set to header-backed cells.

--- a/src/tests/class_tests/openms/source/ProteinGroupArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteinGroupArrowExport_test.cpp
@@ -33,7 +33,9 @@
 
 #include <arrow/api.h>
 
+#include <optional>
 #include <tuple>
+#include <utility>
 
 using namespace OpenMS;
 using namespace std;
@@ -162,6 +164,23 @@ namespace
     return out;
   }
 
+  /// The (label, intensity) pair of one row, keeping the three legal shapes apart:
+  ///   {nullopt, nullopt} -- identification-only: the group is not quantified anywhere,
+  ///   {label,   nullopt} -- evidence in this unit, but no quantity for this label,
+  ///   {label,   value}   -- quantified.
+  /// intensitiesOf() collapses the first two into an empty map, so it cannot express the middle
+  /// state; that is exactly what the two sections at the end of this file are about.
+  using PgCell = std::pair<std::optional<std::string>, std::optional<float>>;
+  PgCell cellOf(const std::shared_ptr<arrow::Table>& table, int64_t row)
+  {
+    auto labels = std::static_pointer_cast<arrow::StringArray>(table->GetColumnByName("label")->chunk(0));
+    auto values = std::static_pointer_cast<arrow::FloatArray>(table->GetColumnByName("intensity")->chunk(0));
+    PgCell out;
+    if (!labels->IsNull(row)) { out.first = labels->GetString(row); }
+    if (!values->IsNull(row)) { out.second = values->Value(row); }
+    return out;
+  }
+
   /// Collect scalar quantities from all rows (for tests with one grouped_runs unit).
   std::map<std::string, float> allIntensities(const std::shared_ptr<arrow::Table>& table)
   {
@@ -255,7 +274,7 @@ START_SECTION(([EXTRA] pg value validation enforces keys, labels, and grouped_ru
   QPXValueValidation anchor_validator(QPXValueValidation::View::PROTEIN_GROUP);
   TEST_FALSE(anchor_validator.validate(empty_anchor).valid)
 
-  // A quantified row sets label and intensity together, and the label must be canonical.
+  // A row that carries an intensity must carry a canonical label beside it.
   arrow::StringBuilder bad_label_builder;
   TEST_TRUE(bad_label_builder.Append("Arg10").ok())
   arrow::FloatBuilder intensity_builder;
@@ -269,12 +288,17 @@ START_SECTION(([EXTRA] pg value validation enforces keys, labels, and grouped_ru
   TEST_FALSE(label_result.valid)
   TEST_TRUE(label_result.toString().find("non-canonical") != std::string::npos)
 
+  // Scaffold for the additional_intensities check below: an identification-only row with its label
+  // overwritten. Deliberately NOT asserted valid either way. pg_id is part of the identity
+  // composite (pg_accessions, grouped_runs, label) and is not recomputed by replaceColumn, so this
+  // row's id no longer matches its own columns -- QPXValueValidation does not re-derive ids, so
+  // asserting on its validity would be asserting on something this fixture cannot speak to. That a
+  // label with a null intensity is accepted is pinned instead on real exporter output, in the two
+  // ConsensusMap sections at the end of this file.
   arrow::StringBuilder lfq_label_builder;
   TEST_TRUE(lfq_label_builder.Append("LFQ").ok())
   auto unmatched_label = replaceColumn(table, QPXPgSchema::LABEL,
                                        lfq_label_builder.Finish().ValueOrDie());
-  QPXValueValidation pair_validator(QPXValueValidation::View::PROTEIN_GROUP);
-  TEST_FALSE(pair_validator.validate(unmatched_label).valid)
 
   // additional_intensities uses the same canonical label as the flattened pg row.
   auto pair_name_builder = std::make_shared<arrow::StringBuilder>();
@@ -1452,17 +1476,244 @@ START_SECTION(([EXTRA] a group carrying only the legacy sample abundances is ref
 }
 END_SECTION
 
+START_SECTION(([EXTRA] ConsensusMap overload - label-free: a cell with evidence but no quantity is null, not zero))
+{
+  // Two fraction groups of one file each, PROT_A quantified in the first only. The second cell has
+  // identification evidence but no quantity, so it keeps its label and takes a null intensity.
+  // Before this, the quantity arrays had to cover every design cell exactly, so the sparse shape
+  // was refused outright and PeptideAndProteinQuant materialised a 0.0 for the missing cell.
+  const std::vector<std::string> paths = {"/data/S1_F1.mzML", "/data/S2_F1.mzML", "/data/S3_F1.mzML"};
+  ConsensusMap cmap;
+  cmap.setExperimentType("label-free");
+  for (Size m = 0; m < paths.size(); ++m)
+  {
+    ConsensusMap::ColumnHeader ch;
+    ch.filename = paths[m];
+    ch.label = "label-free";
+    ch.setMetaValue("fraction", 1);
+    ch.setMetaValue("fraction_group", static_cast<int>(m) + 1);
+    cmap.getColumnHeaders()[m] = ch;
+  }
+
+  ProteinIdentification prot;
+  prot.setIdentifier("merged");
+  prot.setScoreType("q-value");
+  prot.setHigherScoreBetter(false);
+  prot.setPrimaryMSRunPath(StringList(paths.begin(), paths.end()));
+  ProteinHit ph; ph.setAccession("PROT_A");
+  prot.setHits({ph});
+
+  ProteinIdentification::ProteinGroup grp;
+  grp.accessions = {"PROT_A"};
+  grp.probability = 0.01;
+  // Sparse on purpose: PeptideAndProteinQuant's own result map is already sparse this way -- see
+  // PeptideAndProteinQuant_test.cpp asserting 'fraction_group_abundances.count(3) == 0'.
+  setFractionGroupQuantities(grp, {{1, 1, 1000.0f}});
+  prot.insertIndistinguishableProteins(grp);
+  cmap.setProteinIdentifications({prot});
+
+  // Evidence in the first two runs only. The third unit has neither a quantity nor evidence, so
+  // the group was never seen there at all and must not acquire a row: a null intensity claims
+  // "identified here but not quantified", which would be an observation that was never made.
+  cmap.getUnassignedPeptideIdentifications() = {makeMergedPeptide("PROT_A", 0, "PEPTIDEK", "merged"),
+                                                makeMergedPeptide("PROT_A", 1, "PEPTIDER", "merged")};
+
+  const ExperimentalDesign design = ExperimentalDesign::fromConsensusMap(cmap);
+  auto t = ProteinGroupArrowExport::exportToArrow(cmap, design);
+  TEST_NOT_EQUAL(t, nullptr)
+
+  if (t != nullptr)
+  {
+    TEST_EQUAL(t->num_rows(), 2)
+    const auto runs = groupedRuns(t);
+    std::map<std::string, PgCell> by_unit;
+    for (int64_t row = 0; row < t->num_rows(); ++row) { by_unit[runs[row][0]] = cellOf(t, row); }
+
+    // Quantified.
+    TEST_EQUAL(by_unit.count("S1_F1"), 1)
+    TEST_TRUE(by_unit.count("S1_F1") == 1 && by_unit.at("S1_F1").second.has_value())
+    if (by_unit.count("S1_F1") == 1 && by_unit.at("S1_F1").second.has_value())
+    {
+      TEST_REAL_SIMILAR(*by_unit.at("S1_F1").second, 1000.0f)
+    }
+
+    // Evidence, no quantity: the label survives, the intensity is null and specifically not 0.0.
+    TEST_EQUAL(by_unit.count("S2_F1"), 1)
+    TEST_TRUE(by_unit.count("S2_F1") == 1 && by_unit.at("S2_F1").first.has_value())
+    TEST_TRUE(by_unit.count("S2_F1") == 1 && !by_unit.at("S2_F1").second.has_value())
+
+    // Neither quantity nor evidence: no row in any shape. A labelled null here would claim the
+    // group was identified in a unit it was never seen in.
+    TEST_EQUAL(by_unit.count("S3_F1"), 0)
+
+    QPXValueValidation sparse_validator(QPXValueValidation::View::PROTEIN_GROUP);
+    TEST_TRUE(sparse_validator.validate(t).valid)
+  }
+}
+END_SECTION
+
+START_SECTION(([EXTRA] ConsensusMap overload - isobaric: an undetected reporter channel is null, not zero))
+{
+  // The isobaric shape of the same rule, and the case that makes it more than bookkeeping.
+  // IsobaricChannelExtractor resets every channel to 0 before searching the MS2 for its reporter
+  // and inserts the channel handle even when no peak is found, so an undetected reporter arrives
+  // at quantification as a stored 0.0. PeptideAndProteinQuant filters those out before aggregating
+  // (only 'abundance > 0.0' contributes), so a channel whose reporters were all undetected ends up
+  // with no key -- and has to be written as null, because aggregating the resulting empty list
+  // returns 0.0, which is indistinguishable from a real measurement of zero.
+  const std::string path = "/d/plex.mzML";
+  ConsensusMap cmap;
+  cmap.setExperimentType("labeled_MS2");
+  const char* names[3] = {"126", "127N", "127C"};
+  for (Size c = 0; c < 3; ++c)
+  {
+    ConsensusMap::ColumnHeader h;
+    h.filename = path;
+    h.label = std::string("tmt6plex_") + names[c];
+    h.setMetaValue("channel_name", names[c]);
+    h.setMetaValue("channel_id", static_cast<int>(c));
+    cmap.getColumnHeaders()[c] = h;
+  }
+
+  ProteinIdentification prot;
+  prot.setIdentifier("merged");
+  prot.setScoreType("q-value");
+  prot.setHigherScoreBetter(false);
+  prot.setPrimaryMSRunPath({path});
+  ProteinHit ph; ph.setAccession("PROT_A");
+  prot.setHits({ph});
+  ProteinIdentification::ProteinGroup grp;
+  grp.accessions = {"PROT_A"};
+  grp.probability = 0.01;
+  setFractionGroupQuantities(grp, {{1, 1, 100.0f}, {1, 3, 300.0f}});   // 127N is the dead channel
+  prot.insertIndistinguishableProteins(grp);
+  cmap.setProteinIdentifications({prot});
+  cmap.getUnassignedPeptideIdentifications() = {makeMergedPeptide("PROT_A", 0, "PEPTIDEK", "merged")};
+
+  ExperimentalDesign::MSFileSection section;
+  for (unsigned lab = 1; lab <= 3; ++lab)
+  {
+    ExperimentalDesign::MSFileSectionEntry e;
+    e.path = path; e.fraction = 1; e.fraction_group = 1;
+    e.label = lab; e.sample = lab - 1;
+    e.sample_name = "S" + StringUtils::toStr(lab);
+    section.push_back(e);
+  }
+  ExperimentalDesign::SampleSection samples;
+  for (unsigned lab = 1; lab <= 3; ++lab) { samples.addSample("S" + StringUtils::toStr(lab)); }
+  ExperimentalDesign design;
+  design.setMSFileSection(section);
+  design.setSampleSection(samples);
+
+  auto t = ProteinGroupArrowExport::exportToArrow(cmap, design);
+  TEST_NOT_EQUAL(t, nullptr)
+
+  if (t != nullptr)
+  {
+    // The plex keeps its full label vocabulary: the group has evidence in this run, so all three
+    // channels are statements OpenMS is entitled to make.
+    TEST_EQUAL(t->num_rows(), 3)
+    std::map<std::string, PgCell> by_label;
+    for (int64_t row = 0; row < t->num_rows(); ++row)
+    {
+      const PgCell cell = cellOf(t, row);
+      TEST_TRUE(cell.first.has_value())
+      if (cell.first.has_value()) { by_label[*cell.first] = cell; }
+    }
+
+    TEST_EQUAL(by_label.count("TMT126"), 1)
+    TEST_EQUAL(by_label.count("TMT127N"), 1)
+    TEST_EQUAL(by_label.count("TMT127C"), 1)
+
+    // The two measured channels must still carry their values. Without these, a regression that
+    // nulled every channel would leave the labels and the row count intact and slip through.
+    TEST_TRUE(by_label.count("TMT126") == 1 && by_label.at("TMT126").second.has_value())
+    TEST_TRUE(by_label.count("TMT127C") == 1 && by_label.at("TMT127C").second.has_value())
+    if (by_label.count("TMT126") == 1 && by_label.at("TMT126").second.has_value())
+    {
+      TEST_REAL_SIMILAR(*by_label.at("TMT126").second, 100.0f)
+    }
+    if (by_label.count("TMT127C") == 1 && by_label.at("TMT127C").second.has_value())
+    {
+      TEST_REAL_SIMILAR(*by_label.at("TMT127C").second, 300.0f)
+    }
+
+    // The dead channel: null, and specifically not 0.0.
+    TEST_TRUE(by_label.count("TMT127N") == 1 && !by_label.at("TMT127N").second.has_value())
+
+    // The sparse table is a legal QPX pg table in its own right -- this is the self-consistent
+    // positive check the hand-edited fixture above cannot provide, because here pg_id was derived
+    // by the exporter from the label it actually wrote.
+    QPXValueValidation sparse_validator(QPXValueValidation::View::PROTEIN_GROUP);
+    TEST_TRUE(sparse_validator.validate(t).valid)
+
+    // additional_intensities stays keyed on the label, not on the intensity: an empty list on any
+    // labelled row, null only on an identification-only one.
+    auto extras = t->GetColumnByName(QPXPgSchema::ADDITIONAL_INTENSITIES)->chunk(0);
+    for (int64_t row = 0; row < t->num_rows(); ++row) { TEST_FALSE(extras->IsNull(row)) }
+  }
+}
+END_SECTION
+
+START_SECTION(([EXTRA] ConsensusMap overload - the relaxed annotation check still refuses what it must))
+{
+  // The subset check gave up exactly one thing: a design that describes more cells than the group
+  // was measured in. Everything else it used to catch it must still catch, and neither boundary is
+  // covered by the acceptance sections above.
+  const std::string path = "/d/one.mzML";
+  ConsensusMap cmap;
+  cmap.setExperimentType("label-free");
+  ConsensusMap::ColumnHeader ch;
+  ch.filename = path;
+  ch.label = "label-free";
+  ch.setMetaValue("fraction", 1);
+  ch.setMetaValue("fraction_group", 1);
+  cmap.getColumnHeaders()[0] = ch;
+
+  auto mapWith = [&](const std::vector<std::tuple<UInt, UInt, float>>& quantities)
+  {
+    ProteinIdentification prot;
+    prot.setIdentifier("merged");
+    prot.setScoreType("q-value");
+    prot.setHigherScoreBetter(false);
+    prot.setPrimaryMSRunPath({path});
+    ProteinHit ph; ph.setAccession("PROT_A");
+    prot.setHits({ph});
+    ProteinIdentification::ProteinGroup grp;
+    grp.accessions = {"PROT_A"};
+    grp.probability = 0.01;
+    setFractionGroupQuantities(grp, quantities);
+    prot.insertIndistinguishableProteins(grp);
+    ConsensusMap out = cmap;
+    out.setProteinIdentifications({prot});
+    return out;
+  };
+
+  const ExperimentalDesign design = ExperimentalDesign::fromConsensusMap(cmap);
+
+  // The one design cell, quantified: exportable.
+  TEST_NOT_EQUAL(ProteinGroupArrowExport::exportToArrow(mapWith({{1, 1, 500.0f}}), design), nullptr)
+
+  // A key the design cannot name. This is the direction the subset check keeps, and the one
+  // PeptideAndProteinQuant relies on when it restricts its cell set to header-backed cells.
+  TEST_EQUAL(ProteinGroupArrowExport::exportToArrow(mapWith({{2, 1, 500.0f}}), design), nullptr)
+
+  // Arrays present but carrying nothing: a group claiming to be quantified without saying where.
+  TEST_EQUAL(ProteinGroupArrowExport::exportToArrow(mapWith({}), design), nullptr)
+}
+END_SECTION
+
 START_SECTION(([EXTRA] pg value validation - an intensity without a label stays rejected))
 {
   // A pg intensity is only interpretable through its label: the label is what joins the value to
   // a sample (run.samples[].label), and it is a component of the pg_id identity composite. A value
   // with no label therefore cannot be attributed to anything and the row is unusable.
   //
-  // Today this is enforced together with the converse, by a single "set both or neither" check in
-  // QPXValueValidation. That coupling is scheduled to be split so that a group with evidence in a
-  // quantification unit but no quantity for a label can be written as a populated label with a
-  // null intensity -- a shape the QPX schema already permits and the reference writer already
-  // handles. This section pins the half that must survive that split.
+  // This used to be enforced together with the converse, by a single "set both or neither" check
+  // in QPXValueValidation. That coupling was split so a group with evidence in a quantification
+  // unit but no quantity for a label can be written as a populated label with a null intensity --
+  // a shape the QPX schema permits and the reference writer already handles. This section pins the
+  // half that had to survive the split, and which nothing else covers on its own.
   auto prot_id = makeIdOnlyRun({"/data/runA.mzML"});
   auto table = ProteinGroupArrowExport::exportToArrow({prot_id}, makePeptides());
   TEST_NOT_EQUAL(table, nullptr)

--- a/src/tests/class_tests/openms/source/ProteinGroupArrowExport_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteinGroupArrowExport_test.cpp
@@ -1452,4 +1452,34 @@ START_SECTION(([EXTRA] a group carrying only the legacy sample abundances is ref
 }
 END_SECTION
 
+START_SECTION(([EXTRA] pg value validation - an intensity without a label stays rejected))
+{
+  // A pg intensity is only interpretable through its label: the label is what joins the value to
+  // a sample (run.samples[].label), and it is a component of the pg_id identity composite. A value
+  // with no label therefore cannot be attributed to anything and the row is unusable.
+  //
+  // Today this is enforced together with the converse, by a single "set both or neither" check in
+  // QPXValueValidation. That coupling is scheduled to be split so that a group with evidence in a
+  // quantification unit but no quantity for a label can be written as a populated label with a
+  // null intensity -- a shape the QPX schema already permits and the reference writer already
+  // handles. This section pins the half that must survive that split.
+  auto prot_id = makeIdOnlyRun({"/data/runA.mzML"});
+  auto table = ProteinGroupArrowExport::exportToArrow({prot_id}, makePeptides());
+  TEST_NOT_EQUAL(table, nullptr)
+
+  if (table != nullptr)
+  {
+    // The identification-only row has both columns null; give it an intensity and nothing else.
+    arrow::FloatBuilder orphan_intensity_builder;
+    TEST_TRUE(orphan_intensity_builder.Append(42.0f).ok())
+    auto orphan_intensity = replaceColumn(table, QPXPgSchema::INTENSITY,
+                                          orphan_intensity_builder.Finish().ValueOrDie());
+    TEST_TRUE(orphan_intensity->GetColumnByName(QPXPgSchema::LABEL)->chunk(0)->IsNull(0))
+
+    QPXValueValidation orphan_validator(QPXValueValidation::View::PROTEIN_GROUP);
+    TEST_FALSE(orphan_validator.validate(orphan_intensity).valid)
+  }
+}
+END_SECTION
+
 END_TEST


### PR DESCRIPTION
Part of #9864.

## The problem

A protein group quantified in one quantification unit may have no quantity in another, because it was never measured there. The `pg` view could not express that. The annotation check required a group's quantity arrays to cover the design's `(fraction_group, label)` cells **exactly**, so `PeptideAndProteinQuant` materialises every cell and seeds the missing ones with `0.0` (`PeptideAndProteinQuant.cpp:1158-1172`).

A stored `0.0` is indistinguishable from a measurement of zero. It is consumed as data by any sum, ratio, log transform or normalisation downstream — the same class of defect as the `observed_mz = 0.0` sentinel that bigbio/qpx#244 removed for m/z.

## What this PR does

The **structural half** only: it makes the sparse row representable. It changes no numbers, because the producer still emits a dense array. Removing the fabricated zeros from the producer is a separate change.

- `ProteinGroupArrowExport_impl.h` — the design/annotation check becomes a **subset** check. Every key a group carries must still be one the design names; carrying *fewer* is now legal. Arrays present but empty stay refused, as before.
- `ProteinGroupArrowExport.cpp` — guard the quantity lookup. It dereferenced `find()` unconditionally, reachable only once the exact-key-set check stops refusing sparse input first.
- `ProteinGroupArrowExport.cpp` — a cell with **no** quantity is written only where the group has identification evidence, reusing the evidence set the identification-only branch already computes. A null intensity beside a label means "identified here, not quantified for this label"; emitting one for a unit the group was never observed in would assert an observation that was never made. Applies only to the missing-key path, so a dense annotation is unaffected.
- `ProteinGroupArrowExport.cpp` — emit `label` and `intensity` independently instead of keying both off the label.
- `QPXValueValidation.cpp` — the "set both or leave both null" rule loses one direction. An intensity with **no label** is still refused (the label joins the value to a sample and is part of the `pg_id` identity composite). A label with a null intensity is now legal.

Also corrects a class comment that named `anchor_protein` as part of the primary key — identity is derived from the full `pg_accessions` membership, and an anchor is not unique across groups sharing a leading protein (bigbio/qpx#250).

## Grounding against the QPX spec

Checked against bigbio/qpx `v1.1.2` (`main`) and `dev`; `docs/spec/pg.md` and `docs/spec/schemas/pg.yaml` are byte-identical on both.

- `label` and `intensity` are **independently nullable**, with no declared cross-field constraint.
- The normative sentence in `pg.md` constrains only `label`'s nullability, never `intensity`'s.
- `pg_id` hashes `(pg_accessions, grouped_runs, label)`, so a null intensity cannot disturb identity.
- The reference writer already passes this shape through and names OpenMS as its producer (`qpx/writers/pg.py`), and it has shipped since v1.1.0.

**Not yet ratified:** bigbio/qpx#280 asks whether such a cell should instead be omitted entirely. If it resolves that way, the change is to skip the row at the same site — the evidence gate is already there — not to reintroduce a value.

## Verification

- 45 QPX TOPP tests: **45/45 before and after, zero reference files touched.**
- `QPXValueValidation_test`, `QPXCollectionExport_test`, `ArrowSchemaRegistry_test`: unchanged.
- Every new assertion was confirmed to **fail on purpose**. Emitting `0.0` for a missing key, dropping the evidence gate, dropping the empty-array refusal and dropping the extra-key check each redden exactly the assertion covering them, and nothing else.

The isobaric acceptance test is the case that makes this more than bookkeeping: `IsobaricChannelExtractor` writes an undetected reporter as `0.0` and inserts the handle anyway (`:620`, `:663`), `PeptideAndProteinQuant` then filters those out before aggregating (`:1466`), so a channel whose reporters were all undetected reaches aggregation as an empty list and comes back as `0.0`.

## Review points

**One guard is deliberately given up.** For a group carrying no legacy `abundances` array, the exact-key-set check was the only per-group detector of an experimental design that is a strict *superset* of what was quantified — and that shape is exactly what is now legal. Narrower than it sounds: `missingCell()`, `raggedUnit()`, `units.empty()` and the sample-count check all still fire.

**One assertion is flipped.** `ProteinGroupArrowExport_test.cpp` previously asserted that a label with a null intensity is invalid. That is the invariant being removed. The surviving half — an intensity with no label — is pinned in its own section, added as the first commit so it can be seen passing *before* the split.

## The feature/pg disagreement: pinned here, not fixed here

OpenMS's `feature` and `pg` views will disagree about what "not measured" looks like. `ConsensusMapArrowExport.cpp:1239-1246` appends every included handle without filtering on intensity, so an undetected reporter stays an explicit `0.0`; `pg` now writes a null for the same measurement. With the label-aware feature→pg softlink (bigbio/qpx#269) a feature could associate a channel `pg` reports as absent.

**This is latent, not live.** `PeptideAndProteinQuant` is untouched, so the producer is still dense and `pg` does not yet emit a single null — the new path is reachable only from a sparse annotation, which nothing in-tree produces today.

The feature view cannot resolve this the way `pg` did: `QPXFeatureSchema` declares `intensities[].intensity` **non-nullable**, so absence can only be expressed by omitting the entry — which is what the QPX reference converter does (`pg_adapter.py` skips `inten <= 0`).

That is deliberately **not** changed here:

- it moves real output — 13 of the 50 intensity entries in the `IsobaricWorkflow` fixture are non-positive;
- **no test would catch it.** No committed value reference exists for the feature view anywhere; its five TOPP checks are `-schema feature -min_rows N` (`CMakeLists.txt:1145, 2991, 3007, 4155, 4272`), shape and row floor only, plus a sixth comparing two generated outputs (`:4206-4209`);
- the obvious remedy, pinning a TOPP reference first, is the one thing `CMakeLists.txt:3113-3115` explicitly avoids — the feature key contains a float32 `rt` matched at zero tolerance, the one view where a one-ULP cross-platform drift does not degrade gracefully.

So the last commit pins the **current** behaviour in a class test instead, which has neither problem (it builds its own `ConsensusMap`, so there is no mzML parsing and no `rt` to drift). Unifying the policy will then produce a visible diff rather than landing silently green. Confirmed by adding the candidate `inten <= 0` skip to the exporter: it reddens exactly the entry-count and value assertions.

## Commits

1. `[TEST]` pin that an intensity without a label stays rejected — the half of the old coupling that survives, added first so it can be seen passing *before* the split.
2. `[FIX]` the change itself.
3. `[TEST]` pin the feature view's zero-intensity behaviour, per above.
4. `[DOC]` correct the exporter documentation for the evidence condition.
5. `[DOC,TEST]` fixes from two independent final-state reviews: latent-vs-live wording in test comments, "at most one row" cardinality in docs, the pre-existing unlisted-run evidence asymmetry documented at the gate, and a strengthened boundary assertion (one row + value, not just non-null).

Verified on Linux/GCC only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7QNzj4dhRnX5htcHZFmDm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protein-group exports for partially measured samples and sparse experimental designs.
  * Preserved channel labels when intensity values are unavailable, while omitting cells without quantity or identification evidence.
  * Added clearer validation for unlabeled intensities and invalid experimental-design mappings.
  * Ensured zero-intensity reporter channels are exported explicitly as `0.0`.
* **Tests**
  * Expanded coverage for sparse label-free, isobaric, and partially quantified protein-group data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->