### PR TITLE
Update CHANGELOG: Windows installer user survey link

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1045,6 +1045,8 @@ Build System:
   - CI: macOS notarization with timestamping integrated (#8486, #8494, #8527); the .pkg installer no longer
     packages the pyopenms extension modules, which were never signed and are shipped as wheels anyway
     (#9827)
+  - Windows installer: the NSIS "Installation Complete" page now links to a short, optional user survey,
+    to help gauge who is using OpenMS (#9769)
   - CI: the Docker image build fetches the Arrow APT source from packages.apache.org and appends Arrow's
     canonical KEYS to the pinned keyring, reducing NO_PUBKEY nightly failures (#9728, #9729, #9750); the
     Bioconda sync merges instead of rebasing, which had failed every nightly run for 16 days (#9798);


### PR DESCRIPTION
## Description

Routine sweep of recently merged PRs for CHANGELOG coverage. Most recent merges (#9888, #9901, #9898, #9903, #9891, #9905/#9907, #9900, #9892, #9896) already have accurate CHANGELOG entries — several via dedicated follow-up "Update CHANGELOG" PRs, others landed with the entry in the same PR. #9882 (`-in_feat`/`-out_feat` removal) intentionally has no entry, per that PR's own description (the feature never shipped in a release). #9887 (ccache CI strategy) is explicitly marked CI-only/no-CHANGELOG by its author.

The one gap found: #9769 ("Add user survey to installer") added a link to a short user survey on the NSIS Windows installer's "Installation Complete" page, but never got a CHANGELOG entry. This adds one under `Build System`, next to the other installer/packaging entries.

## Checklist
- [x] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

CHANGELOG-only change, no code/build/binding changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bh5AJiPmjK9AM4n5VP5SBm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional link to a user survey on the Windows installer’s “Installation Complete” page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->