### PR TITLE
Fix nightly Deploy to Bioconda: pin gnuplot to avoid broken legacy build

### DIFF
--- a/.github/workflows/bioconda_deploy.yaml
+++ b/.github/workflows/bioconda_deploy.yaml
@@ -117,6 +117,27 @@ jobs:
           # history, so it only conflicts on genuinely unresolved changes.
           git merge --no-edit bioconda/master
 
+      # openms-thirdparty's run requirement on gnuplot (recipes/openms-meta/meta.yaml) is
+      # unpinned, which lets the solver fall back to gnuplot 5.0.3 -- an ancient bioconda
+      # build whose only dependency option is "libgd *.bioconda", a build string no channel
+      # serves anymore. That makes the openms-thirdparty test environment unsatisfiable and
+      # fails the whole openms-meta build (BIOCONDA ERROR: Unsatisfiable dependencies ...
+      # MatchSpec("gnuplot==5.0.3=1"), MatchSpec("libgd==*.bioconda")), which in turn starves
+      # the pyopenms build of libopenms/openms artifacts. Pin to a modern, installable range
+      # here (rather than upstream, since this checkout of bioconda-recipes is never pushed
+      # back) so the solver never reaches that dead end.
+      - name: Pin gnuplot in the openms-thirdparty recipe to avoid a broken legacy build
+        run: |
+          cd bioconda-recipes
+          recipe=recipes/openms-meta/meta.yaml
+          matches=$(grep -c '^\s*- gnuplot$' "$recipe" || true)
+          if [ "$matches" -ne 1 ]; then
+            echo "::error::Expected exactly one unpinned 'gnuplot' run dependency in $recipe, found $matches -- recipe format changed, update this pin."
+            exit 1
+          fi
+          sed -i 's/^\(\s*- \)gnuplot$/\1gnuplot >=5.4/' "$recipe"
+          grep -n 'gnuplot' "$recipe"
+
       # BUILD_ENV_IMAGE comes from the preflight in "Prepare output directory".
       - name: Lint and build OpenMS Bioconda packages
         run: |


### PR DESCRIPTION
## Description

The nightly "Deploy to Bioconda" workflow (`.github/workflows/bioconda_deploy.yaml`, triggered daily from `update_nightly.yml`) has failed **every night since 2026-08-08** (7 consecutive failures as of this PR, run [#221](https://github.com/OpenMS/OpenMS/actions/runs/31658573903) etc.), plus today's run [#223](https://github.com/OpenMS/OpenMS/actions/runs/31761475607).

Root cause: the `openms-thirdparty` output in `recipes/openms-meta/meta.yaml` (in the `OpenMS/bioconda-recipes` fork that this workflow clones at build time) lists `gnuplot` as a `run:` dependency with no version constraint:

```yaml
run:
  ...
  - gnuplot
  - r-gplots
```

Because the rest of the `openms`/`openms-thirdparty` environment pins `xerces-c`/`icu` tightly, the conda solver is forced down the dependency tree and eventually tries the oldest candidate, `gnuplot 5.0.3`, whose only build (`5.0.3=1`) requires `libgd *.bioconda` — a build string from a defunct, years-old bioconda channel layout that no channel serves anymore:

```
BIOCONDA ERROR Unsatisfiable dependencies for platform linux-64:
  {MatchSpec("gnuplot==5.0.3=1"), MatchSpec("libgd==*.bioconda")}
  - nothing provides libgd *.bioconda needed by gnuplot-5.0.3-1
WARNING: Tests failed for openms-thirdparty-3.6.0dev-... - moving package to /opt/conda/conda-bld/broken
BIOCONDA ERROR BUILD SUMMARY: FAILED recipe recipes/openms-meta
```

This fails the whole `openms-meta` build (all outputs, including the successfully-compiled `libopenms`/`openms`, never get copied out of the build container), which in turn starves the follow-up `pyopenms` build of `libopenms==3.6.0dev` ("does not exist ... missing channel"), so both recipe builds fail and the final "Upload Conda packages" step aborts with "No packages found to upload!".

### Fix

This workflow clones `OpenMS/bioconda-recipes` fresh into the runner and never pushes changes back upstream, so the unpinned `gnuplot` line can't be fixed once in the recipe itself from here. Instead, add a step that patches the freshly-cloned recipe to pin `gnuplot >=5.4` (a modern, installable range that excludes the broken `5.0.3` build) before the build step runs. The step fails loudly (not silently) if the expected unpinned line is no longer found, so a future recipe change doesn't leave a stale, silently-ignored patch.

I verified the `sed` patch applies cleanly against the current `recipes/openms-meta/meta.yaml` content fetched from the `OpenMS/bioconda-recipes` `nightly` branch. The actual `bioconda-utils --docker` build (~40+ min, requires Docker) couldn't be run from this environment, so please confirm on the next scheduled nightly run (or via `workflow_dispatch`) that the fix resolves the solver conflict.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

N/A — this is a CI workflow fix only (`.github/workflows/bioconda_deploy.yaml`), no library/binding code changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RQmZkqjtmLdPecGQswcAde)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package deployment validation to ensure the required plotting dependency meets the supported minimum version.
  * Added safeguards to detect missing or duplicated dependency declarations before deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->