### PR TITLE
[CI] Bioconda deploy: let build failures fail their steps (#9905)

### DIFF
--- a/.github/workflows/bioconda_deploy.yaml
+++ b/.github/workflows/bioconda_deploy.yaml
@@ -118,13 +118,6 @@ jobs:
           git merge --no-edit bioconda/master
 
       # BUILD_ENV_IMAGE comes from the preflight in "Prepare output directory".
-      # Build failures are meant to fail these steps. The `|| true` both build
-      # commands used to carry worked around bioconda-utils misreporting
-      # successful --docker --pkg-dir builds as failures; that was fixed in
-      # bioconda-utils 3.5.0 (bioconda/bioconda-utils#838), which anything the
-      # unpinned install above resolves includes. The suppression only deferred
-      # real failures (e.g. the #9905 solver conflict) to a misleading "No
-      # packages found to upload!" in the upload step.
       - name: Lint and build OpenMS Bioconda packages
         run: |
           cd bioconda-recipes

--- a/.github/workflows/bioconda_deploy.yaml
+++ b/.github/workflows/bioconda_deploy.yaml
@@ -118,17 +118,24 @@ jobs:
           git merge --no-edit bioconda/master
 
       # BUILD_ENV_IMAGE comes from the preflight in "Prepare output directory".
+      # Build failures are meant to fail these steps. The `|| true` both build
+      # commands used to carry worked around bioconda-utils misreporting
+      # successful --docker --pkg-dir builds as failures; that was fixed in
+      # bioconda-utils 3.5.0 (bioconda/bioconda-utils#838), which anything the
+      # unpinned install above resolves includes. The suppression only deferred
+      # real failures (e.g. the #9905 solver conflict) to a misleading "No
+      # packages found to upload!" in the upload step.
       - name: Lint and build OpenMS Bioconda packages
         run: |
           cd bioconda-recipes
           bioconda-utils lint --packages pyopenms openms-meta
-          bioconda-utils build --docker --pkg-dir $GITHUB_WORKSPACE/output --packages openms-meta || true
+          bioconda-utils build --docker --pkg-dir $GITHUB_WORKSPACE/output --packages openms-meta
           python -m conda_index $GITHUB_WORKSPACE/output
 
       - name: Build pyopenms package
         run: |
           cd bioconda-recipes
-          bioconda-utils build --docker --mulled-test --pkg-dir $GITHUB_WORKSPACE/output --packages pyopenms || true
+          bioconda-utils build --docker --mulled-test --pkg-dir $GITHUB_WORKSPACE/output --packages pyopenms
           python -m conda_index $GITHUB_WORKSPACE/output
 
       - name: Upload Conda packages

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1065,6 +1065,11 @@ Build System:
     bioconda-utils and the pinnings upstream bioconda actually builds against; the resolved tooling
     versions are echoed into the log, and the build-env image follows the rolling `latest` tag, whose
     publication lags a new bioconda-utils release (#9905)
+  - CI: the Bioconda deploy workflow no longer suppresses the exit code of its two `bioconda-utils build`
+    steps. The `|| true` dated from 2024, when bioconda-utils misreported successful `--docker --pkg-dir`
+    builds as failures; that was fixed upstream in bioconda-utils 3.5.0 (bioconda/bioconda-utils#838), so
+    the suppression only deferred real failures -- like the #9905 dependency conflict -- to a misleading
+    "No packages found to upload!" error two steps later. A failed build now fails its own step (#9905)
   - CI: removed the check-tool-handler.yml and check-authors-file.yml pull_request_target workflows; both
     broke for every fork PR after an actions/checkout change and gave external contributors an unconditional
     unrelated failure (#9785, #9787)


### PR DESCRIPTION
Remove the `|| true` after both `bioconda-utils build` commands. It was
added in November 2024 to work around bioconda-utils misreporting
successful --docker --pkg-dir builds as failures: the success check
looked for the built packages in conda-build's default output folder
instead of the custom --pkg-dir. That was fixed upstream in
bioconda/bioconda-utils#838 (released in 3.5.0, 2024-11-29), so every
bioconda-utils the workflow's unpinned install can resolve carries the
fix.

Since then the suppression has only deferred real failures to the
upload step, which reports them as "No packages found to upload!" --
the misleading top-level error that cost #9905 a round of misdirection
while the actual dependency-solve failure sat two steps earlier. A
failed build now fails its own step, and a failed openms-meta build no
longer lets the pyopenms step run into a confusing secondary failure
on the missing local libopenms package.

Verified against the last nightly (run 31674828721, the first publish
since 2026-07-09): both build steps ended with "BUILD SUMMARY:
successfully built 1 of 1 recipes" with nothing after it, and
bioconda-utils exits 0 exactly when that summary reports no failed
recipes, so the steps stay green without the suppression. That
includes the 16 benign "Pre-solved test failed" errors in the pyopenms
step: they fall back to the full mulled test, which passed for every
variant, and the recipe still counts as successfully built.

Follow-up requested in #9905.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011CGDBJjwrqnHybBopAvX8A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bioconda package build failures are now reported immediately.
  * Deployment checks no longer continue after a failed package build, preventing misleading “No packages found to upload!” errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->