### PR TITLE
Update CHANGELOG: imzML per-peak ion mobility aux arrays (#9908)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -654,6 +654,11 @@ OpenMS Library:
       - on-disc ion image extraction: the shared kernel in IonImageExtraction.h is used by both the
         in-memory and the on-disc path, so single-mass ion images can be visualized from large imzML
         datasets without a full load (one fseek+fread per pixel) (#9654)
+      - per-peak auxiliary FloatDataArrays (e.g. ion mobility, MS:1003006) are now read/written as
+        external .ibd arrays for both in-memory and on-disc loads, instead of being dropped on write and
+        never filled on read; getIMPeakType() is set to IM_PROFILE and getIMUnit() resolves the unit from
+        the PSI-MS ontology (1/K0 for MS:1003006, not milliseconds). OnDiscImzMLExperiment now also
+        rejects zlib-compressed m/z/intensity arrays like the in-memory loader (#9908)
     - Native Parquet I/O for identifications, features and consensus maps:
       - PSMArrowIO reads/writes the .idparquet directory bundle (psms/proteins/protein_groups/
         search_params.parquet), lossless round-trip from PeptideIdentificationList and


### PR DESCRIPTION
## Description

PR #9908 ("Support per-peak ion mobility aux arrays in imzML") added a user-facing feature — reading/writing per-peak auxiliary `FloatDataArray`s (e.g. ion mobility, `MS:1003006`) as external `.ibd` arrays for both in-memory and on-disc imzML loads — but did not include a CHANGELOG entry. This PR adds one under the existing imzML/IMAGING sub-list in the 3.6.0 (under development) section, alongside the other imzML-related entries (#9383, #9521, #9654).

## Checklist
- [x] Add relevant changes and new features to the CHANGELOG file
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mfj2xkVKWi5bzRBLosfG9F)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-peak auxiliary data is now preserved in external binary arrays for both in-memory and on-disc workflows.
  * Ion mobility metadata now includes profile-data classification and ontology-based units.

* **Bug Fixes**
  * Auxiliary per-peak data is populated when reading files.
  * On-disc loading now clearly rejects zlib-compressed m/z and intensity arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->