### PR TITLE
[INTERNAL] UniqueIdGenerator: use std::mt19937_64 instead of boost::random

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1028,6 +1028,13 @@ Documentation:
     and maps the terms onto SDRF-Proteomics and QPX (#9909)
 
 Build System:
+  - UniqueIdGenerator no longer uses boost::random or boost::date_time: it uses std::mt19937_64
+    and std::chrono instead, which removes the boost/random include from the public header
+    <OpenMS/CONCEPT/UniqueIdGenerator.h>. Generated ids are unchanged -- MT19937-64 is a fully
+    specified algorithm and the previous uniform_int over the complete UInt64 range was the
+    identity on the engine output (verified byte-identical, including getUUID()). Math's
+    RandomShuffler deliberately keeps boost::random: its bounded-range distribution is what
+    makes portable_random_shuffle reproducible across standard libraries
   - New multi-OS GitHub Actions workflows for build/test, installer and source packaging, publishing of
     release assets, website-update PRs and automated cherry-pick backports to release branches, replacing
     the previous ad hoc release orchestration scripts (#9523). The version-bump workflow now triggers

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1030,9 +1030,12 @@ Documentation:
 Build System:
   - UniqueIdGenerator no longer uses boost::random or boost::date_time: it uses std::mt19937_64
     and std::chrono instead, which removes the boost/random include from the public header
-    <OpenMS/CONCEPT/UniqueIdGenerator.h>. Generated ids are unchanged -- MT19937-64 is a fully
-    specified algorithm and the previous uniform_int over the complete UInt64 range was the
-    identity on the engine output (verified byte-identical, including getUUID()). Math's
+    <OpenMS/CONCEPT/UniqueIdGenerator.h>. For a given explicit setSeed() value the generated ids
+    are unchanged, including getUUID() -- MT19937-64 is a fully specified algorithm and the
+    previous uniform_int over the complete UInt64 range was the identity on the engine output
+    (verified byte-identical). Without an explicit seed the generator still seeds itself from the
+    current time and the process id, and that time source changed from local time-of-day ticks to
+    system_clock epoch microseconds; such ids vary between runs either way. Math's
     RandomShuffler deliberately keeps boost::random: its bounded-range distribution is what
     makes portable_random_shuffle reproducible across standard libraries
   - New multi-OS GitHub Actions workflows for build/test, installer and source packaging, publishing of

--- a/src/openms/include/OpenMS/CONCEPT/UniqueIdGenerator.h
+++ b/src/openms/include/OpenMS/CONCEPT/UniqueIdGenerator.h
@@ -10,10 +10,7 @@
 
 #include <OpenMS/CONCEPT/Types.h>
 
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <boost/random/uniform_int.hpp>
-
+#include <random>
 #include <string>
 
 
@@ -27,7 +24,10 @@ namespace OpenMS
 
     The unique ids are 64-bit random unsigned random integers.
     The class is implemented as a singleton.
-    The random generator is implemented using boost::random.
+    The random generator is std::mt19937_64 (MT19937-64), whose output sequence is
+    fully specified by the algorithm and therefore identical on every platform and
+    standard library. Ids are the raw 64-bit engine output: drawing them through a
+    uniform distribution over the complete UInt64 range would be the identity.
 
     @ingroup Concept
   */
@@ -60,8 +60,7 @@ protected:
 private:
     static UInt64 seed_;
     static UniqueIdGenerator* instance_;
-    static boost::mt19937_64* rng_;
-    static boost::uniform_int<UInt64>* dist_;
+    static std::mt19937_64* rng_;
 
     static UniqueIdGenerator& getInstance_();
     void init_();

--- a/src/openms/source/CONCEPT/UniqueIdGenerator.cpp
+++ b/src/openms/source/CONCEPT/UniqueIdGenerator.cpp
@@ -10,8 +10,7 @@
 
 #include <OpenMS/SYSTEM/SysInfo.h>
 
-#include <boost/date_time/posix_time/posix_time_types.hpp> //no i/o just types
-
+#include <chrono>
 #include <cstdio>
 #include <cstring>
 
@@ -19,8 +18,7 @@ namespace OpenMS
 {
   UInt64 UniqueIdGenerator::seed_ = 0;
   UniqueIdGenerator* UniqueIdGenerator::instance_ = nullptr;
-  boost::mt19937_64* UniqueIdGenerator::rng_ = nullptr;
-  boost::uniform_int<UInt64>* UniqueIdGenerator::dist_ = nullptr;
+  std::mt19937_64* UniqueIdGenerator::rng_ = nullptr;
 
   UInt64 UniqueIdGenerator::getUniqueId()
   {
@@ -29,12 +27,12 @@ namespace OpenMS
     UInt64 val;
 #pragma omp critical (OPENMS_UniqueIdGenerator_getUniqueId)
     {
-      val = (*instance.dist_)(*instance.rng_);
+      val = (*instance.rng_)();
     }
     // note: OpenMP can only work on a structured block, return needs to be outside that block
     return val; 
 #else
-    return (*instance.dist_)(*instance.rng_);
+    return (*instance.rng_)();
 #endif
   }
 
@@ -75,7 +73,6 @@ namespace OpenMS
       UniqueIdGenerator& instance = getInstance_();
       instance.seed_ = seed;
       instance.rng_->seed( instance.seed_ );
-      instance.dist_->reset();
     }
   }
 
@@ -110,23 +107,20 @@ namespace OpenMS
       // we do not want this here since this seed usually gets initialized at the same program uptime).
       // Reason for high-res: in pipelines, instances of TOPP tools can get initialized almost simultaneously (i.e., resolution in seconds is not enough),
       // leading to identical random numbers (e.g. feature-IDs) in two or more distinct files.
-      // C++11 note: C++ build-in alternative once C++11 can be presumed: 'std::chrono::high_resolution_clock'
-      boost::posix_time::ptime t(boost::posix_time::microsec_clock::local_time() );
-      seed_ = t.time_of_day().ticks();  // independent of implementation; as opposed to nanoseconds(), which need not be available on every platform
+      const auto now = std::chrono::system_clock::now().time_since_epoch();
+      seed_ = static_cast<UInt64>(std::chrono::duration_cast<std::chrono::microseconds>(now).count());
 
       // Mix in process ID to ensure different seeds for parallel processes started at the same microsecond.
       // This prevents duplicate UniqueIds when multiple TOPP tools run simultaneously in a pipeline.
       seed_ ^= static_cast<UInt64>(SysInfo::getProcessId()) << 32;
 
-      rng_ = new boost::mt19937_64 (seed_);
-      dist_ = new boost::uniform_int<UInt64> (0, std::numeric_limits<UInt64>::max());
+      rng_ = new std::mt19937_64 (seed_);
     }
   }
 
   UniqueIdGenerator::~UniqueIdGenerator()
   {
     delete rng_;
-    delete dist_;
   }
 
 }


### PR DESCRIPTION
## Description

Removes `boost::random` (and `boost::date_time`) from `UniqueIdGenerator`, so the public header `<OpenMS/CONCEPT/UniqueIdGenerator.h>` no longer pulls Boost into every consumer's compilation. The engine becomes `std::mt19937_64`; the time-based fallback seeding in the `.cpp` uses `std::chrono`, as the comment there had suggested since the C++11 migration.

Two files, +13/−20.

### Generated ids are unchanged — verified, not assumed

This matters because unique ids end up in reference files, so a changed sequence would mean suite-wide churn. Three checks:

1. **Engine** — MT19937-64 is a fully specified algorithm, so `boost::mt19937_64` and `std::mt19937_64` produce identical sequences. Compared over 100k draws under **both libstdc++ and libc++**: identical.
2. **Distribution** — the previous `boost::uniform_int<UInt64>(0, UInt64 max)` covered the engine's *complete* output range, where the distribution is the identity. Also compared over 100k draws on both standard libraries: identical to the raw engine output. The distribution object is therefore dropped.
3. **End to end** — the same program linked against the old and new `libOpenMS`, with `setSeed(2453440375)`:

```
old (boost)                new (std)
16237515440356837086       16237515440356837086
3525220823171556399        3525220823171556399
6399120712684448661        6399120712684448661
...                        ...
uuid(seed42)=d6e2e56e-…    uuid(seed42)=d6e2e56e-…
```

12 UID-sensitive tests pass (`UniqueIdGenerator`, `UniqueIdIndexer`, `UniqueIdInterface`, `FeatureMap`, `ConsensusMap`, `FeatureXMLFile`, `ConsensusXMLFile`, `IDMapper`, `FileHandler`, `ExperimentalDesign`, `PeptideProteinResolution`, `IDBoostGraph`).

### Why `Math::RandomShuffler` deliberately keeps boost::random

It draws from a **bounded** range, where `std::uniform_int_distribution` is *not* specified to agree between implementations. Measured with the same seed and engine:

| | libstdc++ | libc++ |
|---|---|---|
| raw engine == boost | identical | identical |
| full-range dist == boost | identical | identical |
| **bounded-range dist == boost** | identical | **differs** |

That divergence is exactly what `portable_random_shuffle` exists to prevent, so `MathFunctions.h` is left alone. Only the full-range case is safe to convert, and that is what this PR does.

### Context

Follow-up from #9919, where `UniqueIdGenerator` turned out to be the only reason Boost headers reached the extracted test framework. It stands alone and does not depend on that PR.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file <!-- change authored by Claude on behalf of the maintainer -->
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.) <!-- no API change: signatures and values are identical -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbuL7ckNAxytCK486pxHGR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Unique ID and UUID generation remains byte-identical.
  * Existing reproducible random-shuffling behavior is unchanged.
  * Existing applications and integrations require no changes.

* **Technical Improvements**
  * Updated ID generation to use standard-library random and time facilities, improving portability and reducing external dependencies.
  * Random generation behavior is documented more clearly, including consistent cross-platform sequencing and direct 64-bit value generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->