### PR TITLE
Update CHANGELOG: imzML per-peak ion mobility aux arrays

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -654,6 +654,11 @@ OpenMS Library:
       - on-disc ion image extraction: the shared kernel in IonImageExtraction.h is used by both the
         in-memory and the on-disc path, so single-mass ion images can be visualized from large imzML
         datasets without a full load (one fseek+fread per pixel) (#9654)
+      - per-peak auxiliary FloatDataArrays (e.g. ion mobility, MS:1003006) are now written as additional
+        external .ibd arrays and read back on both the in-memory and on-disc path, so containsIMData() and
+        getIMUnit()/getIMPeakType() work for imaging data the same way they do for mzML; known PSI-MS array
+        names keep their accession and unit, and zlib-compressed m/z/intensity is now rejected on the
+        on-disc path as well as the in-memory one (#9908)
     - Native Parquet I/O for identifications, features and consensus maps:
       - PSMArrowIO reads/writes the .idparquet directory bundle (psms/proteins/protein_groups/
         search_params.parquet), lossless round-trip from PeptideIdentificationList and


### PR DESCRIPTION
## Description

Documents #9908 ("Support per-peak ion mobility aux arrays in imzML"), merged into `develop` without a CHANGELOG entry. That PR adds read/write support for per-peak auxiliary `FloatDataArray`s (e.g. ion mobility, `MS:1003006`) in imzML as external `.ibd` arrays, matching the existing mzML IM contract (`containsIMData()`, `getIMUnit()`/`getIMPeakType()`), and rejects zlib-compressed m/z/intensity on the on-disc path as well as the in-memory one.

Added the entry as a new sub-bullet under the existing "IMAGING module for imaging mass spectrometry" / imzML section (following the style of the neighboring #9383/#9521/#9654 bullets), since it extends that same imzML support.

Other PRs merged recently were checked against the CHANGELOG:
- #9903 (imzML duplicate pixel coordinates), #9909 (ExperimentalDesign docs), #9921 (UniqueIdGenerator RNG), #9898 (Triqler removal), #9901/#9900 (MSstatsConverter/Epifany fixes), #9857 (pyOpenMS thread-safety docs), #9891 (Docker Arrow/Parquet pin), #9769 (installer survey) are all already documented.
- #9914/#9907/#9887 are CI/infra-only (Bioconda deploy, ccache) and don't affect users, so no CHANGELOG entry was added for them.

## Checklist
- [x] Add relevant changes and new features to the CHANGELOG file
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

N/A: this PR only touches the CHANGELOG file, no code changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_017hPLajs4PyQVZ1q2DUYLx2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Imaging data now preserves per-peak auxiliary metadata when stored externally or loaded from memory and disk.
  * Ion-mobility metadata is now available for imaging data.
  * Recognized PSI-MS arrays retain their associated accession and unit information.

* **Bug Fixes**
  * On-disc loading now rejects unsupported zlib-compressed m/z and intensity arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->