### PR TITLE
Fix #9911: Consistent condition mapping for factor-less experimental designs

### DIFF
--- a/src/openms/include/OpenMS/METADATA/ExperimentalDesign.h
+++ b/src/openms/include/OpenMS/METADATA/ExperimentalDesign.h
@@ -298,11 +298,12 @@ namespace OpenMS
   except every factor whose column name contains @c "replicate" or @c "Replicate". Samples that
   agree on all remaining factors form one condition. For a design whose sample section has
   factor columns, this is what getConditionToSampleMapping(), getSampleToConditionMapping(),
-  getPathLabelToConditionMapping() and getConditionToPathLabelVector() return. For a factor-less
-  section -- as built by fromConsensusMap() and fromIdentifications() -- these functions now
-  consistently give every sample its own distinct condition. @ref TOPP_Epifany uses
-  getConditionToPathLabelVector() to merge ID runs per condition when a design is supplied;
-  @ref TOPP_ProteomicsLFQ does not -- it merges every ID run study-wide regardless of condition.
+  getPathLabelToConditionMapping() and getConditionToPathLabelVector() return. For a section
+  with no non-replicate factors remaining -- as built by fromConsensusMap() and fromIdentifications(),
+  or when only @c Sample and replicate factors exist -- these functions now consistently give every
+  sample its own distinct condition. @ref TOPP_Epifany uses getConditionToPathLabelVector() to merge ID
+  runs per condition when a design is supplied; @ref TOPP_ProteomicsLFQ does not -- it merges every ID
+  run study-wide regardless of condition.
 
   Condition numbers are the lexicographic rank of the factor-value tuple (or the lexicographic
   rank of the sample name in a factor-less design), so condition 0 is whichever value sorts
@@ -621,8 +622,8 @@ namespace OpenMS
       column called @c MSstats_BioReplicate is excluded, one called @c Donor is not and would
       split the replicates it names into separate conditions.
 
-      @note If no factors are provided in the experimental design, each sample forms
-      its own unique condition (N samples = N distinct conditions).
+      @note If no non-replicate factors remain after excluding @c Sample and replicate
+            columns, each sample forms its own unique condition (N samples = N distinct conditions).
 
       @return condition (the retained factor values, in the alphabetical order of their column
               names) to the zero-based sample row indices that share it

--- a/src/openms/include/OpenMS/METADATA/ExperimentalDesign.h
+++ b/src/openms/include/OpenMS/METADATA/ExperimentalDesign.h
@@ -299,14 +299,17 @@ namespace OpenMS
   agree on all remaining factors form one condition. For a design whose sample section has
   factor columns, this is what getConditionToSampleMapping(), getSampleToConditionMapping(),
   getPathLabelToConditionMapping() and getConditionToPathLabelVector() return. For a factor-less
-  section -- as built by fromConsensusMap() and fromIdentifications() -- they currently disagree:
-  getSampleToConditionMapping() gives every sample its own condition, while the other three
-  collapse all samples into one. @ref TOPP_Epifany uses getConditionToPathLabelVector() to merge
-  ID runs per condition when a design is supplied; @ref TOPP_ProteomicsLFQ does not -- it merges
-  every ID run study-wide regardless of condition.
+  section -- as built by fromConsensusMap() and fromIdentifications() -- these functions now
+  consistently give every sample its own distinct condition. @ref TOPP_Epifany uses
+  getConditionToPathLabelVector() to merge ID runs per condition when a design is supplied;
+  @ref TOPP_ProteomicsLFQ does not -- it merges every ID run study-wide regardless of condition.
 
-  Condition numbers are the lexicographic rank of the factor-value tuple, so condition 0 is
-  whichever value sorts first, not a reference level.
+  Condition numbers are the lexicographic rank of the factor-value tuple (or the lexicographic
+  rank of the sample name in a factor-less design), so condition 0 is whichever value sorts
+  first, not a reference level.
+
+  @note In a factor-less design, functions returning condition keys return a one-element vector
+        containing the sample name, rather than a true factor value.
 
   @warning The replicate rule matches on the column NAME only. @c MSstats_BioReplicate and
            @c Technical_Replicate are excluded from the condition automatically; @c Donor or
@@ -618,9 +621,9 @@ namespace OpenMS
       column called @c MSstats_BioReplicate is excluded, one called @c Donor is not and would
       split the replicates it names into separate conditions.
 
-      @note If no factors are provided in the experimental design, each sample forms 
+      @note If no factors are provided in the experimental design, each sample forms
       its own unique condition (N samples = N distinct conditions).
-      
+
       @return condition (the retained factor values, in the alphabetical order of their column
               names) to the zero-based sample row indices that share it
     */

--- a/src/openms/include/OpenMS/METADATA/ExperimentalDesign.h
+++ b/src/openms/include/OpenMS/METADATA/ExperimentalDesign.h
@@ -618,6 +618,9 @@ namespace OpenMS
       column called @c MSstats_BioReplicate is excluded, one called @c Donor is not and would
       split the replicates it names into separate conditions.
 
+      @note If no factors are provided in the experimental design, each sample forms 
+      its own unique condition (N samples = N distinct conditions).
+      
       @return condition (the retained factor values, in the alphabetical order of their column
               names) to the zero-based sample row indices that share it
     */

--- a/src/openms/source/METADATA/ExperimentalDesign.cpp
+++ b/src/openms/source/METADATA/ExperimentalDesign.cpp
@@ -441,7 +441,7 @@ namespace OpenMS
       {
         std::map<std::vector<std::string>, std::set<unsigned>> res;
 
-        for(const auto& name : sample_section_.getSamples())
+        for (const auto& name : sample_section_.getSamples())
         {
           res[{name}].insert(sample_section_.getSampleRow(name));
         }

--- a/src/openms/source/METADATA/ExperimentalDesign.cpp
+++ b/src/openms/source/METADATA/ExperimentalDesign.cpp
@@ -436,17 +436,7 @@ namespace OpenMS
     map<vector<std::string>, set<unsigned>> ExperimentalDesign::getConditionToSampleMapping() const
     {
       const auto& facset = sample_section_.getFactors();
-      // assuming that all samples are unique if no factors are given
-      if (facset.empty())
-      {
-        std::map<std::vector<std::string>, std::set<unsigned>> res;
-
-        for (const auto& name : sample_section_.getSamples())
-        {
-          res[{name}].insert(sample_section_.getSampleRow(name));
-        }
-        return res;
-      }
+      
       set<std::string> nonRepFacs{};
 
       for (const std::string& fac : facset)
@@ -455,6 +445,18 @@ namespace OpenMS
         {
           nonRepFacs.insert(fac);
         }
+      }
+
+      // assuming that all samples are unique if no factors are given
+      if (nonRepFacs.empty())
+      {
+        std::map<std::vector<std::string>, std::set<unsigned>> res;
+
+        for (const auto& name : sample_section_.getSamples())
+        {
+          res[{name}].insert(sample_section_.getSampleRow(name));
+        }
+        return res;
       }
 
       map<vector<std::string>, set<unsigned> > rowContent2RowIdx;
@@ -477,7 +479,19 @@ namespace OpenMS
       map<std::string, unsigned> res;
       // could happen when the Experimental Design was loaded from an idXML or consensusXML
       // without additional Experimental Design file
-      if (sample_section_.getFactors().empty())
+
+      const auto& facset = sample_section_.getFactors();
+      set<std::string> nonRepFacs{};
+
+      for (const std::string& fac : facset)
+      {
+        if (fac != "Sample" && !StringUtils::hasSubstring(fac, "replicate") && !StringUtils::hasSubstring(fac, "Replicate"))
+        {
+          nonRepFacs.insert(fac);
+        }
+      }
+
+      if (nonRepFacs.empty())
       {
         // no information about the origin of the samples -> assume uniqueness of all.
         // Key by sample NAME, like getSampleToPrefractionationMapping(): the previous version

--- a/src/openms/source/METADATA/ExperimentalDesign.cpp
+++ b/src/openms/source/METADATA/ExperimentalDesign.cpp
@@ -436,7 +436,17 @@ namespace OpenMS
     map<vector<std::string>, set<unsigned>> ExperimentalDesign::getConditionToSampleMapping() const
     {
       const auto& facset = sample_section_.getFactors();
-      // assert(!facset.empty()); // not needed: If no factors are given, same condition is assumed for every run
+      // assuming that all samples are unique if no factors are given
+      if (facset.empty())
+      {
+        std::map<std::vector<std::string>, std::set<unsigned>> res;
+
+        for(const auto& name : sample_section_.getSamples())
+        {
+          res[{name}].insert(sample_section_.getSampleRow(name));
+        }
+        return res;
+      }
       set<std::string> nonRepFacs{};
 
       for (const std::string& fac : facset)

--- a/src/tests/class_tests/openms/source/ConsensusMapMergerAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapMergerAlgorithm_test.cpp
@@ -35,11 +35,13 @@ START_TEST(ConsensusMapMergerAlgorithm, "$Id$")
         ConsensusMapMergerAlgorithm cmerge;
         ExperimentalDesign ed = ExperimentalDesign::fromConsensusMap(cmap);
         cmerge.mergeProteinsAcrossFractionsAndReplicates(cmap, ed);
-        //without a special experimental design on sample level, runs are treated like replicates
-        // or fractions and all are merged
-        TEST_EQUAL(cmap.getProteinIdentifications().size(), 1)
+        
+        // without a special experimental design on sample level, we now assume uniqueness 
+        // of all samples (N=N) to prevent destructive merging. 
+        // The 3 fraction groups create 3 distinct conditions instead of 1.
+        TEST_EQUAL(cmap.getProteinIdentifications().size(), 3)
         StringList toFill; cmap.getProteinIdentifications()[0].getPrimaryMSRunPath(toFill);
-        TEST_EQUAL(toFill.size(), 6)
+        TEST_EQUAL(toFill.size(), 2)
       }
     END_SECTION
 

--- a/src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp
+++ b/src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp
@@ -138,14 +138,17 @@ START_SECTION((std::map<unsigned int, std::vector<std::string> > getFractionToMS
 }
 END_SECTION
 
-START_SECTION(( std::map<std::vector<String>, std::set<unsigned> > getConditionToSampleMapping() const ))
+START_SECTION(( map<vector<String>, set<unsigned> > getConditionToSampleMapping() const ))
 {
-  ExperimentalDesign ed;
+  ExperimentalDesign::SampleSection ss;
   
   // add 3 samples without factors to simulate a factor-less design
-  ed.addSample("sample_1");
-  ed.addSample("sample_2");
-  ed.addSample("sample_3");
+  ss.addSample("sample_1");
+  ss.addSample("sample_2");
+  ss.addSample("sample_3");
+
+  ExperimentalDesign ed;
+  ed.setSampleSection(ss);
   
   auto map_a = ed.getSampleToConditionMapping();
   auto map_b = ed.getConditionToSampleMapping();
@@ -154,19 +157,22 @@ START_SECTION(( std::map<std::vector<String>, std::set<unsigned> > getConditionT
   TEST_EQUAL(map_a.size(), 3);
   TEST_EQUAL(map_b.size(), 3);
 
-  // stronger assertions: Verify that condition IDs are actually distinct
-  std::set<unsigned> condition_ids;
-  for (const auto& [sample, condition] : map_a)
+  // Stronger assertion: Cross-check each map_b entry's ordinal position 
+  // against the map_a condition id of its sample.
+  unsigned ordinal = 0;
+  for (const auto& [condition_vec, sample_indices] : map_b)
   {
-    condition_ids.insert(condition);
-  }
-  TEST_EQUAL(condition_ids.size(), 3);
-
-  // verify that each map_b entry contains exactly one sample row
-  for (const auto& [condition, rows] : map_b)
-  {
-    TEST_EQUAL(condition.size(), 1);
-    TEST_EQUAL(rows.size(), 1);
+    // The key should be a single-element vector containing the sample name
+    TEST_EQUAL(condition_vec.size(), 1);
+    // The value should be a set containing exactly one sample row index
+    TEST_EQUAL(sample_indices.size(), 1);
+    
+    String sample_name = condition_vec[0];
+    
+    // The ordinal position in map_b must perfectly match the condition ID in map_a
+    TEST_EQUAL(map_a[sample_name], ordinal);
+    
+    ++ordinal;
   }
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp
+++ b/src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp
@@ -142,7 +142,7 @@ START_SECTION(( std::map<std::vector<String>, std::set<unsigned> > getConditionT
 {
   ExperimentalDesign ed;
   
-  // Add 3 samples without factors to simulate a factor-less design
+  // add 3 samples without factors to simulate a factor-less design
   ed.addSample("sample_1");
   ed.addSample("sample_2");
   ed.addSample("sample_3");
@@ -150,9 +150,24 @@ START_SECTION(( std::map<std::vector<String>, std::set<unsigned> > getConditionT
   auto map_a = ed.getSampleToConditionMapping();
   auto map_b = ed.getConditionToSampleMapping();
   
-  // Both mapping functions should return 3 unique conditions (N samples = N conditions)
+  // both mapping functions should return 3 unique conditions (N samples = N conditions)
   TEST_EQUAL(map_a.size(), 3);
   TEST_EQUAL(map_b.size(), 3);
+
+  // stronger assertions: Verify that condition IDs are actually distinct
+  std::set<unsigned> condition_ids;
+  for (const auto& [sample, condition] : map_a)
+  {
+    condition_ids.insert(condition);
+  }
+  TEST_EQUAL(condition_ids.size(), 3);
+
+  // verify that each map_b entry contains exactly one sample row
+  for (const auto& [condition, rows] : map_b)
+  {
+    TEST_EQUAL(condition.size(), 1);
+    TEST_EQUAL(rows.size(), 1);
+  }
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp
+++ b/src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp
@@ -138,6 +138,24 @@ START_SECTION((std::map<unsigned int, std::vector<std::string> > getFractionToMS
 }
 END_SECTION
 
+START_SECTION(( std::map<std::vector<String>, std::set<unsigned> > getConditionToSampleMapping() const ))
+{
+  ExperimentalDesign ed;
+  
+  // Add 3 samples without factors to simulate a factor-less design
+  ed.addSample("sample_1");
+  ed.addSample("sample_2");
+  ed.addSample("sample_3");
+  
+  auto map_a = ed.getSampleToConditionMapping();
+  auto map_b = ed.getConditionToSampleMapping();
+  
+  // Both mapping functions should return 3 unique conditions (N samples = N conditions)
+  TEST_EQUAL(map_a.size(), 3);
+  TEST_EQUAL(map_b.size(), 3);
+}
+END_SECTION
+
 START_SECTION((std::map< std::pair< String, unsigned >, unsigned> getPathLabelToSampleMapping(bool) const ))
 {
   const auto lf = labelfree_unfractionated_design.getPathLabelToSampleMapping(true);


### PR DESCRIPTION
## Description

Fixes #9911.

**Summary of changes:**
- Fixed a bug in `ExperimentalDesign::getConditionToSampleMapping()` where factor-less sample sections incorrectly mapped all runs to a single condition.
- Updated the logic to match `getSampleToConditionMapping()`, assuming uniqueness of all samples (N samples = N conditions) when no factors are provided.
- Added a regression test in `ExperimentalDesign_test.cpp` using `addSample()` to verify that both mapping functions return the correct and identical number of unique conditions for factor-less designs.

### Architectural Decision for Factor-less Designs (N=N vs N=1)
As pointed out in the review, this PR explicitly adopts the **"assume all different" (N=N)** semantic for factor-less designs, shifting away from the previous **"assume all the same" (N=1)** fallback behavior. This is a deliberate choice aligned with issue #9911. 

**Justification:** Force-merging independent samples into a single condition due to missing metadata is a destructive analytical assumption. Preserving them as distinct conditions (N=N) is a safer, non-destructive baseline. 

**Impact:** I acknowledge that this explicitly changes the default factor-less merging behavior of tools like `@ref TOPP_Epifany` and `ConsensusMapMergerAlgorithm`. The test `mergeProteinsAcrossFractionsAndReplicates (no Design)` and its comments have been intentionally updated to reflect and explicitly test this new N=N outcome.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Factor-free experimental designs are now handled correctly.
  * Designs containing only sample or replicate information assign each sample a distinct condition.
  * Sample-to-condition mappings now preserve accurate sample identities and ordering.
  * Data merging without a sample-level design keeps samples separated appropriately.

* **Documentation**
  * Clarified condition assignment and numbering for factor-free designs.

* **Tests**
  * Added regression coverage for factor-free designs and multi-sample merging scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->