### PR TITLE
Update CHANGELOG: vcpkg Windows and macOS integration (#9800)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1053,7 +1053,11 @@ Build System:
     requested with BUILD_TOPP_TOOLS=OFF (#9752). Public headers missing from sources.cmake, which broke
     standalone consumers building against an installed prefix, were registered (#9774)
   - vcpkg integration (GSoC 2026): vcpkg.json, vcpkg-configuration.json and CMakePresets.json manage the
-    build dependencies via vcpkg, validated by a dedicated CI workflow with a binary cache (#9511)
+    build dependencies via vcpkg, validated by a dedicated CI workflow with a binary cache (#9511).
+    Extended to Windows and macOS with platform-specific presets, overlay ports for
+    openms-thermo-bridge, onnxruntime (patched for clang) and opentims, and overlay triplets that fix
+    an empty SDK sysroot in macOS port builds and optionally build release-only variants to cut
+    configure time (#9800)
   - Build speedup: Boost.Spirit qi/karma replaced with std::from_chars/to_chars (C++17 charconv) for numeric
     string conversions in String, DataValue and related utilities; 30-40% less compile time and better
     runtime throughput (#9648). Float-to-string now uses the shortest round-trip representation for


### PR DESCRIPTION
## Summary
- #9800 extended the vcpkg build integration (previously Linux-only, #9511) to Windows and macOS, but left its CHANGELOG checklist item unchecked.
- Extends the existing vcpkg bullet in the Build System section to note the new platform coverage: platform-specific presets, overlay ports for `openms-thermo-bridge`, `onnxruntime` (clang patch) and `opentims`, and overlay triplets that fix an empty macOS SDK sysroot and optionally build release-only variants to speed up configure time.

## Test plan
- [x] Diff-only change to `CHANGELOG`; no code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D13H8VX4aWX96nnYrLycZ9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded dependency-management guidance for Windows and macOS.
  * Documented platform-specific presets and macOS SDK handling.
  * Added guidance for optional release-only builds.
  * Included configuration details for required third-party components and platform integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->