### PR TITLE
Add FAIMS-aware conversion of experiments to SWATH maps for OSW

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -768,6 +768,7 @@ OpenMS Library:
     - TOPPExternalToolBase: tools that shell out to an external executable (search engine adapters, ...)
       derive from a common base instead of duplicating external-process boilerplate; startup handling for
       -write_* options and log-file initialization refined. No change to tool CLI behavior (#9621)
+    - FAIMS-aware adapter for converting pre-loaded MSExperiment/PeakMap data into the existing OpenSWATH SwathMap abstraction (#9932)
   Changes:
     - The OpenMS-native Arrow round-trip writers (.consensusparquet, .featureparquet, .idparquet) no
       longer stamp a qpx_version key in the Parquet footer. Those files are not QPX exchange views --

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64$" AND UNIX AND NOT APPLE)
 endif()
 option(WITH_THERMO_RAW "Build with Thermo RAW file reading support via openms-thermo-bridge" ${_openms_with_thermo_raw_default})
 option(ENABLE_THERMO_RAW_TESTS "Download Thermo RAW test data for integration tests" OFF)
+option(ENABLE_THERMO_FAIMS_DIA_TESTS "Download Thermo FAIMS-DIA test data for integration tests" OFF)
 option(ENABLE_TDL "Load dependency and compile against TDL (required for CWL file support)." OFF)
 option(ENABLE_CWL_GENERATION "Build and validate the CWL description files for all TOPP tools (Requires ENABLE_TDL=ON)." OFF)
 
@@ -169,6 +170,38 @@ if (ENABLE_THERMO_RAW_TESTS AND WITH_THERMO_RAW)
   )
   FetchContent_MakeAvailable(thermo_raw_testdata)
   set(THERMO_RAW_TEST_DATA "${thermo_raw_testdata_SOURCE_DIR}/Angiotensin_AllScans.raw" CACHE PATH "Path to Thermo RAW test file")
+endif()
+
+# Optional end-to-end FAIMS-DIA integration fixture. A developer can either set
+# THERMO_FAIMS_DIA_TEST_DATA explicitly to an existing local RAW file, or enable
+# ENABLE_THERMO_FAIMS_DIA_TESTS to fetch the pinned public PRIDE fixture. The
+# ~308 MB download remains opt-in and is not part of normal OpenMS builds/tests.
+set(THERMO_FAIMS_DIA_TEST_DATA "${THERMO_FAIMS_DIA_TEST_DATA}" CACHE FILEPATH
+    "Path to a Thermo FAIMS-DIA RAW file for integration testing")
+if (ENABLE_THERMO_FAIMS_DIA_TESTS AND WITH_THERMO_RAW AND NOT THERMO_FAIMS_DIA_TEST_DATA)
+  include(FetchContent)
+  # Public single-CV FAIMS-DIA run from PRIDE PXD029902. The pinned hash fixes
+  # the exact 308,209,820-byte input used by ThermoRawFile_test.
+  FetchContent_Declare(
+    thermo_faims_dia_testdata
+    URL "https://ftp.pride.ebi.ac.uk/pride/data/archive/2023/08/PXD029902/20210213_WTC11_DIA_5CV.raw"
+    URL_HASH SHA256=e98b2cc95d162b1dfd24cf003434ef0deef085d7c99ffc0fde695aec8bf236b1
+    DOWNLOAD_NO_EXTRACT TRUE
+  )
+  FetchContent_MakeAvailable(thermo_faims_dia_testdata)
+  set(THERMO_FAIMS_DIA_TEST_DATA
+      "${thermo_faims_dia_testdata_SOURCE_DIR}/20210213_WTC11_DIA_5CV.raw"
+      CACHE FILEPATH "Path to a Thermo FAIMS-DIA RAW file for integration testing" FORCE)
+endif()
+
+if (THERMO_FAIMS_DIA_TEST_DATA AND NOT EXISTS "${THERMO_FAIMS_DIA_TEST_DATA}")
+  message(FATAL_ERROR
+    "THERMO_FAIMS_DIA_TEST_DATA does not exist: ${THERMO_FAIMS_DIA_TEST_DATA}")
+endif()
+
+if ((ENABLE_THERMO_FAIMS_DIA_TESTS OR THERMO_FAIMS_DIA_TEST_DATA) AND NOT WITH_THERMO_RAW)
+  message(WARNING
+    "Thermo FAIMS-DIA integration testing was requested but WITH_THERMO_RAW=OFF; the test will not run.")
 endif()
 
 #------------------------------------------------------------------------------

--- a/src/openms/include/OpenMS/FORMAT/SwathFile.h
+++ b/src/openms/include/OpenMS/FORMAT/SwathFile.h
@@ -17,10 +17,25 @@
 
 #include <vector>
 #include <memory>
+#include <limits>
 
 namespace OpenMS
 {
   class ExperimentalSettings;
+
+  /**
+    @brief One FAIMS compensation-voltage group represented as ordinary OpenSWATH maps.
+
+    @p faims_cv is the compensation voltage in volts. For non-FAIMS input it is NaN,
+    matching IMDataConverter::splitByFAIMSCV(). The individual SwathMap objects remain
+    unchanged and retain their normal DIA isolation-window semantics.
+  */
+  struct OPENMS_DLLAPI FAIMSSwathMapGroup
+  {
+    double faims_cv{std::numeric_limits<double>::quiet_NaN()};
+    std::vector<OpenSwath::SwathMap> swath_maps;
+  };
+
   namespace Interfaces
   {
     class IMSDataConsumer;
@@ -89,6 +104,30 @@ public:
                                                           const std::string& tmp,
                                                           std::shared_ptr<ExperimentalSettings>& exp_meta,
                                                           const std::string& readoptions = "normal");
+
+    /**
+      @brief Partition a pre-loaded experiment once by FAIMS CV and convert each group to SWATH maps.
+
+      This is the FAIMS-aware adapter for in-memory inputs such as Thermo RAW data loaded through
+      ThermoRawFile. It reuses IMDataConverter::splitByFAIMSCV() for CV assignment and
+      loadFromMSExperiment() for the existing SWATH-window conversion. No FAIMS-specific state is
+      added to OpenSwath::SwathMap; the CV is carried by the enclosing FAIMSSwathMapGroup.
+
+      The input experiment is consumed. For non-FAIMS data, one group with a NaN CV is returned.
+      For single-CV FAIMS data, one group with that CV is returned. Multi-CV input produces one
+      group per exact compensation voltage.
+
+      @param[in,out] exp Pre-loaded experiment; spectra are moved into per-CV groups
+      @param[in] tmp Temporary directory (used only for readoptions=="cache")
+      @param[out] exp_meta Experimental metadata copied before @p exp is consumed
+      @param[in] readoptions "normal" (in-memory) or "cache" (disk-cached)
+      @return FAIMS CV groups containing ordinary OpenSWATH maps
+    */
+    std::vector<FAIMSSwathMapGroup> loadFromMSExperimentByFAIMSCV(
+      PeakMap&& exp,
+      const std::string& tmp,
+      std::shared_ptr<ExperimentalSettings>& exp_meta,
+      const std::string& readoptions = "normal");
 
     /// Loads a Swath run from a single mzXML file
     std::vector<OpenSwath::SwathMap> loadMzXML(const std::string& file,

--- a/src/openms/source/FORMAT/SwathFile.cpp
+++ b/src/openms/source/FORMAT/SwathFile.cpp
@@ -15,6 +15,7 @@
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/IONMOBILITY/IMDataConverter.h>
 //TODO remove MzML after we get transform support for our handlers
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/FORMAT/MzXMLFile.h>
@@ -31,6 +32,7 @@
 #include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SimpleOpenMSSpectraAccessFactory.h>
 
 #include <memory> // for make_shared
+#include <utility>
 
 namespace OpenMS
 {
@@ -247,6 +249,41 @@ namespace OpenMS
     std::vector<OpenSwath::SwathMap> swath_maps;
     dataConsumer->retrieveSwathMaps(swath_maps);
     return swath_maps;
+  }
+
+  std::vector<FAIMSSwathMapGroup> SwathFile::loadFromMSExperimentByFAIMSCV(
+    PeakMap&& exp,
+    const std::string& tmp,
+    std::shared_ptr<ExperimentalSettings>& exp_meta,
+    const std::string& readoptions)
+  {
+    // Preserve experiment-level metadata without retaining a second copy of the full spectrum data.
+    auto metadata = std::make_shared<PeakMap>();
+    metadata->getExperimentalSettings() = exp.getExperimentalSettings();
+    exp_meta = metadata;
+
+    // Partition exactly once. splitByFAIMSCV() also provides the established OpenMS fallback for
+    // MS2+ spectra that lack an explicit CV by assigning them to the most recently observed CV.
+    auto cv_experiments = IMDataConverter::splitByFAIMSCV(std::move(exp));
+
+    std::vector<FAIMSSwathMapGroup> result;
+    result.reserve(cv_experiments.size());
+
+    for (auto& cv_experiment : cv_experiments)
+    {
+      const double faims_cv = cv_experiment.first;
+
+      // Process one CV bucket at a time. Moving the PeakMap into a shared_ptr keeps the existing
+      // loadFromMSExperiment() path intact while allowing each source bucket to be released as soon
+      // as its SWATH maps have been constructed.
+      auto group_exp = std::make_shared<PeakMap>(std::move(cv_experiment.second));
+      std::shared_ptr<ExperimentalSettings> group_meta;
+      auto swath_maps = loadFromMSExperiment(group_exp, tmp, group_meta, readoptions);
+
+      result.push_back(FAIMSSwathMapGroup{faims_cv, std::move(swath_maps)});
+    }
+
+    return result;
   }
 
   /// Loads a Swath run from a single mzXML file

--- a/src/tests/class_tests/openms/CMakeLists.txt
+++ b/src/tests/class_tests/openms/CMakeLists.txt
@@ -301,6 +301,17 @@ endif()
 if (TARGET ThermoRawFile_test AND WITH_THERMO_RAW AND THERMO_RAW_TEST_DATA)
   target_compile_definitions(ThermoRawFile_test PRIVATE
     THERMO_RAW_TEST_DATA="${THERMO_RAW_TEST_DATA}")
+endif()
+
+# Optional Thermo FAIMS-DIA integration fixture. It can be supplied explicitly via
+# THERMO_FAIMS_DIA_TEST_DATA or downloaded by ENABLE_THERMO_FAIMS_DIA_TESTS.
+if (TARGET ThermoRawFile_test AND WITH_THERMO_RAW AND THERMO_FAIMS_DIA_TEST_DATA)
+  target_compile_definitions(ThermoRawFile_test PRIVATE
+    THERMO_FAIMS_DIA_TEST_DATA="${THERMO_FAIMS_DIA_TEST_DATA}")
+endif()
+
+if (TARGET ThermoRawFile_test AND WITH_THERMO_RAW AND
+    (THERMO_RAW_TEST_DATA OR THERMO_FAIMS_DIA_TEST_DATA))
   set_tests_properties(ThermoRawFile_test PROPERTIES TIMEOUT 1200)
 
   # Copy the managed bridge runtime (.dll + .runtimeconfig.json) next to the

--- a/src/tests/class_tests/openms/CMakeLists.txt
+++ b/src/tests/class_tests/openms/CMakeLists.txt
@@ -306,8 +306,11 @@ endif()
 # Optional Thermo FAIMS-DIA integration fixture. It can be supplied explicitly via
 # THERMO_FAIMS_DIA_TEST_DATA or downloaded by ENABLE_THERMO_FAIMS_DIA_TESTS.
 if (TARGET ThermoRawFile_test AND WITH_THERMO_RAW AND THERMO_FAIMS_DIA_TEST_DATA)
+  # Normalize manually supplied native paths (especially Windows paths with
+  # backslashes) before embedding the value as a C/C++ string literal.
+  file(TO_CMAKE_PATH "${THERMO_FAIMS_DIA_TEST_DATA}" _thermo_faims_dia_test_data)
   target_compile_definitions(ThermoRawFile_test PRIVATE
-    THERMO_FAIMS_DIA_TEST_DATA="${THERMO_FAIMS_DIA_TEST_DATA}")
+    THERMO_FAIMS_DIA_TEST_DATA="${_thermo_faims_dia_test_data}")
 endif()
 
 if (TARGET ThermoRawFile_test AND WITH_THERMO_RAW AND

--- a/src/tests/class_tests/openms/source/SwathFile_test.cpp
+++ b/src/tests/class_tests/openms/source/SwathFile_test.cpp
@@ -18,6 +18,10 @@
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/SwathMap.h>
 #include <OpenMS/METADATA/Precursor.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/CONCEPT/CommonEnums.h>
+
+#include <cmath>
+#include <utility>
 
 
 using namespace OpenMS;
@@ -82,6 +86,86 @@ void storeSplitSwathFile(std::vector<std::string> filenames)
     s.push_back(p);
     exp.addSpectrum(s);
     MzMLFile().store(filenames[i+1], exp);
+  }
+}
+
+namespace
+{
+  MSSpectrum makeFAIMSSpectrum(int ms_level,
+                               double rt,
+                               double peak_mz,
+                               float peak_intensity,
+                               double faims_cv,
+                               bool annotate_cv,
+                               double isolation_center = 0.0,
+                               double isolation_lower = 0.0,
+                               double isolation_upper = 0.0)
+  {
+    MSSpectrum spectrum;
+    spectrum.setMSLevel(ms_level);
+    spectrum.setRT(rt);
+    Peak1D peak;
+    peak.setMZ(peak_mz);
+    peak.setIntensity(peak_intensity);
+    spectrum.push_back(peak);
+
+    if (annotate_cv)
+    {
+      spectrum.setDriftTime(faims_cv);
+      spectrum.setDriftTimeUnit(DriftTimeUnit::FAIMS_COMPENSATION_VOLTAGE);
+    }
+
+    if (ms_level > 1)
+    {
+      Precursor precursor;
+      precursor.setMZ(isolation_center);
+      precursor.setIsolationWindowLowerOffset(isolation_lower);
+      precursor.setIsolationWindowUpperOffset(isolation_upper);
+      spectrum.setPrecursors({precursor});
+    }
+
+    return spectrum;
+  }
+
+  PeakMap makeTwoWindowDIAExperiment(bool faims,
+                                    double faims_cv,
+                                    double intensity_offset = 0.0,
+                                    bool omit_ms2_cv = false,
+                                    double rt_offset = 0.0)
+  {
+    PeakMap exp;
+
+    exp.addSpectrum(makeFAIMSSpectrum(
+      1,
+      rt_offset,
+      100.0,
+      static_cast<float>(1000.0 + intensity_offset),
+      faims_cv,
+      faims));
+
+    exp.addSpectrum(makeFAIMSSpectrum(
+      2,
+      rt_offset + 1.0,
+      110.0,
+      static_cast<float>(1100.0 + intensity_offset),
+      faims_cv,
+      faims && !omit_ms2_cv,
+      412.5,
+      12.5,
+      12.5));
+
+    exp.addSpectrum(makeFAIMSSpectrum(
+      2,
+      rt_offset + 2.0,
+      120.0,
+      static_cast<float>(1200.0 + intensity_offset),
+      faims_cv,
+      faims,
+      437.5,
+      12.5,
+      12.5));
+
+    return exp;
   }
 }
 
@@ -210,6 +294,86 @@ START_SECTION([EXTRA]std::vector< OpenSwath::SwathMap > loadSplit(StringList fil
     TEST_REAL_SIMILAR(maps[i+1].upper, 425+i*25.0)
   }
 
+}
+END_SECTION
+
+START_SECTION((std::vector<FAIMSSwathMapGroup> loadFromMSExperimentByFAIMSCV(PeakMap&& exp, const std::string& tmp, std::shared_ptr<ExperimentalSettings>& exp_meta, const std::string& readoptions) - non-FAIMS))
+{
+  PeakMap exp = makeTwoWindowDIAExperiment(false, 0.0);
+  std::shared_ptr<ExperimentalSettings> meta;
+
+  auto groups = SwathFile().loadFromMSExperimentByFAIMSCV(
+    std::move(exp), File::getTempDirectory() + "/", meta, "normal");
+
+  TEST_EQUAL(groups.size(), 1)
+  TEST_EQUAL(std::isnan(groups[0].faims_cv), true)
+  TEST_EQUAL(groups[0].swath_maps.size(), 3)
+  TEST_EQUAL(groups[0].swath_maps[0].ms1, true)
+  TEST_REAL_SIMILAR(groups[0].swath_maps[1].lower, 400.0)
+  TEST_REAL_SIMILAR(groups[0].swath_maps[1].upper, 425.0)
+  TEST_REAL_SIMILAR(groups[0].swath_maps[2].lower, 425.0)
+  TEST_REAL_SIMILAR(groups[0].swath_maps[2].upper, 450.0)
+}
+END_SECTION
+
+START_SECTION((std::vector<FAIMSSwathMapGroup> loadFromMSExperimentByFAIMSCV(PeakMap&& exp, const std::string& tmp, std::shared_ptr<ExperimentalSettings>& exp_meta, const std::string& readoptions) - single CV))
+{
+  // The first MS2 spectrum deliberately lacks explicit FAIMS metadata. It should inherit -45 V
+  // from the preceding MS1 spectrum through the existing splitByFAIMSCV() policy.
+  PeakMap exp = makeTwoWindowDIAExperiment(true, -45.0, 0.0, true);
+  std::shared_ptr<ExperimentalSettings> meta;
+
+  auto groups = SwathFile().loadFromMSExperimentByFAIMSCV(
+    std::move(exp), File::getTempDirectory() + "/", meta, "normal");
+
+  TEST_EQUAL(groups.size(), 1)
+  TEST_REAL_SIMILAR(groups[0].faims_cv, -45.0)
+  TEST_EQUAL(groups[0].swath_maps.size(), 3)
+  TEST_EQUAL(groups[0].swath_maps[0].sptr->getNrSpectra(), 1)
+  TEST_EQUAL(groups[0].swath_maps[1].sptr->getNrSpectra(), 1)
+  TEST_EQUAL(groups[0].swath_maps[2].sptr->getNrSpectra(), 1)
+  TEST_REAL_SIMILAR(groups[0].swath_maps[1].lower, 400.0)
+  TEST_REAL_SIMILAR(groups[0].swath_maps[1].upper, 425.0)
+  TEST_REAL_SIMILAR(groups[0].swath_maps[2].lower, 425.0)
+  TEST_REAL_SIMILAR(groups[0].swath_maps[2].upper, 450.0)
+}
+END_SECTION
+
+START_SECTION((std::vector<FAIMSSwathMapGroup> loadFromMSExperimentByFAIMSCV(PeakMap&& exp, const std::string& tmp, std::shared_ptr<ExperimentalSettings>& exp_meta, const std::string& readoptions) - multiple CVs))
+{
+  // First complete DIA cycle.
+  PeakMap minus55 = makeTwoWindowDIAExperiment(true, -55.0, 5500.0, true, 0.0);
+
+  // Following DIA cycle at the second CV.
+  PeakMap minus45 = makeTwoWindowDIAExperiment(true, -45.0, 4500.0, true, 3.0);
+
+  // Preserve acquisition order: one complete DIA cycle at -55 V followed by one at -45 V.
+  PeakMap exp;
+  for (auto& spectrum : minus55.getSpectra()) exp.addSpectrum(std::move(spectrum));
+  for (auto& spectrum : minus45.getSpectra()) exp.addSpectrum(std::move(spectrum));
+
+  std::shared_ptr<ExperimentalSettings> meta;
+  auto groups = SwathFile().loadFromMSExperimentByFAIMSCV(
+    std::move(exp), File::getTempDirectory() + "/", meta, "normal");
+
+  TEST_EQUAL(groups.size(), 2)
+  TEST_REAL_SIMILAR(groups[0].faims_cv, -55.0)
+  TEST_REAL_SIMILAR(groups[1].faims_cv, -45.0)
+
+  for (const auto& group : groups)
+  {
+    TEST_EQUAL(group.swath_maps.size(), 3)
+    TEST_EQUAL(group.swath_maps[0].ms1, true)
+    TEST_REAL_SIMILAR(group.swath_maps[1].lower, 400.0)
+    TEST_REAL_SIMILAR(group.swath_maps[1].upper, 425.0)
+    TEST_REAL_SIMILAR(group.swath_maps[2].lower, 425.0)
+    TEST_REAL_SIMILAR(group.swath_maps[2].upper, 450.0)
+  }
+
+  // Peak intensities encode the source CV group, so this verifies that spectra were not mixed
+  // between CV buckets during SWATH conversion.
+  TEST_REAL_SIMILAR(groups[0].swath_maps[1].sptr->getSpectrumById(0)->getIntensityArray()->data[0], 6600.0)
+  TEST_REAL_SIMILAR(groups[1].swath_maps[1].sptr->getSpectrumById(0)->getIntensityArray()->data[0], 5600.0)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ThermoRawFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ThermoRawFile_test.cpp
@@ -8,6 +8,7 @@
 #include <OpenMS/CONCEPT/ClassTest.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
+#include <OpenMS/FORMAT/SwathFile.h>
 #include <OpenMS/FORMAT/ThermoRawFile.h>
 #include <OpenMS/KERNEL/MSChromatogram.h>
 #include <OpenMS/METADATA/IonSource.h>
@@ -15,6 +16,7 @@
 #include <OpenMS/METADATA/Precursor.h>
 #include <OpenMS/SYSTEM/File.h>
 
+#include <cmath>
 #include <set>
 
 using namespace OpenMS;
@@ -163,6 +165,153 @@ START_SECTION(round-trip load raw -> mzML -> reload MSExperiment)
   TEST_EQUAL(rt_filter > 0, true)
   TEST_EQUAL(rt_tic > 0, true)
   TEST_EQUAL(rt_window > 0, true)
+}
+END_SECTION
+#endif
+
+#ifdef THERMO_FAIMS_DIA_TEST_DATA
+START_SECTION(real Thermo FAIMS-DIA RAW -> FAIMS-aware SWATH maps)
+{
+  ThermoRawFile file;
+  MSExperiment exp;
+  file.load(THERMO_FAIMS_DIA_TEST_DATA, exp);
+
+  TEST_EQUAL(exp.empty(), false)
+  TEST_EQUAL(exp.getSourceFiles().empty(), false)
+
+  Size ms1_count = 0;
+  Size ms2_count = 0;
+  Size explicit_faims_count = 0;
+  Size dia_ms2_count = 0;
+  std::set<double> faims_cvs;
+
+  for (const MSSpectrum& spectrum : exp.getSpectra())
+  {
+    if (spectrum.getMSLevel() == 1)
+    {
+      ++ms1_count;
+    }
+    else if (spectrum.getMSLevel() == 2)
+    {
+      ++ms2_count;
+
+      if (!spectrum.getPrecursors().empty())
+      {
+        const Precursor& precursor = spectrum.getPrecursors()[0];
+        if (precursor.getMZ() > 0.0 &&
+            precursor.getIsolationWindowLowerOffset() > 0.0 &&
+            precursor.getIsolationWindowUpperOffset() > 0.0)
+        {
+          ++dia_ms2_count;
+        }
+      }
+    }
+
+    if (spectrum.getDriftTimeUnit() == DriftTimeUnit::FAIMS_COMPENSATION_VOLTAGE)
+    {
+      ++explicit_faims_count;
+      faims_cvs.insert(spectrum.getDriftTime());
+    }
+  }
+
+  // Pin the native-reader side of the integration boundary to this public fixture.
+  TEST_EQUAL(exp.size(), 92778)
+  TEST_EQUAL(ms1_count, 1974)
+  TEST_EQUAL(ms2_count, 90804)
+  TEST_EQUAL(dia_ms2_count, ms2_count)
+  TEST_EQUAL(explicit_faims_count, exp.size())
+  TEST_EQUAL(faims_cvs.size(), 1)
+  if (!faims_cvs.empty())
+  {
+    TEST_REAL_SIMILAR(*faims_cvs.begin(), -5.0)
+  }
+
+  cout << "Thermo FAIMS-DIA validation: spectra=" << exp.size()
+       << ", MS1=" << ms1_count
+       << ", MS2=" << ms2_count
+       << ", DIA-like MS2=" << dia_ms2_count
+       << ", explicit FAIMS spectra=" << explicit_faims_count
+       << ", unique CVs=" << faims_cvs.size() << '\n';
+  cout << "FAIMS CVs:";
+  for (double cv : faims_cvs) { cout << ' ' << cv; }
+  cout << '\n';
+
+  std::shared_ptr<ExperimentalSettings> exp_meta;
+  auto groups = SwathFile().loadFromMSExperimentByFAIMSCV(
+    std::move(exp), File::getTempDirectory() + "/", exp_meta, "normal");
+
+  TEST_EQUAL(groups.size(), 1)
+  TEST_EQUAL(exp_meta != nullptr, true)
+  if (!groups.empty())
+  {
+    TEST_REAL_SIMILAR(groups[0].faims_cv, -5.0)
+  }
+
+  Size groups_with_ms1 = 0;
+  Size total_swath_windows = 0;
+  for (const auto& group : groups)
+  {
+    TEST_EQUAL(std::isfinite(group.faims_cv), true)
+    TEST_EQUAL(faims_cvs.count(group.faims_cv), 1)
+    TEST_EQUAL(group.swath_maps.empty(), false)
+
+    Size group_ms1_maps = 0;
+    Size group_swath_windows = 0;
+    Size group_ms2_spectra = 0;
+
+    for (const auto& map : group.swath_maps)
+    {
+      TEST_EQUAL(map.sptr != nullptr, true)
+      if (map.sptr == nullptr) { continue; }
+
+      if (map.ms1)
+      {
+        ++group_ms1_maps;
+      }
+      else
+      {
+        ++group_swath_windows;
+        group_ms2_spectra += map.sptr->getNrSpectra();
+        TEST_EQUAL(map.lower < map.upper, true)
+        TEST_EQUAL(map.sptr->getNrSpectra() > 0, true)
+      }
+    }
+
+    // SwathFile should emit at most one MS1 map and at least one DIA window per CV.
+    TEST_EQUAL(group_ms1_maps <= 1, true)
+    TEST_EQUAL(group_swath_windows > 0, true)
+    TEST_EQUAL(group_ms2_spectra > 0, true)
+
+    if (group_ms1_maps == 1) { ++groups_with_ms1; }
+    total_swath_windows += group_swath_windows;
+
+    cout << "  CV " << group.faims_cv
+         << ": maps=" << group.swath_maps.size()
+         << ", MS1 maps=" << group_ms1_maps
+         << ", DIA windows=" << group_swath_windows
+         << ", MS2 spectra=" << group_ms2_spectra << '\n';
+  }
+
+  TEST_EQUAL(groups_with_ms1, 1)
+  TEST_EQUAL(total_swath_windows, 75)
+
+  Size total_ms2_spectra = 0;
+  if (!groups.empty())
+  {
+    TEST_EQUAL(groups[0].swath_maps.size(), 76)
+    for (const auto& map : groups[0].swath_maps)
+    {
+      if (!map.ms1 && map.sptr != nullptr)
+      {
+        total_ms2_spectra += map.sptr->getNrSpectra();
+      }
+    }
+  }
+  TEST_EQUAL(total_ms2_spectra, ms2_count)
+
+  cout << "FAIMS SWATH groups=" << groups.size()
+       << ", groups with MS1=" << groups_with_ms1
+       << ", total DIA windows=" << total_swath_windows << '\n';
 }
 END_SECTION
 #endif


### PR DESCRIPTION
## Description

Adds a FAIMS-aware adapter for converting pre-loaded `MSExperiment`/`PeakMap`
data into the existing OpenSWATH `SwathMap` abstraction.

The implementation reuses the existing OpenMS FAIMS and SWATH infrastructure:

- `IMDataConverter::splitByFAIMSCV()` performs the one-time compensation-voltage
  partitioning.
- `SwathFile::loadFromMSExperiment()` performs the existing DIA isolation-window
  conversion.
- FAIMS CV is carried by a new enclosing `FAIMSSwathMapGroup`; the existing
  `OpenSwath::SwathMap` structure is unchanged.

This keeps FAIMS partitioning outside `OpenSwathWorkflow` and avoids repeatedly
splitting multi-CV datasets during downstream extraction.

## Behavior

`SwathFile::loadFromMSExperimentByFAIMSCV()`:

- consumes a pre-loaded `PeakMap`;
- partitions it once by FAIMS compensation voltage;
- converts each CV bucket using the normal SWATH-map conversion;
- returns one `FAIMSSwathMapGroup` per CV.

For non-FAIMS input, one group with a NaN CV is returned.

For single-CV FAIMS input, one group is returned.

For multi-CV FAIMS input, one independent group is returned for each CV while
preserving the original DIA isolation-window structure.

## Tests

`SwathFile_test` adds synthetic regression coverage for:

- non-FAIMS DIA;
- single-CV FAIMS-DIA;
- multi-CV FAIMS-DIA;
- preservation of DIA window bounds;
- separation of spectra between CV groups.

Existing related tests also pass:

- `FAIMSHelper_test`
- `IMDataConverter_test`
- `ThermoRawFile_test`

## Optional real Thermo FAIMS-DIA integration test

Adds the default-OFF option:

`ENABLE_THERMO_FAIMS_DIA_TESTS`

When enabled, CMake downloads the public PRIDE fixture:

`PXD029902/20210213_WTC11_DIA_5CV.raw`

The file is protected by a pinned SHA-256 checksum.

A manually supplied `THERMO_FAIMS_DIA_TEST_DATA` path can also be used to avoid
redownloading the fixture.

Local validation of the real Thermo RAW produced:

- 92,778 spectra
- 1,974 MS1 spectra
- 90,804 MS2 spectra
- FAIMS CV -5 V
- 1 FAIMS group
- 1 MS1 map
- 75 DIA/SWATH maps
- all 90,804 MS2 spectra retained after FAIMS grouping and SWATH conversion

The real-data integration test passes both with a manually supplied fixture and
with the opt-in automatic download.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for grouping FAIMS-DIA data by compensation voltage and converting each group into SWATH maps.
  * Preserved experiment metadata during FAIMS-DIA processing.
  * Added an opt-in Thermo FAIMS-DIA integration-test fixture using configurable local or downloadable RAW data.

* **Testing**
  * Added validation for FAIMS grouping, SWATH boundaries, metadata, spectrum counts, and compensation-voltage values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->