### PR TITLE
[FIX] MzPAF could not parse a negative charge

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -770,6 +770,10 @@ OpenMS Library:
       -write_* options and log-file initialization refined. No change to tool CLI behavior (#9621)
     - FAIMS-aware adapter for converting pre-loaded MSExperiment/PeakMap data into the existing OpenSWATH SwathMap abstraction (#9932)
   Changes:
+    - Fix: MzPAF could not parse a negative charge. MzPAF::toString() writes the sign it is given
+      ("c1^-1"), but parseCharge_() required a digit straight after the caret, so parse() rejected its
+      own output with INVALID_CHARGE and no negatively charged ion -- i.e. any nucleic acid fragment --
+      could be expressed in mzPAF at all. An optional sign is now read before the number
     - The OpenMS-native Arrow round-trip writers (.consensusparquet, .featureparquet, .idparquet) no
       longer stamp a qpx_version key in the Parquet footer. Those files are not QPX exchange views --
       they use the native schemas and file_type tokens such as consensus_features / features /

--- a/src/openms/source/CHEMISTRY/MzPAF.cpp
+++ b/src/openms/source/CHEMISTRY/MzPAF.cpp
@@ -706,12 +706,23 @@ namespace OpenMS
       {
         advance_();
 
+        // the charge may carry a sign ("c1^-1"), which the tokenizer hands back as its own token.
+        // Without this a negative charge is a parse error, so nucleic acid fragments -- which are always
+        // negatively charged -- cannot be expressed at all, and toString() writes names this parser
+        // then rejects.
+        int sign = 1;
+        if (current_.type == TokenType::MINUS || current_.type == TokenType::PLUS)
+        {
+          sign = (current_.type == TokenType::MINUS) ? -1 : 1;
+          advance_();
+        }
+
         if (current_.type != TokenType::NUMBER)
         {
           error_(MzPAFErrorCode::INVALID_CHARGE, "Expected charge number after '^'");
         }
 
-        ann.charge = parseInt_(current_.text, MzPAFErrorCode::INVALID_CHARGE, "Invalid charge number");
+        ann.charge = sign * parseInt_(current_.text, MzPAFErrorCode::INVALID_CHARGE, "Invalid charge number");
         advance_();
       }
 

--- a/src/tests/class_tests/openms/source/MzPAF_test.cpp
+++ b/src/tests/class_tests/openms/source/MzPAF_test.cpp
@@ -79,6 +79,46 @@ START_SECTION(Ion with charge)
 }
 END_SECTION
 
+START_SECTION(Ion with negative charge)
+{
+  // negative mode: nucleic acid fragments are always negatively charged, so the charge carries a sign.
+  // Without this the parser stopped at the '-' and reported INVALID_CHARGE, so toString() produced names
+  // that parse() could not read back.
+  MzPAFAnnotation ann = MzPAF::parse("c1^-1");
+  TEST_EQUAL(ann.ion_series, MzPAFIonSeries::C)
+  TEST_EQUAL(ann.ordinal.value(), 1)
+  TEST_EQUAL(ann.charge.has_value(), true)
+  TEST_EQUAL(ann.charge.value(), -1)
+  TEST_STRING_EQUAL(MzPAF::toString(ann), "c1^-1")
+
+  ann = MzPAF::parse("a3^-2");
+  TEST_EQUAL(ann.charge.value(), -2)
+  TEST_STRING_EQUAL(MzPAF::toString(ann), "a3^-2")
+
+  // an explicit '+' means the same as no sign
+  ann = MzPAF::parse("y4^+3");
+  TEST_EQUAL(ann.charge.value(), 3)
+  TEST_STRING_EQUAL(MzPAF::toString(ann), "y4^3")
+
+  // a caret with only a sign and no number is still an error
+  TEST_EQUAL(MzPAF::tryParse("y4^-").has_value(), false)
+  TEST_EQUAL(MzPAF::tryParse("y4^").has_value(), false)
+
+  // what toString() writes, parse() reads back -- for every charge, either polarity
+  for (int z : {-5, -2, -1, 1, 2, 5})
+  {
+    MzPAFAnnotation a;
+    a.ion_series = MzPAFIonSeries::Y;
+    a.ordinal = 4;
+    a.charge = z;
+    const std::string written = MzPAF::toString(a);
+    const std::optional<MzPAFAnnotation> read_back = MzPAF::tryParse(written);
+    TEST_EQUAL(read_back.has_value(), true)
+    if (read_back.has_value()) { TEST_EQUAL(read_back->charge.value(), z) }
+  }
+}
+END_SECTION
+
 START_SECTION(Ion with neutral loss)
 {
   MzPAFAnnotation ann = MzPAF::parse("b2-H2O");


### PR DESCRIPTION
## Description

`MzPAF::toString()` writes whatever sign the charge carries, so a negatively charged fragment serialises as `c1^-1`. The parser did not accept that: `parseCharge_()` advanced past the caret and required a `NUMBER` token, while the tokenizer hands the `-` back as a `MINUS` token of its own. So `parse()` raised `INVALID_CHARGE` **on its own output**.

```
y3^2    ->  OK, charge=2, toString=y3^2
y3^1    ->  OK, charge=1, toString=y3^1
c1^-1   ->  PARSE ERROR: Expected charge number after '^'
a3^-2   ->  PARSE ERROR: Expected charge number after '^'
```

The practical consequence is that no negatively charged ion could be expressed in mzPAF at all — which is every nucleic acid fragment, since those are measured in negative mode.

The fix reads an optional sign before the number. A caret followed by a sign and no digits stays an error, as does a bare caret.

```cpp
int sign = 1;
if (current_.type == TokenType::MINUS || current_.type == TokenType::PLUS)
{
  sign = (current_.type == TokenType::MINUS) ? -1 : 1;
  advance_();
}
...
ann.charge = sign * parseInt_(current_.text, MzPAFErrorCode::INVALID_CHARGE, "Invalid charge number");
```

The test covers both polarities, the explicit `+` form (`y4^+3` normalises to `y4^3`), the two error cases, and a `toString()` → `parse()` round trip over a range of charges — that round trip is the property that was actually broken, and no existing test exercised it with a negative value.

Split out of #9931, which needs this to write nucleic acid fragment names in mzPAF's notation. It stands on its own as a parser bug and does not depend on anything in that PR.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

Verified locally: `MzPAF_test` passes with the fix, and fails on the new section when the fix is reverted.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fykx3n9QfA3MMxShXdAfXD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parsing of MzPAF strings with negative charges.
  * Added support for explicitly signed positive charges.
  * Negative-charge strings can now round-trip correctly, including nucleic-acid fragments.

* **Tests**
  * Added coverage for signed charges, round-trip conversion, and invalid sign-only charges.

* **Documentation**
  * Documented the fix in the OpenMS 3.6.0 changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->