### PR TITLE
[FIX] getMultipleSpectra() built the precursor peak at the wrong charge

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -770,6 +770,13 @@ OpenMS Library:
       -write_* options and log-file initialization refined. No change to tool CLI behavior (#9621)
     - FAIMS-aware adapter for converting pre-loaded MSExperiment/PeakMap data into the existing OpenSWATH SwathMap abstraction (#9932)
   Changes:
+    - Fix: NucleicAcidSpectrumGenerator::getMultipleSpectra() built the final precursor peak at the wrong
+      charge. With add_precursor_peaks enabled and add_all_precursor_charges disabled, the loop that
+      fills a spectrum leaves the running charge one past that spectrum's own charge state, and the
+      precursor was computed from it: the -5 spectrum got its precursor at m/z 429.89 as if it were -6,
+      instead of [M-5H]5- at 516.07, and annotated with that wrong charge. Both polarities were affected.
+      This is also why the existing test left add_precursor_peaks disabled -- with it on,
+      getMultipleSpectra() and getSpectrum() disagreed
     - The OpenMS-native Arrow round-trip writers (.consensusparquet, .featureparquet, .idparquet) no
       longer stamp a qpx_version key in the Parquet footer. Those files are not QPX exchange views --
       they use the native schemas and file_type tokens such as consensus_features / features /

--- a/src/openms/source/CHEMISTRY/NucleicAcidSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/NucleicAcidSpectrumGenerator.cpp
@@ -422,8 +422,9 @@ namespace OpenMS
       Int charge = base_charge;
       while (charge_it != charges.rend())
       {
-        MSSpectrum& spectrum = spectra[*charge_it];
-        for (; charge >= *charge_it; --charge)
+        const Int spec_charge = *charge_it; // charge state of the spectrum built in this iteration
+        MSSpectrum& spectrum = spectra[spec_charge];
+        for (; charge >= spec_charge; --charge)
         {
           addChargedSpectrum_(spectrum, uncharged_spectrum, charge, add_all_precursors);
         }
@@ -433,15 +434,17 @@ namespace OpenMS
           spectra[*charge_it] = spectrum; // initialize next spectrum
         }
         // if we want precursor peaks only for selected charge states, add them
-        // after the next spectrum has been initialized:
+        // after the next spectrum has been initialized.
+        // Note: this is the spectrum's own charge state, not 'charge' -- the loop above has already
+        // stepped that one past it, which put the precursor at the wrong m/z and charge.
         if (add_final_precursor)
         {
           spectrum.push_back(uncharged_spectrum.back());
-          spectrum.back().setMZ(std::fabs(spectrum.back().getMZ() / charge + Constants::PROTON_MASS_U));
+          spectrum.back().setMZ(std::fabs(spectrum.back().getMZ() / spec_charge + Constants::PROTON_MASS_U));
           if (add_metainfo_)
           {
             spectrum.getStringDataArrays()[0].push_back("M");
-            spectrum.getIntegerDataArrays()[0].push_back(charge);
+            spectrum.getIntegerDataArrays()[0].push_back(spec_charge);
           }
         }
         spectrum.sortByPosition();
@@ -460,8 +463,9 @@ namespace OpenMS
       Int charge = base_charge;
       while (charge_it != charges.end())
       {
-        MSSpectrum& spectrum = spectra[*charge_it];
-        for (; charge <= *charge_it; ++charge)
+        const Int spec_charge = *charge_it; // charge state of the spectrum built in this iteration
+        MSSpectrum& spectrum = spectra[spec_charge];
+        for (; charge <= spec_charge; ++charge)
         {
           addChargedSpectrum_(spectrum, uncharged_spectrum, charge, add_all_precursors);
         }
@@ -471,15 +475,17 @@ namespace OpenMS
           spectra[*charge_it] = spectrum; // initialize next spectrum
         }
         // if we want precursor peaks only for selected charge states, add them
-        // after the next spectrum has been initialized:
+        // after the next spectrum has been initialized.
+        // Note: this is the spectrum's own charge state, not 'charge' -- the loop above has already
+        // stepped that one past it, which put the precursor at the wrong m/z and charge.
         if (add_final_precursor)
         {
           spectrum.push_back(uncharged_spectrum.back());
-          spectrum.back().setMZ(spectrum.back().getMZ() / charge + Constants::PROTON_MASS_U);
+          spectrum.back().setMZ(spectrum.back().getMZ() / spec_charge + Constants::PROTON_MASS_U);
           if (add_metainfo_)
           {
             spectrum.getStringDataArrays()[0].push_back("M");
-            spectrum.getIntegerDataArrays()[0].push_back(charge);
+            spectrum.getIntegerDataArrays()[0].push_back(spec_charge);
           }
         }
         spectrum.sortByPosition();

--- a/src/tests/class_tests/openms/source/NucleicAcidSpectrumGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/NucleicAcidSpectrumGenerator_test.cpp
@@ -414,8 +414,10 @@ START_SECTION(([EXTRA] getMultipleSpectra() puts the precursor peak at the charg
   }
 
   // same guarantee in positive mode
+  const set<Int> pos_charges = {2, 3};
   spectra.clear();
-  gen.getMultipleSpectra(spectra, seq, set<Int>{2, 3}, 1);
+  gen.getMultipleSpectra(spectra, seq, pos_charges, 1);
+  TEST_EQUAL(spectra.size(), pos_charges.size());
   for (const auto& [charge, spectrum] : spectra)
   {
     const auto& names = spectrum.getStringDataArrays()[0];
@@ -431,6 +433,21 @@ START_SECTION(([EXTRA] getMultipleSpectra() puts the precursor peak at the charg
       }
     }
     TEST_EQUAL(n_precursors, 1);
+  }
+
+  // ... including the agreement between the two APIs
+  vector<MSSpectrum> pos_compare(pos_charges.size());
+  index = 0;
+  for (Int charge : pos_charges)
+  {
+    gen.getSpectrum(pos_compare[index], seq, 1, charge);
+    index++;
+  }
+  index = 0;
+  for (const auto& pair : spectra)
+  {
+    TEST_EQUAL(pos_compare[index] == pair.second, true);
+    index++;
   }
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/NucleicAcidSpectrumGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/NucleicAcidSpectrumGenerator_test.cpp
@@ -356,6 +356,85 @@ START_SECTION((void getMultipleSpectra(std::map<Int, MSSpectrum>& spectra, const
 }
 END_SECTION
 
+START_SECTION(([EXTRA] getMultipleSpectra() puts the precursor peak at the charge state of each spectrum))
+{
+  // The section above leaves add_precursor_peaks off ("// yes or no?") because the two APIs used to
+  // disagree once it was on: the loop that fills a spectrum steps 'charge' one past that spectrum's own
+  // charge state, and the precursor block after it used 'charge'. So the precursor of the -5 spectrum was
+  // computed as if it were -6 -- wrong m/z, and annotated with the wrong charge.
+  NucleicAcidSpectrumGenerator gen;
+  Param param = gen.getParameters();
+  param.setValue("add_metainfo", "true");
+  param.setValue("add_precursor_peaks", "true");
+  param.setValue("add_all_precursor_charges", "false"); // only the spectrum's own charge state
+  param.setValue("add_a_ions", "true");
+  param.setValue("add_w_ions", "true");
+  gen.setParameters(param);
+
+  NASequence seq = NASequence::fromString("[m1A]UCCACAGp");
+  const double neutral_mass = seq.getMonoWeight(NASequence::Full, 0);
+
+  set<Int> charges = {-1, -3, -5};
+  map<Int, MSSpectrum> spectra;
+  gen.getMultipleSpectra(spectra, seq, charges, -1);
+  TEST_EQUAL(spectra.size(), charges.size());
+
+  for (const auto& [charge, spectrum] : spectra)
+  {
+    // exactly one precursor peak, at the spectrum's own charge state
+    const auto& names = spectrum.getStringDataArrays()[0];
+    const auto& peak_charges = spectrum.getIntegerDataArrays()[0];
+    Size n_precursors = 0;
+    for (Size i = 0; i < names.size(); ++i)
+    {
+      if (names[i][0] == 'M') // fragment ion names (a, w, a-B) are lower-case
+      {
+        ++n_precursors;
+        TEST_EQUAL(peak_charges[i], charge);
+        TEST_REAL_SIMILAR(spectrum[i].getMZ(), std::fabs(neutral_mass / charge + Constants::PROTON_MASS_U));
+      }
+    }
+    TEST_EQUAL(n_precursors, 1);
+  }
+
+  // the batch API must agree with getSpectrum() for the same charges, precursor included
+  // (this is the comparison the section above skips by leaving add_precursor_peaks off)
+  vector<MSSpectrum> compare(charges.size());
+  Size index = 0;
+  for (Int charge : charges)
+  {
+    gen.getSpectrum(compare[index], seq, -1, charge);
+    index++;
+  }
+  index = 0;
+  for (const auto& pair : spectra)
+  {
+    TEST_EQUAL(compare[index] == pair.second, true);
+    index++;
+  }
+
+  // same guarantee in positive mode
+  spectra.clear();
+  gen.getMultipleSpectra(spectra, seq, set<Int>{2, 3}, 1);
+  for (const auto& [charge, spectrum] : spectra)
+  {
+    const auto& names = spectrum.getStringDataArrays()[0];
+    const auto& peak_charges = spectrum.getIntegerDataArrays()[0];
+    Size n_precursors = 0;
+    for (Size i = 0; i < names.size(); ++i)
+    {
+      if (names[i][0] == 'M')
+      {
+        ++n_precursors;
+        TEST_EQUAL(peak_charges[i], charge);
+        TEST_REAL_SIMILAR(spectrum[i].getMZ(), neutral_mass / charge + Constants::PROTON_MASS_U);
+      }
+    }
+    TEST_EQUAL(n_precursors, 1);
+  }
+}
+END_SECTION
+
 delete ptr;
 
 /////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

`NucleicAcidSpectrumGenerator::getMultipleSpectra()` builds one spectrum per requested charge, walking a running `charge` down (or up) to each spectrum's charge state. That loop exits with `charge` one step **past** the spectrum it has just filled, and the precursor block after it used `charge` for both the m/z and the recorded charge.

So with `add_precursor_peaks` on and `add_all_precursor_charges` off, every spectrum got a precursor belonging to the next charge state. Measured by reverting the fix under the new test:

| spectrum | precursor m/z written | correct | annotated z | correct z |
| --- | --- | --- | --- | --- |
| −1 | 1291.683 | 2584.373 | −2 | −1 |
| −3 | 645.338 | 860.786 | −4 | −3 |
| −5 | 429.889 | 516.069 | −6 | −5 |

Both polarity branches had it. The fix captures the spectrum's own charge state before the loop and uses that:

```cpp
const Int spec_charge = *charge_it; // charge state of the spectrum built in this iteration
MSSpectrum& spectrum = spectra[spec_charge];
for (; charge >= spec_charge; --charge) { ... }
...
// Note: this is the spectrum's own charge state, not 'charge' -- the loop above has already
// stepped that one past it, which put the precursor at the wrong m/z and charge.
spectrum.back().setMZ(std::fabs(spectrum.back().getMZ() / spec_charge + Constants::PROTON_MASS_U));
```

### Why no existing test caught it

The `getMultipleSpectra` test has carried this line since it was written:

```cpp
// param.setValue("add_precursor_peaks", "true"); // yes or no?
```

This bug is the answer to that question. With precursors enabled, `getMultipleSpectra()` and `getSpectrum()` returned different spectra, so the comparison could not be turned on. The new section enables it and asserts both the per-spectrum precursor (count, charge, m/z) and that the two APIs agree, in both polarities. Reverting the fix fails it on all six assertions plus the equality check.

### Blast radius

None outside the library. `NucleicAcidSearchEngine` sets `add_precursor_peaks` to `false` and is the only caller of `getMultipleSpectra()`, so no tool output and no reference data change — the bug is reachable only through the C++ / pyOpenMS API.

Split out of #9931, which touches the same file for an unrelated notation change. This fix is independent of it and of #9934.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

Verified locally: `NucleicAcidSpectrumGenerator_test` passes with the fix and fails on the new section when the fix is reverted.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fykx3n9QfA3MMxShXdAfXD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed parsing of signed charges.
  - Corrected precursor peak charge assignments when generating multiple nucleic acid spectra.
  - Precursor peaks now use each spectrum’s selected charge state in both positive and negative modes.
  - Corrected precursor m/z values and charge metadata for selected-charge spectra.
  - Improved consistency between batch-generated and individually generated spectra.

- **Tests**
  - Added regression coverage for precursor placement, m/z values, charge metadata, and spectrum equivalence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->