### PR TITLE
Update CHANGELOG: doc-validate ruff pinning (#9906)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1105,6 +1105,10 @@ Build System:
   - CI: removed the check-tool-handler.yml and check-authors-file.yml pull_request_target workflows; both
     broke for every fork PR after an actions/checkout change and gave external contributors an unconditional
     unrelated failure (#9785, #9787)
+  - CI: doc-validate ran an unpinned astral-sh/ruff-action, so ruff 0.16 widening its default lint selection
+    from 59 to 413 rules turned the job red with no commit of its own in between (#9899). The action is now
+    pinned to 0.16.2 and doc/pyopenms/ruff.toml selects the lint rules explicitly, so the result no longer
+    depends on whichever ruff version happens to be installed (#9906)
   - Tests: the 19 assertions on QPX Parquet output were `cmake -E sha256sum` calls that compared the hash to
     nothing, so only file existence was asserted -- a regression emptying a table, renaming every run or
     dropping a column was invisible. They now assert the schema and a row-count floor via the new ParquetDiff


### PR DESCRIPTION
## Description

Routine sweep of recently merged PRs for CHANGELOG gaps. #9906 fixed the `doc-validate` workflow's unpinned `astral-sh/ruff-action` (root cause #9899: ruff 0.16 widened its default lint selection from 59 to 413 rules, breaking the job with no commit of its own in between), but its checklist marked the CHANGELOG update as unnecessary ("documentation/workflow configuration only"). The `Build System` section of the CHANGELOG already documents comparable CI-robustness fixes for the same class of problem (e.g. the Arrow keyring pinning for `NO_PUBKEY` failures, the Bioconda workflow fixes), so this adds a matching entry for #9906 to keep that record complete.

No code changes; CHANGELOG only.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

---
_Generated by [Claude Code](https://claude.ai/code/session_011JLyZgPXLautr2k2sUGCGL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned documentation validation to a specific Ruff version for consistent results.
  * Explicitly defined documentation linting rules to prevent changes from shifting with tool defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->