### PR TITLE
Fix Windows nightly test race: unique temp files for OpenSwathWorkflow_17_cache

### DIFF
--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -2188,10 +2188,10 @@ ${TOPP_BIN_PATH}/OpenSwathDecoyGenerator -test -in ${DATA_DIR_TOPP}/OpenSwathDec
   set_tests_properties("TOPP_OpenSwathWorkflow_17_out1" PROPERTIES DEPENDS "TOPP_OpenSwathWorkflow_17")
   set_tests_properties("TOPP_OpenSwathWorkflow_17_out2" PROPERTIES DEPENDS "TOPP_OpenSwathWorkflow_17")
   # Test with ion mobility
-  add_test("TOPP_OpenSwathWorkflow_17_cache" ${TOPP_BIN_PATH}/OpenSwathWorkflow -in ${DATA_DIR_TOPP}/OpenSwathWorkflow_17_input.mzML -tr ${DATA_DIR_TOPP}/OpenSwathWorkflow_17_input.tsv -out_chrom ${TESTS_TEMP_DIR}/OpenSwathWorkflow_17.chrom.tmp.mzML -out_features ${TESTS_TEMP_DIR}/OpenSwathWorkflow_17.tmp.featureXML -readOptions cache -ion_mobility_window 0.05 -use_ms1_ion_mobility "false" -Scoring:Scores:use_ion_mobility_scores "true" -Calibration:auto_irt:enabled "false" -Calibration:windows:estimate_rt "false" -Calibration:windows:estimate_mz "false" -Calibration:windows:estimate_im "false"
+  add_test("TOPP_OpenSwathWorkflow_17_cache" ${TOPP_BIN_PATH}/OpenSwathWorkflow -in ${DATA_DIR_TOPP}/OpenSwathWorkflow_17_input.mzML -tr ${DATA_DIR_TOPP}/OpenSwathWorkflow_17_input.tsv -out_chrom ${TESTS_TEMP_DIR}/OpenSwathWorkflow_17_cache.chrom.tmp.mzML -out_features ${TESTS_TEMP_DIR}/OpenSwathWorkflow_17_cache.tmp.featureXML -readOptions cache -ion_mobility_window 0.05 -use_ms1_ion_mobility "false" -Scoring:Scores:use_ion_mobility_scores "true" -Calibration:auto_irt:enabled "false" -Calibration:windows:estimate_rt "false" -Calibration:windows:estimate_mz "false" -Calibration:windows:estimate_im "false"
     ${OLD_OSW_PARAM} )
-  add_test("TOPP_OpenSwathWorkflow_17_cache_out1" ${DIFF} -whitelist "id=" -in1 ${TESTS_TEMP_DIR}/OpenSwathWorkflow_17.tmp.featureXML -in2 ${DATA_DIR_TOPP}/OpenSwathWorkflow_17_output.featureXML)
-  add_test("TOPP_OpenSwathWorkflow_17_cache_out2" ${DIFF} -whitelist "id=" ${ZLIB_NG_MZML_WHITELIST} -in1 ${TESTS_TEMP_DIR}/OpenSwathWorkflow_17.chrom.tmp.mzML -in2 ${DATA_DIR_TOPP}/OpenSwathWorkflow_17_output.chrom.mzML)
+  add_test("TOPP_OpenSwathWorkflow_17_cache_out1" ${DIFF} -whitelist "id=" -in1 ${TESTS_TEMP_DIR}/OpenSwathWorkflow_17_cache.tmp.featureXML -in2 ${DATA_DIR_TOPP}/OpenSwathWorkflow_17_output.featureXML)
+  add_test("TOPP_OpenSwathWorkflow_17_cache_out2" ${DIFF} -whitelist "id=" ${ZLIB_NG_MZML_WHITELIST} -in1 ${TESTS_TEMP_DIR}/OpenSwathWorkflow_17_cache.chrom.tmp.mzML -in2 ${DATA_DIR_TOPP}/OpenSwathWorkflow_17_output.chrom.mzML)
   set_tests_properties("TOPP_OpenSwathWorkflow_17_cache_out1" PROPERTIES DEPENDS "TOPP_OpenSwathWorkflow_17_cache")
   set_tests_properties("TOPP_OpenSwathWorkflow_17_cache_out2" PROPERTIES DEPENDS "TOPP_OpenSwathWorkflow_17_cache")
 


### PR DESCRIPTION
## Description

The nightly Windows CI build failed on 2026-08-20 ([run 32321896643](https://github.com/OpenMS/OpenMS/actions/runs/32321896643)) with:

```
2027/2800 Test #2027: TOPP_OpenSwathWorkflow_17_cache ...***Failed  0.13 sec
Cannot write output file given from parameter '-out_features'!
Error: Unable to write file (the file
'D:/a/OpenMS/OpenMS/build/src/tests/topp/tmp_path/OpenSwathWorkflow_17.tmp.featureXML'
could not be created. )
```

> **Note:** an earlier version of this description attributed the abort to Windows
> exclusive file locks defeating a second `CreateFile`. That was wrong. The real
> mechanism is described under "What actually caused the abort" below, and it is
> fixed elsewhere — not by this PR.

### The two tests genuinely race

`TOPP_OpenSwathWorkflow_17` and `TOPP_OpenSwathWorkflow_17_cache`
(`src/tests/topp/CMakeLists.txt`) are independent `add_test()` entries with no
`DEPENDS` relationship, yet both pass the exact same `-out_chrom`/`-out_features`
temp paths (`OpenSwathWorkflow_17.chrom.tmp.mzML` /
`OpenSwathWorkflow_17.tmp.featureXML`). CI runs `ctest --parallel`, and the log
shows the two launched back to back and overlapping:

```
          Start 2024: TOPP_OpenSwathWorkflow_17
          Start 2027: TOPP_OpenSwathWorkflow_17_cache
 583/2800 Test #2027: TOPP_OpenSwathWorkflow_17_cache ...***Failed  0.13 sec
 584/2800 Test #2024: TOPP_OpenSwathWorkflow_17 .........   Passed  0.46 sec
```

`_cache` died 0.13 s in while `_17` was still running.

### What actually caused the abort

Not a file lock, and not Windows-specific. The failure came from the *startup*
writability check — `TOPPBase::outputFileWritable_` → `File::writable` — before
either tool had opened its real output. `File::writable()` had two defects:

1. It asked "does the path exist?" and "may I write it?" as two separate
   syscalls (`fs::exists` then `access`/`_access_s`). `access()` already reports
   `ENOENT`, so the `exists()` call added no information — only a window in which
   another process could change the path between the two queries.
2. For a path that did not exist it probed by opening *that very path* with a
   truncating `ofstream` and then unlinking it. Nothing established that the call
   had created the file, so a probe could delete output another process had just
   written under that name.

Two concurrent probes of one new path therefore lost the race and reported a
perfectly writable path as unwritable, which `outputFileWritable_` turns into
`UnableToCreateFile`. Measured on Linux, that happened in ~2% of attempts, and
the destructive variant destroyed a concurrent writer's output in ~79% — so this
was never a Windows-only phenomenon; Windows simply has a wider window.

**That is fixed in `File::writable()` itself, in a separate change, not here.**
It matters because the same trap applies to *any* two TOPP tools pointed at one
output path — there are 7 such collisions in `src/tests/topp/CMakeLists.txt`,
of which this PR addresses one.

### What this PR does fix: a silent coverage hole

The same CI run shows `TOPP_OpenSwathWorkflow_17_cache` **failing and writing
nothing**, while `TOPP_OpenSwathWorkflow_17_cache_out1` and `_out2` both
**passed**:

```
 583/2800 Test #2027: TOPP_OpenSwathWorkflow_17_cache .......***Failed  0.13 sec
2344/2800 Test #2028: TOPP_OpenSwathWorkflow_17_cache_out1 ...  Passed  0.07 sec
2346/2800 Test #2029: TOPP_OpenSwathWorkflow_17_cache_out2 ...  Passed  0.08 sec
```

They passed because they diffed `TOPP_OpenSwathWorkflow_17`'s output — the same
file. CTest's `DEPENDS` only orders tests; it does not gate them on the
dependency succeeding. So the cache-mode comparisons were never asserting
anything about cache mode whenever the non-cache run wrote last.

This PR gives the `_cache` variant its own output names —
`OpenSwathWorkflow_17_cache.chrom.tmp.mzML` /
`OpenSwathWorkflow_17_cache.tmp.featureXML` — matching what the sibling `_b`
variant already does, and points `_cache_out1`/`_out2` at them. They are still
diffed against the same reference files, since caching mode is expected to
produce equivalent results to the in-memory run.

So this is **not** "no test behavior/coverage changes", as previously stated: it
converts two vacuous comparisons into real ones. Green CI on this branch is the
first actual evidence that cache-mode output matches the reference.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file (test-only change)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes — see note below
- [x] Updated or added python bindings for changed or new classes (not applicable, test-only change)

### Note on verification

The TOPP tests themselves have still not been run locally for this change: the
analysis above was done against a build configured with `BUILD_TOPP_TOOLS=OFF`,
which does not register `TOPP_OpenSwathWorkflow_17*`. What is verified is the CI
run on this branch, which is green on `build-and-test (windows-2025, cl.exe)` —
and since `_cache_out1`/`_out2` now read the cache run's own output rather than
the non-cache run's, that green is meaningful in a way it was not before.

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ion-mobility cache test output handling by using distinct filenames for chromatogram and featureXML results.
  * Updated comparison checks to reference the correct cache-specific outputs.
