### PR TITLE
[FIX] File::writable(): stop destroying files and reporting false negatives

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,6 +46,14 @@ General:
     variable or an old side-by-side install can no longer hijack resolution (most relevant on Windows).
     File::find reports the resolved data directory and where it came from when a file is missing
     (#9635, #9636, #9650)
+  - Fix: File::writable() is no longer destructive and no longer reports false negatives under
+    concurrency. It used to answer "does it exist?" and "may I write it?" with two separate
+    queries, so a concurrent process could change the path in between and make it wrongly report
+    a writable path as unwritable; and it probed a non-existent path by creating that very file
+    and deleting it again, which could unlink output another process had just written there.
+    It now asks once and probes the target *directory* with a uniquely named temporary file.
+    File::readable() lost the same redundant exists() check. This removes a source of
+    intermittent "Cannot write output file" failures when two TOPP tools share an output path
 
 Dependencies:
   - PyOpenMS: Autowrap/Cython replaced with nanobind; nanobind 2.10.0+ fetched automatically (#8699)

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureSelector.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureSelector.h
@@ -296,7 +296,7 @@ public:
       Uses @c LPWrapper with @c LPWrapper::MIN objective sense. For each transition,
       registers one variable per candidate feature (binary or continuous, per
       @c parameters.variable_type) scored by @c computeScore_, and adds a
-      @c DOUBLE_BOUNDED constraint with both bounds equal to @c 1.0 (i.e. exactly one
+      @c FIXED constraint with both bounds equal to @c 1.0 (i.e. exactly one
       feature must be picked per transition). After solving, every column whose value
       is @c >= @c parameters.optimal_threshold contributes its name to @p result.
       @p result is cleared on entry.

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureSelector.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureSelector.cpp
@@ -93,7 +93,7 @@ namespace OpenMS
         }
       }
       std::vector<double> constraints_values(constraints.size(), 1.0);
-      addConstraint_(problem, constraints, constraints_values, elem.second + "_constraint", 1.0, 1.0, LPWrapper::DOUBLE_BOUNDED);
+      addConstraint_(problem, constraints, constraints_values, elem.second + "_constraint", 1.0, 1.0, LPWrapper::FIXED);
     }
     LPWrapper::SolverParam param;
     problem.solve(param);
@@ -203,8 +203,7 @@ namespace OpenMS
         }
       }
       std::vector<double> constraints_values(constraints.size(), 1.0);
-      addConstraint_(problem, constraints, constraints_values, time_to_name[cnt1].second + "_constraint", 1.0, 1.0, LPWrapper::DOUBLE_BOUNDED);
-      // addConstraint_(problem, constraints, constraints_values, time_to_name[cnt1].second + "_constraint", 1.0, 1.0, LPWrapper::FIXED); // glpk
+      addConstraint_(problem, constraints, constraints_values, time_to_name[cnt1].second + "_constraint", 1.0, 1.0, LPWrapper::FIXED);
     }
     LPWrapper::SolverParam param;
     problem.solve(param);

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -29,12 +29,16 @@
 #ifdef OPENMS_WINDOWSPLATFORM
 #include <Windows.h> // for GetCurrentProcessId() && GetModuleFileName() && GetComputerNameA()
 #include <Shlwapi.h> // for PathMatchSpecA
-#include <io.h>      // for _access_s
+#include <io.h>      // for _access_s(), _sopen_s() and _close()
+#include <share.h>   // for _SH_DENYNO
 #pragma comment(lib, "Shlwapi.lib")
 #else
 #include <fnmatch.h>
-#include <unistd.h> // for gethostname()
+#include <unistd.h> // for gethostname() and close()
 #endif
+
+#include <fcntl.h>    // for O_CREAT/O_EXCL (spelled _O_CREAT/_O_EXCL on Windows) and open()
+#include <sys/stat.h> // for the permission bits handed to the exclusive create
 
 #ifdef OPENMS_HAS_UNISTD_H
 #include <unistd.h> // for readLink() and getpid()
@@ -413,43 +417,100 @@ namespace OpenMS
     return pos == string::npos ? no_path : StringUtils::substr(file, 0, pos);
   }
 
+  namespace
+  {
+    /**
+      @brief Ask the OS whether @p file can be accessed with @p mode, creating nothing.
+
+      Returns 0 on success, otherwise an errno-style code -- in particular ENOENT when the
+      path is not there at all. Callers must branch on that return value rather than calling
+      exists() first: two separate queries can disagree, because another process is free to
+      create or delete the path in between, and the caller would then act on an answer that
+      was never true at any single point in time.
+    */
+    int fileAccess_(const std::string& file, int mode)
+    {
+      errno = 0;
+#ifdef OPENMS_WINDOWSPLATFORM
+      if (_access_s(file.c_str(), mode) == 0) return 0;
+#else
+      if (access(file.c_str(), mode) == 0) return 0;
+#endif
+      return errno != 0 ? errno : EACCES;
+    }
+
+    /**
+      @brief Create @p file, failing with EEXIST if it is already there.
+
+      Returns 0 if *this* call created the file, otherwise an errno-style code.
+      The exclusivity is the point: only the call that actually created a file may delete it
+      again. A plain truncating open would clobber -- and then unlink -- whatever another
+      process had put at that path in the meantime.
+    */
+    int createExclusive_(const std::string& file)
+    {
+      errno = 0;
+#ifdef OPENMS_WINDOWSPLATFORM
+      int fd = -1;
+      const int err = _sopen_s(&fd, file.c_str(), _O_CREAT | _O_EXCL | _O_WRONLY, _SH_DENYNO, _S_IREAD | _S_IWRITE);
+      if (err != 0) return errno != 0 ? errno : err;
+      _close(fd);
+#else
+      const int fd = ::open(file.c_str(), O_CREAT | O_EXCL | O_WRONLY, 0666);
+      if (fd < 0) return errno != 0 ? errno : EACCES;
+      ::close(fd);
+#endif
+      return 0;
+    }
+  } // namespace
+
   bool File::readable(const std::string& file)
   {
-    auto p = to_path(file);
-    std::error_code ec;
-    if (!fs::exists(p, ec)) return false;
+    // A single query -- see fileAccess_() for why this must not be preceded by an exists() check.
 #ifdef OPENMS_WINDOWSPLATFORM
-    return _access_s(file.c_str(), 4) == 0; // 4 = read permission
+    return fileAccess_(file, 4) == 0; // 4 = read permission
 #else
-    return access(file.c_str(), R_OK) == 0;
+    return fileAccess_(file, R_OK) == 0;
 #endif
   }
 
   bool File::writable(const std::string& file)
   {
-    auto p = to_path(file);
-    std::error_code ec;
+    if (file.empty()) return false;
 
-    if (fs::exists(p, ec))
-    {
 #ifdef OPENMS_WINDOWSPLATFORM
-      return _access_s(file.c_str(), 2) == 0; // 2 = write permission
+    const int write_mode = 2; // 2 = write permission
 #else
-      return access(file.c_str(), W_OK) == 0;
+    const int write_mode = W_OK;
 #endif
-    }
-    else
+
+    // A single query -- see fileAccess_() for why this must not be preceded by an exists() check.
+    const int err = fileAccess_(file, write_mode);
+    if (err == 0) return true;       // it is there and we may write it
+    if (err != ENOENT) return false; // it is there and we may not
+
+    // The path does not exist, so whether we could create it comes down to whether its
+    // directory accepts new files. Ask that with a probe file of our own instead of creating
+    // and deleting @p file itself: probing under the caller's name is what used to make this
+    // query destructive. Two callers probing the same new path would delete each other's
+    // file and report it unwritable, and a probe could unlink output that a concurrent writer
+    // had just produced under that name.
+    const std::string dir = File::path(file);
+    for (int attempt = 0; attempt < 3; ++attempt)
     {
-      // File does not exist: probe by trying to create it
-      std::ofstream f(file.c_str());
-      bool ok = f.is_open() && f.good();
-      f.close();
-      if (ok)
+      // getUniqueName() mixes in hostname, pid and an atomic counter, so colliding needs a
+      // second machine to pick the same name in the same second on a shared filesystem. Retry
+      // with a fresh name rather than misreport a perfectly writable directory in that case.
+      const std::string probe = dir + "/." + File::getUniqueName() + ".openms_writetest";
+      const int create_err = createExclusive_(probe);
+      if (create_err == 0)
       {
-        std::remove(file.c_str());
+        std::remove(probe.c_str());
+        return true;
       }
-      return ok;
+      if (create_err != EEXIST) return false; // no such directory, read-only medium, ...
     }
+    return false;
   }
 
   std::string File::find(const std::string& filename, StringList directories)

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -19,11 +19,10 @@
 #include <OpenMS/FORMAT/TextFile.h>
 #include <OpenMS/SYSTEM/File.h>
 
-#include <algorithm>
+#include <atomic>
 #include <fstream>
 #include <filesystem>
 #include <thread>
-#include <vector>
 
 using namespace OpenMS;
 using namespace std;
@@ -104,42 +103,54 @@ START_SECTION((static bool writable(const std::string &file)))
     TEST_EQUAL(File::exists(absent), false)                       // probing left no litter
   }
 
-  // Concurrent callers must not sabotage each other. Probing used to create and delete the
-  // caller's own path, so two tools writing the same output file would delete each other's
-  // probe and report the path unwritable -- an intermittent 'Cannot write output file' that
-  // showed up as a flaky Windows CI failure (issue seen in TOPP_OpenSwathWorkflow_17_cache).
+  // Concurrent callers must not sabotage each other. Both of the following are races, so a
+  // single attempt proves nothing -- before the fix they went wrong in roughly 2% and 79% of
+  // attempts respectively, which a one-shot check sails straight past. Repeat instead, and
+  // use a spin barrier: without one the first thread finishes before the second even starts,
+  // and the two never overlap at all.
   {
+    const int repeats = 500;
+    int both_writable = 0;   // two probes of the same new path must both answer 'true'
+    int output_survived = 0; // a probe must not delete what a concurrent writer produced
+
     std::string shared;
     NEW_TMP_FILE(shared);
-    std::filesystem::remove(shared);
-
-    const size_t n_threads = 8;
-    std::vector<char> results(n_threads, 0); // char, not bool: vector<bool> bits are not
-                                             // independently writable from several threads
-    std::vector<std::thread> threads;
-    for (size_t i = 0; i < n_threads; ++i)
-    {
-      threads.emplace_back([&results, &shared, i]() { results[i] = File::writable(shared) ? 1 : 0; });
-    }
-    for (auto& t : threads) t.join();
-
-    TEST_EQUAL(size_t(std::count(results.begin(), results.end(), 1)), n_threads)
-    TEST_EQUAL(File::exists(shared), false) // every probe cleaned up after itself
-  }
-
-  // A probe running alongside a real writer must never remove that writer's output.
-  {
     std::string contended;
     NEW_TMP_FILE(contended);
+
+    for (int i = 0; i < repeats; ++i)
+    {
+      // Two callers race to probe one path that does not exist yet. Probing used to create
+      // and delete that very path, so one prober would delete the other's file and then
+      // report it unwritable -- the intermittent 'Cannot write output file' seen on Windows
+      // CI when two TOPP tools were given the same -out path.
+      std::filesystem::remove(shared);
+      std::atomic<int> go_probe{0};
+      bool first = false, second = false;
+      std::thread p1([&]() { while (go_probe == 0) {} first = File::writable(shared); });
+      std::thread p2([&]() { while (go_probe == 0) {} second = File::writable(shared); });
+      go_probe = 1;
+      p1.join();
+      p2.join();
+      if (first && second) ++both_writable;
+
+      // A probe running alongside a real writer must leave that writer's output alone.
+      std::filesystem::remove(contended);
+      std::atomic<int> go_write{0};
+      std::thread writer([&]() { while (go_write == 0) {} std::ofstream os(contended.c_str()); os << "important"; });
+      std::thread prober([&]() { while (go_write == 0) {} File::writable(contended); });
+      go_write = 1;
+      writer.join();
+      prober.join();
+      std::error_code ec;
+      if (std::filesystem::exists(contended, ec) && std::filesystem::file_size(contended, ec) == 9) ++output_survived;
+    }
+
+    TEST_EQUAL(both_writable, repeats)
+    TEST_EQUAL(output_survived, repeats)
+
+    std::filesystem::remove(shared);
     std::filesystem::remove(contended);
-
-    std::thread writer([&contended]() { std::ofstream os(contended.c_str()); os << "important"; });
-    std::thread prober([&contended]() { File::writable(contended); });
-    writer.join();
-    prober.join();
-
-    TEST_EQUAL(File::exists(contended), true)
-    TEST_EQUAL(size_t(std::filesystem::file_size(contended)), size_t(9))
   }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -19,8 +19,11 @@
 #include <OpenMS/FORMAT/TextFile.h>
 #include <OpenMS/SYSTEM/File.h>
 
+#include <algorithm>
 #include <fstream>
 #include <filesystem>
+#include <thread>
+#include <vector>
 
 using namespace OpenMS;
 using namespace std;
@@ -78,10 +81,66 @@ START_SECTION((static bool writable(const std::string &file)))
   TEST_EQUAL(File::writable("/this/file/cannot/be/written.txt"), false)
   TEST_EQUAL(File::writable(OPENMS_GET_TEST_DATA_PATH("File_test_empty.txt")), true)
   TEST_EQUAL(File::writable(OPENMS_GET_TEST_DATA_PATH("File_test_imaginary.txt")), true)
+  TEST_EQUAL(File::writable(""), false)
 
   std::string filename;
   NEW_TMP_FILE(filename);
   TEST_EQUAL(File::writable(filename), true)
+
+  // writable() is a query: asking the question must not change the answer, and must not
+  // touch anything on disk that the caller did not ask about.
+  {
+    std::string probed;
+    NEW_TMP_FILE(probed);
+    { std::ofstream os(probed.c_str()); os << "payload"; }
+    TEST_EQUAL(File::writable(probed), true)
+    TEST_EQUAL(File::exists(probed), true)                        // still there
+    TEST_EQUAL(size_t(std::filesystem::file_size(probed)), size_t(7)) // and still intact
+
+    std::string absent;
+    NEW_TMP_FILE(absent);
+    std::filesystem::remove(absent);
+    TEST_EQUAL(File::writable(absent), true)
+    TEST_EQUAL(File::exists(absent), false)                       // probing left no litter
+  }
+
+  // Concurrent callers must not sabotage each other. Probing used to create and delete the
+  // caller's own path, so two tools writing the same output file would delete each other's
+  // probe and report the path unwritable -- an intermittent 'Cannot write output file' that
+  // showed up as a flaky Windows CI failure (issue seen in TOPP_OpenSwathWorkflow_17_cache).
+  {
+    std::string shared;
+    NEW_TMP_FILE(shared);
+    std::filesystem::remove(shared);
+
+    const size_t n_threads = 8;
+    std::vector<char> results(n_threads, 0); // char, not bool: vector<bool> bits are not
+                                             // independently writable from several threads
+    std::vector<std::thread> threads;
+    for (size_t i = 0; i < n_threads; ++i)
+    {
+      threads.emplace_back([&results, &shared, i]() { results[i] = File::writable(shared) ? 1 : 0; });
+    }
+    for (auto& t : threads) t.join();
+
+    TEST_EQUAL(size_t(std::count(results.begin(), results.end(), 1)), n_threads)
+    TEST_EQUAL(File::exists(shared), false) // every probe cleaned up after itself
+  }
+
+  // A probe running alongside a real writer must never remove that writer's output.
+  {
+    std::string contended;
+    NEW_TMP_FILE(contended);
+    std::filesystem::remove(contended);
+
+    std::thread writer([&contended]() { std::ofstream os(contended.c_str()); os << "important"; });
+    std::thread prober([&contended]() { File::writable(contended); });
+    writer.join();
+    prober.join();
+
+    TEST_EQUAL(File::exists(contended), true)
+    TEST_EQUAL(size_t(std::filesystem::file_size(contended)), size_t(9))
+  }
 END_SECTION
 
 START_SECTION((static std::string find(const std::string &filename, StringList directories=StringList())))


### PR DESCRIPTION
## Description

`TOPP_OpenSwathWorkflow_17_cache` failed on the Windows nightly with "Cannot write output file given from parameter `-out_features`" 0.13 s after start, while `TOPP_OpenSwathWorkflow_17` — which ctest had launched moments earlier against the same `-out_features` path — ran to completion. The test-side problem (two independent tests sharing one temp path) was fixed separately in #9937; the reason a shared path turned into a hard abort is in `File::writable()`, and that is what this PR fixes.

### `File::writable()` had two defects

**It asked two questions where one would do.** It answered "does the path exist?" and "may I write it?" with separate `exists()` and `access()` calls. `access()`/`_access_s()` already reports `ENOENT` for a missing path, so the `exists()` call in front of it added no information — only a window in which another process could change the path between the two calls. Losing that window makes a writable path report as unwritable, and `TOPPBase::outputFileWritable_` turns that into `UnableToCreateFile`. Two threads probing one new path hit it 2.15% of the time (430/20000) on Linux; the Windows nightly is simply where the wider window made it visible.

**It probed by destroying the caller's file.** For a non-existent path it opened *that very path* with a truncating `ofstream` and then unlinked it. Nothing established that this call had created the file, so a probe could truncate and delete output another process had just written under that name. In a tight race a bare `writable()` call destroyed a concurrent 4096-byte write 79% of the time (15817/20000). A query function must not be able to lose data.

`writable()` now asks once and branches on the error code, and probes for creatability by making a uniquely named temporary file in the target *directory*, so it never touches the caller's path at all. `readable()` loses the same redundant `exists()` check; a single `access(R_OK)` is exactly equivalent for all three outcomes.

### `MRMFeatureSelector`: `DOUBLE_BOUNDED` → `FIXED` for the equal-bound constraints

Both `MRMFeatureSelectorScore::optimize` and `MRMFeatureSelectorQMIP::optimize` add their "exactly one feature per transition" constraint with lower and upper bound both `1.0`, but typed it `DOUBLE_BOUNDED`. `LPWrapper::Type` is numerically identical to GLPK's bound constants and the GLPK backend passes the value straight through (`LPWrapper.cpp:207`), so `DOUBLE_BOUNDED` reaches `glp_set_row_bnds` as `GLP_DB`, which wants `lower < upper`. `FIXED` (`GLP_FX`) is what an equality constraint should have been typed as in the first place, independently of GLPK: `ILPDCWrapper.cpp:259` already writes the same sum-equals-one constraint that way. The QMIP site even carried a commented-out `FIXED` variant tagged `// glpk`; that line is now redundant and removed.

What actually goes wrong on a GLPK build: `glp_set_row_bnds` accepts the degenerate range silently, and the model then fails at solve time — `glp_intopt` prints `row 1: lb = 1, ub = 1; incorrect bounds` and **returns `GLP_EBOUND` without terminating the process**. Because both `optimize()` methods discard the return value of `problem.solve(param)` and read `getColumnValue()` immediately, every column comes back `0.0` and the selection is silently empty. Library and pyOpenMS callers (`MRMBatchFeatureSelector`) therefore got *no features* rather than an error. `MRMFeatureSelector_test` then dies with `SIGSEGV` — not inside GLPK, but at `MRMFeatureSelector_test.cpp:71`, indexing `output_selected[0]` on the resulting empty `FeatureMap`.

This is a no-op for the other two backends: in both `LPWrapper::addRow` and `LPWrapper::setRowBounds`, `DOUBLE_BOUNDED` and `FIXED` fall through to the same `default:` branch for COIN-OR (`model_->setRowBounds(index, lower, upper)`) and for HiGHS (`highs_->changeRowBounds(index, lower, upper)`). Only GLPK distinguishes them. CI never saw this because `LP_SOLVER=AUTO` prefers COIN-OR; a build that selects GLPK (`-DLP_SOLVER=GLPK`, or the vcpkg `lp-glpk` feature) hits it every time.

## Verification

Built and tested on Linux (Ubuntu 24.04, GCC 13.3, Release) against the GLPK backend, chosen so both changes are exercised:

```
cmake -S . -B OpenMS-build -G Ninja -DCMAKE_BUILD_TYPE=Release \
  -DLP_SOLVER=GLPK -DWITH_GUI=OFF -DPYOPENMS=OFF \
  -DENABLE_TUTORIALS=OFF -DENABLE_DOCS=OFF \
  -DWITH_THERMO_RAW=OFF -DARROW_USE_STATIC=OFF
```

- `File_test` passes, 3/3 runs, ~0.1–0.2 s. The new race sections report `both_writable` 500/500 and `output_survived` 500/500. No new compiler warnings.
- `MRMFeatureSelector_test` passes on GLPK (18 solves, no bound complaints). Reverting just the two constraint types back to `DOUBLE_BOUNDED` and rebuilding makes the same binary die with `SIGSEGV`; `gdb` puts the crash in `std::vector<Feature>::operator[]` called from `main`, confirming the empty-selection chain above rather than a GLPK abort.
- The `writable()`/`readable()` rewrite was separately checked for behavioural parity against the pre-PR implementation across 15 edge cases as an unprivileged user (existing writable/read-only file, existing directory, missing file in a writable/read-only/missing directory, trailing slash, `ENOTDIR`, dangling symlink, symlink to a read-only file, over-long name, bare relative name, empty path, `/dev/null`, missing path under `/proc`). All 15 agree with the old answers.
- Both race harnesses go to zero failures over 20000 iterations, with the existing semantics unchanged.

Not covered locally: the **Windows arm of the `#ifdef`s** (`_access_s`, `_sopen_s`) was not compiled — the local build is Linux-only, so that path still depends on the Windows CI job. The API contracts were checked against Microsoft's documentation: `_access_s` returns an error code *and* sets `errno` to the same value, and `_sopen_s` sets `errno` and returns `EEXIST` for `_O_CREAT | _O_EXCL` on an existing file.

## Known limitation

The directory probe uses a generated name (`.<date>_<time>_<hostname>_<pid>_<n>.openms_writetest`, ~54 characters) in place of the caller's own basename, and treats any create failure other than `EEXIST` as "not writable". Where the caller's name is much shorter, that shrinks the usable path budget — on Windows, capped at `MAX_PATH` with no long-path manifest in the tree, a directory path of roughly 202–250 characters can make `writable()` answer `false` for a target it could actually create. Demonstrated on Linux at the equivalent `PATH_MAX` band: with a 4060-character directory, `open(O_CREAT|O_EXCL)` on the real target succeeds but `writable()` returns `false` with `ENAMETOOLONG`. A follow-up shortens the probe name and falls back to querying the directory when the create fails for a name-length reason.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file <!-- File::writable() entry added; the MRMFeatureSelector fix is not yet documented -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>

- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds

</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).