### PR TITLE
[FIX,TEST] File::writable(): don't let the probe's own name decide the answer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -54,6 +54,13 @@ General:
     It now asks once and probes the target *directory* with a uniquely named temporary file.
     File::readable() lost the same redundant exists() check. This removes a source of
     intermittent "Cannot write output file" failures when two TOPP tools share an output path
+    (#9937, #9940, #9941)
+  - Fix: MRMFeatureSelector selected no features at all on builds using the GLPK backend
+    (-DLP_SOLVER=GLPK, or the vcpkg "lp-glpk" feature). Its "exactly one feature per transition"
+    constraints were typed DOUBLE_BOUNDED with both bounds equal, which reaches GLPK as GLP_DB
+    with lb == ub; glp_intopt then returns GLP_EBOUND and leaves every column at zero, and the
+    unchecked return value turned that into a silently empty selection. They are now typed FIXED.
+    No effect on the COIN-OR and HiGHS backends, which treat the two types identically (#9940)
 
 Dependencies:
   - PyOpenMS: Autowrap/Cython replaced with nanobind; nanobind 2.10.0+ fetched automatically (#8699)

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -498,17 +498,33 @@ namespace OpenMS
     const std::string dir = File::path(file);
     for (int attempt = 0; attempt < 3; ++attempt)
     {
-      // getUniqueName() mixes in hostname, pid and an atomic counter, so colliding needs a
-      // second machine to pick the same name in the same second on a shared filesystem. Retry
-      // with a fresh name rather than misreport a perfectly writable directory in that case.
-      const std::string probe = dir + "/." + File::getUniqueName() + ".openms_writetest";
+      // Keep the probe name short. It stands in for the caller's own basename, so every extra
+      // character it carries is a character of path budget the caller loses -- and on Windows
+      // that budget is MAX_PATH, small enough that a needlessly long probe can overflow it for
+      // a directory the caller's own (shorter) name would have fit into. getUniqueName(false)
+      // drops the hostname, roughly halving the name; pid and its atomic counter still make a
+      // collision take a second machine picking the same pid in the same second on a shared
+      // filesystem, and the retry covers even that.
+      const std::string probe = dir + "/." + File::getUniqueName(false) + ".omswt";
       const int create_err = createExclusive_(probe);
       if (create_err == 0)
       {
         std::remove(probe.c_str());
         return true;
       }
-      if (create_err != EEXIST) return false; // no such directory, read-only medium, ...
+      if (create_err == EEXIST) continue; // somebody holds that name -- retry with a fresh one
+
+      // The create can also fail for a reason that is about the probe *name* rather than about
+      // the directory: an over-long probe path reports ENAMETOOLONG on POSIX, and the Windows
+      // CRT folds ERROR_FILENAME_EXCED_RANGE onto ENOENT/EINVAL. Answering "not writable" on
+      // those would be exactly the false negative this function exists to avoid, so fall back
+      // to asking the directory itself. That still answers false when the directory is simply
+      // not there, because access() reports ENOENT for it too.
+      if (create_err == ENAMETOOLONG || create_err == ENOENT || create_err == EINVAL)
+      {
+        return fileAccess_(dir, write_mode) == 0;
+      }
+      return false; // read-only medium, no permission on the directory, ...
     }
     return false;
   }

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -108,6 +108,15 @@ START_SECTION((static bool writable(const std::string &file)))
   // attempts respectively, which a one-shot check sails straight past. Repeat instead, and
   // use a spin barrier: without one the first thread finishes before the second even starts,
   // and the two never overlap at all.
+  //
+  // The spins yield rather than burn the core. That costs nothing natively (500 repeats run in
+  // ~0.1 s either way) but matters by three orders of magnitude under valgrind, whose scheduler
+  // hands a spinning thread a full quantum before switching: measured on the same binary,
+  // 5 repeats take 67 s with a bare spin and 0.11 s with the yield.
+  //
+  // Note this section can only catch the bug where the threads genuinely overlap; pinned to a
+  // single core they serialise and the pre-fix implementation passes too. It is a regression
+  // guard on ordinary multi-core runners, not a proof on every machine.
   {
     const int repeats = 500;
     int both_writable = 0;   // two probes of the same new path must both answer 'true'
@@ -127,8 +136,8 @@ START_SECTION((static bool writable(const std::string &file)))
       std::filesystem::remove(shared);
       std::atomic<int> go_probe{0};
       bool first = false, second = false;
-      std::thread p1([&]() { while (go_probe == 0) {} first = File::writable(shared); });
-      std::thread p2([&]() { while (go_probe == 0) {} second = File::writable(shared); });
+      std::thread p1([&]() { while (go_probe == 0) { std::this_thread::yield(); } first = File::writable(shared); });
+      std::thread p2([&]() { while (go_probe == 0) { std::this_thread::yield(); } second = File::writable(shared); });
       go_probe = 1;
       p1.join();
       p2.join();
@@ -137,8 +146,8 @@ START_SECTION((static bool writable(const std::string &file)))
       // A probe running alongside a real writer must leave that writer's output alone.
       std::filesystem::remove(contended);
       std::atomic<int> go_write{0};
-      std::thread writer([&]() { while (go_write == 0) {} std::ofstream os(contended.c_str()); os << "important"; });
-      std::thread prober([&]() { while (go_write == 0) {} File::writable(contended); });
+      std::thread writer([&]() { while (go_write == 0) { std::this_thread::yield(); } std::ofstream os(contended.c_str()); os << "important"; });
+      std::thread prober([&]() { while (go_write == 0) { std::this_thread::yield(); } File::writable(contended); });
       go_write = 1;
       writer.join();
       prober.join();

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -103,6 +103,57 @@ START_SECTION((static bool writable(const std::string &file)))
     TEST_EQUAL(File::exists(absent), false)                       // probing left no litter
   }
 
+  // A long path must not make writable() lie. writable() answers "could this be
+  // created?" by creating a file of its own in the same directory, and that name is
+  // longer than a typical caller's -- so close to the platform's path limit there is a
+  // band where the caller's own file still fits but the probe no longer does. Reporting
+  // "not writable" there is exactly the false negative this function exists to avoid.
+  //
+  // The limit is not the same on every platform (PATH_MAX, MAX_PATH, and whatever the
+  // filesystem says), so rather than hard-code a length, grow a directory until the OS
+  // refuses to go deeper and then sweep the last stretch of headroom. At every depth the
+  // requirement is the same and is checked against reality rather than against an
+  // expected answer: if the file can actually be created, writable() must say true.
+  {
+    File::TempDir long_path_dir;
+    std::error_code ec;
+    std::string deep = long_path_dir.getPath();
+    const std::string chunk(60, 'd');
+
+    // Cap the descent: a filesystem with no practical path limit must not loop forever.
+    for (int level = 0; level < 200; ++level)
+    {
+      const std::string next = deep + chunk + "/";
+      std::filesystem::create_directory(next, ec);
+      if (ec || !std::filesystem::is_directory(next, ec)) break;
+      deep = next;
+    }
+
+    int agreed = 0, checked = 0;
+    for (size_t tail = 1; tail < 60; tail += 6)
+    {
+      const std::string leaf = deep + std::string(tail, 'e');
+      std::filesystem::create_directory(leaf, ec);
+      if (ec || !std::filesystem::is_directory(leaf, ec)) continue;
+
+      // Ground truth: let the OS itself say whether this file can be created.
+      const std::string target = leaf + "/o";
+      std::ofstream os(target.c_str());
+      const bool creatable = os.is_open() && os.good();
+      os.close();
+      if (creatable) std::filesystem::remove(target, ec);
+
+      ++checked;
+      if (File::writable(target) == creatable) ++agreed;
+      std::filesystem::remove(leaf, ec);
+    }
+
+    TEST_NOT_EQUAL(checked, 0)      // the sweep has to have probed something
+    TEST_EQUAL(agreed, checked)     // ... and writable() has to agree with the OS at every depth
+
+    std::filesystem::remove_all(deep, ec);
+  }
+
   // Concurrent callers must not sabotage each other. Both of the following are races, so a
   // single attempt proves nothing -- before the fix they went wrong in roughly 2% and 79% of
   // attempts respectively, which a one-shot check sails straight past. Repeat instead, and


### PR DESCRIPTION
## Description

Follow-up to #9940, which replaced `File::writable()`'s destructive probe with a uniquely named temporary file in the target *directory*. That fixed the data loss and the TOCTOU, but introduced a narrow false negative of its own, which this PR closes. It also adds the regression test that band never had, and the CHANGELOG entry the `MRMFeatureSelector` change never got.

### The probe's name is not the caller's name

The probe stands in for the caller's file, but its name is generated — `.<date>_<time>_<hostname>_<pid>_<n>.openms_writetest`, about 54 characters, against a typical `out.mzML` at 8. Every extra character comes out of the same path budget, and any create failure other than `EEXIST` returned `false` outright. So a directory that comfortably fits the caller's file can still overflow the platform's path limit for the probe, and `writable()` then reports a genuinely creatable path as unwritable — the same "Cannot write output file" #9940 set out to eliminate, now deterministic rather than racy.

On POSIX the band sits near `PATH_MAX` and is unreachable in practice. On Windows the CRT is capped at `MAX_PATH` and there is no long-path manifest anywhere in the tree, so the band is directory paths of roughly 202–250 characters — reachable via deep OneDrive and organisation trees.

Two changes:

- **Shorter probe name.** `getUniqueName(false)` drops the hostname and the suffix shortens, 54 characters down to 29. The pid and the atomic counter still carry uniqueness, and the existing retry still covers a cross-machine collision on a shared filesystem.
- **A create failure that may be about the *name* no longer decides the answer.** `ENAMETOOLONG` on POSIX, and `ENOENT`/`EINVAL` where the Windows CRT folds `ERROR_FILENAME_EXCED_RANGE`, now fall back to asking the directory itself. This cannot loosen the result: a directory that is not there reports `ENOENT` to `access()` too, so a missing directory still answers `false`. `EACCES`, `EROFS` and friends still return `false` directly, which matters on Windows, where `_access_s` reports *every* existing directory as writable.

### A regression test for it

The band only exists near the platform's path limit, so nothing in `File_test` reached it. Rather than hard-code a length — `PATH_MAX`, `MAX_PATH` and the filesystem all disagree, so any constant would be wrong somewhere — the new section grows a directory until the OS refuses to go deeper, then sweeps the last stretch of headroom. At each depth it asks the OS whether the file can really be created and requires `writable()` to give the same answer, which makes the assertion true by definition on every platform: `writable()` is wrong exactly when it disagrees with reality. The descent is capped so a filesystem without a practical path limit cannot loop.

### `std::this_thread::yield()` in the race barriers

The four spin barriers added in #9940 never yielded. That is free natively, but valgrind hands a spinning thread a full scheduling quantum before switching, so the section cost **67 s for 5 repeats** under memcheck — roughly two hours for the 500 it runs. OpenMS ships `tools/valgrind/openms_external.supp` and the developer FAQ documents running executables under valgrind, so this is a real cost for developers even though no CI job runs it. With the yield, the full 500 repeats take **0.58 s** under memcheck and are unchanged natively (~0.1 s).

The section comment now also records what it can and cannot prove: pinned to a single core the threads never overlap and the pre-#9940 implementation passes too, so it is a regression guard on ordinary multi-core runners rather than a proof everywhere.

### CHANGELOG

Adds the entry for the `MRMFeatureSelector` `DOUBLE_BOUNDED` → `FIXED` fix from #9940. It is the one part of that change a user cannot discover for themselves: on a GLPK build the selector returned an *empty* selection rather than failing, so anyone affected saw plausible-looking empty output and no error at all.

## Verification

Built and tested on Linux (Ubuntu 24.04, GCC 13.3, Release) against the GLPK backend, so both the file and solver paths are exercised:

```
cmake -S . -B OpenMS-build -G Ninja -DCMAKE_BUILD_TYPE=Release \
  -DLP_SOLVER=GLPK -DWITH_GUI=OFF -DPYOPENMS=OFF \
  -DENABLE_TUTORIALS=OFF -DENABLE_DOCS=OFF \
  -DWITH_THERMO_RAW=OFF -DARROW_USE_STATIC=OFF
```

- **The new test fails against the bug.** With the fix, all 7 swept depths agree and `File_test` passes. With `File.cpp` reverted to develop as merged, 6 of the 7 disagree and `File_test` fails (`agreed` 1, expected 7). A regression test that cannot fail against the bug is not worth having, so this one was checked in both directions.
- `File_test` passes 3/3 runs; `MRMFeatureSelector_test` passes. No new compiler warnings.
- Behavioural parity against the pre-#9940 implementation is unchanged by this PR: the same 15-case table (existing writable/read-only file, existing directory, missing file in a writable/read-only/missing directory, trailing slash, `ENOTDIR`, dangling symlink, symlink to a read-only file, over-long name, bare relative name, empty path, `/dev/null`, missing path under `/proc`), run unprivileged, still agrees on all 15.
- The race harness is unaffected: 5000/5000 on both counters with no probe files left behind, while the pre-#9940 code still fails it.

Not covered locally: the Windows arm of the `#ifdef`s was not compiled, so it depends on the Windows CI job as before.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>

- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds

</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file writability checks to be non-destructive and safe during concurrent access.
  - Prevented checks from creating, deleting, or modifying target files.
  - Improved handling of missing files, directories, and unusually long paths.
  - Simplified file readability checks for more reliable results.
  - Fixed feature selection constraints to prevent empty selections when using the GLPK backend.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->