### PR TITLE
Fix multi-arch container deploy race: merge per-arch digests into one manifest list

### DIFF
--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -15,6 +15,13 @@ on:
       - "Release/*"
 
 jobs:
+  # Each matrix leg builds one platform and pushes it to ghcr.io by digest
+  # only (untagged). The tags are created afterwards in merge-docker-manifests,
+  # which combines the per-platform digests into one multi-arch manifest list
+  # per image. Pushing tags directly from the matrix legs would race: whichever
+  # leg finishes last overwrites the tag with its single-arch image
+  # (https://github.com/OpenMS/OpenMS/issues/9951). Pattern from
+  # https://docs.docker.com/build/ci/github-actions/multi-platform/
   deploy-docker:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -67,6 +74,10 @@ jobs:
       - name: Downcase REPO
         run: echo "repo=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
         id: downcase_repo
+      - name: Sanitize platform name for the digests artifact
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> "$GITHUB_ENV"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to GitHub Container Registry
@@ -95,10 +106,10 @@ jobs:
             OPENMS_VERSION_TAG=${{ steps.tag_name.outputs.tag }}
           # cache-from: type=gha
           # cache-to: type=gha,mode=max
-      - name: Build and push library image
+      - name: Build and push library image by digest
+        id: build-library
         uses: docker/build-push-action@v7
         with:
-          push: true # Will only build if this is not here
           file: dockerfiles/Dockerfile
           target: library
           platforms: ${{ matrix.platform }}
@@ -107,14 +118,13 @@ jobs:
             NUM_BUILD_CORES=4
             BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
             OPENMS_VERSION_TAG=${{ steps.tag_name.outputs.tag }}
-          tags: |
-            ghcr.io/${{ steps.downcase_repo.outputs.repo }}-library:${{ steps.tag_name.outputs.tag }}
+          outputs: type=image,name=ghcr.io/${{ steps.downcase_repo.outputs.repo }}-library,push-by-digest=true,name-canonical=true,push=true
           # cache-from: type=gha
           # cache-to: type=gha,mode=max
-      - name: Build and push tools image
+      - name: Build and push tools image by digest
+        id: build-tools
         uses: docker/build-push-action@v7
         with:
-          push: true # Will only build if this is not here
           file: dockerfiles/Dockerfile
           target: tools
           platforms: ${{ matrix.platform }}
@@ -123,15 +133,15 @@ jobs:
             NUM_BUILD_CORES=4
             BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
             OPENMS_VERSION_TAG=${{ steps.tag_name.outputs.tag }}
-          tags: |
-            ghcr.io/${{ steps.downcase_repo.outputs.repo }}-executables:${{ steps.tag_name.outputs.tag }}
-            ghcr.io/${{ steps.downcase_repo.outputs.repo }}-tools:${{ steps.tag_name.outputs.tag }}
+          # The tools image is published under two names; push the digest to
+          # both repositories so each can be tagged from its own repository.
+          outputs: type=image,"name=ghcr.io/${{ steps.downcase_repo.outputs.repo }}-executables,ghcr.io/${{ steps.downcase_repo.outputs.repo }}-tools",push-by-digest=true,name-canonical=true,push=true
           # cache-from: type=gha
           # cache-to: type=gha,mode=max
-      - name: Build and push tools + thirdparty image
+      - name: Build and push tools + thirdparty image by digest
+        id: build-tools-thirdparty
         uses: docker/build-push-action@v7
         with:
-          push: true # Will only build if this is not here
           file: dockerfiles/Dockerfile
           target: tools-thirdparty
           platforms: ${{ matrix.platform }}
@@ -140,13 +150,91 @@ jobs:
             NUM_BUILD_CORES=4
             BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
             OPENMS_VERSION_TAG=${{ steps.tag_name.outputs.tag }}
-          tags: |
-            ghcr.io/${{ steps.downcase_repo.outputs.repo }}-tools-thirdparty:${{ steps.tag_name.outputs.tag }}
+          outputs: type=image,name=ghcr.io/${{ steps.downcase_repo.outputs.repo }}-tools-thirdparty,push-by-digest=true,name-canonical=true,push=true
           # cache-from: type=gha
           # cache-to: type=gha,mode=max
-  deploy-singularity:
+      - name: Export image digests
+        env:
+          DIGEST_LIBRARY: ${{ steps.build-library.outputs.digest }}
+          DIGEST_TOOLS: ${{ steps.build-tools.outputs.digest }}
+          DIGEST_TOOLS_THIRDPARTY: ${{ steps.build-tools-thirdparty.outputs.digest }}
+        run: |
+          set -euo pipefail
+          for digest_var in DIGEST_LIBRARY DIGEST_TOOLS DIGEST_TOOLS_THIRDPARTY; do
+            if [[ -z "${!digest_var}" ]]; then
+              echo "::error::Build did not report a digest for ${digest_var}"
+              exit 1
+            fi
+          done
+          mkdir -p "${RUNNER_TEMP}/digests/library" "${RUNNER_TEMP}/digests/tools" "${RUNNER_TEMP}/digests/tools-thirdparty"
+          touch "${RUNNER_TEMP}/digests/library/${DIGEST_LIBRARY#sha256:}"
+          touch "${RUNNER_TEMP}/digests/tools/${DIGEST_TOOLS#sha256:}"
+          touch "${RUNNER_TEMP}/digests/tools-thirdparty/${DIGEST_TOOLS_THIRDPARTY#sha256:}"
+      - name: Upload image digests
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+          overwrite: true
+  merge-docker-manifests:
     runs-on: ubuntu-latest
     needs: deploy-docker
+    steps:
+      - name: Download image digests
+        uses: actions/download-artifact@v8
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push multi-arch manifest lists
+        shell: bash
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          REPO_BASE: ghcr.io/${{ needs.deploy-docker.outputs.downcase_repo }}
+          TAG: ${{ needs.deploy-docker.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          create_manifest() {
+            local digest_dir="$1" image_repo="$2"
+            local sources=()
+            for digest_file in "${digest_dir}"/*; do
+              sources+=("${image_repo}@sha256:$(basename "${digest_file}")")
+            done
+            docker buildx imagetools create --tag "${image_repo}:${TAG}" "${sources[@]}"
+            ## Fail loudly if the pushed manifest list misses a platform instead
+            ## of publishing a silently single-arch tag again. Keep this list in
+            ## sync with the deploy-docker matrix.
+            local platforms
+            platforms="$(docker buildx imagetools inspect \
+              --format '{{range .Manifest.Manifests}}{{if .Platform}}{{.Platform.OS}}/{{.Platform.Architecture}}{{"\n"}}{{end}}{{end}}' \
+              "${image_repo}:${TAG}")"
+            echo "${image_repo}:${TAG} contains platforms:" "${platforms}"
+            for platform in linux/amd64 linux/arm64; do
+              if ! grep -qx "${platform}" <<< "${platforms}"; then
+                echo "::error::${image_repo}:${TAG} is missing platform ${platform}"
+                exit 1
+              fi
+            done
+          }
+          create_manifest library "${REPO_BASE}-library"
+          ## The tools image is published under two names (see deploy-docker);
+          ## its digests were pushed to both repositories.
+          create_manifest tools "${REPO_BASE}-executables"
+          create_manifest tools "${REPO_BASE}-tools"
+          create_manifest tools-thirdparty "${REPO_BASE}-tools-thirdparty"
+  deploy-singularity:
+    runs-on: ubuntu-latest
+    needs: [deploy-docker, merge-docker-manifests]
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
@@ -158,7 +246,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libglib2.0-dev          
+          sudo apt-get install -y libglib2.0-dev
       - name: Singularity install with defaults
         uses: singularityhub/install-singularity@main
         with:

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -24,6 +24,9 @@ jobs:
   # https://docs.docker.com/build/ci/github-actions/multi-platform/
   deploy-docker:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read # actions/checkout
+      packages: write # push images to ghcr.io
     strategy:
       matrix:
         include:
@@ -181,6 +184,10 @@ jobs:
   merge-docker-manifests:
     runs-on: ubuntu-latest
     needs: deploy-docker
+    permissions:
+      packages: write # push manifest lists to ghcr.io
+      actions: read # for actions/download-artifact
+      artifact-metadata: read # for actions/download-artifact
     steps:
       - name: Download image digests
         uses: actions/download-artifact@v8
@@ -235,6 +242,8 @@ jobs:
   deploy-singularity:
     runs-on: ubuntu-latest
     needs: [deploy-docker, merge-docker-manifests]
+    permissions:
+      packages: write # pull images from and push .sif images to ghcr.io
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -217,21 +217,22 @@ jobs:
             for digest_file in "${digest_dir}"/*; do
               sources+=("${image_repo}@sha256:$(basename "${digest_file}")")
             done
-            docker buildx imagetools create --tag "${image_repo}:${TAG}" "${sources[@]}"
-            ## Fail loudly if the pushed manifest list misses a platform instead
-            ## of publishing a silently single-arch tag again. Keep this list in
-            ## sync with the deploy-docker matrix.
-            local platforms
-            platforms="$(docker buildx imagetools inspect \
-              --format '{{range .Manifest.Manifests}}{{if .Platform}}{{.Platform.OS}}/{{.Platform.Architecture}}{{"\n"}}{{end}}{{end}}' \
-              "${image_repo}:${TAG}")"
-            echo "${image_repo}:${TAG} contains platforms:" "${platforms}"
+            ## Validate the merged manifest list on a dry run BEFORE tagging:
+            ## if a platform is missing (e.g. this list drifted from the
+            ## deploy-docker matrix), the previously published tag is left
+            ## untouched instead of being overwritten with an incomplete
+            ## manifest list.
+            local merged platforms
+            merged="$(docker buildx imagetools create --dry-run --tag "${image_repo}:${TAG}" "${sources[@]}")"
+            platforms="$(jq -r '.manifests[].platform | "\(.os)/\(.architecture)"' <<< "${merged}")"
+            echo "${image_repo}:${TAG} will contain platforms:" "${platforms}"
             for platform in linux/amd64 linux/arm64; do
               if ! grep -qx "${platform}" <<< "${platforms}"; then
-                echo "::error::${image_repo}:${TAG} is missing platform ${platform}"
+                echo "::error::Merged manifest list for ${image_repo}:${TAG} would be missing platform ${platform}; leaving the existing tag untouched"
                 exit 1
               fi
             done
+            docker buildx imagetools create --tag "${image_repo}:${TAG}" "${sources[@]}"
           }
           create_manifest library "${REPO_BASE}-library"
           ## The tools image is published under two names (see deploy-docker);


### PR DESCRIPTION
## Description

Fixes #9951.

The `deploy-docker` matrix legs (amd64, arm64) in `.github/workflows/containerdeploy.yml` each pushed a complete single-platform image under the **same** tags, so whichever leg finished last silently overwrote the tag with its own architecture. The published `-library`/`-executables`/`-tools`/`-tools-thirdparty` tags were therefore never real multi-arch manifest lists, and on nights when the arm64 leg finished last, `deploy-singularity` (which needs linux/amd64) failed with `no image found in image index for architecture amd64`.

This PR restructures the workflow to the pattern from [Docker's multi-platform CI guide](https://docs.docker.com/build/ci/github-actions/multi-platform/):

- Each matrix leg now pushes **untagged, by digest only** (`push-by-digest=true`), so the legs can no longer overwrite each other. The tools image digest is pushed to both of its repository names (`-executables` and `-tools`) so each tag is later created from digests in its own repository.
- The digests are handed to a new `merge-docker-manifests` job via artifacts; it creates one real multi-arch manifest list per tag with `docker buildx imagetools create`, then **fails loudly if the result is missing `linux/amd64` or `linux/arm64`** — a silently single-arch tag can't slip through again.
- `deploy-singularity` now also depends on the merge job, so it always resolves its amd64 image through a complete manifest list, regardless of matrix leg ordering.

Tag derivation, the runtime-base test build, `provenance: mode=max`, and the singularity steps are unchanged.

**Local validation** (the workflow can't be fully exercised pre-merge since it pushes to ghcr.io):
- `actionlint` passes on the modified workflow.
- Replicated the full pipeline locally against a local OCI registry with a minimal 3-target Dockerfile: ran both "legs" (linux/amd64 + linux/arm64 × library/tools/tools-thirdparty) using the exact `--output` strings from the workflow (including the quoted dual-name form and `provenance mode=max`), exported digests the same way, then executed the merge script **verbatim as extracted from the workflow YAML**. All four tags came out as proper OCI image indexes containing linux/amd64 + linux/arm64 (plus attestation manifests); `crane config --platform` and `docker pull --platform` resolve the correct architecture from every tag — the same resolution path `singularity build docker://…` uses.
- Negative test: the merge job's platform check correctly fails when a manifest list is missing an architecture.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file *(not applicable — CI-workflow-only change, no user-facing code change)*
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes *(no C++ changes; workflow logic validated locally as described above)*
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>

- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds

</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

---
_Generated by [Claude Code](https://claude.ai/code/session_016eZKwLNoEPhsUAMZCrxXhG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Container images now support verified multi-platform releases for AMD64 and ARM64 environments.
  * Image publishing validates both platforms before updating release tags, helping prevent incomplete or inconsistent images.
  * Tools images are available through both supported image paths.
  * Singularity deployments now wait for finalized image releases, reducing the risk of pulling incomplete or mismatched images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->