### PR TITLE
ExternalProcess_test: run in a private temp directory to fix parallel-ctest flakiness

### DIFF
--- a/src/tests/class_tests/openms/source/ExternalProcess_test.cpp
+++ b/src/tests/class_tests/openms/source/ExternalProcess_test.cpp
@@ -14,6 +14,7 @@
 ///////////////////////////
 
 #include <OpenMS/config.h>
+#include <OpenMS/SYSTEM/File.h>
 
 #include <filesystem>
 #include <fstream>
@@ -55,19 +56,28 @@ END_SECTION
 
 START_SECTION(RETURNSTATE run(const std::string& exe, const std::vector<std::string>& args, const std::string& working_dir, bool verbose, std::string& error_msg, IO_MODE io_mode, const std::map<std::string, std::string>& env, std::function<void()> idle_callback))
 {
+  // run everything in a private working directory: the test binary runs in a directory
+  // shared by all tests, and under 'ctest --parallel' the other tests' temp files appear
+  // and vanish while 'ls -l' walks it, making it print errors and exit non-zero (#9948)
+  File::TempDir tmp_dir;
+  { // one stable entry, so 'ls -l' has something to list
+    std::ofstream file(tmp_dir.getPath() + "some_file.txt");
+    file << "content\n";
+  }
+
   std::string error_msg;
   { // without callbacks
     ExternalProcess ep;
     std::string error_msg;
-    auto r = ep.run(exe, args, "", true, error_msg);
+    auto r = ep.run(exe, args, tmp_dir.getPath(), true, error_msg);
     TEST_EQUAL(r, ExternalProcess::RETURNSTATE::SUCCESS)
     TEST_EQUAL(error_msg.size(), 0)
 
-    r = ep.run("this_exe_does_not_exist", args, "", true, error_msg);
+    r = ep.run("this_exe_does_not_exist", args, tmp_dir.getPath(), true, error_msg);
     TEST_EQUAL(r,ExternalProcess::RETURNSTATE::FAILED_TO_START)
     TEST_NOT_EQUAL(error_msg.size(), 0);
 
-    r = ep.run(exe, args_broken, "", true, error_msg);
+    r = ep.run(exe, args_broken, tmp_dir.getPath(), true, error_msg);
     TEST_EQUAL(r, ExternalProcess::RETURNSTATE::NONZERO_EXIT)
     TEST_NOT_EQUAL(error_msg.size(), 0);
   }
@@ -76,7 +86,7 @@ START_SECTION(RETURNSTATE run(const std::string& exe, const std::vector<std::str
     auto l_out = [&](const std::string& out) {all_out += out;};
     auto l_err = [&](const std::string& out) {all_err += out;};
     ExternalProcess ep(l_out, l_err);
-    auto r = ep.run(exe, args, "", true, error_msg);
+    auto r = ep.run(exe, args, tmp_dir.getPath(), true, error_msg);
     TEST_EQUAL(r, ExternalProcess::RETURNSTATE::SUCCESS)
     TEST_EQUAL(error_msg.size(), 0);
     TEST_NOT_EQUAL(all_out.size(), 0)
@@ -84,7 +94,7 @@ START_SECTION(RETURNSTATE run(const std::string& exe, const std::vector<std::str
     all_out.clear();
     all_err.clear();
 
-    r = ep.run(exe, args_broken, "", false, error_msg);
+    r = ep.run(exe, args_broken, tmp_dir.getPath(), false, error_msg);
     TEST_EQUAL(r, ExternalProcess::RETURNSTATE::NONZERO_EXIT)
     TEST_NOT_EQUAL(error_msg.size(), 0);
     TEST_EQUAL(all_out.size(), 0)
@@ -94,7 +104,7 @@ START_SECTION(RETURNSTATE run(const std::string& exe, const std::vector<std::str
     all_err.clear();
 
     ep.setCallbacks(l_err, l_out); // swap callbacks
-    r = ep.run(exe, args_broken, "", false, error_msg);
+    r = ep.run(exe, args_broken, tmp_dir.getPath(), false, error_msg);
     TEST_EQUAL(r, ExternalProcess::RETURNSTATE::NONZERO_EXIT)
     TEST_NOT_EQUAL(error_msg.size(), 0);
     TEST_NOT_EQUAL(all_out.size(), 0)


### PR DESCRIPTION
## Description

Fixes #9948.

`ExternalProcess_test` runs plain `ls -l` with an empty `working_dir`, i.e. in the working directory shared by all tests. Under `ctest --parallel`, other tests concurrently create and delete their temp files there; when an entry vanishes between `ls`'s `readdir()` and `stat()`, `ls` reports the missing file on stderr and exits non-zero, intermittently failing the `SUCCESS` / empty-`error_msg` / empty-stderr assertions (observed on the `ubuntu-24.04-arm` CI runner, and reproduced locally in the issue).

This PR makes the `run()` section independent of the shared working directory: it creates a private `File::TempDir` (the existing RAII temp-dir utility, which lives under the system temp directory) with one stable file in it, and passes it as `working_dir` to every `ep.run()` call in that section. The `[EXTRA]` spaces section still passes an empty `working_dir`, so that default code path keeps its coverage. No library code is changed and no assertion is weakened.

**Verification** (local Linux x64, gcc 13, Release):
- `ctest -R ExternalProcess_test` passes.
- Stress harness reproducing the issue (a background loop continuously creating/deleting batches of temp files in the test's CWD while the test runs):
  - pre-fix binary: **3/10 rounds failed**, line-for-line the CI signature (`NONZERO_EXIT`, 78-byte `error_msg`, non-empty stderr at lines 80/81/83) — one round also failed in the earlier no-callbacks block (lines 63/64), which is why the fix covers every `ep.run()` in the section rather than only the run CI happened to catch.
  - fixed binary: **0/20 rounds failed** under identical churn.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file (test-only change, no AUTHORS update)
- [x] Add relevant changes and new features to the CHANGELOG file (not applicable: test-only flakiness fix)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8XDEnycb7ubURcc5AoGJf

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8XDEnycb7ubURcc5AoGJf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of external process tests by running commands in an isolated temporary directory.
  * Ensured success, failure, and callback scenarios use a consistent test file and working environment.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->