### PR TITLE
Fix silent LP solver failures: make LPWrapper status reliable and check it at all call sites

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -61,6 +61,14 @@ General:
     with lb == ub; glp_intopt then returns GLP_EBOUND and leaves every column at zero, and the
     unchecked return value turned that into a silently empty selection. They are now typed FIXED.
     No effect on the COIN-OR and HiGHS backends, which treat the two types identically (#9940)
+  - Fix: LP/ILP solver failures are no longer silent. LPWrapper::getStatus() now reports the real
+    solution status on the COIN-OR backend (it unconditionally returned UNDEFINED there, and the raw
+    solve() return value cannot signal failure: COIN-OR and HiGHS report a completed run even for a
+    proven-infeasible model). LPWrapper::solve() logs a warning whenever no feasible solution was
+    produced, and its callers (MRMFeatureSelector, ILPDCWrapper/Decharger) now check getStatus() and
+    throw an informative exception instead of reading the all-zero non-solution back as valid output
+    - previously any solver failure (infeasible model, bad bounds, resource limit) yielded silently
+    empty results (#9944)
 
 Dependencies:
   - PyOpenMS: Autowrap/Cython replaced with nanobind; nanobind 2.10.0+ fetched automatically (#8699)

--- a/src/openms/include/OpenMS/DATASTRUCTURES/LPWrapper.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/LPWrapper.h
@@ -467,14 +467,24 @@ public:
       @param[in] solver_param
       @param[in] verbose_level
 
-      @return solver dependent (todo: fix)
+      @return the raw return code of the backend solver (glp_intopt() for GLPK, CbcModel::status() for
+              COIN-OR, HighsStatus for HiGHS). The raw code is solver dependent and a code indicating a
+              completed run does not imply that a solution exists (e.g. COIN-OR reports a completed run
+              for proven infeasibility). Use getStatus() after solving to check - portably across
+              backends - whether an optimal/feasible solution was actually found before reading it
+              via getColumnValue() or getObjectiveValue(). If no feasible solution was produced, a
+              warning is logged.
     */
     Int solve(SolverParam& solver_param, const Size verbose_level = 0);
 
     /**
       @brief Get solution status.
 
-      @return status: 1 - undefined, 2 - integer optimal, 3- integer feasible (no optimality proven), 4- no integer feasible solution
+      Call this after solve(): only the states OPTIMAL and FEASIBLE indicate that the solver produced
+      a usable solution, i.e. that the values returned by getColumnValue() and getObjectiveValue()
+      are meaningful.
+
+      @return status: 1 - undefined, 2 - integer feasible (no optimality proven), 4 - no integer feasible solution, 5 - integer optimal
      */
     SolverStatus getStatus();
 
@@ -521,6 +531,7 @@ protected:
 #ifdef OPENMS_HAS_COINOR
     CoinModel * model_ = nullptr;      ///< COIN-OR model object for the LP problem
     std::vector<double> solution_;     ///< Solution vector when using COIN-OR
+    SolverStatus solver_status_ = UNDEFINED; ///< Status of the last solve() call (the COIN-OR solver object only lives during solve(), so the status must be stored for getStatus())
 #elif defined(OPENMS_HAS_HIGHS)
     std::unique_ptr<Highs> highs_;     ///< HiGHS solver instance
     std::vector<double> solution_;     ///< Solution vector when using HiGHS

--- a/src/openms/source/ANALYSIS/DECHARGING/ILPDCWrapper.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/ILPDCWrapper.cpp
@@ -8,6 +8,7 @@
 
 #include <OpenMS/ANALYSIS/DECHARGING/ILPDCWrapper.h>
 
+#include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/DATASTRUCTURES/ChargePair.h>
 #include <OpenMS/DATASTRUCTURES/LPWrapper.h>
@@ -269,6 +270,13 @@ namespace OpenMS
     param.enable_presolve = true;
 
     build.solve(param);
+    const LPWrapper::SolverStatus solution_status = build.getStatus();
+    if (solution_status != LPWrapper::OPTIMAL && solution_status != LPWrapper::FEASIBLE)
+    { // without this check a failed solve would silently deactivate all edges (see issue #9944)
+      throw Exception::FailedAPICall(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "The ILP solver did not find a feasible charge assignment (solver status: " +
+        StringUtils::toStr(static_cast<Int>(solution_status)) + ").");
+    }
 
     for (UInt iColumn = 0; iColumn < margin_right - margin_left; ++iColumn)
     {
@@ -435,10 +443,17 @@ namespace OpenMS
     time1.start();
     build.solve(param);
     time1.stop();
+    const LPWrapper::SolverStatus solution_status = build.getStatus();
+    if (solution_status != LPWrapper::OPTIMAL && solution_status != LPWrapper::FEASIBLE)
+    { // without this check a failed solve would silently deactivate all edges (see issue #9944)
+      throw Exception::FailedAPICall(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "The ILP solver did not find a feasible charge assignment (solver status: " +
+        StringUtils::toStr(static_cast<Int>(solution_status)) + ").");
+    }
     if (verbose_level > 0)
       OPENMS_LOG_INFO << " Branch and cut took " << time1.getClockTime() << " seconds, "
                << " with objective value: " << build.getObjectiveValue() << "."
-               << " Status: " << (!build.getStatus() ? " Finished" : " Not finished")
+               << " Status: " << (solution_status == LPWrapper::OPTIMAL ? " Finished" : " Not finished")
                << std::endl;
 
     // variable values

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureSelector.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureSelector.cpp
@@ -8,6 +8,7 @@
 
 #include <OpenMS/ANALYSIS/OPENSWATH/MRMFeatureSelector.h>
 
+#include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/DATASTRUCTURES/LPWrapper.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
@@ -97,6 +98,13 @@ namespace OpenMS
     }
     LPWrapper::SolverParam param;
     problem.solve(param);
+    const LPWrapper::SolverStatus solution_status = problem.getStatus();
+    if (solution_status != LPWrapper::OPTIMAL && solution_status != LPWrapper::FEASIBLE)
+    { // without this check a failed solve would silently yield an empty feature selection (see issue #9944)
+      throw Exception::FailedAPICall(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "The LP solver did not find a feasible feature selection (solver status: " +
+        StringUtils::toStr(static_cast<Int>(solution_status)) + ").");
+    }
     for (Int c = 0; c < problem.getNumberOfColumns(); ++c)
     {
       if (problem.getColumnValue(c) >= parameters.optimal_threshold)
@@ -207,6 +215,13 @@ namespace OpenMS
     }
     LPWrapper::SolverParam param;
     problem.solve(param);
+    const LPWrapper::SolverStatus solution_status = problem.getStatus();
+    if (solution_status != LPWrapper::OPTIMAL && solution_status != LPWrapper::FEASIBLE)
+    { // without this check a failed solve would silently yield an empty feature selection (see issue #9944)
+      throw Exception::FailedAPICall(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "The LP solver did not find a feasible feature selection (solver status: " +
+        StringUtils::toStr(static_cast<Int>(solution_status)) + ").");
+    }
     for (Int c = 0; c < problem.getNumberOfColumns(); ++c)
     {
       const std::string name = problem.getColumnName(c);

--- a/src/openms/source/DATASTRUCTURES/LPWrapper.cpp
+++ b/src/openms/source/DATASTRUCTURES/LPWrapper.cpp
@@ -744,12 +744,34 @@ namespace OpenMS
     //                                        << model.getObjValue()
     //                                        << (!model.status() ? " Finished" : " Not finished")
     //                                        << std::endl;
-    for (Int i = 0; i < model_->numberColumns(); ++i)
+    // determine the solution status now: the CbcModel only lives inside this function, so it cannot
+    // be queried by getStatus() later
+    if (model.isProvenOptimal())
     {
-      solution_.push_back(model.solver()->getColSolution()[i]);
+      solver_status_ = LPWrapper::OPTIMAL;
+    }
+    else if (model.bestSolution() != nullptr)
+    { // stopped early (e.g. a limit was hit), but an integer feasible solution exists
+      solver_status_ = LPWrapper::FEASIBLE;
+    }
+    else if (model.isProvenInfeasible() || model.isProvenDualInfeasible())
+    {
+      solver_status_ = LPWrapper::NO_FEASIBLE_SOL;
+    }
+    else
+    {
+      solver_status_ = LPWrapper::UNDEFINED;
+    }
+
+    solution_.clear();
+    if (solver_status_ == LPWrapper::OPTIMAL || solver_status_ == LPWrapper::FEASIBLE)
+    {
+      const double* col_solution = model.solver()->getColSolution();
+      solution_.assign(col_solution, col_solution + model_->numberColumns());
     }
     OPENMS_LOG_INFO << (model.isProvenOptimal() ? "Optimal solution found!" : "No solution found!") << "\n";
-    return model.status();
+    // note: CbcModel::status() is 0 ('search completed') even for proven infeasibility
+    const Int raw_solver_return = model.status();
 #elif defined(OPENMS_HAS_HIGHS)
     OPENMS_LOG_INFO << "Using solver 'highs' ...\n";
     // Configure HiGHS options based on solver_param
@@ -780,7 +802,7 @@ namespace OpenMS
     {
       OPENMS_LOG_INFO << "No solution found!\n";
     }
-    return static_cast<Int>(status);
+    const Int raw_solver_return = static_cast<Int>(status);
 #else
     OPENMS_LOG_INFO << "Using solver 'glpk' ...\n";
 
@@ -823,14 +845,23 @@ namespace OpenMS
     {
       solver_param_glp.binarize = GLP_ON; // only with presolve
     }
-    return glp_intopt(lp_problem_, &solver_param_glp);
+    const Int raw_solver_return = glp_intopt(lp_problem_, &solver_param_glp);
 #endif
+    // make solver failures visible: without a feasible solution all column values read as zero,
+    // which is indistinguishable from a genuine all-zero optimum (see issue #9944)
+    const SolverStatus solution_status = getStatus();
+    if (solution_status != LPWrapper::OPTIMAL && solution_status != LPWrapper::FEASIBLE)
+    {
+      OPENMS_LOG_WARN << "LPWrapper::solve(): the solver did not find a feasible solution (raw solver return code: " << raw_solver_return
+                      << "). Solution values are not meaningful; check getStatus() before using them." << std::endl;
+    }
+    return raw_solver_return;
   }
 
   LPWrapper::SolverStatus LPWrapper::getStatus()
   {
 #ifdef OPENMS_HAS_COINOR
-    return LPWrapper::UNDEFINED;
+    return solver_status_; // stored by solve(), since the COIN-OR solver object cannot be queried here
 #elif defined(OPENMS_HAS_HIGHS)
     HighsModelStatus model_status = highs_->getModelStatus();
     switch (model_status)
@@ -844,6 +875,11 @@ namespace OpenMS
     case HighsModelStatus::kUnbounded:
       return LPWrapper::NO_FEASIBLE_SOL;
     default:
+      // e.g. a time/iteration limit was hit: an integer feasible (incumbent) solution may still exist
+      if (highs_->getHighsInfo().primal_solution_status == kSolutionStatusFeasible)
+      {
+        return LPWrapper::FEASIBLE;
+      }
       return LPWrapper::UNDEFINED;
     }
 #else
@@ -886,7 +922,9 @@ namespace OpenMS
   double LPWrapper::getColumnValue(Int index)
   {
 #ifdef OPENMS_HAS_COINOR
-    return solution_[index];
+    if (index >= 0 && index < (Int)solution_.size())
+      return solution_[index];
+    return 0.0; // no solution stored (solve() failed or was not called yet)
 #elif defined(OPENMS_HAS_HIGHS)
     if (index >= 0 && index < (Int)solution_.size())
       return solution_[index];

--- a/src/pyOpenMS/bindings/bind_datastructures.cpp
+++ b/src/pyOpenMS/bindings/bind_datastructures.cpp
@@ -523,12 +523,12 @@ Solve problems, parameters like enabled heuristics can be given via solver_param
 The verbose level (0,1,2) determines if the solver prints status messages and internals
 :param solver_param: Parameters of the solver introduced by SolverParam
 :param verbose_level: Sets verbose level
-:return: solver dependent
+:return: the raw return code of the backend solver (solver dependent); use getStatus() to check portably whether a feasible solution was found
 )doc")
         .def("getStatus", [](OpenMS::LPWrapper& self) { return self.getStatus(); },
             R"doc(
-Returns solution status
-:return: status: 1 - undefined, 2 - integer optimal, 3- integer feasible (no optimality proven), 4- no integer feasible solution
+Returns solution status; call after solve(). Only OPTIMAL and FEASIBLE indicate that a usable solution exists
+:return: status: 1 - undefined, 2 - integer feasible (no optimality proven), 4 - no integer feasible solution, 5 - integer optimal
 )doc")
         .def("getObjectiveValue", [](OpenMS::LPWrapper& self) { return self.getObjectiveValue(); },
             R"doc(

--- a/src/tests/class_tests/openms/source/LPWrapper_test.cpp
+++ b/src/tests/class_tests/openms/source/LPWrapper_test.cpp
@@ -438,23 +438,24 @@ LPWrapper::SolverParam param4;
 lp4.solve(param4);
 START_SECTION((SolverStatus getStatus()))
 {
-  if(lp4.getSolver() == LPWrapper::SOLVER_GLPK)
-    {
-      TEST_EQUAL(lp4.getStatus(),LPWrapper::OPTIMAL)
-    }
-#ifdef OPENMS_HAS_COINOR
-  else if (lp4.getSolver() == LPWrapper::SOLVER_COINOR)
-  {
-    TEST_EQUAL(lp4.getStatus(),LPWrapper::UNDEFINED)
-  }
-#endif
-#ifdef OPENMS_HAS_HIGHS
-  else if (lp4.getSolver() == LPWrapper::SOLVER_HIGHS)
-  {
-    TEST_EQUAL(lp4.getStatus(),LPWrapper::OPTIMAL)
-  }
-#endif
+  // all backends report OPTIMAL for this simple, solvable integer problem
+  TEST_EQUAL(lp4.getStatus(),LPWrapper::OPTIMAL)
 
+  // an infeasible problem must not report a usable solution on any backend (see issue #9944)
+  LPWrapper lp5;
+  Int col = lp5.addColumn();
+  lp5.setColumnBounds(col, 0.0, 10.0, LPWrapper::DOUBLE_BOUNDED);
+  lp5.setColumnType(col, LPWrapper::INTEGER);
+  lp5.setObjective(col, 1.0);
+  lp5.setObjectiveSense(LPWrapper::MAX);
+  std::vector<Int> idx5(1, col);
+  std::vector<double> val5(1, 1.0);
+  lp5.addRow(idx5, val5, std::string("le1"), 0.0, 1.0, LPWrapper::UPPER_BOUND_ONLY); // x <= 1
+  lp5.addRow(idx5, val5, std::string("ge2"), 2.0, 0.0, LPWrapper::LOWER_BOUND_ONLY); // x >= 2 -> infeasible
+  LPWrapper::SolverParam param5;
+  lp5.solve(param5);
+  LPWrapper::SolverStatus status5 = lp5.getStatus();
+  TEST_EQUAL(status5 == LPWrapper::OPTIMAL || status5 == LPWrapper::FEASIBLE, false)
 }
 END_SECTION
 


### PR DESCRIPTION
## Description

Fixes #9944: `LPWrapper::solve()` returns a status code that every C++ call site discarded, so a solver that *declined to solve* was indistinguishable from one that returned an all-zero optimum — solver failures (infeasible model, bad bounds as in #9940, resource limits) silently became empty feature selections / empty charge assignments.

Checking the raw return value at the call sites would not even have been enough: verified empirically, **COIN-OR (`CbcModel::status()`) and HiGHS (`HighsStatus`) both report a completed run (`0`) for a proven-infeasible model**. The reliable, portable signal is `getStatus()` — which in turn returned `UNDEFINED` unconditionally on the COIN-OR path. This PR makes `getStatus()` reliable and then uses it:

**`LPWrapper` (normalisation inside the wrapper, as suggested in the issue):**
- COIN-OR: the solution status is captured while the `CbcModel` is alive (`isProvenOptimal()` → `OPTIMAL`, incumbent via `bestSolution()` → `FEASIBLE`, `isProvenInfeasible()`/`isProvenDualInfeasible()` → `NO_FEASIBLE_SOL`) and stored, so `getStatus()` now reports it instead of always `UNDEFINED`.
- COIN-OR: the solution vector is cleared before storing (repeated `solve()` on the same object used to append and return stale values) and is only populated when a solution exists; `getColumnValue()` is bounds-checked like on the HiGHS path instead of indexing out of range after a failed solve.
- HiGHS: `getStatus()` recognises an integer-feasible incumbent (via `HighsInfo::primal_solution_status`) when the run stopped for a non-terminal reason (e.g. time limit).
- `solve()` logs a warning whenever the backend reports no feasible solution, so even callers that ignore the status get an actionable message instead of silent zeros.
- Documentation of `solve()`/`getStatus()` corrected (the old `getStatus()` doc listed wrong enum values; `solve()`'s "solver dependent (todo: fix)" now explains the contract), also in the pyOpenMS docstrings.

**Call sites (all four from the issue):**
- `MRMFeatureSelector.cpp` (`MRMFeatureSelectorScore::optimize`, `MRMFeatureSelectorQMIP::optimize`) and `ILPDCWrapper.cpp` (`computeSlice_`, `computeSliceOld_`) now check `getStatus()` after `solve()` and throw `Exception::FailedAPICall` with the status instead of reading back an all-zero non-solution. Neither call path runs inside an OpenMP region (the pragma in `ILPDCWrapper::compute()` is commented out), so throwing is safe.
- `computeSliceOld_`'s verbose status print compared the `SolverStatus` enum against 0, a value it can never take (`" Status: " << (!build.getStatus() ? ...)`), and therefore always printed " Not finished"; it now checks against `OPTIMAL`.

**Tests:**
- `LPWrapper_test` no longer enshrines the broken COIN-OR behaviour (it asserted `getStatus() == UNDEFINED` after a successful solve); all backends now assert `OPTIMAL`.
- New test: an infeasible problem must not report `OPTIMAL`/`FEASIBLE` on any backend.

### Validation

- Full local Linux build (Release, COIN-OR backend selected via `LP_SOLVER=AUTO`); `LPWrapper_test`, `MRMFeatureSelector_test`, `ILPDCWrapper_test`, `FeatureDeconvolution_test`, `MetaboliteFeatureDeconvolution_test` and `MRMBatchFeatureSelector_test` pass via ctest.
- The changed `LPWrapper.cpp`/test compile against all three backends (GLPK 5.0, COIN-OR Cbc 2.10, HiGHS v1.14.0 — the FetchContent-pinned version) and a runtime driver exercising feasible/infeasible/re-solve scenarios passes on all three; backend status semantics (incl. the #9940 `GLP_EBOUND` scenario: `glp_mip_status` stays `GLP_UNDEF`, columns read 0) were verified with standalone programs against the real solver libraries.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJYjGzaG1C6WEqN2RhR9hZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJYjGzaG1C6WEqN2RhR9hZ)_