### PR TITLE
Fix pyOpenMS import failure when built with WITH_WNETALIGN=OFF

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -168,6 +168,11 @@ PyOpenMS:
   - Fix: FileTypes wrapping updated with missing enum values and static methods (#8720); backward
     compatibility restored for the file I/O methods of IdXMLFile, PepXMLFile and MzIdentMLFile (#8553);
     getAAFrequencies() loop bug in the AASequence addon (#8502)
+  - Fix: a build with -DWITH_WNETALIGN=OFF produced a pyOpenMS that could not be imported at all
+    (undefined WNetMatcher symbol in _pyopenms_misc), because the WNet bindings referenced symbols
+    that are excluded from libOpenMS by that option. The WNetMatcher and FeatureGroupingAlgorithmWNet
+    bindings are now compiled only when WNet support is built, mirroring the BrukerTimsFile /
+    WITH_OPENTIMS pattern, and feature-detectable via hasattr(pyopenms, "WNetMatcher") (#9946)
   - Docs: type hints in the docstrings of 133 functions (#8483), docstring format validation tests
     (#8674), 6 docutils ERROR-level warnings resolved (#9629), and corrected/added MSChromatogram and
     Mobilogram docstrings (#9812)

--- a/src/pyOpenMS/bindings/bind_misc.cpp
+++ b/src/pyOpenMS/bindings/bind_misc.cpp
@@ -3,6 +3,7 @@
 
 #include "all_casters.h"
 #include "nanobind_ms_data_consumer.h"
+#include <OpenMS/config.h> // for WITH_WNETALIGN
 #include <OpenMS/ANALYSIS/DECHARGING/FeatureDeconvolution.h>
 #include <OpenMS/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.h>
 #include <OpenMS/ANALYSIS/ID/AScore.h>
@@ -37,9 +38,11 @@
 #include <OpenMS/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmLabeled.h>
 #include <OpenMS/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmQT.h>
 #include <OpenMS/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmUnlabeled.h>
+#ifdef WITH_WNETALIGN
 #include <OpenMS/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmWNet.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/PipEchoAlgorithm.h>
 #include <OpenMS/ANALYSIS/MAPMATCHING/WNetMatcher.h>
+#endif
+#include <OpenMS/ANALYSIS/MAPMATCHING/PipEchoAlgorithm.h>
 #include <OpenMS/ANALYSIS/MAPMATCHING/LabeledPairFinder.h>
 #include <OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmIdentification.h>
 #include <OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmPoseClustering.h>
@@ -842,6 +845,7 @@ FeatureGroupingAlgorithm
         .def("setReference", [](OpenMS::FeatureGroupingAlgorithmUnlabeled& self, int map_id, const OpenMS::FeatureMap& map) { self.setReference(map_id, map); }, "map_id"_a, "map"_a)
         ;
 
+#ifdef WITH_WNETALIGN
     // -----------------------------------------------------------------------
     // WNetMatcher
     // -----------------------------------------------------------------------
@@ -874,6 +878,10 @@ a minimum-cost network flow problem. Returns 1-to-1 matched index pairs.
 This provides a minimal, FeatureMap-independent interface to the WNetAlign
 algorithm. For feature-level grouping across multiple maps, use
 FeatureGroupingAlgorithmWNet instead.
+
+This class is only available when OpenMS is built with
+``WITH_WNETALIGN=ON`` (the default). Use
+``hasattr(pyopenms, "WNetMatcher")`` to feature-detect at runtime.
 )doc")
         .def_static("match", &OpenMS::WNetMatcher::match,
             "positions_a"_a, "intensities_a"_a,
@@ -898,6 +906,11 @@ Finds pairwise optimal 1-to-1 feature matchings via minimum-cost network
 flow on (m/z, RT) positions; the subsequent merge across multiple maps is
 heuristic and not globally optimal.
 
+This class is only available when OpenMS is built with
+``WITH_WNETALIGN=ON`` (the default). Use
+``hasattr(pyopenms, "FeatureGroupingAlgorithmWNet")`` to feature-detect
+at runtime.
+
 FeatureGroupingAlgorithm
 )doc")
         .def(nb::init<>(), "Construct a FeatureGroupingAlgorithmWNet with default parameters")
@@ -914,6 +927,7 @@ FeatureGroupingAlgorithm
             "maps"_a, "out"_a,
             "Transfers subelements (grouped features) from input consensus maps to the result consensus map")
         ;
+#endif // WITH_WNETALIGN
 
     // -----------------------------------------------------------------------
     // File


### PR DESCRIPTION
## Description

Fixes #9946.

Building with `-DWITH_WNETALIGN=OFF` excludes `WNetMatcher.cpp` and `FeatureGroupingAlgorithmWNet.cpp` from libOpenMS, but `bind_misc.cpp` referenced their symbols unconditionally. Since shared modules resolve symbols lazily, the build succeeded with zero errors and every `import pyopenms` then failed with an undefined-symbol `ImportError` in `_pyopenms_misc` — making the entire package unusable.

**The fix:** guard the WNet includes and the `WNetMatcherDistanceMetric` / `WNetMatchResult` / `WNetMatcher` / `FeatureGroupingAlgorithmWNet` bindings with `#ifdef WITH_WNETALIGN`, and note the availability plus the `hasattr(pyopenms, "WNetMatcher")` feature-detection idiom in the docstrings — the same pattern used for `BrukerTimsFile` / `WITH_OPENTIMS`.

**Why no CMake change** (deviating from the approach sketched in the issue): `config.h.in` already carries `#cmakedefine WITH_WNETALIGN 1`, which `ToolHandler.cpp` already uses to conditionally register `FeatureLinkerWNet`. Reusing that macro (via an explicit `#include <OpenMS/config.h>`) needs no build-system change and also works for standalone wheel builds against an installed OpenMS, where `config.h` is installed with the headers. Exporting `OPENMS_HAS_WNETALIGN` publicly would have added a second, redundant mechanism — that macro is currently defined but referenced nowhere.

**Verified locally** on Ubuntu 24.04 / GCC 13.3 (the issue's repro environment) with `-DCMAKE_BUILD_TYPE=Release -DWITH_GUI=OFF -DPYOPENMS=ON -DWITH_WNETALIGN=OFF`:
- `import pyopenms` succeeds; all four WNet names are absent and feature-detectable via `hasattr`
- `nm -D _pyopenms_misc.so` shows zero WNet symbol references (previously `U OpenMS::WNetMatcher::metricFromString(...)`)
- full pyOpenMS test suite: **5673 passed, 86 skipped, 11 xfailed, 7 xpassed, 0 failed**
- a preprocessor-projection check confirms the default `WITH_WNETALIGN=ON` path compiles the identical binding set as before (CI exercises that configuration)

## Checklist
- [x] Make sure that you are listed in the AUTHORS file *(no new author; driven by @timosachsenberg, already listed)*
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdWTAurDnbxsMorHTuCQTT)_