### PR TITLE
Fix nightly Windows CI: exclude Internal::Looper from Doxygen output

### DIFF
--- a/doc/doxygen/Doxyfile.in
+++ b/doc/doxygen/Doxyfile.in
@@ -914,7 +914,7 @@ EXCLUDE_PATTERNS       = */.git/* \
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        = 
+EXCLUDE_SYMBOLS        = OpenMS::Internal::Looper*
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include


### PR DESCRIPTION
## Summary

The nightly `Release` workflow's Windows `Package` step has failed for several nights in a row ([08-24](https://github.com/OpenMS/OpenMS/actions/runs/32680579142/job/97296454850), [08-25](https://github.com/OpenMS/OpenMS/actions/runs/32798490849/job/97654593127)) with the same error:

```
CPack Error: Problem running NSIS command: "C:/Program Files (x86)/NSIS/makensis.exe" ...
File: failed opening file "...\_CPack_Packages\win64\NSIS\OpenMS-3.6.0-pre-nightly-2026-08-25-Win64\share\doc\html\structOpenMS_1_1Internal_1_1Looper_3_01grid__size_00_01grid__size_00_01EvalResult_00_01Tuple_00_6df0894035a0cfaef9564a517a83612f_org.svg"
```

### Root cause

`OpenMS::Internal::Looper` (`src/openms/include/OpenMS/ML/GRIDSEARCH/GridSearch.h`) is a compile-time template-metaprogramming helper with multiple partial specializations. Doxygen mangles each specialization's fully-instantiated template signature into its generated HTML/graph filenames. The collaboration-graph SVG for one specialization ends up at a full path of **262 characters** once nested under the NSIS staging directory — 2 over Windows' classic `MAX_PATH` (260) limit — so `makensis.exe` cannot open the file while compressing the installer, and packaging aborts.

I verified this locally with a standalone `doxygen` run against `GridSearch.h`: without the exclusion, Doxygen emits several `Looper`-related files, the longest bare filename being 133 characters (before even adding the NSIS staging path prefix); with the exclusion, none are emitted.

### Fix

`Looper` is a private implementation detail in `namespace Internal` with no documentation value to end users, so it is excluded from Doxygen's output via `EXCLUDE_SYMBOLS` in `doc/doxygen/Doxyfile.in`, rather than working around the packaging step itself (e.g. shortening paths, disabling long-path-unsafe features generally, or skipping the Windows docs bundling). This removes the problematic generated file at the source rather than papering over the symptom in CI.

## Test plan

- [x] Verified with a standalone `doxygen`+`graphviz` run against `GridSearch.h` that `EXCLUDE_SYMBOLS = OpenMS::Internal::Looper*` removes all `Looper`-related generated files (confirmed present before the change, absent after).
- [ ] Nightly `Release` workflow's Windows `Package` step should complete without the NSIS long-path error on the next run against this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HwnHHTek9pvx6CroRf5LFk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated generated API documentation to omit internal looping symbols, keeping public documentation focused and streamlined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->