### PR TITLE
Fix nightly Windows CI: shorten NSIS staging path, exclude Internal::Looper from Doxygen

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,14 +130,29 @@ jobs:
             )
           fi
 
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            # The deep GitHub Actions checkout/preset path leaves NSIS staging paths
+            # (build/<preset>/_CPack_Packages/win64/NSIS/<package-name>/...) only a few
+            # characters under Windows' 260-char MAX_PATH; a heavily templated symbol's
+            # generated doc/graph file can push a single path over the limit and abort
+            # makensis.exe. Stage the package under a short path instead.
+            export CPACK_PACKAGE_DIRECTORY="C:/cp"
+          fi
+
           cmake "${cmake_options[@]}" ../..
 
           if ! ninja dist; then
             if [[ "$RUNNER_OS" == "Windows" ]]; then
-              cat _CPack_Packages/win64/NSIS/NSISOutput.log
+              cat "$CPACK_PACKAGE_DIRECTORY/_CPack_Packages/win64/NSIS/NSISOutput.log"
             fi
 
             exit 1
+          fi
+
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            # Move the installer back next to the build tree, where the artifact
+            # upload step expects to find it.
+            mv "$CPACK_PACKAGE_DIRECTORY"/*.exe .
           fi
 
       # Notarize macOS packages for Gatekeeper approval

--- a/cmake/package_nsis.cmake
+++ b/cmake/package_nsis.cmake
@@ -68,6 +68,14 @@ if((DEFINED ENV{CPACK_PACKAGE_FILE_NAME}) AND (NOT "$ENV{CPACK_PACKAGE_FILE_NAME
 else()
   set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${OPENMS_PACKAGE_VERSION_FULLSTRING}-Win${PLATFORM}")
 endif()
+
+## NSIS stages the installer under CPACK_PACKAGE_DIRECTORY/_CPack_Packages/<platform>/NSIS/<package-name>/...
+## Combined with a deep build directory (e.g. nested CI checkout + preset binary dirs), the staged path to a
+## generated doc/graph file can exceed Windows' 260-character MAX_PATH, aborting makensis.exe. Allow CI to
+## point staging at a short path (e.g. "C:/cp") without affecting the default local-build behavior.
+if((DEFINED ENV{CPACK_PACKAGE_DIRECTORY}) AND (NOT "$ENV{CPACK_PACKAGE_DIRECTORY}" STREQUAL ""))
+  set(CPACK_PACKAGE_DIRECTORY "$ENV{CPACK_PACKAGE_DIRECTORY}")
+endif()
 set(CPACK_PACKAGE_ICON "${PROJECT_SOURCE_DIR}/cmake/Windows/OpenMS.ico")
 
 ## Create own target because you cannot "depend" on the internal target 'package'

--- a/doc/doxygen/Doxyfile.in
+++ b/doc/doxygen/Doxyfile.in
@@ -914,7 +914,7 @@ EXCLUDE_PATTERNS       = */.git/* \
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        = 
+EXCLUDE_SYMBOLS        = OpenMS::Internal::Looper*
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include


### PR DESCRIPTION
## Summary

The nightly `Release` workflow's Windows `Package` step failed again last night ([08-26 run](https://github.com/OpenMS/OpenMS/actions/runs/32919914190/job/98031306778)), with the same error as previous nights:

```
CPack Error: Problem running NSIS command: "C:/Program Files (x86)/NSIS/makensis.exe" ...
File: failed opening file "...\_CPack_Packages\win64\NSIS\OpenMS-3.6.0-pre-nightly-2026-08-25-Win64\share\doc\html\structOpenMS_1_1Internal_1_1Looper_3_...svg"
```

#9959 already diagnosed the root cause and proposed excluding `OpenMS::Internal::Looper` (a template-heavy compile-time helper with no doc value) from Doxygen output, but it hasn't been merged yet, so last night's nightly hit the same failure. That PR's own follow-up analysis also points out the fix is thin: the failing path was measured at exactly **260 chars, 1 over the usable limit** — excluding `Looper` clears the one file that's currently over, but buys back no structural margin. The next heavily-templated symbol, a longer branch name, or one more directory level reproduces this.

This PR includes that same Doxygen exclusion, plus the more durable complement #9959 flagged: shortening CPack's NSIS staging directory on Windows CI so there's real headroom instead of a 1-character margin.

## Changes

- `doc/doxygen/Doxyfile.in`: exclude `OpenMS::Internal::Looper*` via `EXCLUDE_SYMBOLS` (same change as #9959).
- `cmake/package_nsis.cmake`: honor an optional `CPACK_PACKAGE_DIRECTORY` environment override, following the same pattern already used for `CPACK_PACKAGE_FILE_NAME` in this file. Local/default builds are unaffected since the override is opt-in.
- `.github/workflows/release.yml`: on Windows, point CPack staging at `C:/cp` instead of the deep checkout/preset path (`D:/a/OpenMS/OpenMS/build/<preset>/...`), then move the resulting installer back next to the build tree so the existing artifact-upload step keeps working unchanged. This cuts ~35 characters off every staged path (260 → 226 for the file that failed last night), giving durable margin rather than a one-file fix.

## Test plan

- [x] Verified the `Doxyfile.in` change is byte-identical to the one in #9959, which already passed the `Build and Test` workflow on its own branch.
- [x] Recomputed the staged path length for the exact file that failed on 08-26 with `CPACK_PACKAGE_DIRECTORY=C:/cp`: 226 chars, well under Windows' 260-char `MAX_PATH`.
- [x] Confirmed `cmake/package_nsis.cmake`'s existing `CPACK_PACKAGE_FILE_NAME` override pattern is read via `$ENV{...}` at `include(CPack)` time, and mirrored it for `CPACK_PACKAGE_DIRECTORY`.
- [ ] Nightly `Release` workflow's Windows `Package` step should complete on the next scheduled run against this change.

This should supersede #9959 (same Doxygen change, plus the structural fix its analysis recommended) — closing that one in favor of this PR is reasonable once this is reviewed.


---
_Generated by [Claude Code](https://claude.ai/code/session_016zpKTC67DKcWLfCjY8VwQL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows installer generation to prevent failures caused by long file paths.
  * Installer artifacts are now reliably placed in the build output for publishing.

* **Documentation**
  * Internal looping symbols are excluded from generated API documentation for clearer reference materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->