### PR TITLE
Update CHANGELOG: ProSE per-PSM/open-search performance fixes (#9963)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -984,6 +984,12 @@ OpenMS Library:
     - Removed avoidable heavy copies in OpenMP regions and hot loops across OPXLHelper::digestDatabase,
       MultiplexFilteringProfile, MzMLSqliteHandler, SwathFileConsumer, SimpleSearchEngineAlgorithm,
       ProSEAlgorithm and NuXLAnnotateAndLocate (#9686)
+    - ProSEAlgorithm: TheoreticalSpectrumGenerator and SpectrumAlignment used for post-scoring peak
+      annotation are now built once per run instead of per PSM, a redundant open-search
+      modification-analysis pass whose only effect was logging was dropped, each spectrum's candidate
+      list is pruned to max(report:top_hits, 2) as soon as scoring moves past it instead of staying at
+      scoring:max_candidates_per_spectrum, and the calibration pass reuses one spectrum buffer across
+      candidates. Output-identical; closed search ~26% and open search ~30% faster (#9963)
     - PrecursorCorrection::correctToNearestFeature() replaced the Cartesian product over precursors and
       features (8e8 overlap checks, each rebuilding a non-memoized bounding box) with one precomputed
       bounding box per feature and a sweep line over increasing precursor m/z (#4787, #9801)


### PR DESCRIPTION
## Description

Scanned recently merged PRs for changes not yet reflected in the CHANGELOG.

Most recent merges (#9929, #9934, #9939, #9947, #9952, #9956, #9961, ...) already carry their own CHANGELOG entries. One was missing: **#9963** ("ProSE: cut per-PSM and duplicate open-search overhead in ProSEAlgorithm") never touched the CHANGELOG despite delivering a measured 26–30% speedup in ProSEAlgorithm (shared `TheoreticalSpectrumGenerator`/`SpectrumAlignment` instances instead of per-PSM construction, dropping a logging-only open-search modification pass, bounding retained candidates, and reusing the calibration spectrum buffer — all verified output-identical).

Added a bullet for it under `OpenMS Library: Performance:`, next to the existing ProSEAlgorithm/NuXLAnnotateAndLocate performance entry (#9686), which covers a different, earlier round of copy-removal work.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file (not applicable: CHANGELOG-only change)
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas (not applicable: no code changed)
- [x] New and existing unit tests pass locally with my changes (not applicable: no code changed)
- [x] Updated or added python bindings for changed or new classes (not applicable: no code changed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyEnZhhjqeds26BnKmZuZ2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved ProSEAlgorithm performance, with closed searches running approximately 26% faster and open searches approximately 30% faster.
  * Reduced processing overhead during peak annotation, candidate handling, and calibration.
  * Search results and output remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->