### PR TITLE
Fix Windows NSIS packaging failure in nightly Release workflow (MAX_PATH)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,14 +130,35 @@ jobs:
             )
           fi
 
+          # makensis.exe opens every staged file (including the Doxygen HTML
+          # docs) through the plain Win32 file APIs, which are bound by
+          # MAX_PATH (260 chars). Deeply-mangled template filenames in the
+          # docs (e.g. GridSearch's nested Looper struct) combined with
+          # CPack's default staging path under this already-long build
+          # directory push some files past that limit and abort the NSIS
+          # build. Stage the CPack package build in a short, fixed directory
+          # on Windows instead, so the full staged path stays well under
+          # MAX_PATH; the resulting installer is moved back next to the
+          # other build output below so later steps don't need to know.
+          WIN_CPACK_STAGE_DIR="C:/cpk"
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            rm -rf "/c/cpk"
+            mkdir -p "/c/cpk"
+            cmake_options+=("-DCPACK_PACKAGE_DIRECTORY=$WIN_CPACK_STAGE_DIR")
+          fi
+
           cmake "${cmake_options[@]}" ../..
 
           if ! ninja dist; then
             if [[ "$RUNNER_OS" == "Windows" ]]; then
-              cat _CPack_Packages/win64/NSIS/NSISOutput.log
+              cat /c/cpk/_CPack_Packages/win64/NSIS/NSISOutput.log
             fi
 
             exit 1
+          fi
+
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            mv /c/cpk/*.exe .
           fi
 
       # Notarize macOS packages for Gatekeeper approval


### PR DESCRIPTION
## Summary

The nightly `Release` workflow's Windows job (`Build, Test, and Package (windows-2025, cl.exe)`) has failed on the `Package` step for the last three nights in a row (2026-08-24, 2026-08-25, 2026-08-26), and the run in progress at the time of writing was on track to fail the same way.

`makensis.exe` aborts while staging files for the NSIS installer:

```
File: failed opening file "D:/a/OpenMS/OpenMS/build/windows-x64-ci/_CPack_Packages/win64/NSIS/OpenMS-3.6.0-pre-nightly-2026-08-25-Win64/share/doc\html\structOpenMS_1_1Internal_1_1Looper_3_01grid__size_00_01grid__size_00_01EvalResult_00_01Tuple_00_6df0894035a0cfaef9564a517a83612f_org.svg"
Error in script "...\project.nsi" on line 318 -- aborting creation process
```

That path is exactly 260 characters — Windows' `MAX_PATH` limit. `makensis.exe` opens staged files through the plain (non-long-path-aware) Win32 file APIs, and the Doxygen-generated HTML docs contain deeply-mangled template filenames (here, from `GridSearch`'s nested `Looper` struct — see `src/openms/include/OpenMS/ML/GRIDSEARCH/GridSearch.h`) that, combined with CPack's default staging path nested under the build directory (`build/windows-x64-ci/_CPack_Packages/win64/NSIS/<versioned package name>/...`), push some files just past the limit.

## Fix

Point CPack's staging directory (`CPACK_PACKAGE_DIRECTORY`) at a short, fixed path (`C:/cpk`) for the Windows packaging step only, so the full staged path stays well under `MAX_PATH` regardless of how long individual generated filenames get. The resulting `.exe` is moved back next to the build directory afterwards so the existing artifact-upload step doesn't need to change. No content is excluded from the installer and no other platform is affected.

This is an infrastructure-level fix (shortening the packaging working directory), not a workaround — no tests, checks, or packaged content are skipped or disabled.

## Test plan

- [x] Validated the modified workflow YAML parses correctly.
- [x] Validated the modified `run:` shell block passes `bash -n` syntax check.
- [ ] Confirm the nightly `Release` workflow's Windows job completes packaging successfully on the next scheduled run (or a manual `workflow_dispatch` on `nightly`).


---
_Generated by [Claude Code](https://claude.ai/code/session_019BnMrKrADAriTtfdTvkU3s)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows installer packaging to avoid path-length limitations.
  * Ensured generated Windows installers are placed in the expected build output directory.
  * Improved error reporting when Windows installer packaging fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->