### PR TITLE
Add Percolator rescoring features to ProSE (+0.4% to +1.2% PSMs at 1% FDR)

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
@@ -682,10 +682,18 @@ class OPENMS_DLLAPI ProSEAlgorithm :
      * FragmentIndex whose parameters already reflect any calibrated tolerances
      * the caller wants to apply.
      *
+     * @param[in] spectra Preprocessed MS2 spectra to score.
+     * @param[in] fi Pre-built FragmentIndex to query for candidates.
+     * @param[in] db Database the FragmentIndex was built from, used to reconstruct candidate sequences.
+     * @param[in] spectrum_generator Generator for the theoretical spectrum of each candidate.
+     * @param[in] effective_fragment_tol Fragment mass tolerance to score with (calibrated, if calibration ran).
+     * @param[in] fragment_mass_tolerance_unit_ppm Whether @p effective_fragment_tol is in ppm rather than Da.
+     * @param[in] open_search_mode Whether to record the precursor delta mass on each hit.
      * @param[in,out] annotated_hits Per-spectrum candidate hits, one entry per spectrum.
      * @param[in,out] pool_stats Per-spectrum summary of the full (unpruned) candidate
      *                pool, one entry per spectrum. Accumulated rather than overwritten,
      *                so chunked callers can pass the same vector for every chunk.
+     * @param[in] progress_label Label shown by the progress logger for this scoring pass.
      */
     void scoreSpectraAgainstIndex_(
         const PeakMap& spectra,

--- a/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
@@ -514,6 +514,67 @@ class OPENMS_DLLAPI ProSEAlgorithm :
       }
     };
 
+    /**
+     * @brief Running summary of the *complete* candidate pool of one spectrum.
+     *
+     * scoreSpectraAgainstIndex_() prunes each spectrum to max(report_top_hits_, 2)
+     * candidates as soon as it has scored them, so by the time postProcessHits_()
+     * runs the surviving hits are no longer a sample of the search space: with the
+     * default report:top_hits=1 only two candidates remain, and derived features
+     * such as `ln_num_candidates` or `hyperscore_zscore` would degenerate into a
+     * binary flag and a rescaled delta score respectively.
+     *
+     * add() is therefore called for every candidate the moment it is scored --
+     * before pruning and before zero-scoring candidates are dropped -- so the
+     * summary reflects the full pool. Instances accumulate across chunks in the
+     * chunked search paths, where each chunk contributes its own candidates for
+     * the same spectrum.
+     */
+    struct CandidatePoolStats_
+    {
+      double sum = 0.0;         ///< sum of all candidate scores
+      double sumsq = 0.0;       ///< sum of squared candidate scores
+      double best = 0.0;        ///< best candidate score (HyperScore is non-negative, so 0 doubles as "none seen")
+      double second_best = 0.0; ///< runner-up candidate score
+      Size count = 0;           ///< number of candidates scored
+
+      /// Fold one freshly scored candidate into the summary.
+      void add(double score)
+      {
+        if (score > best) { second_best = best; best = score; }
+        else if (score > second_best) { second_best = score; }
+        sum += score;
+        sumsq += score * score;
+        ++count;
+      }
+
+      /// Best minus runner-up over the full pool.
+      double deltaScore() const { return best - second_best; }
+
+      /**
+       * @brief How much of an outlier the best score is within its own candidate pool.
+       *
+       * Standard score of `best` against the mean and (population) SD of all
+       * `count` candidates -- a lightweight significance proxy, since HyperScore
+       * (unlike e.g. MS-GF+'s SpecEValue) has no closed-form e-value.
+       *
+       * Standardising against the whole pool rather than against the `count - 1`
+       * non-best candidates keeps the statistic bounded: by Samuelson's inequality
+       * a pool member cannot deviate from its own mean by more than sqrt(count - 1)
+       * SDs, so the feature tops out at sqrt(scoring:max_candidates_per_spectrum - 1)
+       * (7 at the default cap of 50). The leave-one-out form has no such bound --
+       * with two candidates the SD of the single remaining score is 0 by
+       * construction, and the ratio diverges. That mattered in practice: on a
+       * 70k-PSM Orbitrap run the leave-one-out form produced values up to 6.5e+07,
+       * which is enough to dominate Percolator's feature standardisation.
+       *
+       * Returns 0 when fewer than two candidates were scored, and when every
+       * candidate scored the same -- in both cases the best candidate does not
+       * stand out from the pool.
+       */
+      double zScore() const;
+    };
+
     /// @brief filter, deisotope, decharge spectra
     static void preprocessSpectra_(PeakMap& exp, double fragment_mass_tolerance, bool fragment_mass_tolerance_unit_ppm, bool deisotope_requested, Size peaks_keep_n, Int peaks_window_top);
 
@@ -616,9 +677,15 @@ class OPENMS_DLLAPI ProSEAlgorithm :
      * @brief Score all spectra against one FragmentIndex.
      *
      * Shared by the non-chunked and chunked search paths. Appends per-scan
-     * AnnotatedHit_ entries to annotated_hits; does not prune or sort. Expects
-     * a pre-built FragmentIndex whose parameters already reflect any
-     * calibrated tolerances the caller wants to apply.
+     * AnnotatedHit_ entries to annotated_hits and prunes each spectrum to
+     * max(report_top_hits_, 2) candidates to bound memory. Expects a pre-built
+     * FragmentIndex whose parameters already reflect any calibrated tolerances
+     * the caller wants to apply.
+     *
+     * @param[in,out] annotated_hits Per-spectrum candidate hits, one entry per spectrum.
+     * @param[in,out] pool_stats Per-spectrum summary of the full (unpruned) candidate
+     *                pool, one entry per spectrum. Accumulated rather than overwritten,
+     *                so chunked callers can pass the same vector for every chunk.
      */
     void scoreSpectraAgainstIndex_(
         const PeakMap& spectra,
@@ -629,6 +696,7 @@ class OPENMS_DLLAPI ProSEAlgorithm :
         bool fragment_mass_tolerance_unit_ppm,
         bool open_search_mode,
         std::vector<std::vector<AnnotatedHit_>>& annotated_hits,
+        std::vector<CandidatePoolStats_>& pool_stats,
         const std::string& progress_label) const;
 
     /**
@@ -640,6 +708,9 @@ class OPENMS_DLLAPI ProSEAlgorithm :
      *
      * @param[in] exp Input MS experiment providing spectra/metadata for annotation.
      * @param[in,out] annotated_hits Per-spectrum candidate hits (trimmed to @p top_hits in-place).
+     * @param[in] pool_stats Per-spectrum summary of the full candidate pool as collected
+     *            by scoreSpectraAgainstIndex_(), used for the pool-derived PSM features
+     *            (delta score, z-score, candidate count). Must match @p annotated_hits in size.
      * @param[out] protein_ids Output container for protein-level identification and search metadata.
      * @param[out] peptide_ids Output container for spectrum-level peptide identifications (PSMs).
      * @param[in] top_hits Number of top-scoring hits to retain per spectrum (report_top_hits_).
@@ -657,6 +728,7 @@ class OPENMS_DLLAPI ProSEAlgorithm :
      */
     void postProcessHits_(const PeakMap& exp,
       std::vector<std::vector<ProSEAlgorithm::AnnotatedHit_> >& annotated_hits,
+      const std::vector<CandidatePoolStats_>& pool_stats,
       std::vector<ProteinIdentification>& protein_ids,
       PeptideIdentificationList& peptide_ids,
       Size top_hits,

--- a/src/openms/include/OpenMS/CONCEPT/Constants.h
+++ b/src/openms/include/OpenMS/CONCEPT/Constants.h
@@ -393,6 +393,23 @@ namespace OpenMS
       */
       inline const std::string   ISOTOPE_ERROR = "isotope_error";
 
+      // User parameter name for a delta score between the best and the worst-scoring candidate for a spectrum
+      inline const std::string DELTA_SCORE_WORST = "delta_score_worst";
+
+      // User parameter name for the z-score of the best candidate's score relative to the
+      // mean/SD of the other (non-best) candidates scored for the same spectrum
+      inline const std::string HYPERSCORE_ZSCORE = "hyperscore_zscore";
+
+      // User parameter name for the natural log of the number of candidates scored for a spectrum
+      inline const std::string LN_NUM_CANDIDATES = "ln_num_candidates";
+
+      // User parameter name for the matched ion current normalized by the spectrum's total ion current
+      inline const std::string MATCHED_ION_CURRENT_FRACTION = "matched_ion_current_fraction";
+
+      // User parameter name for the fraction of cleavage sites where both a prefix ion and its
+      // complementary suffix ion were matched
+      inline const std::string COMPLEMENTARY_IONS_FRACTION = "complementary_ions_fraction";
+
       /** User parameter name to indicate a peptide q-value
               String
       */

--- a/src/openms/include/OpenMS/CONCEPT/Constants.h
+++ b/src/openms/include/OpenMS/CONCEPT/Constants.h
@@ -410,6 +410,15 @@ namespace OpenMS
       // complementary suffix ion were matched
       inline const std::string COMPLEMENTARY_IONS_FRACTION = "complementary_ions_fraction";
 
+      // User parameter name for log1p of the matched ion current. Percolator's SVM is linear,
+      // so the log transform of this right-skewed quantity is not redundant with the raw value
+      // (cf. MS2Rescore's "ln_explained_intensity").
+      inline const std::string LN_EXPLAINED_INTENSITY = "ln_explained_intensity";
+
+      // User parameter name for log1p of the spectrum's total ion current, a spectrum-quality /
+      // complexity proxy (cf. MS2Rescore's "ln_total_intensity")
+      inline const std::string LN_TOTAL_INTENSITY = "ln_total_intensity";
+
       /** User parameter name to indicate a peptide q-value
               String
       */

--- a/src/openms/include/OpenMS/CONCEPT/Constants.h
+++ b/src/openms/include/OpenMS/CONCEPT/Constants.h
@@ -393,9 +393,6 @@ namespace OpenMS
       */
       inline const std::string   ISOTOPE_ERROR = "isotope_error";
 
-      // User parameter name for a delta score between the best and the worst-scoring candidate for a spectrum
-      inline const std::string DELTA_SCORE_WORST = "delta_score_worst";
-
       // User parameter name for the z-score of the best candidate's score relative to the
       // mean/SD of the other (non-best) candidates scored for the same spectrum
       inline const std::string HYPERSCORE_ZSCORE = "hyperscore_zscore";
@@ -409,29 +406,6 @@ namespace OpenMS
       // User parameter name for the fraction of cleavage sites where both a prefix ion and its
       // complementary suffix ion were matched
       inline const std::string COMPLEMENTARY_IONS_FRACTION = "complementary_ions_fraction";
-
-      // User parameter name for log1p of the matched ion current. Percolator's SVM is linear,
-      // so the log transform of this right-skewed quantity is not redundant with the raw value
-      // (cf. MS2Rescore's "ln_explained_intensity").
-      inline const std::string LN_EXPLAINED_INTENSITY = "ln_explained_intensity";
-
-      // User parameter name for log1p of the spectrum's total ion current, a spectrum-quality /
-      // complexity proxy (cf. MS2Rescore's "ln_total_intensity")
-      inline const std::string LN_TOTAL_INTENSITY = "ln_total_intensity";
-
-      // User parameter name for a binomial fragment-match score, -10*log10 P(X >= matched) with
-      // X ~ Binomial(#theoretical ions, peak density). The statistical model behind Andromeda and
-      // MS Amanda; independent of the hyperscore's factorial/intensity-product formulation.
-      inline const std::string BINOMIAL_MATCH_SCORE = "binomial_match_score";
-
-      // User parameter name for the Tailor-calibrated score: the hit's score divided by a low-order
-      // quantile of the same spectrum's candidate score distribution (Sulc et al. 2020). Per-spectrum
-      // calibration by division, which unlike a difference also absorbs the distribution's width.
-      inline const std::string TAILOR_SCORE = "tailor_score";
-
-      // User parameter name for the fraction of the spectrum's most intense peaks that the PSM
-      // explains. Uses intensity *rank* rather than summed intensity.
-      inline const std::string TOP_PEAKS_EXPLAINED_FRACTION = "top_peaks_explained_fraction";
 
       /** User parameter name to indicate a peptide q-value
               String

--- a/src/openms/include/OpenMS/CONCEPT/Constants.h
+++ b/src/openms/include/OpenMS/CONCEPT/Constants.h
@@ -393,11 +393,15 @@ namespace OpenMS
       */
       inline const std::string   ISOTOPE_ERROR = "isotope_error";
 
-      // User parameter name for the z-score of the best candidate's score relative to the
-      // mean/SD of the other (non-best) candidates scored for the same spectrum
+      // User parameter name for the standard score of the best candidate's score within
+      // the pool of all candidates scored for the same spectrum. 0 when fewer than two
+      // candidates were scored or when all of them tied.
       inline const std::string HYPERSCORE_ZSCORE = "hyperscore_zscore";
 
-      // User parameter name for the natural log of the number of candidates scored for a spectrum
+      // User parameter name for ln(1 + number of candidates scored for a spectrum).
+      // The +1 offset keeps the value defined for spectra without any candidate; it is
+      // order-preserving, so the feature stays monotone in the candidate count. The count
+      // is capped by the search engine's per-spectrum candidate limit, so this saturates.
       inline const std::string LN_NUM_CANDIDATES = "ln_num_candidates";
 
       // User parameter name for the matched ion current normalized by the spectrum's total ion current

--- a/src/openms/include/OpenMS/CONCEPT/Constants.h
+++ b/src/openms/include/OpenMS/CONCEPT/Constants.h
@@ -419,6 +419,20 @@ namespace OpenMS
       // complexity proxy (cf. MS2Rescore's "ln_total_intensity")
       inline const std::string LN_TOTAL_INTENSITY = "ln_total_intensity";
 
+      // User parameter name for a binomial fragment-match score, -10*log10 P(X >= matched) with
+      // X ~ Binomial(#theoretical ions, peak density). The statistical model behind Andromeda and
+      // MS Amanda; independent of the hyperscore's factorial/intensity-product formulation.
+      inline const std::string BINOMIAL_MATCH_SCORE = "binomial_match_score";
+
+      // User parameter name for the Tailor-calibrated score: the hit's score divided by a low-order
+      // quantile of the same spectrum's candidate score distribution (Sulc et al. 2020). Per-spectrum
+      // calibration by division, which unlike a difference also absorbs the distribution's width.
+      inline const std::string TAILOR_SCORE = "tailor_score";
+
+      // User parameter name for the fraction of the spectrum's most intense peaks that the PSM
+      // explains. Uses intensity *rank* rather than summed intensity.
+      inline const std::string TOP_PEAKS_EXPLAINED_FRACTION = "top_peaks_explained_fraction";
+
       /** User parameter name to indicate a peptide q-value
               String
       */

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -2500,7 +2500,9 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
                                 Constants::UserParam::HYPERSCORE_ZSCORE,
                                 Constants::UserParam::LN_NUM_CANDIDATES,
                                 Constants::UserParam::MATCHED_ION_CURRENT_FRACTION,
-                                Constants::UserParam::COMPLEMENTARY_IONS_FRACTION}
+                                Constants::UserParam::COMPLEMENTARY_IONS_FRACTION,
+                                Constants::UserParam::LN_EXPLAINED_INTENSITY,
+                                Constants::UserParam::LN_TOTAL_INTENSITY}
     );
     defaults_.setValue("report:top_hits", 1, "Maximum number of top scoring hits per spectrum that are reported.");
     defaults_.setSectionDescription("report", "Reporting Options");

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -2480,13 +2480,27 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
     defaults_.setValue("decoys", "false", "Should decoys be generated?");
     defaults_.setValidStrings("decoys", {"true","false"} );
     defaults_.setValue("annotate:PSM",  std::vector<std::string>{"ALL"}, "Annotations added to each PSM.");
+    // Kept in sync with ProSEAlgorithm's own "annotate:PSM" valid-strings list
+    // (ProSEAlgorithm.cpp) — both declare this parameter since the merged Search:
+    // subtree is passed down to FragmentIndex as well.
     defaults_.setValidStrings("annotate:PSM",
                               std::vector<std::string>{
                                 "ALL",
                                 Constants::UserParam::FRAGMENT_ERROR_MEDIAN_PPM_USERPARAM,
                                 Constants::UserParam::PRECURSOR_ERROR_PPM_USERPARAM,
                                 Constants::UserParam::MATCHED_PREFIX_IONS_FRACTION,
-                                Constants::UserParam::MATCHED_SUFFIX_IONS_FRACTION}
+                                Constants::UserParam::MATCHED_SUFFIX_IONS_FRACTION,
+                                Constants::UserParam::NUM_MATCHED_PEAKS,
+                                Constants::UserParam::MATCHED_PREFIX_IONS,
+                                Constants::UserParam::MATCHED_SUFFIX_IONS,
+                                Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE,
+                                Constants::UserParam::MATCHED_ION_CURRENT,
+                                Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM,
+                                Constants::UserParam::DELTA_SCORE_WORST,
+                                Constants::UserParam::HYPERSCORE_ZSCORE,
+                                Constants::UserParam::LN_NUM_CANDIDATES,
+                                Constants::UserParam::MATCHED_ION_CURRENT_FRACTION,
+                                Constants::UserParam::COMPLEMENTARY_IONS_FRACTION}
     );
     defaults_.setValue("report:top_hits", 1, "Maximum number of top scoring hits per spectrum that are reported.");
     defaults_.setSectionDescription("report", "Reporting Options");

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -2496,16 +2496,10 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
                                 Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE,
                                 Constants::UserParam::MATCHED_ION_CURRENT,
                                 Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM,
-                                Constants::UserParam::DELTA_SCORE_WORST,
                                 Constants::UserParam::HYPERSCORE_ZSCORE,
                                 Constants::UserParam::LN_NUM_CANDIDATES,
                                 Constants::UserParam::MATCHED_ION_CURRENT_FRACTION,
-                                Constants::UserParam::COMPLEMENTARY_IONS_FRACTION,
-                                Constants::UserParam::LN_EXPLAINED_INTENSITY,
-                                Constants::UserParam::LN_TOTAL_INTENSITY,
-                                Constants::UserParam::BINOMIAL_MATCH_SCORE,
-                                Constants::UserParam::TAILOR_SCORE,
-                                Constants::UserParam::TOP_PEAKS_EXPLAINED_FRACTION}
+                                Constants::UserParam::COMPLEMENTARY_IONS_FRACTION}
     );
     defaults_.setValue("report:top_hits", 1, "Maximum number of top scoring hits per spectrum that are reported.");
     defaults_.setSectionDescription("report", "Reporting Options");

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -2502,7 +2502,10 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
                                 Constants::UserParam::MATCHED_ION_CURRENT_FRACTION,
                                 Constants::UserParam::COMPLEMENTARY_IONS_FRACTION,
                                 Constants::UserParam::LN_EXPLAINED_INTENSITY,
-                                Constants::UserParam::LN_TOTAL_INTENSITY}
+                                Constants::UserParam::LN_TOTAL_INTENSITY,
+                                Constants::UserParam::BINOMIAL_MATCH_SCORE,
+                                Constants::UserParam::TAILOR_SCORE,
+                                Constants::UserParam::TOP_PEAKS_EXPLAINED_FRACTION}
     );
     defaults_.setValue("report:top_hits", 1, "Maximum number of top scoring hits per spectrum that are reported.");
     defaults_.setSectionDescription("report", "Reporting Options");

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -50,6 +50,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
+#include <numeric>
 #include <iomanip>
 #include <locale>
 #include <ostream>
@@ -164,7 +166,10 @@ namespace OpenMS
         Constants::UserParam::MATCHED_ION_CURRENT_FRACTION,
         Constants::UserParam::COMPLEMENTARY_IONS_FRACTION,
         Constants::UserParam::LN_EXPLAINED_INTENSITY,
-        Constants::UserParam::LN_TOTAL_INTENSITY}
+        Constants::UserParam::LN_TOTAL_INTENSITY,
+        Constants::UserParam::BINOMIAL_MATCH_SCORE,
+        Constants::UserParam::TAILOR_SCORE,
+        Constants::UserParam::TOP_PEAKS_EXPLAINED_FRACTION}
       );
 
     defaults_.setSectionDescription("annotate", "Annotation Options");
@@ -499,7 +504,11 @@ namespace OpenMS
     std::vector<float> delta_scores_worst(annotated_hits.size(), 0.0f);
     std::vector<float> hyperscore_zscores(annotated_hits.size(), 0.0f);
     std::vector<float> ln_num_candidates(annotated_hits.size(), 0.0f);
-#pragma omp parallel for default(none) shared(annotated_hits, top_hits, delta_scores, delta_scores_worst, hyperscore_zscores, ln_num_candidates)
+    // Tailor calibration (Sulc et al. 2020): best score divided by the score at position
+    // max(3, N/100) of the same spectrum's descending candidate scores. Dividing rather than
+    // subtracting also normalises away the width of the per-spectrum score distribution.
+    std::vector<float> tailor_scores(annotated_hits.size(), 0.0f);
+#pragma omp parallel for default(none) shared(annotated_hits, top_hits, delta_scores, delta_scores_worst, hyperscore_zscores, ln_num_candidates, tailor_scores)
     for (SignedSize scan_index = 0; scan_index < (SignedSize)annotated_hits.size(); ++scan_index)
     {
       auto& hits = annotated_hits[scan_index];
@@ -533,6 +542,20 @@ namespace OpenMS
         hyperscore_zscores[scan_index] = static_cast<float>((best_score - mean_rest) / (std::sqrt(var_rest) + 1e-6));
       }
 
+      // Tailor: needs the score at a fixed low rank, so partial_sort far enough to expose it.
+      // The paper pins the quantile position at no earlier than rank 3 to avoid the top of the
+      // distribution, which is contaminated by peptides correlated with the true one.
+      if (!hits.empty())
+      {
+        const Size tailor_rank = std::max<Size>(3, static_cast<Size>(hits.size() / 100));
+        const Size tailor_idx = std::min(tailor_rank, hits.size()) - 1;
+        std::partial_sort(hits.begin(), hits.begin() + tailor_idx + 1, hits.end(), AnnotatedHit_::hasBetterScore);
+        const double q = hits[tailor_idx].score;
+        // q <= 0 happens for spectra whose candidates all score 0; leave the feature at 0 there
+        // rather than emitting an arbitrarily large ratio.
+        if (q > 0) { tailor_scores[scan_index] = static_cast<float>(best_score / q); }
+      }
+
       // sort and keep n best elements according to score (unchanged)
       Size topn = top_hits > hits.size() ? hits.size() : top_hits;
       std::partial_sort(hits.begin(), hits.begin() + topn, hits.end(), AnnotatedHit_::hasBetterScore);
@@ -557,6 +580,9 @@ namespace OpenMS
     bool annotation_complementary_ions_fraction = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::COMPLEMENTARY_IONS_FRACTION) != annotate_psm_.end();
     bool annotation_ln_explained_intensity = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::LN_EXPLAINED_INTENSITY) != annotate_psm_.end();
     bool annotation_ln_total_intensity = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::LN_TOTAL_INTENSITY) != annotate_psm_.end();
+    bool annotation_binomial_match_score = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::BINOMIAL_MATCH_SCORE) != annotate_psm_.end();
+    bool annotation_tailor_score = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::TAILOR_SCORE) != annotate_psm_.end();
+    bool annotation_top_peaks_explained = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::TOP_PEAKS_EXPLAINED_FRACTION) != annotate_psm_.end();
 
     // "ALL" adds all annotations
     if (std::find(annotate_psm_.begin(), annotate_psm_.end(), "ALL") != annotate_psm_.end())
@@ -576,6 +602,9 @@ namespace OpenMS
       annotation_ln_num_candidates = true;
       annotation_matched_ion_current_fraction = true;
       annotation_complementary_ions_fraction = true;
+      annotation_binomial_match_score = true;
+      annotation_tailor_score = true;
+      annotation_top_peaks_explained = true;
       // NOTE: LN_EXPLAINED_INTENSITY and LN_TOTAL_INTENSITY are deliberately NOT part of "ALL".
       // They are opt-in only. Benchmarked on a Bruker timsTOF HeLa run and a Q Exactive HF
       // ProteoBench run, each rescored under five Percolator seeds, neither feature produced a
@@ -590,7 +619,16 @@ namespace OpenMS
     // the experimental spectrum, so it does not require an alignment.
     const bool need_alignment = annotation_fragment_error_ppm || annotation_fragment_annotations || annotation_longest_ion_run
       || annotation_matched_ion_current || annotation_matched_ion_current_fraction || annotation_complementary_ions_fraction
-      || annotation_ln_explained_intensity;
+      || annotation_ln_explained_intensity || annotation_top_peaks_explained;
+
+    // Number of backbone fragment series actually generated, used as the trial count of the
+    // binomial model below (each enabled series contributes one ion per cleavage site).
+    const Size n_ion_series = (add_a_ions_ ? 1 : 0) + (add_b_ions_ ? 1 : 0) + (add_c_ions_ ? 1 : 0)
+                            + (add_x_ions_ ? 1 : 0) + (add_y_ions_ ? 1 : 0) + (add_z_ions_ ? 1 : 0);
+    // Andromeda's per-peak random-match probability: the spectrum was reduced to at most
+    // peaks_window_top_ peaks per 100 Th window, so that density is the chance a given
+    // theoretical m/z lands on a retained peak.
+    const double binomial_p = std::clamp(static_cast<double>(peaks_window_top_) / 100.0, 1e-6, 0.999);
 
     // Both configurations depend only on the fragment tolerance, so they are
     // shared read-only by every thread of the loop below: getSpectrum() and
@@ -765,6 +803,8 @@ namespace OpenMS
             // isotope), so we must sum each exp_idx at most once. Sized only
             // when MIC is actually requested.
             std::vector<char> counted_exp_peaks(need_mic ? spec.size() : 0, 0);
+            // Which experimental peaks this PSM explains, for the intensity-rank feature below.
+            std::vector<char> is_matched_exp(annotation_top_peaks_explained ? spec.size() : 0, 0);
             peak_annotations.reserve(alignment.size());
 
             for (const auto& [theo_idx, exp_idx] : alignment)
@@ -784,6 +824,8 @@ namespace OpenMS
                 matched_ion_current += spec[exp_idx].getIntensity();
                 counted_exp_peaks[exp_idx] = 1;
               }
+
+              if (annotation_top_peaks_explained) { is_matched_exp[exp_idx] = 1; }
 
               if (need_ordinals && ion_names[theo_idx].size() >= 2)
               {
@@ -824,6 +866,27 @@ namespace OpenMS
             if (annotation_ln_explained_intensity)
             {
               ph.setMetaValue(Constants::UserParam::LN_EXPLAINED_INTENSITY, std::log1p(matched_ion_current));
+            }
+
+            if (annotation_top_peaks_explained)
+            {
+              // Fraction of the most intense peaks that this PSM explains. Unlike the summed
+              // intensity features, this depends only on intensity *rank*, so a spectrum
+              // dominated by one huge peak cannot mask an otherwise poor explanation.
+              constexpr Size TOP_N = 10;
+              const Size n_consider = std::min<Size>(TOP_N, spec.size());
+              double fraction = 0.0;
+              if (n_consider > 0)
+              {
+                std::vector<Size> idx(spec.size());
+                std::iota(idx.begin(), idx.end(), Size(0));
+                std::partial_sort(idx.begin(), idx.begin() + n_consider, idx.end(),
+                  [&spec](Size a, Size b) { return spec[a].getIntensity() > spec[b].getIntensity(); });
+                Size hit_count = 0;
+                for (Size i = 0; i < n_consider; ++i) { if (is_matched_exp[idx[i]]) { ++hit_count; } }
+                fraction = static_cast<double>(hit_count) / static_cast<double>(n_consider);
+              }
+              ph.setMetaValue(Constants::UserParam::TOP_PEAKS_EXPLAINED_FRACTION, fraction);
             }
 
             if (need_ordinals)
@@ -877,6 +940,44 @@ namespace OpenMS
           if (annotation_ln_total_intensity)
           {
             ph.setMetaValue(Constants::UserParam::LN_TOTAL_INTENSITY, std::log1p(spectrum_tic));
+          }
+
+          if (annotation_tailor_score)
+          {
+            ph.setMetaValue(Constants::UserParam::TAILOR_SCORE, tailor_scores[scan_index]);
+          }
+
+          if (annotation_binomial_match_score)
+          {
+            // -10 log10 P(X >= k), X ~ Binomial(n, binomial_p): the probability of matching at
+            // least this many fragments by chance. Summed in log space because the individual
+            // terms underflow for the long, well-matched peptides that matter most.
+            const Size k = static_cast<Size>(ah.matched_prefix_ions) + static_cast<Size>(ah.matched_suffix_ions);
+            const Size n = n_ion_series * (ah.sequence.size() > 1 ? ah.sequence.size() - 1 : 0);
+            double score = 0.0;
+            if (n > 0 && k > 0 && k <= n)
+            {
+              const double log_p = std::log(binomial_p);
+              const double log_1mp = std::log1p(-binomial_p);
+              const double lgn = std::lgamma(static_cast<double>(n) + 1.0);
+              double max_log_term = -std::numeric_limits<double>::infinity();
+              std::vector<double> log_terms;
+              log_terms.reserve(n - k + 1);
+              for (Size j = k; j <= n; ++j)
+              {
+                const double lt = lgn - std::lgamma(static_cast<double>(j) + 1.0)
+                                      - std::lgamma(static_cast<double>(n - j) + 1.0)
+                                  + static_cast<double>(j) * log_p
+                                  + static_cast<double>(n - j) * log_1mp;
+                log_terms.push_back(lt);
+                if (lt > max_log_term) { max_log_term = lt; }
+              }
+              double sum_exp = 0.0;
+              for (double lt : log_terms) { sum_exp += std::exp(lt - max_log_term); }
+              const double log10_prob = (max_log_term + std::log(sum_exp)) / std::log(10.0);
+              score = -10.0 * log10_prob;
+            }
+            ph.setMetaValue(Constants::UserParam::BINOMIAL_MATCH_SCORE, score);
           }
 
           // Add isotope error metavalue (always; exposed as Percolator feature)
@@ -971,6 +1072,9 @@ namespace OpenMS
     if (annotation_ln_explained_intensity) feature_set.push_back(Constants::UserParam::LN_EXPLAINED_INTENSITY);
     if (annotation_ln_total_intensity) feature_set.push_back(Constants::UserParam::LN_TOTAL_INTENSITY);
     if (annotation_complementary_ions_fraction) feature_set.push_back(Constants::UserParam::COMPLEMENTARY_IONS_FRACTION);
+    if (annotation_binomial_match_score) feature_set.push_back(Constants::UserParam::BINOMIAL_MATCH_SCORE);
+    if (annotation_tailor_score) feature_set.push_back(Constants::UserParam::TAILOR_SCORE);
+    if (annotation_top_peaks_explained) feature_set.push_back(Constants::UserParam::TOP_PEAKS_EXPLAINED_FRACTION);
     if (annotation_delta_score_worst) feature_set.push_back(Constants::UserParam::DELTA_SCORE_WORST);
     if (annotation_hyperscore_zscore) feature_set.push_back(Constants::UserParam::HYPERSCORE_ZSCORE);
     if (annotation_ln_num_candidates) feature_set.push_back(Constants::UserParam::LN_NUM_CANDIDATES);

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -157,7 +157,12 @@ namespace OpenMS
         Constants::UserParam::MATCHED_SUFFIX_IONS,
         Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE,
         Constants::UserParam::MATCHED_ION_CURRENT,
-        Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM}
+        Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM,
+        Constants::UserParam::DELTA_SCORE_WORST,
+        Constants::UserParam::HYPERSCORE_ZSCORE,
+        Constants::UserParam::LN_NUM_CANDIDATES,
+        Constants::UserParam::MATCHED_ION_CURRENT_FRACTION,
+        Constants::UserParam::COMPLEMENTARY_IONS_FRACTION}
       );
 
     defaults_.setSectionDescription("annotate", "Annotation Options");

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -51,7 +51,6 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
-#include <numeric>
 #include <iomanip>
 #include <locale>
 #include <ostream>
@@ -160,16 +159,10 @@ namespace OpenMS
         Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE,
         Constants::UserParam::MATCHED_ION_CURRENT,
         Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM,
-        Constants::UserParam::DELTA_SCORE_WORST,
         Constants::UserParam::HYPERSCORE_ZSCORE,
         Constants::UserParam::LN_NUM_CANDIDATES,
         Constants::UserParam::MATCHED_ION_CURRENT_FRACTION,
-        Constants::UserParam::COMPLEMENTARY_IONS_FRACTION,
-        Constants::UserParam::LN_EXPLAINED_INTENSITY,
-        Constants::UserParam::LN_TOTAL_INTENSITY,
-        Constants::UserParam::BINOMIAL_MATCH_SCORE,
-        Constants::UserParam::TAILOR_SCORE,
-        Constants::UserParam::TOP_PEAKS_EXPLAINED_FRACTION}
+        Constants::UserParam::COMPLEMENTARY_IONS_FRACTION}
       );
 
     defaults_.setSectionDescription("annotate", "Annotation Options");
@@ -496,42 +489,33 @@ namespace OpenMS
     std::vector<float> delta_scores(annotated_hits.size(), 0.0f);
     // Side vectors for candidate-pool statistics, computed the same way as delta_scores
     // (before truncation to top_hits, one value per spectrum):
-    //  - delta_scores_worst: best - worst candidate score (Comet deltaLCn analogue)
     //  - hyperscore_zscores: how much of an outlier the best score is relative to the
     //    mean/SD of the *other* candidates — a lightweight statistical-significance
     //    proxy, since HyperScore (unlike e.g. MS-GF+'s SpecEValue) has no closed-form e-value
     //  - ln_num_candidates: ln(1 + number of candidates), a search-space-size proxy
-    std::vector<float> delta_scores_worst(annotated_hits.size(), 0.0f);
     std::vector<float> hyperscore_zscores(annotated_hits.size(), 0.0f);
     std::vector<float> ln_num_candidates(annotated_hits.size(), 0.0f);
-    // Tailor calibration (Sulc et al. 2020): best score divided by the score at position
-    // max(3, N/100) of the same spectrum's descending candidate scores. Dividing rather than
-    // subtracting also normalises away the width of the per-spectrum score distribution.
-    std::vector<float> tailor_scores(annotated_hits.size(), 0.0f);
-#pragma omp parallel for default(none) shared(annotated_hits, top_hits, delta_scores, delta_scores_worst, hyperscore_zscores, ln_num_candidates, tailor_scores)
+#pragma omp parallel for default(none) shared(annotated_hits, top_hits, delta_scores, hyperscore_zscores, ln_num_candidates)
     for (SignedSize scan_index = 0; scan_index < (SignedSize)annotated_hits.size(); ++scan_index)
     {
       auto& hits = annotated_hits[scan_index];
 
-      // O(N) pass: find best/second-best/worst scores and sum/sum-of-squares over all
+      // O(N) pass: find best/second-best scores and sum/sum-of-squares over all
       // candidates. Leaves partial_sort unchanged.
       double best_score = -std::numeric_limits<double>::infinity();
       double second_best_score = -std::numeric_limits<double>::infinity();
-      double worst_score = std::numeric_limits<double>::infinity();
       double sum = 0.0, sumsq = 0.0;
       for (const auto& h : hits)
       {
         if (h.score > best_score) { second_best_score = best_score; best_score = h.score; }
         else if (h.score > second_best_score) { second_best_score = h.score; }
-        if (h.score < worst_score) { worst_score = h.score; }
         sum += h.score;
         sumsq += h.score * h.score;
       }
-      if (hits.empty()) { best_score = 0.0; second_best_score = 0.0; worst_score = 0.0; }
+      if (hits.empty()) { best_score = 0.0; second_best_score = 0.0; }
       if (!std::isfinite(second_best_score)) { second_best_score = 0.0; } // single-candidate spectrum: no second-best
 
       delta_scores[scan_index] = static_cast<float>(best_score - second_best_score);
-      delta_scores_worst[scan_index] = static_cast<float>(best_score - worst_score);
       ln_num_candidates[scan_index] = static_cast<float>(std::log1p(static_cast<double>(hits.size())));
 
       const Size n_rest = hits.size() > 0 ? hits.size() - 1 : 0;
@@ -540,20 +524,6 @@ namespace OpenMS
         const double mean_rest = (sum - best_score) / static_cast<double>(n_rest);
         const double var_rest = std::max(0.0, (sumsq - best_score * best_score) / static_cast<double>(n_rest) - mean_rest * mean_rest);
         hyperscore_zscores[scan_index] = static_cast<float>((best_score - mean_rest) / (std::sqrt(var_rest) + 1e-6));
-      }
-
-      // Tailor: needs the score at a fixed low rank, so partial_sort far enough to expose it.
-      // The paper pins the quantile position at no earlier than rank 3 to avoid the top of the
-      // distribution, which is contaminated by peptides correlated with the true one.
-      if (!hits.empty())
-      {
-        const Size tailor_rank = std::max<Size>(3, static_cast<Size>(hits.size() / 100));
-        const Size tailor_idx = std::min(tailor_rank, hits.size()) - 1;
-        std::partial_sort(hits.begin(), hits.begin() + tailor_idx + 1, hits.end(), AnnotatedHit_::hasBetterScore);
-        const double q = hits[tailor_idx].score;
-        // q <= 0 happens for spectra whose candidates all score 0; leave the feature at 0 there
-        // rather than emitting an arbitrarily large ratio.
-        if (q > 0) { tailor_scores[scan_index] = static_cast<float>(best_score / q); }
       }
 
       // sort and keep n best elements according to score (unchanged)
@@ -573,16 +543,10 @@ namespace OpenMS
     bool annotation_longest_ion_run = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE) != annotate_psm_.end();
     bool annotation_matched_ion_current = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_ION_CURRENT) != annotate_psm_.end();
     bool annotation_fragment_annotations = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM) != annotate_psm_.end();
-    bool annotation_delta_score_worst = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::DELTA_SCORE_WORST) != annotate_psm_.end();
     bool annotation_hyperscore_zscore = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::HYPERSCORE_ZSCORE) != annotate_psm_.end();
     bool annotation_ln_num_candidates = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::LN_NUM_CANDIDATES) != annotate_psm_.end();
     bool annotation_matched_ion_current_fraction = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_ION_CURRENT_FRACTION) != annotate_psm_.end();
     bool annotation_complementary_ions_fraction = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::COMPLEMENTARY_IONS_FRACTION) != annotate_psm_.end();
-    bool annotation_ln_explained_intensity = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::LN_EXPLAINED_INTENSITY) != annotate_psm_.end();
-    bool annotation_ln_total_intensity = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::LN_TOTAL_INTENSITY) != annotate_psm_.end();
-    bool annotation_binomial_match_score = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::BINOMIAL_MATCH_SCORE) != annotate_psm_.end();
-    bool annotation_tailor_score = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::TAILOR_SCORE) != annotate_psm_.end();
-    bool annotation_top_peaks_explained = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::TOP_PEAKS_EXPLAINED_FRACTION) != annotate_psm_.end();
 
     // "ALL" adds all annotations
     if (std::find(annotate_psm_.begin(), annotate_psm_.end(), "ALL") != annotate_psm_.end())
@@ -601,41 +565,12 @@ namespace OpenMS
       annotation_ln_num_candidates = true;
       annotation_matched_ion_current_fraction = true;
       annotation_complementary_ions_fraction = true;
-      // NOTE: DELTA_SCORE_WORST is opt-in. It is the weakest of the candidate-pool features and
-      // largely restates DELTA_SCORE, which already contrasts the best hit with the rest of the
-      // pool: dropping it from the default cost 15.6 PSMs on timsTOF (t = -0.69) and 4.0 on
-      // Q Exactive HF (t = -0.12), i.e. nothing resolvable above the seed-to-seed spread.
-      // NOTE: BINOMIAL_MATCH_SCORE, TAILOR_SCORE and TOP_PEAKS_EXPLAINED_FRACTION are also
-      // opt-in. Each clearly improves on the *original* feature set (t = 1.4 / 1.1 / 4.8 on
-      // timsTOF, 3.7 / 3.5 / 3.4 on Q Exactive HF), but none adds anything once the
-      // candidate-pool and structural features below are present: against that default the
-      // best of them reaches only |t| = 1.8, and all three together give t = -1.08 (timsTOF)
-      // and +0.53 (Q Exactive HF). They measure separation that the default set already
-      // captures, so enabling them by default would cost annotation size for no gain.
-      // NOTE: LN_EXPLAINED_INTENSITY and LN_TOTAL_INTENSITY are deliberately NOT part of "ALL".
-      // They are opt-in only. Benchmarked on a Bruker timsTOF HeLa run and a Q Exactive HF
-      // ProteoBench run, each rescored under five Percolator seeds, neither feature produced a
-      // significant change in target PSMs at 1% FDR -- on their own (Welch t = 0.33 / 0.70 and
-      // 1.99 / 0.66) or on top of the other added features (|t| <= 1.72). Enabling them by
-      // default would grow every PSM's annotation for no measured gain. They remain selectable
-      // via annotate:PSM for data this benchmark did not cover (e.g. ETD/EThcD).
     }
 
     // Alignment is needed for fragment error, fragment annotations, longest ion run, MIC,
-    // normalized MIC, log-MIC, and complementary ion pairs. ln_total_intensity depends only on
-    // the experimental spectrum, so it does not require an alignment.
+    // normalized MIC, and complementary ion pairs
     const bool need_alignment = annotation_fragment_error_ppm || annotation_fragment_annotations || annotation_longest_ion_run
-      || annotation_matched_ion_current || annotation_matched_ion_current_fraction || annotation_complementary_ions_fraction
-      || annotation_ln_explained_intensity || annotation_top_peaks_explained;
-
-    // Number of backbone fragment series actually generated, used as the trial count of the
-    // binomial model below (each enabled series contributes one ion per cleavage site).
-    const Size n_ion_series = (add_a_ions_ ? 1 : 0) + (add_b_ions_ ? 1 : 0) + (add_c_ions_ ? 1 : 0)
-                            + (add_x_ions_ ? 1 : 0) + (add_y_ions_ ? 1 : 0) + (add_z_ions_ ? 1 : 0);
-    // Andromeda's per-peak random-match probability: the spectrum was reduced to at most
-    // peaks_window_top_ peaks per 100 Th window, so that density is the chance a given
-    // theoretical m/z lands on a retained peak.
-    const double binomial_p = std::clamp(static_cast<double>(peaks_window_top_) / 100.0, 1e-6, 0.999);
+      || annotation_matched_ion_current || annotation_matched_ion_current_fraction || annotation_complementary_ions_fraction;
 
     // Both configurations depend only on the fragment tolerance, so they are
     // shared read-only by every thread of the loop below: getSpectrum() and
@@ -696,7 +631,7 @@ namespace OpenMS
         // Spectrum-level quantity, identical for every candidate of this spectrum, so it is
         // computed once here rather than per hit.
         const double spectrum_tic =
-          (annotation_matched_ion_current_fraction || annotation_ln_total_intensity) ? spec.calculateTIC() : 0.0;
+          annotation_matched_ion_current_fraction ? spec.calculateTIC() : 0.0;
 
         // create full peptide hit structure from annotated hits
         vector<PeptideHit> phs;
@@ -773,10 +708,6 @@ namespace OpenMS
 
           ph.setMetaValue(Constants::UserParam::DELTA_SCORE, delta_scores[scan_index]);
 
-          if (annotation_delta_score_worst)
-          {
-            ph.setMetaValue(Constants::UserParam::DELTA_SCORE_WORST, delta_scores_worst[scan_index]);
-          }
           if (annotation_hyperscore_zscore)
           {
             ph.setMetaValue(Constants::UserParam::HYPERSCORE_ZSCORE, hyperscore_zscores[scan_index]);
@@ -802,16 +733,13 @@ namespace OpenMS
             std::vector<PeptideHit::PeakAnnotation> peak_annotations;
             std::vector<int> prefix_ordinals, suffix_ordinals;
             double matched_ion_current = 0.0;
-            const bool need_mic = annotation_matched_ion_current || annotation_matched_ion_current_fraction
-              || annotation_ln_explained_intensity;
+            const bool need_mic = annotation_matched_ion_current || annotation_matched_ion_current_fraction;
             const bool need_ordinals = annotation_longest_ion_run || annotation_complementary_ions_fraction;
             // Dedup guard for MIC: in ppm-alignment mode a single experimental
             // peak can match multiple theoretical peaks (e.g. b-ion and near
             // isotope), so we must sum each exp_idx at most once. Sized only
             // when MIC is actually requested.
             std::vector<char> counted_exp_peaks(need_mic ? spec.size() : 0, 0);
-            // Which experimental peaks this PSM explains, for the intensity-rank feature below.
-            std::vector<char> is_matched_exp(annotation_top_peaks_explained ? spec.size() : 0, 0);
             peak_annotations.reserve(alignment.size());
 
             for (const auto& [theo_idx, exp_idx] : alignment)
@@ -831,8 +759,6 @@ namespace OpenMS
                 matched_ion_current += spec[exp_idx].getIntensity();
                 counted_exp_peaks[exp_idx] = 1;
               }
-
-              if (annotation_top_peaks_explained) { is_matched_exp[exp_idx] = 1; }
 
               if (need_ordinals && ion_names[theo_idx].size() >= 2)
               {
@@ -868,32 +794,6 @@ namespace OpenMS
             {
               ph.setMetaValue(Constants::UserParam::MATCHED_ION_CURRENT_FRACTION,
                               spectrum_tic > 0 ? matched_ion_current / spectrum_tic : 0.0);
-            }
-
-            if (annotation_ln_explained_intensity)
-            {
-              ph.setMetaValue(Constants::UserParam::LN_EXPLAINED_INTENSITY, std::log1p(matched_ion_current));
-            }
-
-            if (annotation_top_peaks_explained)
-            {
-              // Fraction of the most intense peaks that this PSM explains. Unlike the summed
-              // intensity features, this depends only on intensity *rank*, so a spectrum
-              // dominated by one huge peak cannot mask an otherwise poor explanation.
-              constexpr Size TOP_N = 10;
-              const Size n_consider = std::min<Size>(TOP_N, spec.size());
-              double fraction = 0.0;
-              if (n_consider > 0)
-              {
-                std::vector<Size> idx(spec.size());
-                std::iota(idx.begin(), idx.end(), Size(0));
-                std::partial_sort(idx.begin(), idx.begin() + n_consider, idx.end(),
-                  [&spec](Size a, Size b) { return spec[a].getIntensity() > spec[b].getIntensity(); });
-                Size hit_count = 0;
-                for (Size i = 0; i < n_consider; ++i) { if (is_matched_exp[idx[i]]) { ++hit_count; } }
-                fraction = static_cast<double>(hit_count) / static_cast<double>(n_consider);
-              }
-              ph.setMetaValue(Constants::UserParam::TOP_PEAKS_EXPLAINED_FRACTION, fraction);
             }
 
             if (need_ordinals)
@@ -943,49 +843,6 @@ namespace OpenMS
             }
           }
 
-          // Spectrum-level intensity feature (no alignment needed)
-          if (annotation_ln_total_intensity)
-          {
-            ph.setMetaValue(Constants::UserParam::LN_TOTAL_INTENSITY, std::log1p(spectrum_tic));
-          }
-
-          if (annotation_tailor_score)
-          {
-            ph.setMetaValue(Constants::UserParam::TAILOR_SCORE, tailor_scores[scan_index]);
-          }
-
-          if (annotation_binomial_match_score)
-          {
-            // -10 log10 P(X >= k), X ~ Binomial(n, binomial_p): the probability of matching at
-            // least this many fragments by chance. Summed in log space because the individual
-            // terms underflow for the long, well-matched peptides that matter most.
-            const Size k = static_cast<Size>(ah.matched_prefix_ions) + static_cast<Size>(ah.matched_suffix_ions);
-            const Size n = n_ion_series * (ah.sequence.size() > 1 ? ah.sequence.size() - 1 : 0);
-            double score = 0.0;
-            if (n > 0 && k > 0 && k <= n)
-            {
-              const double log_p = std::log(binomial_p);
-              const double log_1mp = std::log1p(-binomial_p);
-              const double lgn = std::lgamma(static_cast<double>(n) + 1.0);
-              double max_log_term = -std::numeric_limits<double>::infinity();
-              std::vector<double> log_terms;
-              log_terms.reserve(n - k + 1);
-              for (Size j = k; j <= n; ++j)
-              {
-                const double lt = lgn - std::lgamma(static_cast<double>(j) + 1.0)
-                                      - std::lgamma(static_cast<double>(n - j) + 1.0)
-                                  + static_cast<double>(j) * log_p
-                                  + static_cast<double>(n - j) * log_1mp;
-                log_terms.push_back(lt);
-                if (lt > max_log_term) { max_log_term = lt; }
-              }
-              double sum_exp = 0.0;
-              for (double lt : log_terms) { sum_exp += std::exp(lt - max_log_term); }
-              const double log10_prob = (max_log_term + std::log(sum_exp)) / std::log(10.0);
-              score = -10.0 * log10_prob;
-            }
-            ph.setMetaValue(Constants::UserParam::BINOMIAL_MATCH_SCORE, score);
-          }
 
           // Add isotope error metavalue (always; exposed as Percolator feature)
           ph.setMetaValue(Constants::UserParam::ISOTOPE_ERROR, ah.isotope_error);
@@ -1076,13 +933,7 @@ namespace OpenMS
     if (annotation_matched_suffix_ions) feature_set.push_back(Constants::UserParam::MATCHED_SUFFIX_IONS);
     if (annotation_matched_ion_current) feature_set.push_back(Constants::UserParam::MATCHED_ION_CURRENT);
     if (annotation_matched_ion_current_fraction) feature_set.push_back(Constants::UserParam::MATCHED_ION_CURRENT_FRACTION);
-    if (annotation_ln_explained_intensity) feature_set.push_back(Constants::UserParam::LN_EXPLAINED_INTENSITY);
-    if (annotation_ln_total_intensity) feature_set.push_back(Constants::UserParam::LN_TOTAL_INTENSITY);
     if (annotation_complementary_ions_fraction) feature_set.push_back(Constants::UserParam::COMPLEMENTARY_IONS_FRACTION);
-    if (annotation_binomial_match_score) feature_set.push_back(Constants::UserParam::BINOMIAL_MATCH_SCORE);
-    if (annotation_tailor_score) feature_set.push_back(Constants::UserParam::TAILOR_SCORE);
-    if (annotation_top_peaks_explained) feature_set.push_back(Constants::UserParam::TOP_PEAKS_EXPLAINED_FRACTION);
-    if (annotation_delta_score_worst) feature_set.push_back(Constants::UserParam::DELTA_SCORE_WORST);
     if (annotation_hyperscore_zscore) feature_set.push_back(Constants::UserParam::HYPERSCORE_ZSCORE);
     if (annotation_ln_num_candidates) feature_set.push_back(Constants::UserParam::LN_NUM_CANDIDATES);
     feature_set.push_back(Constants::UserParam::DELTA_SCORE);

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -482,19 +482,49 @@ namespace OpenMS
     // in a side vector (one float per spectrum) to avoid adding a field to every
     // AnnotatedHit_ candidate during scoring.
     std::vector<float> delta_scores(annotated_hits.size(), 0.0f);
-#pragma omp parallel for default(none) shared(annotated_hits, top_hits, delta_scores)
+    // Side vectors for candidate-pool statistics, computed the same way as delta_scores
+    // (before truncation to top_hits, one value per spectrum):
+    //  - delta_scores_worst: best - worst candidate score (Comet deltaLCn analogue)
+    //  - hyperscore_zscores: how much of an outlier the best score is relative to the
+    //    mean/SD of the *other* candidates — a lightweight statistical-significance
+    //    proxy, since HyperScore (unlike e.g. MS-GF+'s SpecEValue) has no closed-form e-value
+    //  - ln_num_candidates: ln(1 + number of candidates), a search-space-size proxy
+    std::vector<float> delta_scores_worst(annotated_hits.size(), 0.0f);
+    std::vector<float> hyperscore_zscores(annotated_hits.size(), 0.0f);
+    std::vector<float> ln_num_candidates(annotated_hits.size(), 0.0f);
+#pragma omp parallel for default(none) shared(annotated_hits, top_hits, delta_scores, delta_scores_worst, hyperscore_zscores, ln_num_candidates)
     for (SignedSize scan_index = 0; scan_index < (SignedSize)annotated_hits.size(); ++scan_index)
     {
       auto& hits = annotated_hits[scan_index];
 
-      // O(N) pass: find top-2 scores for delta. Leaves partial_sort unchanged.
-      double best_score = 0.0, second_best_score = 0.0;
+      // O(N) pass: find best/second-best/worst scores and sum/sum-of-squares over all
+      // candidates. Leaves partial_sort unchanged.
+      double best_score = -std::numeric_limits<double>::infinity();
+      double second_best_score = -std::numeric_limits<double>::infinity();
+      double worst_score = std::numeric_limits<double>::infinity();
+      double sum = 0.0, sumsq = 0.0;
       for (const auto& h : hits)
       {
         if (h.score > best_score) { second_best_score = best_score; best_score = h.score; }
         else if (h.score > second_best_score) { second_best_score = h.score; }
+        if (h.score < worst_score) { worst_score = h.score; }
+        sum += h.score;
+        sumsq += h.score * h.score;
       }
+      if (hits.empty()) { best_score = 0.0; second_best_score = 0.0; worst_score = 0.0; }
+      if (!std::isfinite(second_best_score)) { second_best_score = 0.0; } // single-candidate spectrum: no second-best
+
       delta_scores[scan_index] = static_cast<float>(best_score - second_best_score);
+      delta_scores_worst[scan_index] = static_cast<float>(best_score - worst_score);
+      ln_num_candidates[scan_index] = static_cast<float>(std::log1p(static_cast<double>(hits.size())));
+
+      const Size n_rest = hits.size() > 0 ? hits.size() - 1 : 0;
+      if (n_rest > 0)
+      {
+        const double mean_rest = (sum - best_score) / static_cast<double>(n_rest);
+        const double var_rest = std::max(0.0, (sumsq - best_score * best_score) / static_cast<double>(n_rest) - mean_rest * mean_rest);
+        hyperscore_zscores[scan_index] = static_cast<float>((best_score - mean_rest) / (std::sqrt(var_rest) + 1e-6));
+      }
 
       // sort and keep n best elements according to score (unchanged)
       Size topn = top_hits > hits.size() ? hits.size() : top_hits;
@@ -513,6 +543,11 @@ namespace OpenMS
     bool annotation_longest_ion_run = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE) != annotate_psm_.end();
     bool annotation_matched_ion_current = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_ION_CURRENT) != annotate_psm_.end();
     bool annotation_fragment_annotations = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM) != annotate_psm_.end();
+    bool annotation_delta_score_worst = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::DELTA_SCORE_WORST) != annotate_psm_.end();
+    bool annotation_hyperscore_zscore = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::HYPERSCORE_ZSCORE) != annotate_psm_.end();
+    bool annotation_ln_num_candidates = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::LN_NUM_CANDIDATES) != annotate_psm_.end();
+    bool annotation_matched_ion_current_fraction = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_ION_CURRENT_FRACTION) != annotate_psm_.end();
+    bool annotation_complementary_ions_fraction = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::COMPLEMENTARY_IONS_FRACTION) != annotate_psm_.end();
 
     // "ALL" adds all annotations
     if (std::find(annotate_psm_.begin(), annotate_psm_.end(), "ALL") != annotate_psm_.end())
@@ -527,10 +562,17 @@ namespace OpenMS
       annotation_longest_ion_run = true;
       annotation_matched_ion_current = true;
       annotation_fragment_annotations = true;
+      annotation_delta_score_worst = true;
+      annotation_hyperscore_zscore = true;
+      annotation_ln_num_candidates = true;
+      annotation_matched_ion_current_fraction = true;
+      annotation_complementary_ions_fraction = true;
     }
 
-    // Alignment is needed for fragment error, fragment annotations, longest ion run, and MIC
-    const bool need_alignment = annotation_fragment_error_ppm || annotation_fragment_annotations || annotation_longest_ion_run || annotation_matched_ion_current;
+    // Alignment is needed for fragment error, fragment annotations, longest ion run, MIC,
+    // normalized MIC, and complementary ion pairs
+    const bool need_alignment = annotation_fragment_error_ppm || annotation_fragment_annotations || annotation_longest_ion_run
+      || annotation_matched_ion_current || annotation_matched_ion_current_fraction || annotation_complementary_ions_fraction;
 
     // Both configurations depend only on the fragment tolerance, so they are
     // shared read-only by every thread of the loop below: getSpectrum() and
@@ -663,8 +705,23 @@ namespace OpenMS
 
           ph.setMetaValue(Constants::UserParam::DELTA_SCORE, delta_scores[scan_index]);
 
-          // Fragment annotations, longest ion run, and MIC all iterate the alignment + ion names
-          if (annotation_fragment_annotations || annotation_longest_ion_run || annotation_matched_ion_current)
+          if (annotation_delta_score_worst)
+          {
+            ph.setMetaValue(Constants::UserParam::DELTA_SCORE_WORST, delta_scores_worst[scan_index]);
+          }
+          if (annotation_hyperscore_zscore)
+          {
+            ph.setMetaValue(Constants::UserParam::HYPERSCORE_ZSCORE, hyperscore_zscores[scan_index]);
+          }
+          if (annotation_ln_num_candidates)
+          {
+            ph.setMetaValue(Constants::UserParam::LN_NUM_CANDIDATES, ln_num_candidates[scan_index]);
+          }
+
+          // Fragment annotations, longest ion run, MIC, normalized MIC, and complementary
+          // ion pairs all iterate the alignment + ion names
+          if (annotation_fragment_annotations || annotation_longest_ion_run || annotation_matched_ion_current
+            || annotation_matched_ion_current_fraction || annotation_complementary_ions_fraction)
           {
             const auto& ion_names = theoretical_spec.getStringDataArrays()[0];
             const auto& ion_charges = theoretical_spec.getIntegerDataArrays()[0];
@@ -677,12 +734,13 @@ namespace OpenMS
             std::vector<PeptideHit::PeakAnnotation> peak_annotations;
             std::vector<int> prefix_ordinals, suffix_ordinals;
             double matched_ion_current = 0.0;
+            const bool need_mic = annotation_matched_ion_current || annotation_matched_ion_current_fraction;
+            const bool need_ordinals = annotation_longest_ion_run || annotation_complementary_ions_fraction;
             // Dedup guard for MIC: in ppm-alignment mode a single experimental
             // peak can match multiple theoretical peaks (e.g. b-ion and near
             // isotope), so we must sum each exp_idx at most once. Sized only
             // when MIC is actually requested.
-            std::vector<char> counted_exp_peaks(
-                annotation_matched_ion_current ? spec.size() : 0, 0);
+            std::vector<char> counted_exp_peaks(need_mic ? spec.size() : 0, 0);
             peak_annotations.reserve(alignment.size());
 
             for (const auto& [theo_idx, exp_idx] : alignment)
@@ -697,13 +755,13 @@ namespace OpenMS
                 peak_annotations.push_back(pa);
               }
 
-              if (annotation_matched_ion_current && !counted_exp_peaks[exp_idx])
+              if (need_mic && !counted_exp_peaks[exp_idx])
               {
                 matched_ion_current += spec[exp_idx].getIntensity();
                 counted_exp_peaks[exp_idx] = 1;
               }
 
-              if (annotation_longest_ion_run && ion_names[theo_idx].size() >= 2)
+              if (need_ordinals && ion_names[theo_idx].size() >= 2)
               {
                 const std::string& name = ion_names[theo_idx];
                 const char c = name[0];
@@ -733,9 +791,17 @@ namespace OpenMS
               ph.setMetaValue(Constants::UserParam::MATCHED_ION_CURRENT, matched_ion_current);
             }
 
-            if (annotation_longest_ion_run)
+            if (annotation_matched_ion_current_fraction)
             {
-              // Compute longest consecutive run across prefix and suffix series
+              const double tic = spec.calculateTIC();
+              ph.setMetaValue(Constants::UserParam::MATCHED_ION_CURRENT_FRACTION, tic > 0 ? matched_ion_current / tic : 0.0);
+            }
+
+            if (need_ordinals)
+            {
+              // Compute longest consecutive run across prefix and suffix series.
+              // Sorts + deduplicates each ordinal vector in place (a backbone position
+              // matched by multiple ion types, e.g. a3 and b3, counts once).
               auto longestRun = [](std::vector<int>& v) -> int {
                 if (v.empty()) return 0;
                 std::sort(v.begin(), v.end());
@@ -748,8 +814,33 @@ namespace OpenMS
                 }
                 return best;
               };
-              int longest = std::max(longestRun(prefix_ordinals), longestRun(suffix_ordinals));
-              ph.setMetaValue(Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE, longest);
+              int longest_prefix = longestRun(prefix_ordinals);
+              int longest_suffix = longestRun(suffix_ordinals);
+
+              if (annotation_longest_ion_run)
+              {
+                ph.setMetaValue(Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE, std::max(longest_prefix, longest_suffix));
+              }
+
+              if (annotation_complementary_ions_fraction)
+              {
+                // A prefix ion at backbone position i (a_i/b_i/c_i) is complementary to a
+                // suffix ion at position (peptide_length - i) (x/y/z at the same cleavage
+                // site). Andromeda-style structural signal, distinct from the independently
+                // computed prefix/suffix fractions above.
+                const int pep_len = static_cast<int>(ah.sequence.size());
+                double complementary_fraction = 0.0;
+                if (pep_len > 1)
+                {
+                  Size n_complementary = 0;
+                  for (int p : prefix_ordinals)
+                  {
+                    if (std::binary_search(suffix_ordinals.begin(), suffix_ordinals.end(), pep_len - p)) { ++n_complementary; }
+                  }
+                  complementary_fraction = static_cast<double>(n_complementary) / static_cast<double>(pep_len - 1);
+                }
+                ph.setMetaValue(Constants::UserParam::COMPLEMENTARY_IONS_FRACTION, complementary_fraction);
+              }
             }
           }
 
@@ -841,6 +932,11 @@ namespace OpenMS
     if (annotation_matched_prefix_ions) feature_set.push_back(Constants::UserParam::MATCHED_PREFIX_IONS);
     if (annotation_matched_suffix_ions) feature_set.push_back(Constants::UserParam::MATCHED_SUFFIX_IONS);
     if (annotation_matched_ion_current) feature_set.push_back(Constants::UserParam::MATCHED_ION_CURRENT);
+    if (annotation_matched_ion_current_fraction) feature_set.push_back(Constants::UserParam::MATCHED_ION_CURRENT_FRACTION);
+    if (annotation_complementary_ions_fraction) feature_set.push_back(Constants::UserParam::COMPLEMENTARY_IONS_FRACTION);
+    if (annotation_delta_score_worst) feature_set.push_back(Constants::UserParam::DELTA_SCORE_WORST);
+    if (annotation_hyperscore_zscore) feature_set.push_back(Constants::UserParam::HYPERSCORE_ZSCORE);
+    if (annotation_ln_num_candidates) feature_set.push_back(Constants::UserParam::LN_NUM_CANDIDATES);
     feature_set.push_back(Constants::UserParam::DELTA_SCORE);
     feature_set.push_back(Constants::UserParam::ISOTOPE_ERROR);
     // note: precursor error is calculated by percolator itself

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -576,8 +576,13 @@ namespace OpenMS
       annotation_ln_num_candidates = true;
       annotation_matched_ion_current_fraction = true;
       annotation_complementary_ions_fraction = true;
-      annotation_ln_explained_intensity = true;
-      annotation_ln_total_intensity = true;
+      // NOTE: LN_EXPLAINED_INTENSITY and LN_TOTAL_INTENSITY are deliberately NOT part of "ALL".
+      // They are opt-in only. Benchmarked on a Bruker timsTOF HeLa run and a Q Exactive HF
+      // ProteoBench run, each rescored under five Percolator seeds, neither feature produced a
+      // significant change in target PSMs at 1% FDR -- on their own (Welch t = 0.33 / 0.70 and
+      // 1.99 / 0.66) or on top of the other added features (|t| <= 1.72). Enabling them by
+      // default would grow every PSM's annotation for no measured gain. They remain selectable
+      // via annotate:PSM for data this benchmark did not cover (e.g. ETD/EThcD).
     }
 
     // Alignment is needed for fragment error, fragment annotations, longest ion run, MIC,

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -597,11 +597,14 @@ namespace OpenMS
       annotation_longest_ion_run = true;
       annotation_matched_ion_current = true;
       annotation_fragment_annotations = true;
-      annotation_delta_score_worst = true;
       annotation_hyperscore_zscore = true;
       annotation_ln_num_candidates = true;
       annotation_matched_ion_current_fraction = true;
       annotation_complementary_ions_fraction = true;
+      // NOTE: DELTA_SCORE_WORST is opt-in. It is the weakest of the candidate-pool features and
+      // largely restates DELTA_SCORE, which already contrasts the best hit with the rest of the
+      // pool: dropping it from the default cost 15.6 PSMs on timsTOF (t = -0.69) and 4.0 on
+      // Q Exactive HF (t = -0.12), i.e. nothing resolvable above the seed-to-seed spread.
       // NOTE: BINOMIAL_MATCH_SCORE, TAILOR_SCORE and TOP_PEAKS_EXPLAINED_FRACTION are also
       // opt-in. Each clearly improves on the *original* feature set (t = 1.4 / 1.1 / 4.8 on
       // timsTOF, 3.7 / 3.5 / 3.4 on Q Exactive HF), but none adds anything once the

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -162,7 +162,9 @@ namespace OpenMS
         Constants::UserParam::HYPERSCORE_ZSCORE,
         Constants::UserParam::LN_NUM_CANDIDATES,
         Constants::UserParam::MATCHED_ION_CURRENT_FRACTION,
-        Constants::UserParam::COMPLEMENTARY_IONS_FRACTION}
+        Constants::UserParam::COMPLEMENTARY_IONS_FRACTION,
+        Constants::UserParam::LN_EXPLAINED_INTENSITY,
+        Constants::UserParam::LN_TOTAL_INTENSITY}
       );
 
     defaults_.setSectionDescription("annotate", "Annotation Options");
@@ -553,6 +555,8 @@ namespace OpenMS
     bool annotation_ln_num_candidates = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::LN_NUM_CANDIDATES) != annotate_psm_.end();
     bool annotation_matched_ion_current_fraction = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_ION_CURRENT_FRACTION) != annotate_psm_.end();
     bool annotation_complementary_ions_fraction = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::COMPLEMENTARY_IONS_FRACTION) != annotate_psm_.end();
+    bool annotation_ln_explained_intensity = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::LN_EXPLAINED_INTENSITY) != annotate_psm_.end();
+    bool annotation_ln_total_intensity = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::LN_TOTAL_INTENSITY) != annotate_psm_.end();
 
     // "ALL" adds all annotations
     if (std::find(annotate_psm_.begin(), annotate_psm_.end(), "ALL") != annotate_psm_.end())
@@ -572,12 +576,16 @@ namespace OpenMS
       annotation_ln_num_candidates = true;
       annotation_matched_ion_current_fraction = true;
       annotation_complementary_ions_fraction = true;
+      annotation_ln_explained_intensity = true;
+      annotation_ln_total_intensity = true;
     }
 
     // Alignment is needed for fragment error, fragment annotations, longest ion run, MIC,
-    // normalized MIC, and complementary ion pairs
+    // normalized MIC, log-MIC, and complementary ion pairs. ln_total_intensity depends only on
+    // the experimental spectrum, so it does not require an alignment.
     const bool need_alignment = annotation_fragment_error_ppm || annotation_fragment_annotations || annotation_longest_ion_run
-      || annotation_matched_ion_current || annotation_matched_ion_current_fraction || annotation_complementary_ions_fraction;
+      || annotation_matched_ion_current || annotation_matched_ion_current_fraction || annotation_complementary_ions_fraction
+      || annotation_ln_explained_intensity;
 
     // Both configurations depend only on the fragment tolerance, so they are
     // shared read-only by every thread of the loop below: getSpectrum() and
@@ -634,6 +642,11 @@ namespace OpenMS
         }
 
         Size charge = spec.getPrecursors()[0].getCharge();
+
+        // Spectrum-level quantity, identical for every candidate of this spectrum, so it is
+        // computed once here rather than per hit.
+        const double spectrum_tic =
+          (annotation_matched_ion_current_fraction || annotation_ln_total_intensity) ? spec.calculateTIC() : 0.0;
 
         // create full peptide hit structure from annotated hits
         vector<PeptideHit> phs;
@@ -739,7 +752,8 @@ namespace OpenMS
             std::vector<PeptideHit::PeakAnnotation> peak_annotations;
             std::vector<int> prefix_ordinals, suffix_ordinals;
             double matched_ion_current = 0.0;
-            const bool need_mic = annotation_matched_ion_current || annotation_matched_ion_current_fraction;
+            const bool need_mic = annotation_matched_ion_current || annotation_matched_ion_current_fraction
+              || annotation_ln_explained_intensity;
             const bool need_ordinals = annotation_longest_ion_run || annotation_complementary_ions_fraction;
             // Dedup guard for MIC: in ppm-alignment mode a single experimental
             // peak can match multiple theoretical peaks (e.g. b-ion and near
@@ -798,8 +812,13 @@ namespace OpenMS
 
             if (annotation_matched_ion_current_fraction)
             {
-              const double tic = spec.calculateTIC();
-              ph.setMetaValue(Constants::UserParam::MATCHED_ION_CURRENT_FRACTION, tic > 0 ? matched_ion_current / tic : 0.0);
+              ph.setMetaValue(Constants::UserParam::MATCHED_ION_CURRENT_FRACTION,
+                              spectrum_tic > 0 ? matched_ion_current / spectrum_tic : 0.0);
+            }
+
+            if (annotation_ln_explained_intensity)
+            {
+              ph.setMetaValue(Constants::UserParam::LN_EXPLAINED_INTENSITY, std::log1p(matched_ion_current));
             }
 
             if (need_ordinals)
@@ -847,6 +866,12 @@ namespace OpenMS
                 ph.setMetaValue(Constants::UserParam::COMPLEMENTARY_IONS_FRACTION, complementary_fraction);
               }
             }
+          }
+
+          // Spectrum-level intensity feature (no alignment needed)
+          if (annotation_ln_total_intensity)
+          {
+            ph.setMetaValue(Constants::UserParam::LN_TOTAL_INTENSITY, std::log1p(spectrum_tic));
           }
 
           // Add isotope error metavalue (always; exposed as Percolator feature)
@@ -938,6 +963,8 @@ namespace OpenMS
     if (annotation_matched_suffix_ions) feature_set.push_back(Constants::UserParam::MATCHED_SUFFIX_IONS);
     if (annotation_matched_ion_current) feature_set.push_back(Constants::UserParam::MATCHED_ION_CURRENT);
     if (annotation_matched_ion_current_fraction) feature_set.push_back(Constants::UserParam::MATCHED_ION_CURRENT_FRACTION);
+    if (annotation_ln_explained_intensity) feature_set.push_back(Constants::UserParam::LN_EXPLAINED_INTENSITY);
+    if (annotation_ln_total_intensity) feature_set.push_back(Constants::UserParam::LN_TOTAL_INTENSITY);
     if (annotation_complementary_ions_fraction) feature_set.push_back(Constants::UserParam::COMPLEMENTARY_IONS_FRACTION);
     if (annotation_delta_score_worst) feature_set.push_back(Constants::UserParam::DELTA_SCORE_WORST);
     if (annotation_hyperscore_zscore) feature_set.push_back(Constants::UserParam::HYPERSCORE_ZSCORE);

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -602,9 +602,13 @@ namespace OpenMS
       annotation_ln_num_candidates = true;
       annotation_matched_ion_current_fraction = true;
       annotation_complementary_ions_fraction = true;
-      annotation_binomial_match_score = true;
-      annotation_tailor_score = true;
-      annotation_top_peaks_explained = true;
+      // NOTE: BINOMIAL_MATCH_SCORE, TAILOR_SCORE and TOP_PEAKS_EXPLAINED_FRACTION are also
+      // opt-in. Each clearly improves on the *original* feature set (t = 1.4 / 1.1 / 4.8 on
+      // timsTOF, 3.7 / 3.5 / 3.4 on Q Exactive HF), but none adds anything once the
+      // candidate-pool and structural features below are present: against that default the
+      // best of them reaches only |t| = 1.8, and all three together give t = -1.08 (timsTOF)
+      // and +0.53 (Q Exactive HF). They measure separation that the default set already
+      // captures, so enabling them by default would cost annotation size for no gain.
       // NOTE: LN_EXPLAINED_INTENSITY and LN_TOTAL_INTENSITY are deliberately NOT part of "ALL".
       // They are opt-in only. Benchmarked on a Bruker timsTOF HeLa run and a Q Exactive HF
       // ProteoBench run, each rescored under five Percolator seeds, neither feature produced a

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -462,8 +462,19 @@ namespace OpenMS
     }
   }
 
+  double ProSEAlgorithm::CandidatePoolStats_::zScore() const
+  {
+    if (count < 2) return 0.0;
+    const double n = static_cast<double>(count);
+    const double mean = sum / n;
+    const double var = std::max(0.0, sumsq / n - mean * mean);
+    if (var <= 0.0) return 0.0; // every candidate scored the same: the best one is not an outlier
+    return (best - mean) / std::sqrt(var);
+  }
+
   void ProSEAlgorithm::postProcessHits_(const PeakMap& exp,
         std::vector<std::vector<ProSEAlgorithm::AnnotatedHit_> >& annotated_hits,
+        const std::vector<CandidatePoolStats_>& pool_stats,
         std::vector<ProteinIdentification>& protein_ids,
         PeptideIdentificationList& peptide_ids,
         Size top_hits,
@@ -482,51 +493,36 @@ namespace OpenMS
         const std::string& enzyme,
         const std::string& database_name) const
   {
-    // remove all but top n scoring; compute delta_score (best - second-best)
-    // before truncation so it's available even when top_hits=1. Delta is stored
-    // in a side vector (one float per spectrum) to avoid adding a field to every
-    // AnnotatedHit_ candidate during scoring.
+    // Candidate-pool features (delta score, z-score, candidate count) are derived
+    // from @p pool_stats rather than from @p annotated_hits: scoreSpectraAgainstIndex_
+    // already pruned each spectrum to max(top_hits, 2) candidates, so the hits left
+    // here are the report set, not the search space. pool_stats summarises every
+    // candidate that was scored, zero-scoring ones included, and is accumulated
+    // across chunks by the chunked search paths.
+    if (pool_stats.size() != annotated_hits.size())
+    {
+      throw Exception::InvalidSize(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, pool_stats.size(),
+        "Candidate-pool statistics must hold one entry per spectrum.");
+    }
+
+    // One value per spectrum, kept in side vectors so scoring does not have to carry
+    // them on every AnnotatedHit_ candidate.
     std::vector<float> delta_scores(annotated_hits.size(), 0.0f);
-    // Side vectors for candidate-pool statistics, computed the same way as delta_scores
-    // (before truncation to top_hits, one value per spectrum):
-    //  - hyperscore_zscores: how much of an outlier the best score is relative to the
-    //    mean/SD of the *other* candidates — a lightweight statistical-significance
-    //    proxy, since HyperScore (unlike e.g. MS-GF+'s SpecEValue) has no closed-form e-value
-    //  - ln_num_candidates: ln(1 + number of candidates), a search-space-size proxy
     std::vector<float> hyperscore_zscores(annotated_hits.size(), 0.0f);
     std::vector<float> ln_num_candidates(annotated_hits.size(), 0.0f);
-#pragma omp parallel for default(none) shared(annotated_hits, top_hits, delta_scores, hyperscore_zscores, ln_num_candidates)
+#pragma omp parallel for default(none) shared(annotated_hits, top_hits, pool_stats, delta_scores, hyperscore_zscores, ln_num_candidates)
     for (SignedSize scan_index = 0; scan_index < (SignedSize)annotated_hits.size(); ++scan_index)
     {
-      auto& hits = annotated_hits[scan_index];
-
-      // O(N) pass: find best/second-best scores and sum/sum-of-squares over all
-      // candidates. Leaves partial_sort unchanged.
-      double best_score = -std::numeric_limits<double>::infinity();
-      double second_best_score = -std::numeric_limits<double>::infinity();
-      double sum = 0.0, sumsq = 0.0;
-      for (const auto& h : hits)
-      {
-        if (h.score > best_score) { second_best_score = best_score; best_score = h.score; }
-        else if (h.score > second_best_score) { second_best_score = h.score; }
-        sum += h.score;
-        sumsq += h.score * h.score;
-      }
-      if (hits.empty()) { best_score = 0.0; second_best_score = 0.0; }
-      if (!std::isfinite(second_best_score)) { second_best_score = 0.0; } // single-candidate spectrum: no second-best
-
-      delta_scores[scan_index] = static_cast<float>(best_score - second_best_score);
-      ln_num_candidates[scan_index] = static_cast<float>(std::log1p(static_cast<double>(hits.size())));
-
-      const Size n_rest = hits.size() > 0 ? hits.size() - 1 : 0;
-      if (n_rest > 0)
-      {
-        const double mean_rest = (sum - best_score) / static_cast<double>(n_rest);
-        const double var_rest = std::max(0.0, (sumsq - best_score * best_score) / static_cast<double>(n_rest) - mean_rest * mean_rest);
-        hyperscore_zscores[scan_index] = static_cast<float>((best_score - mean_rest) / (std::sqrt(var_rest) + 1e-6));
-      }
+      const CandidatePoolStats_& stats = pool_stats[scan_index];
+      delta_scores[scan_index] = static_cast<float>(stats.deltaScore());
+      hyperscore_zscores[scan_index] = static_cast<float>(stats.zScore());
+      // log1p rather than log: a spectrum can end up with zero candidates, and
+      // ln(0) is not representable. The +1 offset is order-preserving, so this
+      // stays a monotone proxy for the size of the scored search space.
+      ln_num_candidates[scan_index] = static_cast<float>(std::log1p(static_cast<double>(stats.count)));
 
       // sort and keep n best elements according to score (unchanged)
+      auto& hits = annotated_hits[scan_index];
       Size topn = top_hits > hits.size() ? hits.size() : top_hits;
       std::partial_sort(hits.begin(), hits.begin() + topn, hits.end(), AnnotatedHit_::hasBetterScore);
       hits.resize(topn);
@@ -1230,8 +1226,14 @@ namespace OpenMS
       bool fragment_mass_tolerance_unit_ppm,
       bool open_search_mode,
       std::vector<std::vector<AnnotatedHit_>>& annotated_hits,
+      std::vector<CandidatePoolStats_>& pool_stats,
       const std::string& progress_label) const
   {
+    if (pool_stats.size() != annotated_hits.size())
+    {
+      throw Exception::InvalidSize(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, pool_stats.size(),
+        "Candidate-pool statistics must hold one entry per spectrum.");
+    }
     startProgress(0, spectra.size(), progress_label);
     size_t count_spectra{};
     const double proton_mass_u = Constants::PROTON_MASS_U;
@@ -1240,7 +1242,7 @@ namespace OpenMS
     const double c13c12_massdiff_u = Constants::C13C12_MASSDIFF_U;
     const Size keep = std::max(report_top_hits_, Size(2)); // keep ≥2 for delta score
 
-#pragma omp parallel for schedule(dynamic) default(none) shared(annotated_hits, count_spectra, fi, spectrum_generator, db, fragment_mass_tolerance_unit_ppm, spectra, open_search_mode, proton_mass_u, c13c12_massdiff_u, effective_fragment_tol, keep)
+#pragma omp parallel for schedule(dynamic) default(none) shared(annotated_hits, pool_stats, count_spectra, fi, spectrum_generator, db, fragment_mass_tolerance_unit_ppm, spectra, open_search_mode, proton_mass_u, c13c12_massdiff_u, effective_fragment_tol, keep)
     for (SignedSize scan_index = 0; scan_index < (SignedSize)spectra.size(); ++scan_index)
     {
       #pragma omp atomic
@@ -1330,6 +1332,13 @@ namespace OpenMS
 
         HyperScore::PSMDetail detail;
         const double& score = HyperScore::computeWithDetail(effective_fragment_tol, fragment_mass_tolerance_unit_ppm, exp_spectrum, theo_spectrum, detail);
+
+        // Summarise the candidate before it can be dropped below or pruned at the
+        // end of the loop: the pool-derived PSM features describe the whole search
+        // space, so a candidate that scored 0 (no fragment matched) still counts
+        // and still belongs in the null distribution the z-score is measured against.
+        // Each scan_index is owned by exactly one thread, so this needs no guard.
+        pool_stats[scan_index].add(score);
 
         if (score == 0) continue;
 
@@ -1518,6 +1527,9 @@ namespace OpenMS
     // 4. Allocate per-spectrum hit accumulator (persists across chunks).
     vector<vector<AnnotatedHit_>> annotated_hits(spectra.size());
     for (auto& a : annotated_hits) { a.reserve(report_top_hits_); }
+    // Accumulates across chunks: every chunk contributes its own candidates for the
+    // same spectrum, and the pool features must see all of them.
+    std::vector<CandidatePoolStats_> pool_stats(spectra.size());
 
     // 5. Chunk loop.
     const Size chunk_size = database_chunk_size_;
@@ -1548,7 +1560,7 @@ namespace OpenMS
       // Score all spectra against this chunk's index.
       scoreSpectraAgainstIndex_(spectra, chunk_fi, chunk_db, spectrum_generator,
                                 effective_fragment_tol, fragment_mass_tolerance_unit_ppm,
-                                open_search_mode, annotated_hits,
+                                open_search_mode, annotated_hits, pool_stats,
                                 "Scoring chunk " + StringUtils::toStr(chunk_idx) + "...");
 
       // Prune to top-N per spectrum after each chunk to bound memory growth.
@@ -1580,6 +1592,7 @@ namespace OpenMS
     startProgress(0, 1, "Post-processing PSMs...");
     postProcessHits_(spectra,
       annotated_hits,
+      pool_stats,
       protein_ids,
       peptide_ids,
       report_top_hits_,
@@ -1814,13 +1827,14 @@ namespace OpenMS
     // preallocate storage for PSMs
     vector<vector<AnnotatedHit_> > annotated_hits(spectra.size(), vector<AnnotatedHit_>());
     for (auto & a : annotated_hits) { a.reserve(report_top_hits_); }
+    std::vector<CandidatePoolStats_> pool_stats(spectra.size());
 
     bool open_search_mode = open_search;
 
     StopWatch sw_search; sw_search.start();
     scoreSpectraAgainstIndex_(spectra, fragment_index_, db, spectrum_generator,
                               effective_fragment_tol, fragment_mass_tolerance_unit_ppm,
-                              open_search_mode, annotated_hits,
+                              open_search_mode, annotated_hits, pool_stats,
                               "Scoring peptide models against spectra...");
 
     // M1: release the fragment index eagerly when the caller opted in (single-
@@ -1839,6 +1853,7 @@ namespace OpenMS
     startProgress(0, 1, "Post-processing PSMs...");
     ProSEAlgorithm::postProcessHits_(spectra,
       annotated_hits,
+      pool_stats,
       protein_ids,
       peptide_ids,
       report_top_hits_,
@@ -2350,10 +2365,13 @@ namespace OpenMS
 
       // Per-file hit accumulators.
       std::vector<std::vector<std::vector<AnnotatedHit_>>> per_file_hits(in_spectra_files.size());
+      // One pool summary per spectrum per file; accumulates across chunks.
+      std::vector<std::vector<CandidatePoolStats_>> per_file_pool_stats(in_spectra_files.size());
       for (Size i = 0; i < in_spectra_files.size(); ++i)
       {
         per_file_hits[i].resize(all_spectra[i].size());
         for (auto& a : per_file_hits[i]) a.reserve(report_top_hits_);
+        per_file_pool_stats[i].resize(all_spectra[i].size());
       }
       OPENMS_LOG_INFO << "[ProSE] Chunk-major multi-file: " << full_db.size()
                       << " proteins, " << n_chunks << " chunks, "
@@ -2399,7 +2417,7 @@ namespace OpenMS
           scoreSpectraAgainstIndex_(all_spectra[i], chunk_fi, chunk_db,
                                     spectrum_generator, per_file_cal[i].effective_fragment_tol,
                                     fragment_mass_tolerance_unit_ppm, open_search_mode,
-                                    per_file_hits[i],
+                                    per_file_hits[i], per_file_pool_stats[i],
                                     "  file " + StringUtils::toStr(i + 1) + " chunk " + StringUtils::toStr(chunk_idx));
         }
         // Restore base FI params for next chunk (in case calibration modified them).
@@ -2437,7 +2455,7 @@ namespace OpenMS
         SearchResult result;
         result.is_open_search = open_search_mode;
 
-        postProcessHits_(all_spectra[i], per_file_hits[i],
+        postProcessHits_(all_spectra[i], per_file_hits[i], per_file_pool_stats[i],
           result.protein_ids, result.peptide_ids,
           report_top_hits_, modifications_fixed_, modifications_variable_,
           peptide_missed_cleavages_,

--- a/src/tests/topp/ProSE_1_out.idXML
+++ b/src/tests/topp/ProSE_1_out.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="/home/user/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.1" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,ln_explained_intensity,ln_total_intensity,complementary_ions_fraction,delta_score_worst,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
+				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,complementary_ions_fraction,delta_score_worst,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
 				<UserParam type="string" name="open_search" value="false"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string" value="DECOY_"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string_position" value="prefix"/>
@@ -18,7 +18,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2026-08-26T20:13:56" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-08-26T20:55:26" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -48,10 +48,8 @@
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="1.781957282219082"/>
 				<UserParam type="float" name="matched_ion_current_fraction" value="0.308665716724222"/>
-				<UserParam type="float" name="ln_explained_intensity" value="1.023154738321924"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
 				<UserParam type="float" name="complementary_ions_fraction" value="0.230769230769231"/>
-				<UserParam type="float" name="ln_total_intensity" value="1.912958517752952"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -74,10 +72,8 @@
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="7.878095272928476"/>
 				<UserParam type="float" name="matched_ion_current_fraction" value="0.382467675228915"/>
-				<UserParam type="float" name="ln_explained_intensity" value="2.183587037704621"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="11"/>
 				<UserParam type="float" name="complementary_ions_fraction" value="0.185185185185185"/>
-				<UserParam type="float" name="ln_total_intensity" value="3.072603877232593"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -100,10 +96,8 @@
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="8.528975328430533"/>
 				<UserParam type="float" name="matched_ion_current_fraction" value="0.533896463252728"/>
-				<UserParam type="float" name="ln_explained_intensity" value="2.254337191258967"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="float" name="complementary_ions_fraction" value="0.272727272727273"/>
-				<UserParam type="float" name="ln_total_intensity" value="2.831739392489154"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>

--- a/src/tests/topp/ProSE_1_out.idXML
+++ b/src/tests/topp/ProSE_1_out.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="/home/user/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.1" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,complementary_ions_fraction,delta_score_worst,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
+				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,ln_explained_intensity,ln_total_intensity,complementary_ions_fraction,delta_score_worst,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
 				<UserParam type="string" name="open_search" value="false"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string" value="DECOY_"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string_position" value="prefix"/>
@@ -18,7 +18,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2026-08-26T18:25:11" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-08-26T20:13:56" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -48,8 +48,10 @@
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="1.781957282219082"/>
 				<UserParam type="float" name="matched_ion_current_fraction" value="0.308665716724222"/>
+				<UserParam type="float" name="ln_explained_intensity" value="1.023154738321924"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
 				<UserParam type="float" name="complementary_ions_fraction" value="0.230769230769231"/>
+				<UserParam type="float" name="ln_total_intensity" value="1.912958517752952"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -72,8 +74,10 @@
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="7.878095272928476"/>
 				<UserParam type="float" name="matched_ion_current_fraction" value="0.382467675228915"/>
+				<UserParam type="float" name="ln_explained_intensity" value="2.183587037704621"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="11"/>
 				<UserParam type="float" name="complementary_ions_fraction" value="0.185185185185185"/>
+				<UserParam type="float" name="ln_total_intensity" value="3.072603877232593"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -96,8 +100,10 @@
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="8.528975328430533"/>
 				<UserParam type="float" name="matched_ion_current_fraction" value="0.533896463252728"/>
+				<UserParam type="float" name="ln_explained_intensity" value="2.254337191258967"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="float" name="complementary_ions_fraction" value="0.272727272727273"/>
+				<UserParam type="float" name="ln_total_intensity" value="2.831739392489154"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>

--- a/src/tests/topp/ProSE_1_out.idXML
+++ b/src/tests/topp/ProSE_1_out.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="/home/user/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.1" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,complementary_ions_fraction,delta_score_worst,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
+				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,complementary_ions_fraction,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
 				<UserParam type="string" name="open_search" value="false"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string" value="DECOY_"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string_position" value="prefix"/>
@@ -18,7 +18,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2026-08-26T20:55:26" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-08-27T06:14:06" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -43,7 +43,6 @@
 				<UserParam type="int" name="matched_prefix_ions" value="3"/>
 				<UserParam type="int" name="matched_suffix_ions" value="8"/>
 				<UserParam type="float" name="delta_score" value="13.195273399353027"/>
-				<UserParam type="float" name="delta_score_worst" value="0.0"/>
 				<UserParam type="float" name="hyperscore_zscore" value="0.0"/>
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="1.781957282219082"/>
@@ -67,7 +66,6 @@
 				<UserParam type="int" name="matched_prefix_ions" value="13"/>
 				<UserParam type="int" name="matched_suffix_ions" value="13"/>
 				<UserParam type="float" name="delta_score" value="47.256179809570312"/>
-				<UserParam type="float" name="delta_score_worst" value="0.0"/>
 				<UserParam type="float" name="hyperscore_zscore" value="0.0"/>
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="7.878095272928476"/>
@@ -91,7 +89,6 @@
 				<UserParam type="int" name="matched_prefix_ions" value="12"/>
 				<UserParam type="int" name="matched_suffix_ions" value="12"/>
 				<UserParam type="float" name="delta_score" value="42.152938842773438"/>
-				<UserParam type="float" name="delta_score_worst" value="0.0"/>
 				<UserParam type="float" name="hyperscore_zscore" value="0.0"/>
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="8.528975328430533"/>

--- a/src/tests/topp/ProSE_1_out.idXML
+++ b/src/tests/topp/ProSE_1_out.idXML
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="/home/sachsenb/dev/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.1" peak_mass_tolerance_ppm="false" >
+	<SearchParameters id="SP_0" db="/home/user/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.1" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,delta_score,isotope_error"/>
+				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,complementary_ions_fraction,delta_score_worst,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
 				<UserParam type="string" name="open_search" value="false"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string" value="DECOY_"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string_position" value="prefix"/>
@@ -18,7 +18,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2026-04-17T20:18:33" search_engine="ProSE" search_engine_version="3.6.0-pre-feat-prose-database-chunking-2026-04-17" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-08-26T18:25:11" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -34,7 +34,7 @@
 		</ProteinIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="520.262817382812045" RT="2655.095703125" spectrum_reference="spectrum=0" >
 			<PeptideHit score="13.195273686121649" sequence="DFASSGGYVLHLHR" charge="3" aa_before="[" aa_after="E" start="0" end="13" protein_refs="PH_0" >
-				<UserParam type="string" name="fragment_annotation" value="175.119094848632813,0.145235076546669,1,&quot;y1+&quot;|263.10302734375,0.269983410835266,1,&quot;b2+&quot;|281.664825439453125,0.045622423291206,2,&quot;y4++&quot;|334.140472412109375,0.038884554058313,1,&quot;b3+&quot;|338.206695556640625,0.036569740623236,2,&quot;y5++&quot;|387.74066162109375,0.041254211217165,2,&quot;y6++&quot;|425.263031005859375,0.154225364327431,1,&quot;y3+&quot;|469.2728271484375,0.031441166996956,2,&quot;y7++&quot;|497.783782958984375,0.041119836270809,2,&quot;y8++&quot;|526.29443359375,0.094272904098034,2,&quot;y9++&quot;|569.81048583984375,0.115230679512024,2,&quot;y10++&quot;|613.32598876953125,0.102093867957592,2,&quot;y11++&quot;|622.2730712890625,4.212265368551016e-03,1,&quot;b7+&quot;|648.84503173828125,0.051233120262623,2,&quot;y12++&quot;|675.40625,0.336008250713348,1,&quot;y5+&quot;|937.53729248046875,0.061362523585558,1,&quot;y7+&quot;|994.55938720703125,0.057263620197773,1,&quot;y8+&quot;|1051.580810546875,0.09991666674614,1,&quot;y9+&quot;|1138.6112060546875,0.048153448849916,1,&quot;y10+&quot;|1225.658935546875,7.874150760471821e-03,1,&quot;y11+&quot;"/>
+				<UserParam type="string" name="fragment_annotation" value="175.119094848632812,0.145235076546669,1,&quot;y1+&quot;|263.10302734375,0.269983410835266,1,&quot;b2+&quot;|281.664825439453125,0.045622423291206,2,&quot;y4++&quot;|334.140472412109375,0.038884554058313,1,&quot;b3+&quot;|338.206695556640625,0.036569740623236,2,&quot;y5++&quot;|387.74066162109375,0.041254211217165,2,&quot;y6++&quot;|425.263031005859375,0.154225364327431,1,&quot;y3+&quot;|469.2728271484375,0.031441166996956,2,&quot;y7++&quot;|497.783782958984375,0.041119836270809,2,&quot;y8++&quot;|526.29443359375,0.094272904098034,2,&quot;y9++&quot;|569.81048583984375,0.115230679512024,2,&quot;y10++&quot;|613.32598876953125,0.102093867957592,2,&quot;y11++&quot;|622.2730712890625,4.212265368551016e-03,1,&quot;b7+&quot;|648.84503173828125,0.051233120262623,2,&quot;y12++&quot;|675.40625,0.336008250713348,1,&quot;y5+&quot;|937.53729248046875,0.061362523585558,1,&quot;y7+&quot;|994.55938720703125,0.057263620197773,1,&quot;y8+&quot;|1051.580810546875,0.09991666674614,1,&quot;y9+&quot;|1138.6112060546875,0.048153448849916,1,&quot;y10+&quot;|1225.658935546875,7.87415076047182e-03,1,&quot;y11+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.809573809163447"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="-1.415652739967919"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.214285716414452"/>
@@ -43,8 +43,13 @@
 				<UserParam type="int" name="matched_prefix_ions" value="3"/>
 				<UserParam type="int" name="matched_suffix_ions" value="8"/>
 				<UserParam type="float" name="delta_score" value="13.195273399353027"/>
+				<UserParam type="float" name="delta_score_worst" value="0.0"/>
+				<UserParam type="float" name="hyperscore_zscore" value="0.0"/>
+				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="1.781957282219082"/>
+				<UserParam type="float" name="matched_ion_current_fraction" value="0.308665716724222"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
+				<UserParam type="float" name="complementary_ions_fraction" value="0.230769230769231"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -52,8 +57,8 @@
 			<UserParam type="int" name="scan_index" value="0"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="1063.209838867190001" RT="4587.6689453125" spectrum_reference="spectrum=1" >
-			<PeptideHit score="47.256181302684944" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="[" aa_after="E" start="0" end="27" protein_refs="PH_1" >
-				<UserParam type="string" name="fragment_annotation" value="147.112884521484375,0.073362722992897,1,&quot;y1+&quot;|185.128372192382813,0.304318636655808,1,&quot;b2+&quot;|294.18121337890625,0.199159145355225,1,&quot;y2+&quot;|298.212554931640625,0.030436070635915,1,&quot;b3+&quot;|426.25994873046875,0.053214963525534,2,&quot;b8++&quot;|604.2803955078125,0.367977857589722,1,&quot;y4+&quot;|638.34381103515625,0.023529993370175,1,&quot;b6+&quot;|675.31707763671875,0.364999026060104,1,&quot;y5+&quot;|681.91497802734375,0.018387651070952,2,&quot;b13++&quot;|746.35400390625,0.278303116559982,1,&quot;y6+&quot;|752.44500732421875,0.043161459267139,1,&quot;b7+&quot;|851.50775146484375,0.140275537967682,1,&quot;b8+&quot;|909.41217041015625,0.246380671858788,1,&quot;y7+&quot;|980.553148337916468,0.612667679786682,1,&quot;b9+&quot;|1079.6219482421875,1.0,1,&quot;b10+&quot;|1138.490478515625,0.284363687038422,1,&quot;y9+&quot;|1178.689378806666582,0.277622222900391,1,&quot;b11+&quot;|1221.7279052734375,0.205706641077995,2,&quot;b22++&quot;|1239.53515625,0.73640251159668,1,&quot;y10+&quot;|1249.726318359375,0.724085569381714,1,&quot;b12+&quot;|1352.6168212890625,0.234000310301781,1,&quot;y11+&quot;|1362.8125,0.279476225376129,1,&quot;b13+&quot;|1476.8531494140625,0.269533842802048,1,&quot;b14+&quot;|1499.689453125,0.080423474311829,1,&quot;y12+&quot;|1591.881591796875,0.727882027626038,1,&quot;b15+&quot;|1596.741455078125,0.219704270362854,1,&quot;y13+&quot;|1688.953905173854082,0.01809080503881,1,&quot;b16+&quot;|1711.765380859375,0.032515596598387,1,&quot;y14+&quot;|1825.8343505859375,0.032113555818796,1,&quot;y15+&quot;"/>
+			<PeptideHit score="47.256181302684936" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="[" aa_after="E" start="0" end="27" protein_refs="PH_1" >
+				<UserParam type="string" name="fragment_annotation" value="147.112884521484375,0.073362722992897,1,&quot;y1+&quot;|185.128372192382812,0.304318636655807,1,&quot;b2+&quot;|294.18121337890625,0.199159145355225,1,&quot;y2+&quot;|298.212554931640625,0.030436070635915,1,&quot;b3+&quot;|426.25994873046875,0.053214963525534,2,&quot;b8++&quot;|604.2803955078125,0.367977857589722,1,&quot;y4+&quot;|638.34381103515625,0.023529993370175,1,&quot;b6+&quot;|675.31707763671875,0.364999026060104,1,&quot;y5+&quot;|681.91497802734375,0.018387651070952,2,&quot;b13++&quot;|746.35400390625,0.278303116559982,1,&quot;y6+&quot;|752.44500732421875,0.043161459267139,1,&quot;b7+&quot;|851.50775146484375,0.140275537967682,1,&quot;b8+&quot;|909.41217041015625,0.246380671858788,1,&quot;y7+&quot;|980.553148337916468,0.612667679786682,1,&quot;b9+&quot;|1079.6219482421875,1.0,1,&quot;b10+&quot;|1138.490478515625,0.284363687038422,1,&quot;y9+&quot;|1178.689378806666582,0.277622222900391,1,&quot;b11+&quot;|1221.7279052734375,0.205706641077995,2,&quot;b22++&quot;|1239.53515625,0.73640251159668,1,&quot;y10+&quot;|1249.726318359375,0.724085569381714,1,&quot;b12+&quot;|1352.6168212890625,0.234000310301781,1,&quot;y11+&quot;|1362.8125,0.279476225376129,1,&quot;b13+&quot;|1476.8531494140625,0.269533842802048,1,&quot;b14+&quot;|1499.689453125,0.080423474311829,1,&quot;y12+&quot;|1591.881591796875,0.727882027626038,1,&quot;b15+&quot;|1596.741455078125,0.219704270362854,1,&quot;y13+&quot;|1688.953905173854082,0.01809080503881,1,&quot;b16+&quot;|1711.765380859375,0.032515596598387,1,&quot;y14+&quot;|1825.8343505859375,0.032113555818796,1,&quot;y15+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.086640460710327"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="0.532776127422444"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.46428570151329"/>
@@ -61,9 +66,14 @@
 				<UserParam type="int" name="num_matched_peaks" value="26"/>
 				<UserParam type="int" name="matched_prefix_ions" value="13"/>
 				<UserParam type="int" name="matched_suffix_ions" value="13"/>
-				<UserParam type="float" name="delta_score" value="47.256179809570313"/>
+				<UserParam type="float" name="delta_score" value="47.256179809570312"/>
+				<UserParam type="float" name="delta_score_worst" value="0.0"/>
+				<UserParam type="float" name="hyperscore_zscore" value="0.0"/>
+				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="7.878095272928476"/>
+				<UserParam type="float" name="matched_ion_current_fraction" value="0.382467675228915"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="11"/>
+				<UserParam type="float" name="complementary_ions_fraction" value="0.185185185185185"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -71,8 +81,8 @@
 			<UserParam type="int" name="scan_index" value="1"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="775.38720703125" RT="4923.77734375" spectrum_reference="spectrum=2" >
-			<PeptideHit score="42.152939453592801" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" aa_before="[" aa_after="A" start="0" end="22" protein_refs="PH_2" >
-				<UserParam type="string" name="fragment_annotation" value="175.118865966796875,0.150531977415085,1,&quot;y1+&quot;|254.148391723632813,0.206978902220726,1,&quot;b2+&quot;|322.18890380859375,0.049145385622978,1,&quot;y2+&quot;|379.209442138671875,0.17941327393055,1,&quot;y3+&quot;|382.223785400390625,0.022014291957021,1,&quot;b4+&quot;|435.20831298828125,0.068259246647358,2,&quot;b9++&quot;|450.24664306640625,0.259074866771698,1,&quot;y4+&quot;|463.720184326171875,0.089691311120987,2,&quot;b10++&quot;|497.24560546875,0.120945297181606,1,&quot;b5+&quot;|537.2552490234375,0.10333526879549,2,&quot;b11++&quot;|565.7642822265625,0.180150553584099,2,&quot;b12++&quot;|578.30462646484375,0.339738875627518,1,&quot;y5+&quot;|594.27630615234375,0.12102073431015,2,&quot;b13++&quot;|649.341552734375,0.642973005771637,1,&quot;y6+&quot;|650.82373046875,0.047898273915052,2,&quot;b14++&quot;|699.30572509765625,0.504444420337677,1,&quot;b7+&quot;|762.42547607421875,0.540082812309265,1,&quot;y7+&quot;|812.39007568359375,0.212916702032089,1,&quot;b8+&quot;|813.406494140625,0.049756519496441,2,&quot;y16++&quot;|869.41009521484375,0.156664118170738,1,&quot;b9+&quot;|877.45343017578125,0.795250296592712,1,&quot;y8+&quot;|926.434326171875,0.743671417236328,1,&quot;b10+&quot;|1007.50408935546875,0.035724259912968,2,&quot;y20++&quot;|1024.5223388671875,1.0,1,&quot;y9+&quot;|1073.5008544921875,0.200163260102272,1,&quot;b11+&quot;|1130.526123046875,0.135533377528191,1,&quot;b12+&quot;|1137.608154296875,0.113550938665867,1,&quot;y10+&quot;|1187.544189453125,0.804915189743042,1,&quot;b13+&quot;|1194.62841796875,0.170546039938927,1,&quot;y11+&quot;|1251.6474609375,0.285297006368637,1,&quot;y12+&quot;|1300.6290283203125,0.159593641757965,1,&quot;b14+&quot;|1562.7510986328125,0.039694063365459,1,&quot;b16+&quot;"/>
+			<PeptideHit score="42.152939453592808" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" aa_before="[" aa_after="A" start="0" end="22" protein_refs="PH_2" >
+				<UserParam type="string" name="fragment_annotation" value="175.118865966796875,0.150531977415085,1,&quot;y1+&quot;|254.148391723632812,0.206978902220726,1,&quot;b2+&quot;|322.18890380859375,0.049145385622978,1,&quot;y2+&quot;|379.209442138671875,0.17941327393055,1,&quot;y3+&quot;|382.223785400390625,0.022014291957021,1,&quot;b4+&quot;|435.20831298828125,0.068259246647358,2,&quot;b9++&quot;|450.24664306640625,0.259074866771698,1,&quot;y4+&quot;|463.720184326171875,0.089691311120987,2,&quot;b10++&quot;|497.24560546875,0.120945297181606,1,&quot;b5+&quot;|537.2552490234375,0.10333526879549,2,&quot;b11++&quot;|565.7642822265625,0.180150553584099,2,&quot;b12++&quot;|578.30462646484375,0.339738875627518,1,&quot;y5+&quot;|594.27630615234375,0.12102073431015,2,&quot;b13++&quot;|649.341552734375,0.642973005771637,1,&quot;y6+&quot;|650.82373046875,0.047898273915052,2,&quot;b14++&quot;|699.30572509765625,0.504444420337677,1,&quot;b7+&quot;|762.42547607421875,0.540082812309265,1,&quot;y7+&quot;|812.39007568359375,0.212916702032089,1,&quot;b8+&quot;|813.406494140625,0.049756519496441,2,&quot;y16++&quot;|869.41009521484375,0.156664118170738,1,&quot;b9+&quot;|877.45343017578125,0.795250296592712,1,&quot;y8+&quot;|926.434326171875,0.743671417236328,1,&quot;b10+&quot;|1007.50408935546875,0.035724259912968,2,&quot;y20++&quot;|1024.5223388671875,1.0,1,&quot;y9+&quot;|1073.5008544921875,0.200163260102272,1,&quot;b11+&quot;|1130.526123046875,0.135533377528191,1,&quot;b12+&quot;|1137.608154296875,0.113550938665867,1,&quot;y10+&quot;|1187.544189453125,0.804915189743042,1,&quot;b13+&quot;|1194.62841796875,0.170546039938927,1,&quot;y11+&quot;|1251.6474609375,0.285297006368637,1,&quot;y12+&quot;|1300.6290283203125,0.159593641757965,1,&quot;b14+&quot;|1562.7510986328125,0.039694063365459,1,&quot;b16+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.389253520212976"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="2.251259146760969"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.52173912525177"/>
@@ -81,8 +91,13 @@
 				<UserParam type="int" name="matched_prefix_ions" value="12"/>
 				<UserParam type="int" name="matched_suffix_ions" value="12"/>
 				<UserParam type="float" name="delta_score" value="42.152938842773438"/>
+				<UserParam type="float" name="delta_score_worst" value="0.0"/>
+				<UserParam type="float" name="hyperscore_zscore" value="0.0"/>
+				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="8.528975328430533"/>
+				<UserParam type="float" name="matched_ion_current_fraction" value="0.533896463252728"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
+				<UserParam type="float" name="complementary_ions_fraction" value="0.272727272727273"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>

--- a/src/tests/topp/ProSE_2_out.idXML
+++ b/src/tests/topp/ProSE_2_out.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="/home/user/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.1" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,complementary_ions_fraction,delta_score_worst,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
+				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,complementary_ions_fraction,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
 				<UserParam type="string" name="open_search" value="false"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string" value="DECOY_"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string_position" value="prefix"/>
@@ -18,7 +18,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2026-08-26T20:55:26" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-08-27T06:14:06" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -43,7 +43,6 @@
 				<UserParam type="int" name="matched_prefix_ions" value="3"/>
 				<UserParam type="int" name="matched_suffix_ions" value="8"/>
 				<UserParam type="float" name="delta_score" value="13.195273399353027"/>
-				<UserParam type="float" name="delta_score_worst" value="0.0"/>
 				<UserParam type="float" name="hyperscore_zscore" value="0.0"/>
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="1.781957282219082"/>
@@ -67,7 +66,6 @@
 				<UserParam type="int" name="matched_prefix_ions" value="13"/>
 				<UserParam type="int" name="matched_suffix_ions" value="13"/>
 				<UserParam type="float" name="delta_score" value="47.256179809570312"/>
-				<UserParam type="float" name="delta_score_worst" value="0.0"/>
 				<UserParam type="float" name="hyperscore_zscore" value="0.0"/>
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="7.878095272928476"/>
@@ -91,7 +89,6 @@
 				<UserParam type="int" name="matched_prefix_ions" value="12"/>
 				<UserParam type="int" name="matched_suffix_ions" value="12"/>
 				<UserParam type="float" name="delta_score" value="42.152938842773438"/>
-				<UserParam type="float" name="delta_score_worst" value="0.0"/>
 				<UserParam type="float" name="hyperscore_zscore" value="0.0"/>
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="8.528975328430533"/>

--- a/src/tests/topp/ProSE_2_out.idXML
+++ b/src/tests/topp/ProSE_2_out.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="/home/user/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.1" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,complementary_ions_fraction,delta_score_worst,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
+				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,ln_explained_intensity,ln_total_intensity,complementary_ions_fraction,delta_score_worst,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
 				<UserParam type="string" name="open_search" value="false"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string" value="DECOY_"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string_position" value="prefix"/>
@@ -18,7 +18,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2026-08-26T18:25:11" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-08-26T20:13:57" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -48,8 +48,10 @@
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="1.781957282219082"/>
 				<UserParam type="float" name="matched_ion_current_fraction" value="0.308665716724222"/>
+				<UserParam type="float" name="ln_explained_intensity" value="1.023154738321924"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
 				<UserParam type="float" name="complementary_ions_fraction" value="0.230769230769231"/>
+				<UserParam type="float" name="ln_total_intensity" value="1.912958517752952"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -72,8 +74,10 @@
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="7.878095272928476"/>
 				<UserParam type="float" name="matched_ion_current_fraction" value="0.382467675228915"/>
+				<UserParam type="float" name="ln_explained_intensity" value="2.183587037704621"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="11"/>
 				<UserParam type="float" name="complementary_ions_fraction" value="0.185185185185185"/>
+				<UserParam type="float" name="ln_total_intensity" value="3.072603877232593"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -96,8 +100,10 @@
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="8.528975328430533"/>
 				<UserParam type="float" name="matched_ion_current_fraction" value="0.533896463252728"/>
+				<UserParam type="float" name="ln_explained_intensity" value="2.254337191258967"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="float" name="complementary_ions_fraction" value="0.272727272727273"/>
+				<UserParam type="float" name="ln_total_intensity" value="2.831739392489154"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>

--- a/src/tests/topp/ProSE_2_out.idXML
+++ b/src/tests/topp/ProSE_2_out.idXML
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="/home/sachsenb/dev/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.1" peak_mass_tolerance_ppm="false" >
+	<SearchParameters id="SP_0" db="/home/user/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.1" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,delta_score,isotope_error"/>
+				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,complementary_ions_fraction,delta_score_worst,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
 				<UserParam type="string" name="open_search" value="false"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string" value="DECOY_"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string_position" value="prefix"/>
@@ -18,7 +18,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2026-04-17T20:18:33" search_engine="ProSE" search_engine_version="3.6.0-pre-feat-prose-database-chunking-2026-04-17" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-08-26T18:25:11" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -34,7 +34,7 @@
 		</ProteinIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="520.262817382812045" RT="2655.095703125" spectrum_reference="spectrum=0" >
 			<PeptideHit score="13.195273686121649" sequence="DFASSGGYVLHLHR" charge="3" aa_before="[" aa_after="E" start="0" end="13" protein_refs="PH_0" >
-				<UserParam type="string" name="fragment_annotation" value="175.119094848632813,0.145235076546669,1,&quot;y1+&quot;|263.10302734375,0.269983410835266,1,&quot;b2+&quot;|281.664825439453125,0.045622423291206,2,&quot;y4++&quot;|334.140472412109375,0.038884554058313,1,&quot;b3+&quot;|338.206695556640625,0.036569740623236,2,&quot;y5++&quot;|387.74066162109375,0.041254211217165,2,&quot;y6++&quot;|425.263031005859375,0.154225364327431,1,&quot;y3+&quot;|469.2728271484375,0.031441166996956,2,&quot;y7++&quot;|497.783782958984375,0.041119836270809,2,&quot;y8++&quot;|526.29443359375,0.094272904098034,2,&quot;y9++&quot;|569.81048583984375,0.115230679512024,2,&quot;y10++&quot;|613.32598876953125,0.102093867957592,2,&quot;y11++&quot;|622.2730712890625,4.212265368551016e-03,1,&quot;b7+&quot;|648.84503173828125,0.051233120262623,2,&quot;y12++&quot;|675.40625,0.336008250713348,1,&quot;y5+&quot;|937.53729248046875,0.061362523585558,1,&quot;y7+&quot;|994.55938720703125,0.057263620197773,1,&quot;y8+&quot;|1051.580810546875,0.09991666674614,1,&quot;y9+&quot;|1138.6112060546875,0.048153448849916,1,&quot;y10+&quot;|1225.658935546875,7.874150760471821e-03,1,&quot;y11+&quot;"/>
+				<UserParam type="string" name="fragment_annotation" value="175.119094848632812,0.145235076546669,1,&quot;y1+&quot;|263.10302734375,0.269983410835266,1,&quot;b2+&quot;|281.664825439453125,0.045622423291206,2,&quot;y4++&quot;|334.140472412109375,0.038884554058313,1,&quot;b3+&quot;|338.206695556640625,0.036569740623236,2,&quot;y5++&quot;|387.74066162109375,0.041254211217165,2,&quot;y6++&quot;|425.263031005859375,0.154225364327431,1,&quot;y3+&quot;|469.2728271484375,0.031441166996956,2,&quot;y7++&quot;|497.783782958984375,0.041119836270809,2,&quot;y8++&quot;|526.29443359375,0.094272904098034,2,&quot;y9++&quot;|569.81048583984375,0.115230679512024,2,&quot;y10++&quot;|613.32598876953125,0.102093867957592,2,&quot;y11++&quot;|622.2730712890625,4.212265368551016e-03,1,&quot;b7+&quot;|648.84503173828125,0.051233120262623,2,&quot;y12++&quot;|675.40625,0.336008250713348,1,&quot;y5+&quot;|937.53729248046875,0.061362523585558,1,&quot;y7+&quot;|994.55938720703125,0.057263620197773,1,&quot;y8+&quot;|1051.580810546875,0.09991666674614,1,&quot;y9+&quot;|1138.6112060546875,0.048153448849916,1,&quot;y10+&quot;|1225.658935546875,7.87415076047182e-03,1,&quot;y11+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.809573809163447"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="-1.415652739967919"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.214285716414452"/>
@@ -43,8 +43,13 @@
 				<UserParam type="int" name="matched_prefix_ions" value="3"/>
 				<UserParam type="int" name="matched_suffix_ions" value="8"/>
 				<UserParam type="float" name="delta_score" value="13.195273399353027"/>
+				<UserParam type="float" name="delta_score_worst" value="0.0"/>
+				<UserParam type="float" name="hyperscore_zscore" value="0.0"/>
+				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="1.781957282219082"/>
+				<UserParam type="float" name="matched_ion_current_fraction" value="0.308665716724222"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
+				<UserParam type="float" name="complementary_ions_fraction" value="0.230769230769231"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -52,8 +57,8 @@
 			<UserParam type="int" name="scan_index" value="0"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="1063.209838867190001" RT="4587.6689453125" spectrum_reference="spectrum=1" >
-			<PeptideHit score="47.256181302684944" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="[" aa_after="E" start="0" end="27" protein_refs="PH_1" >
-				<UserParam type="string" name="fragment_annotation" value="147.112884521484375,0.073362722992897,1,&quot;y1+&quot;|185.128372192382813,0.304318636655808,1,&quot;b2+&quot;|294.18121337890625,0.199159145355225,1,&quot;y2+&quot;|298.212554931640625,0.030436070635915,1,&quot;b3+&quot;|426.25994873046875,0.053214963525534,2,&quot;b8++&quot;|604.2803955078125,0.367977857589722,1,&quot;y4+&quot;|638.34381103515625,0.023529993370175,1,&quot;b6+&quot;|675.31707763671875,0.364999026060104,1,&quot;y5+&quot;|681.91497802734375,0.018387651070952,2,&quot;b13++&quot;|746.35400390625,0.278303116559982,1,&quot;y6+&quot;|752.44500732421875,0.043161459267139,1,&quot;b7+&quot;|851.50775146484375,0.140275537967682,1,&quot;b8+&quot;|909.41217041015625,0.246380671858788,1,&quot;y7+&quot;|980.553148337916468,0.612667679786682,1,&quot;b9+&quot;|1079.6219482421875,1.0,1,&quot;b10+&quot;|1138.490478515625,0.284363687038422,1,&quot;y9+&quot;|1178.689378806666582,0.277622222900391,1,&quot;b11+&quot;|1221.7279052734375,0.205706641077995,2,&quot;b22++&quot;|1239.53515625,0.73640251159668,1,&quot;y10+&quot;|1249.726318359375,0.724085569381714,1,&quot;b12+&quot;|1352.6168212890625,0.234000310301781,1,&quot;y11+&quot;|1362.8125,0.279476225376129,1,&quot;b13+&quot;|1476.8531494140625,0.269533842802048,1,&quot;b14+&quot;|1499.689453125,0.080423474311829,1,&quot;y12+&quot;|1591.881591796875,0.727882027626038,1,&quot;b15+&quot;|1596.741455078125,0.219704270362854,1,&quot;y13+&quot;|1688.953905173854082,0.01809080503881,1,&quot;b16+&quot;|1711.765380859375,0.032515596598387,1,&quot;y14+&quot;|1825.8343505859375,0.032113555818796,1,&quot;y15+&quot;"/>
+			<PeptideHit score="47.256181302684936" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="[" aa_after="E" start="0" end="27" protein_refs="PH_1" >
+				<UserParam type="string" name="fragment_annotation" value="147.112884521484375,0.073362722992897,1,&quot;y1+&quot;|185.128372192382812,0.304318636655807,1,&quot;b2+&quot;|294.18121337890625,0.199159145355225,1,&quot;y2+&quot;|298.212554931640625,0.030436070635915,1,&quot;b3+&quot;|426.25994873046875,0.053214963525534,2,&quot;b8++&quot;|604.2803955078125,0.367977857589722,1,&quot;y4+&quot;|638.34381103515625,0.023529993370175,1,&quot;b6+&quot;|675.31707763671875,0.364999026060104,1,&quot;y5+&quot;|681.91497802734375,0.018387651070952,2,&quot;b13++&quot;|746.35400390625,0.278303116559982,1,&quot;y6+&quot;|752.44500732421875,0.043161459267139,1,&quot;b7+&quot;|851.50775146484375,0.140275537967682,1,&quot;b8+&quot;|909.41217041015625,0.246380671858788,1,&quot;y7+&quot;|980.553148337916468,0.612667679786682,1,&quot;b9+&quot;|1079.6219482421875,1.0,1,&quot;b10+&quot;|1138.490478515625,0.284363687038422,1,&quot;y9+&quot;|1178.689378806666582,0.277622222900391,1,&quot;b11+&quot;|1221.7279052734375,0.205706641077995,2,&quot;b22++&quot;|1239.53515625,0.73640251159668,1,&quot;y10+&quot;|1249.726318359375,0.724085569381714,1,&quot;b12+&quot;|1352.6168212890625,0.234000310301781,1,&quot;y11+&quot;|1362.8125,0.279476225376129,1,&quot;b13+&quot;|1476.8531494140625,0.269533842802048,1,&quot;b14+&quot;|1499.689453125,0.080423474311829,1,&quot;y12+&quot;|1591.881591796875,0.727882027626038,1,&quot;b15+&quot;|1596.741455078125,0.219704270362854,1,&quot;y13+&quot;|1688.953905173854082,0.01809080503881,1,&quot;b16+&quot;|1711.765380859375,0.032515596598387,1,&quot;y14+&quot;|1825.8343505859375,0.032113555818796,1,&quot;y15+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.086640460710327"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="0.532776127422444"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.46428570151329"/>
@@ -61,9 +66,14 @@
 				<UserParam type="int" name="num_matched_peaks" value="26"/>
 				<UserParam type="int" name="matched_prefix_ions" value="13"/>
 				<UserParam type="int" name="matched_suffix_ions" value="13"/>
-				<UserParam type="float" name="delta_score" value="47.256179809570313"/>
+				<UserParam type="float" name="delta_score" value="47.256179809570312"/>
+				<UserParam type="float" name="delta_score_worst" value="0.0"/>
+				<UserParam type="float" name="hyperscore_zscore" value="0.0"/>
+				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="7.878095272928476"/>
+				<UserParam type="float" name="matched_ion_current_fraction" value="0.382467675228915"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="11"/>
+				<UserParam type="float" name="complementary_ions_fraction" value="0.185185185185185"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -71,8 +81,8 @@
 			<UserParam type="int" name="scan_index" value="1"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="775.38720703125" RT="4923.77734375" spectrum_reference="spectrum=2" >
-			<PeptideHit score="42.152939453592801" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" aa_before="[" aa_after="A" start="0" end="22" protein_refs="PH_2" >
-				<UserParam type="string" name="fragment_annotation" value="175.118865966796875,0.150531977415085,1,&quot;y1+&quot;|254.148391723632813,0.206978902220726,1,&quot;b2+&quot;|322.18890380859375,0.049145385622978,1,&quot;y2+&quot;|379.209442138671875,0.17941327393055,1,&quot;y3+&quot;|382.223785400390625,0.022014291957021,1,&quot;b4+&quot;|435.20831298828125,0.068259246647358,2,&quot;b9++&quot;|450.24664306640625,0.259074866771698,1,&quot;y4+&quot;|463.720184326171875,0.089691311120987,2,&quot;b10++&quot;|497.24560546875,0.120945297181606,1,&quot;b5+&quot;|537.2552490234375,0.10333526879549,2,&quot;b11++&quot;|565.7642822265625,0.180150553584099,2,&quot;b12++&quot;|578.30462646484375,0.339738875627518,1,&quot;y5+&quot;|594.27630615234375,0.12102073431015,2,&quot;b13++&quot;|649.341552734375,0.642973005771637,1,&quot;y6+&quot;|650.82373046875,0.047898273915052,2,&quot;b14++&quot;|699.30572509765625,0.504444420337677,1,&quot;b7+&quot;|762.42547607421875,0.540082812309265,1,&quot;y7+&quot;|812.39007568359375,0.212916702032089,1,&quot;b8+&quot;|813.406494140625,0.049756519496441,2,&quot;y16++&quot;|869.41009521484375,0.156664118170738,1,&quot;b9+&quot;|877.45343017578125,0.795250296592712,1,&quot;y8+&quot;|926.434326171875,0.743671417236328,1,&quot;b10+&quot;|1007.50408935546875,0.035724259912968,2,&quot;y20++&quot;|1024.5223388671875,1.0,1,&quot;y9+&quot;|1073.5008544921875,0.200163260102272,1,&quot;b11+&quot;|1130.526123046875,0.135533377528191,1,&quot;b12+&quot;|1137.608154296875,0.113550938665867,1,&quot;y10+&quot;|1187.544189453125,0.804915189743042,1,&quot;b13+&quot;|1194.62841796875,0.170546039938927,1,&quot;y11+&quot;|1251.6474609375,0.285297006368637,1,&quot;y12+&quot;|1300.6290283203125,0.159593641757965,1,&quot;b14+&quot;|1562.7510986328125,0.039694063365459,1,&quot;b16+&quot;"/>
+			<PeptideHit score="42.152939453592808" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" aa_before="[" aa_after="A" start="0" end="22" protein_refs="PH_2" >
+				<UserParam type="string" name="fragment_annotation" value="175.118865966796875,0.150531977415085,1,&quot;y1+&quot;|254.148391723632812,0.206978902220726,1,&quot;b2+&quot;|322.18890380859375,0.049145385622978,1,&quot;y2+&quot;|379.209442138671875,0.17941327393055,1,&quot;y3+&quot;|382.223785400390625,0.022014291957021,1,&quot;b4+&quot;|435.20831298828125,0.068259246647358,2,&quot;b9++&quot;|450.24664306640625,0.259074866771698,1,&quot;y4+&quot;|463.720184326171875,0.089691311120987,2,&quot;b10++&quot;|497.24560546875,0.120945297181606,1,&quot;b5+&quot;|537.2552490234375,0.10333526879549,2,&quot;b11++&quot;|565.7642822265625,0.180150553584099,2,&quot;b12++&quot;|578.30462646484375,0.339738875627518,1,&quot;y5+&quot;|594.27630615234375,0.12102073431015,2,&quot;b13++&quot;|649.341552734375,0.642973005771637,1,&quot;y6+&quot;|650.82373046875,0.047898273915052,2,&quot;b14++&quot;|699.30572509765625,0.504444420337677,1,&quot;b7+&quot;|762.42547607421875,0.540082812309265,1,&quot;y7+&quot;|812.39007568359375,0.212916702032089,1,&quot;b8+&quot;|813.406494140625,0.049756519496441,2,&quot;y16++&quot;|869.41009521484375,0.156664118170738,1,&quot;b9+&quot;|877.45343017578125,0.795250296592712,1,&quot;y8+&quot;|926.434326171875,0.743671417236328,1,&quot;b10+&quot;|1007.50408935546875,0.035724259912968,2,&quot;y20++&quot;|1024.5223388671875,1.0,1,&quot;y9+&quot;|1073.5008544921875,0.200163260102272,1,&quot;b11+&quot;|1130.526123046875,0.135533377528191,1,&quot;b12+&quot;|1137.608154296875,0.113550938665867,1,&quot;y10+&quot;|1187.544189453125,0.804915189743042,1,&quot;b13+&quot;|1194.62841796875,0.170546039938927,1,&quot;y11+&quot;|1251.6474609375,0.285297006368637,1,&quot;y12+&quot;|1300.6290283203125,0.159593641757965,1,&quot;b14+&quot;|1562.7510986328125,0.039694063365459,1,&quot;b16+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.389253520212976"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="2.251259146760969"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.52173912525177"/>
@@ -81,8 +91,13 @@
 				<UserParam type="int" name="matched_prefix_ions" value="12"/>
 				<UserParam type="int" name="matched_suffix_ions" value="12"/>
 				<UserParam type="float" name="delta_score" value="42.152938842773438"/>
+				<UserParam type="float" name="delta_score_worst" value="0.0"/>
+				<UserParam type="float" name="hyperscore_zscore" value="0.0"/>
+				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="8.528975328430533"/>
+				<UserParam type="float" name="matched_ion_current_fraction" value="0.533896463252728"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
+				<UserParam type="float" name="complementary_ions_fraction" value="0.272727272727273"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>

--- a/src/tests/topp/ProSE_2_out.idXML
+++ b/src/tests/topp/ProSE_2_out.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="/home/user/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.1" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,ln_explained_intensity,ln_total_intensity,complementary_ions_fraction,delta_score_worst,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
+				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,complementary_ions_fraction,delta_score_worst,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
 				<UserParam type="string" name="open_search" value="false"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string" value="DECOY_"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string_position" value="prefix"/>
@@ -18,7 +18,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2026-08-26T20:13:57" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-08-26T20:55:26" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -48,10 +48,8 @@
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="1.781957282219082"/>
 				<UserParam type="float" name="matched_ion_current_fraction" value="0.308665716724222"/>
-				<UserParam type="float" name="ln_explained_intensity" value="1.023154738321924"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
 				<UserParam type="float" name="complementary_ions_fraction" value="0.230769230769231"/>
-				<UserParam type="float" name="ln_total_intensity" value="1.912958517752952"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -74,10 +72,8 @@
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="7.878095272928476"/>
 				<UserParam type="float" name="matched_ion_current_fraction" value="0.382467675228915"/>
-				<UserParam type="float" name="ln_explained_intensity" value="2.183587037704621"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="11"/>
 				<UserParam type="float" name="complementary_ions_fraction" value="0.185185185185185"/>
-				<UserParam type="float" name="ln_total_intensity" value="3.072603877232593"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -100,10 +96,8 @@
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="8.528975328430533"/>
 				<UserParam type="float" name="matched_ion_current_fraction" value="0.533896463252728"/>
-				<UserParam type="float" name="ln_explained_intensity" value="2.254337191258967"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="float" name="complementary_ions_fraction" value="0.272727272727273"/>
-				<UserParam type="float" name="ln_total_intensity" value="2.831739392489154"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>

--- a/src/tests/topp/ProSE_4_out.idXML
+++ b/src/tests/topp/ProSE_4_out.idXML
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="/home/sachsenb/dev/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="15" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.0177775416523218" peak_mass_tolerance_ppm="false" >
+	<SearchParameters id="SP_0" db="/home/user/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="9.25127490529077" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.0177775416523218" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,delta_score,isotope_error"/>
+				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,complementary_ions_fraction,delta_score_worst,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
 				<UserParam type="string" name="open_search" value="false"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string" value="DECOY_"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string_position" value="prefix"/>
@@ -18,7 +18,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2026-04-17T20:18:34" search_engine="ProSE" search_engine_version="3.6.0-pre-feat-prose-database-chunking-2026-04-17" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-08-26T18:25:11" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -34,7 +34,7 @@
 		</ProteinIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="520.266459222533967" RT="2655.095703125" spectrum_reference="spectrum=0" >
 			<PeptideHit score="12.094764845630944" sequence="DFASSGGYVLHLHR" charge="3" aa_before="[" aa_after="E" start="0" end="13" protein_refs="PH_0" >
-				<UserParam type="string" name="fragment_annotation" value="175.119094848632813,0.145235076546669,1,&quot;y1+&quot;|263.10302734375,0.269983410835266,1,&quot;b2+&quot;|281.664825439453125,0.045622423291206,2,&quot;y4++&quot;|334.140472412109375,0.038884554058313,1,&quot;b3+&quot;|338.206695556640625,0.036569740623236,2,&quot;y5++&quot;|387.74066162109375,0.041254211217165,2,&quot;y6++&quot;|425.263031005859375,0.154225364327431,1,&quot;y3+&quot;|469.2728271484375,0.031441166996956,2,&quot;y7++&quot;|497.783782958984375,0.041119836270809,2,&quot;y8++&quot;|526.29443359375,0.094272904098034,2,&quot;y9++&quot;|569.81048583984375,0.115230679512024,2,&quot;y10++&quot;|613.32598876953125,0.102093867957592,2,&quot;y11++&quot;|648.84503173828125,0.051233120262623,2,&quot;y12++&quot;|675.40625,0.336008250713348,1,&quot;y5+&quot;|937.53729248046875,0.061362523585558,1,&quot;y7+&quot;|994.55938720703125,0.057263620197773,1,&quot;y8+&quot;|1051.580810546875,0.09991666674614,1,&quot;y9+&quot;|1138.6112060546875,0.048153448849916,1,&quot;y10+&quot;|1225.658935546875,7.874150760471821e-03,1,&quot;y11+&quot;"/>
+				<UserParam type="string" name="fragment_annotation" value="175.119094848632812,0.145235076546669,1,&quot;y1+&quot;|263.10302734375,0.269983410835266,1,&quot;b2+&quot;|281.664825439453125,0.045622423291206,2,&quot;y4++&quot;|334.140472412109375,0.038884554058313,1,&quot;b3+&quot;|338.206695556640625,0.036569740623236,2,&quot;y5++&quot;|387.74066162109375,0.041254211217165,2,&quot;y6++&quot;|425.263031005859375,0.154225364327431,1,&quot;y3+&quot;|469.2728271484375,0.031441166996956,2,&quot;y7++&quot;|497.783782958984375,0.041119836270809,2,&quot;y8++&quot;|526.29443359375,0.094272904098034,2,&quot;y9++&quot;|569.81048583984375,0.115230679512024,2,&quot;y10++&quot;|613.32598876953125,0.102093867957592,2,&quot;y11++&quot;|648.84503173828125,0.051233120262623,2,&quot;y12++&quot;|675.40625,0.336008250713348,1,&quot;y5+&quot;|937.53729248046875,0.061362523585558,1,&quot;y7+&quot;|994.55938720703125,0.057263620197773,1,&quot;y8+&quot;|1051.580810546875,0.09991666674614,1,&quot;y9+&quot;|1138.6112060546875,0.048153448849916,1,&quot;y10+&quot;|1225.658935546875,7.87415076047182e-03,1,&quot;y11+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.786757794293868"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="5.584337350929088"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.142857149243355"/>
@@ -43,17 +43,22 @@
 				<UserParam type="int" name="matched_prefix_ions" value="2"/>
 				<UserParam type="int" name="matched_suffix_ions" value="8"/>
 				<UserParam type="float" name="delta_score" value="12.094764709472656"/>
+				<UserParam type="float" name="delta_score_worst" value="0.0"/>
+				<UserParam type="float" name="hyperscore_zscore" value="0.0"/>
+				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="1.777745016850531"/>
+				<UserParam type="float" name="matched_ion_current_fraction" value="0.307936079755935"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
+				<UserParam type="float" name="complementary_ions_fraction" value="0.153846153846154"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
 			<UserParam type="int" name="scan_index" value="0"/>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="1063.217281336060069" RT="4587.6689453125" spectrum_reference="spectrum=1" >
+		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="1063.217281336060068" RT="4587.6689453125" spectrum_reference="spectrum=1" >
 			<PeptideHit score="39.632766000034948" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="[" aa_after="E" start="0" end="27" protein_refs="PH_1" >
-				<UserParam type="string" name="fragment_annotation" value="147.112884521484375,0.073362722992897,1,&quot;y1+&quot;|185.128372192382813,0.304318636655808,1,&quot;b2+&quot;|294.18121337890625,0.199159145355225,1,&quot;y2+&quot;|298.212554931640625,0.030436070635915,1,&quot;b3+&quot;|426.25994873046875,0.053214963525534,2,&quot;b8++&quot;|604.2803955078125,0.367977857589722,1,&quot;y4+&quot;|675.31707763671875,0.364999026060104,1,&quot;y5+&quot;|681.91497802734375,0.018387651070952,2,&quot;b13++&quot;|746.35400390625,0.278303116559982,1,&quot;y6+&quot;|752.44500732421875,0.043161459267139,1,&quot;b7+&quot;|851.50775146484375,0.140275537967682,1,&quot;b8+&quot;|909.41217041015625,0.246380671858788,1,&quot;y7+&quot;|980.553148337916468,0.612667679786682,1,&quot;b9+&quot;|1079.6219482421875,1.0,1,&quot;b10+&quot;|1138.490478515625,0.284363687038422,1,&quot;y9+&quot;|1178.689378806666582,0.277622222900391,1,&quot;b11+&quot;|1239.53515625,0.73640251159668,1,&quot;y10+&quot;|1249.726318359375,0.724085569381714,1,&quot;b12+&quot;|1352.6168212890625,0.234000310301781,1,&quot;y11+&quot;|1362.8125,0.279476225376129,1,&quot;b13+&quot;|1476.8531494140625,0.269533842802048,1,&quot;b14+&quot;|1499.689453125,0.080423474311829,1,&quot;y12+&quot;|1591.881591796875,0.727882027626038,1,&quot;b15+&quot;|1596.741455078125,0.219704270362854,1,&quot;y13+&quot;|1711.765380859375,0.032515596598387,1,&quot;y14+&quot;"/>
+				<UserParam type="string" name="fragment_annotation" value="147.112884521484375,0.073362722992897,1,&quot;y1+&quot;|185.128372192382812,0.304318636655807,1,&quot;b2+&quot;|294.18121337890625,0.199159145355225,1,&quot;y2+&quot;|298.212554931640625,0.030436070635915,1,&quot;b3+&quot;|426.25994873046875,0.053214963525534,2,&quot;b8++&quot;|604.2803955078125,0.367977857589722,1,&quot;y4+&quot;|675.31707763671875,0.364999026060104,1,&quot;y5+&quot;|681.91497802734375,0.018387651070952,2,&quot;b13++&quot;|746.35400390625,0.278303116559982,1,&quot;y6+&quot;|752.44500732421875,0.043161459267139,1,&quot;b7+&quot;|851.50775146484375,0.140275537967682,1,&quot;b8+&quot;|909.41217041015625,0.246380671858788,1,&quot;y7+&quot;|980.553148337916468,0.612667679786682,1,&quot;b9+&quot;|1079.6219482421875,1.0,1,&quot;b10+&quot;|1138.490478515625,0.284363687038422,1,&quot;y9+&quot;|1178.689378806666582,0.277622222900391,1,&quot;b11+&quot;|1239.53515625,0.73640251159668,1,&quot;y10+&quot;|1249.726318359375,0.724085569381714,1,&quot;b12+&quot;|1352.6168212890625,0.234000310301781,1,&quot;y11+&quot;|1362.8125,0.279476225376129,1,&quot;b13+&quot;|1476.8531494140625,0.269533842802048,1,&quot;b14+&quot;|1499.689453125,0.080423474311829,1,&quot;y12+&quot;|1591.881591796875,0.727882027626038,1,&quot;b15+&quot;|1596.741455078125,0.219704270362854,1,&quot;y13+&quot;|1711.765380859375,0.032515596598387,1,&quot;y14+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="0.803162051232014"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="7.532779854971471"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.392857134342194"/>
@@ -61,9 +66,14 @@
 				<UserParam type="int" name="num_matched_peaks" value="23"/>
 				<UserParam type="int" name="matched_prefix_ions" value="11"/>
 				<UserParam type="int" name="matched_suffix_ions" value="12"/>
-				<UserParam type="float" name="delta_score" value="39.632766723632813"/>
+				<UserParam type="float" name="delta_score" value="39.632766723632812"/>
+				<UserParam type="float" name="delta_score_worst" value="0.0"/>
+				<UserParam type="float" name="hyperscore_zscore" value="0.0"/>
+				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="7.5986542776227"/>
+				<UserParam type="float" name="matched_ion_current_fraction" value="0.368901306184672"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="9"/>
+				<UserParam type="float" name="complementary_ions_fraction" value="0.074074074074074"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -71,8 +81,8 @@
 			<UserParam type="int" name="scan_index" value="1"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="775.392634741698998" RT="4923.77734375" spectrum_reference="spectrum=2" >
-			<PeptideHit score="39.663528910153673" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" aa_before="[" aa_after="A" start="0" end="22" protein_refs="PH_2" >
-				<UserParam type="string" name="fragment_annotation" value="175.118865966796875,0.150531977415085,1,&quot;y1+&quot;|254.148391723632813,0.206978902220726,1,&quot;b2+&quot;|322.18890380859375,0.049145385622978,1,&quot;y2+&quot;|379.209442138671875,0.17941327393055,1,&quot;y3+&quot;|382.223785400390625,0.022014291957021,1,&quot;b4+&quot;|435.20831298828125,0.068259246647358,2,&quot;b9++&quot;|450.24664306640625,0.259074866771698,1,&quot;y4+&quot;|463.720184326171875,0.089691311120987,2,&quot;b10++&quot;|497.24560546875,0.120945297181606,1,&quot;b5+&quot;|537.2552490234375,0.10333526879549,2,&quot;b11++&quot;|565.7642822265625,0.180150553584099,2,&quot;b12++&quot;|578.30462646484375,0.339738875627518,1,&quot;y5+&quot;|594.27630615234375,0.12102073431015,2,&quot;b13++&quot;|649.341552734375,0.642973005771637,1,&quot;y6+&quot;|650.82373046875,0.047898273915052,2,&quot;b14++&quot;|699.30572509765625,0.504444420337677,1,&quot;b7+&quot;|762.42547607421875,0.540082812309265,1,&quot;y7+&quot;|812.39007568359375,0.212916702032089,1,&quot;b8+&quot;|869.41009521484375,0.156664118170738,1,&quot;b9+&quot;|877.45343017578125,0.795250296592712,1,&quot;y8+&quot;|926.434326171875,0.743671417236328,1,&quot;b10+&quot;|1007.50408935546875,0.035724259912968,2,&quot;y20++&quot;|1024.5223388671875,1.0,1,&quot;y9+&quot;|1073.5008544921875,0.200163260102272,1,&quot;b11+&quot;|1130.526123046875,0.135533377528191,1,&quot;b12+&quot;|1137.608154296875,0.113550938665867,1,&quot;y10+&quot;|1187.544189453125,0.804915189743042,1,&quot;b13+&quot;|1194.62841796875,0.170546039938927,1,&quot;y11+&quot;|1251.6474609375,0.285297006368637,1,&quot;y12+&quot;|1300.6290283203125,0.159593641757965,1,&quot;b14+&quot;"/>
+			<PeptideHit score="39.66352891015368" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" aa_before="[" aa_after="A" start="0" end="22" protein_refs="PH_2" >
+				<UserParam type="string" name="fragment_annotation" value="175.118865966796875,0.150531977415085,1,&quot;y1+&quot;|254.148391723632812,0.206978902220726,1,&quot;b2+&quot;|322.18890380859375,0.049145385622978,1,&quot;y2+&quot;|379.209442138671875,0.17941327393055,1,&quot;y3+&quot;|382.223785400390625,0.022014291957021,1,&quot;b4+&quot;|435.20831298828125,0.068259246647358,2,&quot;b9++&quot;|450.24664306640625,0.259074866771698,1,&quot;y4+&quot;|463.720184326171875,0.089691311120987,2,&quot;b10++&quot;|497.24560546875,0.120945297181606,1,&quot;b5+&quot;|537.2552490234375,0.10333526879549,2,&quot;b11++&quot;|565.7642822265625,0.180150553584099,2,&quot;b12++&quot;|578.30462646484375,0.339738875627518,1,&quot;y5+&quot;|594.27630615234375,0.12102073431015,2,&quot;b13++&quot;|649.341552734375,0.642973005771637,1,&quot;y6+&quot;|650.82373046875,0.047898273915052,2,&quot;b14++&quot;|699.30572509765625,0.504444420337677,1,&quot;b7+&quot;|762.42547607421875,0.540082812309265,1,&quot;y7+&quot;|812.39007568359375,0.212916702032089,1,&quot;b8+&quot;|869.41009521484375,0.156664118170738,1,&quot;b9+&quot;|877.45343017578125,0.795250296592712,1,&quot;y8+&quot;|926.434326171875,0.743671417236328,1,&quot;b10+&quot;|1007.50408935546875,0.035724259912968,2,&quot;y20++&quot;|1024.5223388671875,1.0,1,&quot;y9+&quot;|1073.5008544921875,0.200163260102272,1,&quot;b11+&quot;|1130.526123046875,0.135533377528191,1,&quot;b12+&quot;|1137.608154296875,0.113550938665867,1,&quot;y10+&quot;|1187.544189453125,0.804915189743042,1,&quot;b13+&quot;|1194.62841796875,0.170546039938927,1,&quot;y11+&quot;|1251.6474609375,0.285297006368637,1,&quot;y12+&quot;|1300.6290283203125,0.159593641757965,1,&quot;b14+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.245510510605525"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="9.251274905290774"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.47826087474823"/>
@@ -80,9 +90,14 @@
 				<UserParam type="int" name="num_matched_peaks" value="23"/>
 				<UserParam type="int" name="matched_prefix_ions" value="11"/>
 				<UserParam type="int" name="matched_suffix_ions" value="12"/>
-				<UserParam type="float" name="delta_score" value="39.663528442382813"/>
+				<UserParam type="float" name="delta_score" value="39.663528442382812"/>
+				<UserParam type="float" name="delta_score_worst" value="0.0"/>
+				<UserParam type="float" name="hyperscore_zscore" value="0.0"/>
+				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="8.439524745568633"/>
+				<UserParam type="float" name="matched_ion_current_fraction" value="0.528297039173417"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
+				<UserParam type="float" name="complementary_ions_fraction" value="0.181818181818182"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>

--- a/src/tests/topp/ProSE_4_out.idXML
+++ b/src/tests/topp/ProSE_4_out.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="/home/user/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="9.25127490529077" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.0177775416523218" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,complementary_ions_fraction,delta_score_worst,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
+				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,ln_explained_intensity,ln_total_intensity,complementary_ions_fraction,delta_score_worst,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
 				<UserParam type="string" name="open_search" value="false"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string" value="DECOY_"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string_position" value="prefix"/>
@@ -18,7 +18,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2026-08-26T18:25:11" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-08-26T20:13:57" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -48,8 +48,10 @@
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="1.777745016850531"/>
 				<UserParam type="float" name="matched_ion_current_fraction" value="0.307936079755935"/>
+				<UserParam type="float" name="ln_explained_intensity" value="1.021639453528624"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
 				<UserParam type="float" name="complementary_ions_fraction" value="0.153846153846154"/>
+				<UserParam type="float" name="ln_total_intensity" value="1.912958517752952"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -72,8 +74,10 @@
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="7.5986542776227"/>
 				<UserParam type="float" name="matched_ion_current_fraction" value="0.368901306184672"/>
+				<UserParam type="float" name="ln_explained_intensity" value="2.151605711669094"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="9"/>
 				<UserParam type="float" name="complementary_ions_fraction" value="0.074074074074074"/>
+				<UserParam type="float" name="ln_total_intensity" value="3.072603877232593"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -96,8 +100,10 @@
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="8.439524745568633"/>
 				<UserParam type="float" name="matched_ion_current_fraction" value="0.528297039173417"/>
+				<UserParam type="float" name="ln_explained_intensity" value="2.244905634140984"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="float" name="complementary_ions_fraction" value="0.181818181818182"/>
+				<UserParam type="float" name="ln_total_intensity" value="2.831739392489154"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>

--- a/src/tests/topp/ProSE_4_out.idXML
+++ b/src/tests/topp/ProSE_4_out.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="/home/user/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="9.25127490529077" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.0177775416523218" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,complementary_ions_fraction,delta_score_worst,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
+				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,complementary_ions_fraction,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
 				<UserParam type="string" name="open_search" value="false"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string" value="DECOY_"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string_position" value="prefix"/>
@@ -18,7 +18,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2026-08-26T20:55:26" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-08-27T06:14:07" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -43,7 +43,6 @@
 				<UserParam type="int" name="matched_prefix_ions" value="2"/>
 				<UserParam type="int" name="matched_suffix_ions" value="8"/>
 				<UserParam type="float" name="delta_score" value="12.094764709472656"/>
-				<UserParam type="float" name="delta_score_worst" value="0.0"/>
 				<UserParam type="float" name="hyperscore_zscore" value="0.0"/>
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="1.777745016850531"/>
@@ -67,7 +66,6 @@
 				<UserParam type="int" name="matched_prefix_ions" value="11"/>
 				<UserParam type="int" name="matched_suffix_ions" value="12"/>
 				<UserParam type="float" name="delta_score" value="39.632766723632812"/>
-				<UserParam type="float" name="delta_score_worst" value="0.0"/>
 				<UserParam type="float" name="hyperscore_zscore" value="0.0"/>
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="7.5986542776227"/>
@@ -91,7 +89,6 @@
 				<UserParam type="int" name="matched_prefix_ions" value="11"/>
 				<UserParam type="int" name="matched_suffix_ions" value="12"/>
 				<UserParam type="float" name="delta_score" value="39.663528442382812"/>
-				<UserParam type="float" name="delta_score_worst" value="0.0"/>
 				<UserParam type="float" name="hyperscore_zscore" value="0.0"/>
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="8.439524745568633"/>

--- a/src/tests/topp/ProSE_4_out.idXML
+++ b/src/tests/topp/ProSE_4_out.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="/home/user/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="9.25127490529077" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.0177775416523218" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,ln_explained_intensity,ln_total_intensity,complementary_ions_fraction,delta_score_worst,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
+				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,matched_ion_current_fraction,complementary_ions_fraction,delta_score_worst,hyperscore_zscore,ln_num_candidates,delta_score,isotope_error"/>
 				<UserParam type="string" name="open_search" value="false"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string" value="DECOY_"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string_position" value="prefix"/>
@@ -18,7 +18,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2026-08-26T20:13:57" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-08-26T20:55:26" search_engine="ProSE" search_engine_version="3.6.0-pre-claude-prose-percolator-rescoring-features-txnsxy-2026-08-26" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -48,10 +48,8 @@
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="1.777745016850531"/>
 				<UserParam type="float" name="matched_ion_current_fraction" value="0.307936079755935"/>
-				<UserParam type="float" name="ln_explained_intensity" value="1.021639453528624"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
 				<UserParam type="float" name="complementary_ions_fraction" value="0.153846153846154"/>
-				<UserParam type="float" name="ln_total_intensity" value="1.912958517752952"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -74,10 +72,8 @@
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="7.5986542776227"/>
 				<UserParam type="float" name="matched_ion_current_fraction" value="0.368901306184672"/>
-				<UserParam type="float" name="ln_explained_intensity" value="2.151605711669094"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="9"/>
 				<UserParam type="float" name="complementary_ions_fraction" value="0.074074074074074"/>
-				<UserParam type="float" name="ln_total_intensity" value="3.072603877232593"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -100,10 +96,8 @@
 				<UserParam type="float" name="ln_num_candidates" value="0.6931471824646"/>
 				<UserParam type="float" name="matched_ion_current" value="8.439524745568633"/>
 				<UserParam type="float" name="matched_ion_current_fraction" value="0.528297039173417"/>
-				<UserParam type="float" name="ln_explained_intensity" value="2.244905634140984"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="float" name="complementary_ions_fraction" value="0.181818181818182"/>
-				<UserParam type="float" name="ln_total_intensity" value="2.831739392489154"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>


### PR DESCRIPTION
## Description

Adds four per-PSM features to `ProSEAlgorithm::postProcessHits_` and registers them in ProSE's `extra_features` list, so `PercolatorAdapter` picks them up automatically. All four are computed from data already gathered during scoring/alignment (the per-spectrum candidate pool and the existing ion-matching loop), so no extra pass over the spectra is introduced.

| feature | what it adds |
|---|---|
| `hyperscore_zscore` | standard score of the best candidate against the mean/SD of its own candidate pool. ProSE's HyperScore has no closed-form e-value (unlike MS-GF+'s SpecEValue or Comet's lnExpect); this is a lightweight significance proxy from the pool that scoring already builds. Bounded by `sqrt(n-1)` via Samuelson's inequality, so it needs no epsilon or clamp. |
| `ln_num_candidates` | `ln(1 + number of candidates scored)` — search-space/ambiguity proxy (Comet's `lnNumSP` analogue). Saturates at `scoring:max_candidates_per_spectrum`. |
| `matched_ion_current_fraction` | matched ion current normalised by the spectrum's TIC, removing the scale confound in the existing absolute `matched_ion_current`. |
| `complementary_ions_fraction` | fraction of cleavage sites where both the prefix ion and its complementary suffix ion matched (Andromeda-style structural signal, distinct from the independent prefix/suffix fractions). |

The default set therefore grows from 10 to 14 entries.

Two bugs are fixed along the way:

- **Pre-existing:** `FragmentIndex`'s `annotate:PSM` valid-strings list was out of sync with `ProSEAlgorithm`'s and was already missing six of the original annotation names, so selecting e.g. `longest_peptide_ion_sequence` explicitly failed validation before this PR.
- **Introduced earlier in this PR, caught in review:** the two candidate-pool features were computed in `postProcessHits_` from `annotated_hits`, which is not the candidate pool. `scoreSpectraAgainstIndex_` prunes each spectrum to `max(report_top_hits_, 2)` in *every* search path (not only the chunked one) and drops candidates scoring 0, so with the default `report:top_hits=1` the statistics saw at most two candidates. `ln_num_candidates` took exactly two distinct values across a 70k-PSM run, and the leave-one-out z-score diverged — with two candidates the SD of the single remaining score is 0 by construction, giving values up to 6.5e+07, enough to dominate Percolator's feature standardisation. Fixed by accumulating count/sum/sum-of-squares/best/second-best inside the scoring loop before the prune (merging across chunks), and by standardising the z-score against the whole pool rather than leave-one-out. `delta_score` is unaffected — the top two candidates always survive the prune.

### Evaluation

Benchmarked on three DDA runs from archive.openms.de, using ProSE's built-in in-process Percolator: a Bruker timsTOF HeLa QC run (human SwissProt), a Q Exactive HF ProteoBench run, and an Orbitrap Astral ProteoBench run (the latter two against the matched HYE FASTA). Target PSMs at 1% FDR, five Percolator seeds per configuration, Welch *t*:

| | timsTOF HeLa | Q Exactive HF | Orbitrap Astral |
|---|---|---|---|
| no rescoring | 4538 | 51314 | 23309 |
| Percolator, original 10 features | 4835.6 ± 9.9 (**+6.6%**) | 56407.6 ± 57.4 (**+9.9%**) | 30490.6 ± 127.1 (**+30.8%**) |
| Percolator, all 14 features | 4871.6 ± 40.2 | 56655.0 ± 19.9 | 30841.4 ± 103.7 |
| effect of the four added features | +36.0 (+0.74%), t = 1.94 | **+247.4 (+0.44%), t = 9.11** | **+350.8 (+1.15%), t = 4.78** |

Rescoring itself is by far the larger effect. The added features are a significant gain on top on both Orbitrap runs, and a positive but not significant one (t = 1.94 on five seeds) on the timsTOF run, which yields 4.9k PSMs against 23k–56k and so has a proportionally much larger noise floor.

Multi-seed testing was necessary rather than incidental: seed-to-seed SD is ~0.6% on the timsTOF run, i.e. the same order as the effects measured, so single-seed comparisons here are not reliable.

**Leave-one-out from the 14-feature set** (Δ PSMs when the feature is removed):

| feature dropped | timsTOF HeLa | Q Exactive HF | Orbitrap Astral |
|---|---|---|---|
| `hyperscore_zscore` | −10.4 (t = −0.54) | **−93.0 (t = −7.12)** | −6.2 (t = −0.11) |
| `ln_num_candidates` | +4.4 (t = +0.21) | +6.6 (t = +0.53) | −12.0 (t = −0.22) |
| `matched_ion_current_fraction` | +1.6 (t = +0.08) | −3.6 (t = −0.33) | −24.2 (t = −0.48) |
| `complementary_ions_fraction` | −3.0 (t = −0.13) | +0.4 (t = +0.03) | +76.0 (t = +1.47) |

**Individual addition** of each candidate-pool feature to the other twelve, which is what the leave-one-out above cannot show:

| | timsTOF HeLa | Q Exactive HF | Orbitrap Astral |
|---|---|---|---|
| `+ ln_num_candidates` | −6.8 (t = −0.32) | +144.4 (t = +8.65) | **+348.2 (t = +7.16)** |
| `+ hyperscore_zscore` | +15.6 (t = +0.94) | **+244.2 (t = +14.99)** | **+342.4 (t = +7.39)** |
| `+ both` | +6.2 (t = +0.29) | +237.2 (t = +14.47) | +354.4 (t = +6.11) |

The two candidate-pool features are largely interchangeable: each is individually worth several hundred PSMs on Astral, yet dropping either one from the full set costs nothing there, because the other covers it. Which of the two carries the gain is instrument-dependent — on Q Exactive HF the z-score is essential (−93 without it) and `ln_num_candidates` adds nothing on top, while on Astral either alone reproduces almost the whole effect. Both are kept: they come from the same accumulator, so the second is free to compute, and neither is significantly harmful on any of the three runs.

For reference, the pool fix alone moves the shipped 14-feature set on identical spectra: 56524.4 → 56655.0 on Q Exactive HF (+0.23%, t = 5.17) and 4867.0 → 4868.8 on timsTOF (t = 0.08).

<sub>A SCIEX TripleTOF 6600 run (PXD060911) was also attempted as a vendor-independent fourth dataset and discarded without being scored: its converted mzML carries no precursor charge-state annotation at all, so ProSE must guess charges and the search collapses (1210 PSMs from 66709 spectra, target:decoy 1.17). Widening precursor and fragment tolerances made it worse, consistent with the charge defect rather than a tolerance mismatch.</sub>

### Also evaluated and deliberately not included

Six further features were implemented, benchmarked under the same protocol, and then removed — they are recorded in the branch history rather than left as dead opt-in code:

- **MS²Rescore-derived** `ln_explained_intensity`, `ln_total_intensity` — no significant effect anywhere (|t| ≤ 1.99).
- **Alternative scoring functions** `binomial_match_score` (Andromeda/MS Amanda binomial model), `tailor_score` ([Tailor](https://doi.org/10.1101/831776) per-spectrum calibration), `top_peaks_explained_fraction` (intensity-rank based). Each *significantly beats the original feature set* (t up to 4.82), but none improves on the default above (best |t| = 1.76; all three together t = −1.08 / +0.53). They restate separation the default already captures — Tailor and `hyperscore_zscore` are both per-spectrum calibrations of the candidate distribution, and the binomial score and HyperScore both turn matched-ion counts into a significance-like quantity.
- `delta_score_worst` (Comet `deltaLCn` analogue) — weakest of the candidate-pool features and largely a restatement of `delta_score`; removing it cost 15.6 PSMs (t = −0.69) and 4.0 (t = −0.12).

A survey of MS²Rescore's generators found its model-free `MS2FeatureGenerator` is largely already covered by ProSE, and its `BasicFeatureGenerator` is fully covered by Percolator's standard `.pin` columns. The remaining headroom appears to need fragment-intensity or RT prediction (MS²PIP / DeepLC / IM2Deep), not further hand-crafted scores.

<sub>Note on scope: per-ion-series features (b vs y separately) were skipped deliberately — with ProSE's default b/y configuration they are redundant with the existing prefix/suffix aggregation, and none of the benchmark datasets exercises ETD/EThcD where they would pay off.</sub>

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

`ctest -R 'ProSE|PercolatorFeatureSetHelper_test'`: 36/36 pass; `ctest -R 'ProSE|FragmentIndex|PercolatorAdapter'`: 41/41 pass. The three `ProSE_*_out.idXML` fixtures were regenerated when the four features were first added, each regeneration preceded by a filtered diff confirming nothing else changed; the pool fix needed no further regeneration, because every spectrum in the TOPP test data yields exactly one candidate and so emits `log1p(1)` and `z = 0` both before and after. No public API changed, so no pyOpenMS update was needed.

CHANGELOG is left unticked — happy to add an entry if you'd like one for this.