### PR TITLE
Add PeptDeep prediction-based rescoring features to ProSE (+3.7% / +15.0% PSMs at 1% FDR)

### DIFF
--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -405,5 +405,9 @@ if(WITH_ONNX)
     source/ML/PEPTDEEP/PeptDeepInput.cpp
     source/ML/PEPTDEEP/PeptDeepRTInference.cpp
     source/ML/PEPTDEEP/PeptDeepMS2Inference.cpp
+    source/ANALYSIS/ID/PeptDeepRescoring.cpp
   )
+  # Lets dependent code (e.g. ProSEAlgorithm) compile out the PeptDeep calls when the
+  # runtime is absent, the same way WITH_OPENTIMS / WITH_THERMO_RAW are handled.
+  target_compile_definitions(OpenMS PUBLIC WITH_ONNX=1)
 endif()

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptDeepRescoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptDeepRescoring.h
@@ -14,6 +14,7 @@
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -118,7 +119,7 @@ namespace OpenMS
     /// Annotates the PSMs of a single identification run. Each run gets its own
     /// collision energy and its own retention-time calibration, since neither
     /// transfers across runs with different gradients or acquisition settings.
-    void annotateRun_(const PeakMap& spectra,
+    void annotateRun_(const std::map<std::string, double>& collision_energies,
                       PeptideIdentificationList& peptide_ids,
                       const std::vector<Row>& rows,
                       const std::vector<Size>& run_rows,

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptDeepRescoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptDeepRescoring.h
@@ -1,0 +1,121 @@
+// Copyright (c) 2002-present, OpenMS Team -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/config.h>
+#include <OpenMS/CONCEPT/ProgressLogger.h>
+#include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/KERNEL/StandardTypes.h>
+
+#include <string>
+#include <vector>
+
+namespace OpenMS
+{
+  class PeptideIdentificationList;
+  class ProteinIdentification;
+
+  /**
+    @brief Annotates PSMs with rescoring features derived from PeptDeep predictions.
+
+    Compares every PSM against an AlphaPeptDeep prediction of the same peptide and
+    stores the agreement as per-hit features, which are then registered in the search
+    parameters' @p extra_features list so that PercolatorAdapter picks them up:
+
+    - @p ms2_cosine, @p ms2_spectral_angle, @p ms2_pearson, @p ms2_frac_pred_found --
+      predicted versus observed fragment intensities
+    - @p rt_abs_error -- observed retention time versus a per-run calibration of the
+      predicted retention time
+
+    Observed intensities are taken from the PSM's own peak annotations, so no second
+    pass over the spectra is needed; the search engine must have been run with
+    fragment annotation enabled (ProSE's @p annotate:PSM default of @p ALL does this).
+    Predicted ions that were not matched contribute zero on the observed side, which is
+    what makes a wrong peptide score badly rather than simply score on fewer ions.
+
+    Two per-run quantities are calibrated from the data rather than being asked of the
+    user, because both are properties of the run and neither has a safe global default:
+
+    - <b>Normalised collision energy.</b> The model's NCE scale does not coincide with
+      the number the instrument reports, so the mzML value is used only as the centre of
+      a small search grid. Each candidate is scored on a sample of confident PSMs and the
+      one with the highest median cosine wins. With @p nce set to a positive value the
+      scan is skipped and that value is used directly.
+    - <b>Retention time.</b> Predicted RT is in the model's own iRT-like units, so it is
+      mapped onto the run's observed gradient by fitting a TransformationModel on
+      confident PSMs before the residual is taken.
+
+    Confident PSMs are selected by search score rather than by spectral similarity: using
+    similarity here would tie the RT feature to the MS2 features and let one feature's
+    errors propagate into the other.
+
+    @htmlinclude OpenMS_PeptDeepRescoring.parameters
+
+    @ingroup Analysis_ID
+  */
+  class OPENMS_DLLAPI PeptDeepRescoring :
+    public DefaultParamHandler,
+    public ProgressLogger
+  {
+  public:
+    PeptDeepRescoring();
+    ~PeptDeepRescoring() override;
+
+    /// Names of the features this class adds to each PSM, in a stable order.
+    static StringList featureNames();
+
+    /**
+      @brief Annotates @p peptide_ids in place and registers the features for rescoring.
+
+      @param[in] spectra Spectra the identifications were made on; supplies retention
+             time and, for the NCE scan, the instrument's reported collision energy.
+      @param[in,out] protein_ids Search metadata; the feature names are appended to the
+             first run's @p extra_features.
+      @param[in,out] peptide_ids PSMs to annotate. Every hit receives every feature, so
+             that no run ends up with a feature present on only some of its PSMs.
+
+      @throws Exception::FileNotFound if a configured model file does not exist.
+      @throws Exception::MissingInformation if no PSM carries peak annotations, since
+              every MS2 feature would otherwise be silently zero.
+    */
+    void annotate(const PeakMap& spectra,
+                  std::vector<ProteinIdentification>& protein_ids,
+                  PeptideIdentificationList& peptide_ids);
+
+    /// Normalised collision energy used for the last annotate() call (after any scan).
+    double getUsedNCE() const;
+
+    /// Median absolute RT residual over the calibration set of the last annotate() call.
+    double getRTCalibrationError() const;
+
+  protected:
+    void updateMembers_() override;
+
+    std::string ms2_model_;
+    std::string rt_model_;
+    double nce_{-1.0};
+    double nce_grid_halfwidth_{6.0};
+    double nce_grid_step_{2.0};
+    double nce_fallback_{30.0};
+    Size nce_sample_size_{2000};
+    std::string instrument_;
+    double calibration_quantile_{0.5};
+    std::string rt_model_type_{"b_spline"};
+    Size rt_num_nodes_{5};
+    int ms2_min_ordinal_{1};
+    double ms2_strong_fraction_{0.05};
+    Size batch_size_{500};
+    Int threads_{4};
+
+    mutable double used_nce_{-1.0};
+    mutable double rt_calibration_error_{-1.0};
+  };
+
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptDeepRescoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptDeepRescoring.h
@@ -122,7 +122,8 @@ namespace OpenMS
     /// Annotates the PSMs of a single identification run. Each run gets its own
     /// collision energy and its own retention-time calibration, since neither
     /// transfers across runs with different gradients or acquisition settings.
-    void annotateRun_(const std::map<std::string, double>& collision_energies,
+    void annotateRun_(const std::string& run_id,
+                      const std::map<std::string, double>& collision_energies,
                       PeptideIdentificationList& peptide_ids,
                       const std::vector<Row>& rows,
                       const std::vector<Size>& run_rows,

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptDeepRescoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptDeepRescoring.h
@@ -90,6 +90,21 @@ namespace OpenMS
       @param[in,out] peptide_ids PSMs to annotate. Every hit receives every feature, so
              that no run ends up with a feature present on only some of its PSMs.
 
+      Multiple runs in one call are fine: PSMs are partitioned by
+      PeptideIdentification::getIdentifier() and each run gets its own NCE scan and its
+      own RT calibration.
+
+      @note That partition is only as good as the run identifiers, so call this
+            <em>before</em> any step that collapses several runs into one -- ProSE's
+            @p out_merged and IDMergerAlgorithm, which remap every identifier onto a
+            single merged run, or @ref TOPP_IDMerger with @p merge_proteins_add_PSMs
+            (its default appends runs and is therefore safe). Both calibrated quantities
+            genuinely differ between runs: six files of one HLA ligand atlas dataset
+            (PXD019643) calibrated to median RT residuals between 98 s and 625 s. On
+            already-collapsed input this silently fits one NCE and one RT curve across
+            all of them, and nothing here can detect it after the fact -- the merged
+            input is indistinguishable from a genuine single run.
+
       @throws Exception::FileNotFound if a configured model file does not exist.
       @throws Exception::MissingInformation if no PSM carries peak annotations, since
               every MS2 feature would otherwise be silently zero.

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptDeepRescoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptDeepRescoring.h
@@ -21,6 +21,8 @@ namespace OpenMS
 {
   class PeptideIdentificationList;
   class ProteinIdentification;
+  class PeptDeepMS2Inference;
+  class PeptDeepRTInference;
 
   /**
     @brief Annotates PSMs with rescoring features derived from PeptDeep predictions.
@@ -65,7 +67,10 @@ namespace OpenMS
     public ProgressLogger
   {
   public:
+    /// Constructor. Sets the default parameters; the model paths start empty and must be set.
     PeptDeepRescoring();
+
+    /// Destructor.
     ~PeptDeepRescoring() override;
 
     /// Names of the features this class adds to each PSM, in a stable order.
@@ -89,14 +94,39 @@ namespace OpenMS
                   std::vector<ProteinIdentification>& protein_ids,
                   PeptideIdentificationList& peptide_ids);
 
-    /// Normalised collision energy used for the last annotate() call (after any scan).
+    /// Normalised collision energy used for the run annotated last (after any scan).
+    /// -1 if annotate() has not run, or returned before selecting one.
     double getUsedNCE() const;
 
-    /// Median absolute RT residual over the calibration set of the last annotate() call.
+    /// Median absolute RT residual over the calibration set of the run annotated last.
+    /// -1 if annotate() has not run, or could not calibrate.
     double getRTCalibrationError() const;
 
   protected:
     void updateMembers_() override;
+
+    /// Row of the flat PSM work list built by annotate().
+    struct Row
+    {
+      Size pi;      ///< index into the PeptideIdentificationList
+      Size hit;     ///< index into that identification's hits
+      Size len;     ///< peptide length
+      Size key;     ///< index into the de-duplicated (sequence, charge) list
+      double score; ///< search score, used to pick the calibration set
+    };
+
+    /// Annotates the PSMs of a single identification run. Each run gets its own
+    /// collision energy and its own retention-time calibration, since neither
+    /// transfers across runs with different gradients or acquisition settings.
+    void annotateRun_(const PeakMap& spectra,
+                      PeptideIdentificationList& peptide_ids,
+                      const std::vector<Row>& rows,
+                      const std::vector<Size>& run_rows,
+                      const std::vector<std::string>& uniq_seq,
+                      const std::vector<float>& uniq_charge,
+                      bool higher_score_better,
+                      PeptDeepMS2Inference& ms2_inference,
+                      PeptDeepRTInference& rt_inference);
 
     std::string ms2_model_;
     std::string rt_model_;
@@ -114,8 +144,8 @@ namespace OpenMS
     Size batch_size_{500};
     Int threads_{4};
 
-    mutable double used_nce_{-1.0};
-    mutable double rt_calibration_error_{-1.0};
+    double used_nce_{-1.0};
+    double rt_calibration_error_{-1.0};
   };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptDeepRescoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptDeepRescoring.h
@@ -59,7 +59,10 @@ namespace OpenMS
     similarity here would tie the RT feature to the MS2 features and let one feature's
     errors propagate into the other.
 
-    @htmlinclude OpenMS_PeptDeepRescoring.parameters
+    Parameters are not pulled into the generated documentation with
+    @c \@htmlinclude: that requires the class to be registered in
+    DefaultParamHandlerDocumenter, which cannot instantiate a type that only
+    exists in ONNX-enabled builds. ProSEAlgorithm omits it for the same reason.
 
     @ingroup Analysis_ID
   */

--- a/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
@@ -752,6 +752,23 @@ class OPENMS_DLLAPI ProSEAlgorithm :
       const std::string& enzyme,
       const std::string& database_name) const;
 
+    /**
+     * @brief Adds PeptDeep-prediction-derived rescoring features to the PSMs.
+     *
+     * No-op unless both @p peptdeep:ms2_model and @p peptdeep:rt_model are set. Warns
+     * and does nothing when OpenMS was built without ONNX support, so an ini file that
+     * requests the models still runs (without those features) on such a build.
+     */
+    void annotatePeptDeepFeatures_(const PeakMap& spectra,
+                                   std::vector<ProteinIdentification>& protein_ids,
+                                   PeptideIdentificationList& peptide_ids) const;
+
+    std::string peptdeep_ms2_model_;
+    std::string peptdeep_rt_model_;
+    std::string peptdeep_instrument_{"QE"};
+    double peptdeep_nce_{-1.0};
+    std::string peptdeep_rt_model_type_{"b_spline"};
+
     /// Calibration overwrites these with the calibrated magnitudes for the duration of
     /// search(); pure runtime-state mutation that does not affect the logical const-ness
     /// of search(), matching the `mutable` pattern used by last_calibration_result_.

--- a/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
@@ -763,6 +763,7 @@ class OPENMS_DLLAPI ProSEAlgorithm :
                                    std::vector<ProteinIdentification>& protein_ids,
                                    PeptideIdentificationList& peptide_ids) const;
 
+    bool peptdeep_enable_{false};
     std::string peptdeep_ms2_model_;
     std::string peptdeep_rt_model_;
     std::string peptdeep_instrument_{"QE"};

--- a/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
@@ -769,6 +769,7 @@ class OPENMS_DLLAPI ProSEAlgorithm :
     std::string peptdeep_instrument_{"QE"};
     double peptdeep_nce_{-1.0};
     std::string peptdeep_rt_model_type_{"b_spline"};
+    int peptdeep_batch_size_{500};
 
     /// Calibration overwrites these with the calibrated magnitudes for the duration of
     /// search(); pure runtime-state mutation that does not affect the logical const-ness

--- a/src/openms/include/OpenMS/ANALYSIS/ID/sources.cmake
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/sources.cmake
@@ -51,6 +51,12 @@ SiriusExportAlgorithm.h
 SiriusMSConverter.h
 )
 
+if (WITH_ONNX)
+    list(APPEND sources_list_h
+        PeptDeepRescoring.h
+    )
+endif()
+
 ### add path to the filenames
 set(sources_h)
 foreach(i ${sources_list_h})

--- a/src/openms/include/OpenMS/CONCEPT/Constants.h
+++ b/src/openms/include/OpenMS/CONCEPT/Constants.h
@@ -411,6 +411,30 @@ namespace OpenMS
       // complementary suffix ion were matched
       inline const std::string COMPLEMENTARY_IONS_FRACTION = "complementary_ions_fraction";
 
+      // --- PeptDeep (ONNX) prediction-derived PSM features -----------------------------
+      // All five compare a PSM against a deep-learning prediction for the same peptide,
+      // so they are only present when the search engine was run with a PeptDeep model.
+
+      // User parameter name for the cosine similarity between predicted and observed
+      // fragment intensities over the shared b/y ion set
+      inline const std::string MS2_COSINE = "ms2_cosine";
+
+      // User parameter name for the spectral angle 1 - 2*acos(cosine)/pi. Monotone in the
+      // cosine but spreads the crowded high-similarity end, as used by Prosit.
+      inline const std::string MS2_SPECTRAL_ANGLE = "ms2_spectral_angle";
+
+      // User parameter name for Pearson correlation between predicted and observed
+      // fragment intensities
+      inline const std::string MS2_PEARSON = "ms2_pearson";
+
+      // User parameter name for the fraction of confidently predicted fragment ions that
+      // were actually observed
+      inline const std::string MS2_FRAC_PRED_FOUND = "ms2_frac_pred_found";
+
+      // User parameter name for |observed RT - calibrated predicted RT|. The calibration
+      // maps predicted to observed retention time per run, so the value is in RT units.
+      inline const std::string RT_ABS_ERROR = "rt_abs_error";
+
       /** User parameter name to indicate a peptide q-value
               String
       */

--- a/src/openms/source/ANALYSIS/ID/PeptDeepRescoring.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptDeepRescoring.cpp
@@ -319,7 +319,7 @@ namespace OpenMS
     if (rows_by_run.size() > 1)
     {
       OPENMS_LOG_INFO << "[PeptDeepRescoring] " << rows_by_run.size()
-                      << " identification runs; calibrating each separately." << std::endl;
+                      << " identification runs; calibrating each separately." << '\n';
     }
     for (const auto& [run_id, run_rows] : rows_by_run)
     {
@@ -455,13 +455,13 @@ namespace OpenMS
         }
         std::nth_element(cosines.begin(), cosines.begin() + cosines.size() / 2, cosines.end());
         const double med = cosines[cosines.size() / 2];
-        OPENMS_LOG_DEBUG << "[PeptDeepRescoring] NCE " << cand << " -> median cosine " << med << std::endl;
+        OPENMS_LOG_DEBUG << "[PeptDeepRescoring] NCE " << cand << " -> median cosine " << med << '\n';
         if (med > best_median) { best_median = med; nce = cand; }
         setProgress(++done);
       }
       endProgress();
       OPENMS_LOG_INFO << "[PeptDeepRescoring] NCE " << nce << " selected from a grid centred on "
-                      << centre << " (median cosine " << best_median << ")" << std::endl;
+                      << centre << " (median cosine " << best_median << ")" << '\n';
     }
     used_nce_ = nce;
 
@@ -536,7 +536,7 @@ namespace OpenMS
       catch (Exception::BaseException& e)
       {
         OPENMS_LOG_WARN << "[PeptDeepRescoring] retention-time calibration (" << rt_model_type_
-                        << ") failed (" << e.getName() << "); falling back to a linear fit." << std::endl;
+                        << ") failed (" << e.getName() << "); falling back to a linear fit." << '\n';
         model.reset();
       }
       if (!model)
@@ -560,12 +560,12 @@ namespace OpenMS
         rt_calibration_error_ = conf_residuals[conf_residuals.size() / 2];
       }
       OPENMS_LOG_INFO << "[PeptDeepRescoring] retention-time calibration (" << rt_model_type_ << ") on "
-                      << points.size() << " PSMs, median residual " << rt_calibration_error_ << " s" << std::endl;
+                      << points.size() << " PSMs, median residual " << rt_calibration_error_ << " s" << '\n';
     }
     else
     {
       OPENMS_LOG_WARN << "[PeptDeepRescoring] too few PSMs to calibrate retention time; "
-                      << Constants::UserParam::RT_ABS_ERROR << " will be 0 for this run." << std::endl;
+                      << Constants::UserParam::RT_ABS_ERROR << " will be 0 for this run." << '\n';
     }
 
     // ---- write the features back ----

--- a/src/openms/source/ANALYSIS/ID/PeptDeepRescoring.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptDeepRescoring.cpp
@@ -444,8 +444,16 @@ namespace OpenMS
                                confident.begin() + std::min(nce_sample_size_, confident.size()));
       std::vector<std::string> s_seq;
       std::vector<float> s_charge;
-      s_seq.reserve(sample.size()); s_charge.reserve(sample.size());
-      for (Size i : sample) { s_seq.push_back(uniq_seq[rows[i].key]); s_charge.push_back(uniq_charge[rows[i].key]); }
+      // The observed spectrum does not depend on the candidate energy, so parse the peak
+      // annotations once here rather than once per grid point.
+      std::vector<IonMap> s_obs;
+      s_seq.reserve(sample.size()); s_charge.reserve(sample.size()); s_obs.reserve(sample.size());
+      for (Size i : sample)
+      {
+        s_seq.push_back(uniq_seq[rows[i].key]);
+        s_charge.push_back(uniq_charge[rows[i].key]);
+        s_obs.push_back(observedIons_(peptide_ids[rows[i].pi].getHits()[rows[i].hit]));
+      }
 
       double best_median = -1.0;
       nce = centre;
@@ -462,11 +470,10 @@ namespace OpenMS
         for (Size k = 0; k < sample.size(); ++k)
         {
           const Row& r = rows[sample[k]];
-          Size channels = r.len > 1 ? pred[k].size() / (r.len - 1) : DEFAULT_ION_CHANNELS;
+          Size channels = (r.len > 1 && !pred[k].empty()) ? pred[k].size() / (r.len - 1) : DEFAULT_ION_CHANNELS;
           if (channels == 0) { channels = DEFAULT_ION_CHANNELS; }
-          const PeptideHit& hit = peptide_ids[r.pi].getHits()[r.hit];
           cosines.push_back(similarity_(predictedIons_(pred[k], r.len, channels),
-                                        observedIons_(hit), ms2_min_ordinal_, r.len, ms2_strong_fraction_).cosine);
+                                        s_obs[k], ms2_min_ordinal_, r.len, ms2_strong_fraction_).cosine);
         }
         std::nth_element(cosines.begin(), cosines.begin() + cosines.size() / 2, cosines.end());
         const double med = cosines[cosines.size() / 2];

--- a/src/openms/source/ANALYSIS/ID/PeptDeepRescoring.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptDeepRescoring.cpp
@@ -238,6 +238,10 @@ namespace OpenMS
                                    std::vector<ProteinIdentification>& protein_ids,
                                    PeptideIdentificationList& peptide_ids)
   {
+    // Diagnostics describe the call that is about to happen, not the previous one.
+    used_nce_ = -1.0;
+    rt_calibration_error_ = -1.0;
+
     if (ms2_model_.empty() || rt_model_.empty())
     {
       throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
@@ -253,12 +257,14 @@ namespace OpenMS
     if (peptide_ids.empty()) { return; }
 
     // ---- gather the PSMs, and the distinct (sequence, charge) pairs to predict ----
-    struct Row { Size pi, hit; Size len; Size key; double score; };
     std::vector<Row> rows;
     std::map<std::pair<std::string, int>, Size> seen;
     std::vector<std::string> uniq_seq;
     std::vector<float> uniq_charge;
     Size n_with_annotations = 0;
+    // Runs are calibrated separately, so keep their rows apart. std::map keeps the
+    // order stable, which keeps the log output reproducible.
+    std::map<std::string, std::vector<Size>> rows_by_run;
 
     for (Size pi = 0; pi < peptide_ids.size(); ++pi)
     {
@@ -279,6 +285,7 @@ namespace OpenMS
           uniq_seq.push_back(str);
           uniq_charge.push_back(static_cast<float>(z));
         }
+        rows_by_run[peptide_ids[pi].getIdentifier()].push_back(rows.size());
         rows.push_back(Row{pi, h, seq.size(), it->second, hits[h].getScore()});
       }
     }
@@ -291,26 +298,85 @@ namespace OpenMS
         "'fragment_annotation').");
     }
 
-    // Confident PSMs, used both to score NCE candidates and to fit the RT calibration.
-    // Ranking by search score keeps this independent of the MS2 features themselves.
     const bool higher_better = peptide_ids[0].isHigherScoreBetter();
-    std::vector<Size> by_score(rows.size());
-    std::iota(by_score.begin(), by_score.end(), 0);
+
+    // Loading a model is expensive, so both sessions are created once and reused by
+    // every run.
+    PeptDeepMS2Inference ms2(ms2_model_, threads_, batch_size_);
+    PeptDeepRTInference rt(rt_model_, threads_, batch_size_);
+
+    if (rows_by_run.size() > 1)
+    {
+      OPENMS_LOG_INFO << "[PeptDeepRescoring] " << rows_by_run.size()
+                      << " identification runs; calibrating each separately." << std::endl;
+    }
+    for (const auto& [run_id, run_rows] : rows_by_run)
+    {
+      annotateRun_(spectra, peptide_ids, rows, run_rows, uniq_seq, uniq_charge, higher_better, ms2, rt);
+    }
+
+    // ---- register the features for rescoring, per run ----
+    // Each PeptideIdentification names its run, so the features belong on that run's
+    // ProteinIdentification rather than unconditionally on the first one.
+    StringList names = featureNames();
+    bool any_matched = false;
+    for (ProteinIdentification& prot : protein_ids)
+    {
+      if (rows_by_run.find(prot.getIdentifier()) == rows_by_run.end()) { continue; }
+      any_matched = true;
+      ProteinIdentification::SearchParameters sp = prot.getSearchParameters();
+      StringList features = sp.metaValueExists("extra_features")
+        ? ListUtils::create<std::string>(sp.getMetaValue("extra_features").toString(), ',')
+        : StringList();
+      for (const std::string& f : names)
+      {
+        if (std::find(features.begin(), features.end(), f) == features.end()) { features.push_back(f); }
+      }
+      sp.setMetaValue("extra_features", ListUtils::concatenate(features, ","));
+      prot.setSearchParameters(sp);
+    }
+    if (!any_matched && !protein_ids.empty())
+    {
+      // Identifiers do not line up (e.g. hand-assembled input): fall back to the first
+      // run rather than silently dropping the features.
+      ProteinIdentification::SearchParameters sp = protein_ids[0].getSearchParameters();
+      StringList features = sp.metaValueExists("extra_features")
+        ? ListUtils::create<std::string>(sp.getMetaValue("extra_features").toString(), ',')
+        : StringList();
+      for (const std::string& f : names)
+      {
+        if (std::find(features.begin(), features.end(), f) == features.end()) { features.push_back(f); }
+      }
+      sp.setMetaValue("extra_features", ListUtils::concatenate(features, ","));
+      protein_ids[0].setSearchParameters(sp);
+    }
+  }
+
+  void PeptDeepRescoring::annotateRun_(const PeakMap& spectra,
+                                       PeptideIdentificationList& peptide_ids,
+                                       const std::vector<Row>& rows,
+                                       const std::vector<Size>& run_rows,
+                                       const std::vector<std::string>& uniq_seq,
+                                       const std::vector<float>& uniq_charge,
+                                       bool higher_better,
+                                       PeptDeepMS2Inference& ms2,
+                                       PeptDeepRTInference& rt)
+  {
+    if (run_rows.empty()) { return; }
+
+    // Confident PSMs of this run, used both to score NCE candidates and to fit the RT
+    // calibration. Ranking by search score keeps this independent of the MS2 features.
+    std::vector<Size> by_score(run_rows);
     std::sort(by_score.begin(), by_score.end(), [&](Size a, Size b)
       { return higher_better ? rows[a].score > rows[b].score : rows[a].score < rows[b].score; });
-    const Size n_conf = std::max<Size>(1, static_cast<Size>(rows.size() * (1.0 - calibration_quantile_)));
-    std::vector<char> is_confident(rows.size(), 0);
-    for (Size i = 0; i < n_conf; ++i) { is_confident[by_score[i]] = 1; }
+    const Size n_conf = std::max<Size>(1, static_cast<Size>(by_score.size() * (1.0 - calibration_quantile_)));
+    std::vector<Size> confident(by_score.begin(), by_score.begin() + std::min(n_conf, by_score.size()));
 
-    PeptDeepMS2Inference ms2(ms2_model_, threads_, batch_size_);
+    const int64_t instrument = instrumentIndex_(instrument_);
 
     // ---- normalised collision energy ----
-    const int64_t instrument = instrumentIndex_(instrument_);
-    if (nce_ > 0.0)
-    {
-      used_nce_ = nce_;
-    }
-    else
+    double nce = nce_;
+    if (nce <= 0.0)
     {
       // Centre the grid on what the instrument recorded, when it recorded anything.
       std::vector<double> ces;
@@ -337,20 +403,17 @@ namespace OpenMS
       }
       if (grid.empty()) { grid.push_back(centre); }
 
-      // Score each candidate on a sample of confident PSMs and keep the best.
-      std::vector<Size> sample;
-      for (Size i : by_score)
-      {
-        if (sample.size() >= nce_sample_size_) { break; }
-        sample.push_back(i);
-      }
+      // Sample only from the confident set, so the selected NCE follows the same
+      // calibration_quantile as the retention-time fit.
+      std::vector<Size> sample(confident.begin(),
+                               confident.begin() + std::min(nce_sample_size_, confident.size()));
       std::vector<std::string> s_seq;
       std::vector<float> s_charge;
       s_seq.reserve(sample.size()); s_charge.reserve(sample.size());
       for (Size i : sample) { s_seq.push_back(uniq_seq[rows[i].key]); s_charge.push_back(uniq_charge[rows[i].key]); }
 
       double best_median = -1.0;
-      used_nce_ = centre;
+      nce = centre;
       startProgress(0, grid.size(), "Selecting collision energy...");
       Size done = 0;
       for (double cand : grid)
@@ -364,39 +427,51 @@ namespace OpenMS
         for (Size k = 0; k < sample.size(); ++k)
         {
           const Row& r = rows[sample[k]];
-          const Size channels = r.len > 1 ? pred[k].size() / (r.len - 1) : DEFAULT_ION_CHANNELS;
+          Size channels = r.len > 1 ? pred[k].size() / (r.len - 1) : DEFAULT_ION_CHANNELS;
+          if (channels == 0) { channels = DEFAULT_ION_CHANNELS; }
           const PeptideHit& hit = peptide_ids[r.pi].getHits()[r.hit];
-          cosines.push_back(similarity_(predictedIons_(pred[k], r.len, channels ? channels : DEFAULT_ION_CHANNELS),
+          cosines.push_back(similarity_(predictedIons_(pred[k], r.len, channels),
                                         observedIons_(hit), ms2_min_ordinal_, r.len, ms2_strong_fraction_).cosine);
         }
         std::nth_element(cosines.begin(), cosines.begin() + cosines.size() / 2, cosines.end());
         const double med = cosines[cosines.size() / 2];
         OPENMS_LOG_DEBUG << "[PeptDeepRescoring] NCE " << cand << " -> median cosine " << med << std::endl;
-        if (med > best_median) { best_median = med; used_nce_ = cand; }
+        if (med > best_median) { best_median = med; nce = cand; }
         setProgress(++done);
       }
       endProgress();
-      OPENMS_LOG_INFO << "[PeptDeepRescoring] NCE " << used_nce_ << " selected from a grid centred on "
+      OPENMS_LOG_INFO << "[PeptDeepRescoring] NCE " << nce << " selected from a grid centred on "
                       << centre << " (median cosine " << best_median << ")" << std::endl;
     }
+    used_nce_ = nce;
 
-    // ---- predictions for every distinct peptide ----
+    // ---- predictions for this run's distinct peptides ----
+    std::vector<Size> keys;
+    keys.reserve(run_rows.size());
+    for (Size i : run_rows) { keys.push_back(rows[i].key); }
+    std::sort(keys.begin(), keys.end());
+    keys.erase(std::unique(keys.begin(), keys.end()), keys.end());
+    std::map<Size, Size> key_pos;
+    std::vector<std::string> seqs;
+    std::vector<float> charges;
+    seqs.reserve(keys.size()); charges.reserve(keys.size());
+    for (Size k : keys) { key_pos[k] = seqs.size(); seqs.push_back(uniq_seq[k]); charges.push_back(uniq_charge[k]); }
+
     startProgress(0, 2, "Predicting fragment intensities and retention times...");
-    const std::vector<float> nces(uniq_seq.size(), static_cast<float>(used_nce_));
-    const std::vector<int64_t> instruments(uniq_seq.size(), instrument);
-    const std::vector<std::vector<float>> ms2_pred = ms2.predictMS2(uniq_seq, uniq_charge, nces, instruments);
+    const std::vector<float> nces(seqs.size(), static_cast<float>(nce));
+    const std::vector<int64_t> instruments(seqs.size(), instrument);
+    const std::vector<std::vector<float>> ms2_pred = ms2.predictMS2(seqs, charges, nces, instruments);
     setProgress(1);
-    PeptDeepRTInference rt(rt_model_, threads_, batch_size_);
-    const std::vector<float> rt_pred_uniq = rt.predictRT(uniq_seq);
+    const std::vector<float> rt_pred = rt.predictRT(seqs);
     setProgress(2);
     endProgress();
 
     // ---- MS2 agreement ----
-    std::vector<Similarity> sims(rows.size());
-    for (Size i = 0; i < rows.size(); ++i)
+    std::map<Size, Similarity> sims;
+    for (Size i : run_rows)
     {
       const Row& r = rows[i];
-      const std::vector<float>& pred = ms2_pred[r.key];
+      const std::vector<float>& pred = ms2_pred[key_pos[r.key]];
       Size channels = (r.len > 1 && !pred.empty()) ? pred.size() / (r.len - 1) : DEFAULT_ION_CHANNELS;
       if (channels == 0) { channels = DEFAULT_ION_CHANNELS; }
       const PeptideHit& hit = peptide_ids[r.pi].getHits()[r.hit];
@@ -408,17 +483,16 @@ namespace OpenMS
     // Predicted RT is in the model's own units; map it onto this run's gradient before
     // taking a residual, otherwise the feature measures the unit mismatch.
     TransformationModel::DataPoints points;
-    points.reserve(n_conf);
-    for (Size i = 0; i < rows.size(); ++i)
+    points.reserve(confident.size());
+    for (Size i : confident)
     {
-      if (!is_confident[i]) { continue; }
-      points.emplace_back(static_cast<double>(rt_pred_uniq[rows[i].key]), peptide_ids[rows[i].pi].getRT());
+      points.emplace_back(static_cast<double>(rt_pred[key_pos[rows[i].key]]), peptide_ids[rows[i].pi].getRT());
     }
 
-    std::vector<double> rt_err(rows.size(), 0.0);
-    std::unique_ptr<TransformationModel> model;
+    std::map<Size, double> rt_err;
     if (points.size() >= 4)
     {
+      std::unique_ptr<TransformationModel> model;
       Param mp;
       try
       {
@@ -452,14 +526,14 @@ namespace OpenMS
         model = std::make_unique<TransformationModelLinear>(points, lp);
       }
 
-      std::vector<double> conf_residuals;
-      conf_residuals.reserve(points.size());
-      for (Size i = 0; i < rows.size(); ++i)
+      for (Size i : run_rows)
       {
-        const double fitted = model->evaluate(static_cast<double>(rt_pred_uniq[rows[i].key]));
+        const double fitted = model->evaluate(static_cast<double>(rt_pred[key_pos[rows[i].key]]));
         rt_err[i] = std::abs(peptide_ids[rows[i].pi].getRT() - fitted);
-        if (is_confident[i]) { conf_residuals.push_back(rt_err[i]); }
       }
+      std::vector<double> conf_residuals;
+      conf_residuals.reserve(confident.size());
+      for (Size i : confident) { conf_residuals.push_back(rt_err[i]); }
       if (!conf_residuals.empty())
       {
         std::nth_element(conf_residuals.begin(), conf_residuals.begin() + conf_residuals.size() / 2, conf_residuals.end());
@@ -471,23 +545,31 @@ namespace OpenMS
     else
     {
       OPENMS_LOG_WARN << "[PeptDeepRescoring] too few PSMs to calibrate retention time; "
-                      << Constants::UserParam::RT_ABS_ERROR << " will be 0 for every PSM." << std::endl;
+                      << Constants::UserParam::RT_ABS_ERROR << " will be 0 for this run." << std::endl;
     }
 
     // ---- write the features back ----
-    // Every hit gets every feature: a feature present on only some PSMs of a run is
-    // dropped for all of them by the Percolator feature-set check.
-    std::map<std::pair<Size, Size>, Size> row_of;
-    for (Size i = 0; i < rows.size(); ++i) { row_of[{rows[i].pi, rows[i].hit}] = i; }
-
-    for (Size pi = 0; pi < peptide_ids.size(); ++pi)
+    // Every hit of this run gets every feature: a feature present on only some PSMs of
+    // a run is dropped for all of them by the Percolator feature-set check.
+    std::map<Size, std::vector<Size>> rows_by_pi;
+    for (Size i : run_rows) { rows_by_pi[rows[i].pi].push_back(i); }
+    for (const auto& [pi, idxs] : rows_by_pi)
     {
       std::vector<PeptideHit> hits = peptide_ids[pi].getHits();
+      std::map<Size, Size> row_of_hit;
+      for (Size i : idxs) { row_of_hit[rows[i].hit] = i; }
       for (Size h = 0; h < hits.size(); ++h)
       {
-        const auto it = row_of.find({pi, h});
-        const Similarity s = (it == row_of.end()) ? Similarity{} : sims[it->second];
-        const double e = (it == row_of.end()) ? 0.0 : rt_err[it->second];
+        const auto it = row_of_hit.find(h);
+        Similarity s;
+        double e = 0.0;
+        if (it != row_of_hit.end())
+        {
+          const auto si = sims.find(it->second);
+          if (si != sims.end()) { s = si->second; }
+          const auto ei = rt_err.find(it->second);
+          if (ei != rt_err.end()) { e = ei->second; }
+        }
         hits[h].setMetaValue(Constants::UserParam::MS2_COSINE, s.cosine);
         hits[h].setMetaValue(Constants::UserParam::MS2_SPECTRAL_ANGLE, s.spectral_angle);
         hits[h].setMetaValue(Constants::UserParam::MS2_PEARSON, s.pearson);
@@ -495,20 +577,6 @@ namespace OpenMS
         hits[h].setMetaValue(Constants::UserParam::RT_ABS_ERROR, e);
       }
       peptide_ids[pi].setHits(std::move(hits));
-    }
-
-    if (!protein_ids.empty())
-    {
-      ProteinIdentification::SearchParameters sp = protein_ids[0].getSearchParameters();
-      StringList features = sp.metaValueExists("extra_features")
-        ? ListUtils::create<std::string>(sp.getMetaValue("extra_features").toString(), ',')
-        : StringList();
-      for (const std::string& f : featureNames())
-      {
-        if (std::find(features.begin(), features.end(), f) == features.end()) { features.push_back(f); }
-      }
-      sp.setMetaValue("extra_features", ListUtils::concatenate(features, ","));
-      protein_ids[0].setSearchParameters(sp);
     }
   }
 

--- a/src/openms/source/ANALYSIS/ID/PeptDeepRescoring.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptDeepRescoring.cpp
@@ -262,7 +262,11 @@ namespace OpenMS
     std::map<std::pair<std::string, int>, Size> seen;
     std::vector<std::string> uniq_seq;
     std::vector<float> uniq_charge;
-    Size n_with_annotations = 0;
+    // Counted per run, not per file: a merged input where one run carries peak
+    // annotations and another does not would otherwise pass the global check below and
+    // leave the unannotated run with four MS2 features that are silently zero for every
+    // one of its PSMs -- a constant block that Percolator reads as a run separator.
+    std::map<std::string, Size> annotated_by_run;
     // Runs are calibrated separately, so keep their rows apart. std::map keeps the
     // order stable, which keeps the log output reproducible.
     std::map<std::string, std::vector<Size>> rows_by_run;
@@ -274,7 +278,9 @@ namespace OpenMS
       {
         const AASequence& seq = hits[h].getSequence();
         if (seq.empty()) { continue; }
-        if (!hits[h].getPeakAnnotations().empty()) { ++n_with_annotations; }
+        const std::string& run_id = peptide_ids[pi].getIdentifier();
+        annotated_by_run.try_emplace(run_id, 0);
+        if (!hits[h].getPeakAnnotations().empty()) { ++annotated_by_run[run_id]; }
         const std::string str = seq.toString();
         int z = hits[h].getCharge();
         if (z <= 0) { z = 2; }
@@ -291,12 +297,30 @@ namespace OpenMS
       }
     }
     if (rows.empty()) { return; }
-    if (n_with_annotations == 0)
+
+    StringList unannotated_runs;
+    for (const auto& [run_id, n] : annotated_by_run)
+    {
+      if (n == 0) { unannotated_runs.push_back(run_id); }
+    }
+    if (unannotated_runs.size() == annotated_by_run.size())
     {
       throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
         "No PSM carries peak annotations, so every MS2 feature would be zero. Re-run the "
         "search with fragment annotation enabled (ProSE: annotate:PSM contains 'ALL' or "
         "'fragment_annotation').");
+    }
+    if (!unannotated_runs.empty())
+    {
+      // Some runs are annotated and some are not. Say so rather than emitting a block of
+      // zeros that looks like a real measurement: those runs' MS2 features carry no
+      // information, and pooling them with annotated runs biases the rescoring.
+      OPENMS_LOG_WARN << "[PeptDeepRescoring] no peak annotations in "
+                      << unannotated_runs.size() << " of " << annotated_by_run.size()
+                      << " identification runs (" << ListUtils::concatenate(unannotated_runs, ", ")
+                      << "); their MS2 features will be zero for every PSM while other runs carry "
+                         "real values. Re-run the search with fragment annotation enabled for all "
+                         "runs, or rescore the runs separately." << '\n';
     }
 
     // Collision energy per spectrum, keyed by native ID so each run can pick out its
@@ -342,7 +366,7 @@ namespace OpenMS
       // can hold runs from engines that disagree on it, and picking the wrong direction
       // would calibrate on the *worst* PSMs.
       const bool higher_better = peptide_ids[rows[run_rows.front()].pi].isHigherScoreBetter();
-      annotateRun_(collision_energies, peptide_ids, rows, run_rows, uniq_seq, uniq_charge,
+      annotateRun_(run_id, collision_energies, peptide_ids, rows, run_rows, uniq_seq, uniq_charge,
                    higher_better, ms2, rt);
     }
 
@@ -383,7 +407,8 @@ namespace OpenMS
     }
   }
 
-  void PeptDeepRescoring::annotateRun_(const std::map<std::string, double>& collision_energies,
+  void PeptDeepRescoring::annotateRun_(const std::string& run_id,
+                                       const std::map<std::string, double>& collision_energies,
                                        PeptideIdentificationList& peptide_ids,
                                        const std::vector<Row>& rows,
                                        const std::vector<Size>& run_rows,
@@ -482,8 +507,9 @@ namespace OpenMS
         setProgress(++done);
       }
       endProgress();
-      OPENMS_LOG_INFO << "[PeptDeepRescoring] NCE " << nce << " selected from a grid centred on "
-                      << centre << " (median cosine " << best_median << ")" << '\n';
+      OPENMS_LOG_INFO << "[PeptDeepRescoring] run '" << run_id << "': NCE " << nce
+                      << " selected from a grid centred on " << centre
+                      << " (median cosine " << best_median << ")" << '\n';
     }
     used_nce_ = nce;
 
@@ -581,13 +607,17 @@ namespace OpenMS
         std::nth_element(conf_residuals.begin(), conf_residuals.begin() + conf_residuals.size() / 2, conf_residuals.end());
         rt_calibration_error_ = conf_residuals[conf_residuals.size() / 2];
       }
-      OPENMS_LOG_INFO << "[PeptDeepRescoring] retention-time calibration (" << rt_model_type_ << ") on "
-                      << points.size() << " PSMs, median residual " << rt_calibration_error_ << " s" << '\n';
+      OPENMS_LOG_INFO << "[PeptDeepRescoring] run '" << run_id << "': retention-time calibration ("
+                      << rt_model_type_ << ") on " << points.size() << " PSMs, median residual "
+                      << rt_calibration_error_ << " s" << '\n';
     }
     else
     {
-      OPENMS_LOG_WARN << "[PeptDeepRescoring] too few PSMs to calibrate retention time; "
-                      << Constants::UserParam::RT_ABS_ERROR << " will be 0 for this run." << '\n';
+      OPENMS_LOG_WARN << "[PeptDeepRescoring] run '" << run_id << "': only " << points.size()
+                      << " confident PSMs, too few to calibrate retention time; "
+                      << Constants::UserParam::RT_ABS_ERROR
+                      << " will be 0 for every PSM of this run while other runs carry real "
+                         "residuals." << '\n';
     }
 
     // ---- write the features back ----

--- a/src/openms/source/ANALYSIS/ID/PeptDeepRescoring.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptDeepRescoring.cpp
@@ -292,6 +292,8 @@ namespace OpenMS
           uniq_seq.push_back(str);
           uniq_charge.push_back(static_cast<float>(z));
         }
+        // The run identifier is what keeps NCE and RT calibration per-run, so it has to
+        // still distinguish the runs by the time we get here -- see the note on annotate().
         rows_by_run[peptide_ids[pi].getIdentifier()].push_back(rows.size());
         rows.push_back(Row{pi, h, seq.size(), it->second, hits[h].getScore()});
       }

--- a/src/openms/source/ANALYSIS/ID/PeptDeepRescoring.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptDeepRescoring.cpp
@@ -1,0 +1,515 @@
+// Copyright (c) 2002-present, OpenMS Team -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/ANALYSIS/ID/PeptDeepRescoring.h>
+
+#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelBSpline.h>
+#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLinear.h>
+#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLowess.h>
+#include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/METADATA/PeptideHit.h>
+#include <OpenMS/METADATA/PeptideIdentificationList.h>
+#include <OpenMS/METADATA/Precursor.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/ML/PEPTDEEP/PeptDeepMS2Inference.h>
+#include <OpenMS/ML/PEPTDEEP/PeptDeepRTInference.h>
+#include <OpenMS/SYSTEM/File.h>
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace
+{
+  using namespace OpenMS;
+
+  /// Slot layout of the PeptDeep MS2 output: eight ion channels per fragment position,
+  /// of which the first four are the singly and doubly charged b and y ions.
+  constexpr int ION_B1 = 0, ION_B2 = 1, ION_Y1 = 2, ION_Y2 = 3;
+  constexpr Size DEFAULT_ION_CHANNELS = 8;
+
+  /// (ion type, charge, ordinal) -> intensity
+  using IonMap = std::map<std::tuple<char, int, int>, double>;
+
+  /// Observed fragment intensities from a hit's peak annotations.
+  IonMap observedIons_(const PeptideHit& hit)
+  {
+    IonMap out;
+    for (const PeptideHit::PeakAnnotation& pa : hit.getPeakAnnotations())
+    {
+      const std::string& ann = pa.annotation;
+      // Annotations look like "y5+", "b12++"; take the leading ion letter and its ordinal.
+      Size i = 0;
+      while (i < ann.size() && !(ann[i] >= 'a' && ann[i] <= 'z')) { ++i; }
+      if (i >= ann.size()) { continue; }
+      const char type = ann[i];
+      if (type != 'a' && type != 'b' && type != 'c' && type != 'x' && type != 'y' && type != 'z') { continue; }
+      Size j = i + 1;
+      int ordinal = 0;
+      while (j < ann.size() && ann[j] >= '0' && ann[j] <= '9') { ordinal = ordinal * 10 + (ann[j] - '0'); ++j; }
+      if (ordinal == 0) { continue; }
+      const int z = pa.charge > 0 ? pa.charge : 1;
+      out[std::make_tuple(type, z, ordinal)] += pa.intensity;
+    }
+    return out;
+  }
+
+  /// Predicted b/y intensities, keyed like observedIons_().
+  ///
+  /// Fragment position i carries b_(i+1) and y_(len-1-i): the model emits fragments
+  /// N-to-C, so the y series is numbered from the other end.
+  IonMap predictedIons_(const std::vector<float>& flat, Size pep_len, Size channels)
+  {
+    IonMap out;
+    if (pep_len < 2 || channels == 0) { return out; }
+    for (Size pos = 0; pos + 1 < pep_len; ++pos)
+    {
+      const Size base = pos * channels;
+      if (base + ION_Y2 >= flat.size()) { break; }
+      out[std::make_tuple('b', 1, static_cast<int>(pos + 1))] = flat[base + ION_B1];
+      out[std::make_tuple('b', 2, static_cast<int>(pos + 1))] = flat[base + ION_B2];
+      out[std::make_tuple('y', 1, static_cast<int>(pep_len - 1 - pos))] = flat[base + ION_Y1];
+      out[std::make_tuple('y', 2, static_cast<int>(pep_len - 1 - pos))] = flat[base + ION_Y2];
+    }
+    return out;
+  }
+
+  struct Similarity
+  {
+    double cosine = 0.0;
+    double spectral_angle = 0.0;
+    double pearson = 0.0;
+    double frac_found = 0.0;
+  };
+
+  /// Agreement between predicted and observed intensities over the predicted ion set.
+  /// Predicted ions that were never matched enter with an observed intensity of 0.
+  Similarity similarity_(const IonMap& pred, const IonMap& obs, int min_ordinal, Size pep_len,
+                         double strong_fraction)
+  {
+    std::vector<double> p, o;
+    p.reserve(pred.size()); o.reserve(pred.size());
+    for (const auto& [key, pv] : pred)
+    {
+      const int ordinal = std::get<2>(key);
+      if (ordinal < min_ordinal || ordinal > static_cast<int>(pep_len) - 1) { continue; }
+      p.push_back(pv);
+      const auto it = obs.find(key);
+      o.push_back(it == obs.end() ? 0.0 : it->second);
+    }
+    Similarity s;
+    if (p.empty()) { return s; }
+
+    const double sum_p = std::accumulate(p.begin(), p.end(), 0.0);
+    const double sum_o = std::accumulate(o.begin(), o.end(), 0.0);
+    if (sum_p <= 0.0 || sum_o <= 0.0) { return s; }
+
+    double dot = 0.0, np2 = 0.0, no2 = 0.0;
+    for (Size i = 0; i < p.size(); ++i) { dot += p[i] * o[i]; np2 += p[i] * p[i]; no2 += o[i] * o[i]; }
+    if (np2 <= 0.0 || no2 <= 0.0) { return s; }
+    s.cosine = std::clamp(dot / (std::sqrt(np2) * std::sqrt(no2)), -1.0, 1.0);
+    s.spectral_angle = 1.0 - 2.0 * std::acos(s.cosine) / Constants::PI;
+
+    const double mp = sum_p / p.size(), mo = sum_o / o.size();
+    double cov = 0.0, vp = 0.0, vo = 0.0;
+    for (Size i = 0; i < p.size(); ++i)
+    {
+      cov += (p[i] - mp) * (o[i] - mo);
+      vp += (p[i] - mp) * (p[i] - mp);
+      vo += (o[i] - mo) * (o[i] - mo);
+    }
+    s.pearson = (vp > 0.0 && vo > 0.0) ? std::clamp(cov / std::sqrt(vp * vo), -1.0, 1.0) : 0.0;
+
+    const double peak = *std::max_element(p.begin(), p.end());
+    Size strong = 0, strong_found = 0;
+    for (Size i = 0; i < p.size(); ++i)
+    {
+      if (p[i] > strong_fraction * peak) { ++strong; if (o[i] > 0.0) { ++strong_found; } }
+    }
+    s.frac_found = strong > 0 ? static_cast<double>(strong_found) / static_cast<double>(strong) : 0.0;
+    return s;
+  }
+
+  /// peptdeep's categorical instrument encoding.
+  int64_t instrumentIndex_(const std::string& name)
+  {
+    if (name == "Lumos") { return 0; }
+    if (name == "QE") { return 1; }
+    if (name == "timsTOF") { return 2; }
+    if (name == "SciexTOF") { return 3; }
+    return 1;
+  }
+}
+
+namespace OpenMS
+{
+  PeptDeepRescoring::PeptDeepRescoring() :
+    DefaultParamHandler("PeptDeepRescoring")
+  {
+    defaults_.setValue("ms2_model", "", "Path to the PeptDeep MS2 fragment-intensity ONNX model. Required.");
+    defaults_.setValue("rt_model", "", "Path to the PeptDeep retention-time ONNX model. Required.");
+
+    defaults_.setValue("instrument", "QE", "Instrument class passed to the MS2 model.");
+    defaults_.setValidStrings("instrument", {"Lumos", "QE", "timsTOF", "SciexTOF"});
+
+    defaults_.setValue("nce", -1.0, "Normalised collision energy for the MS2 model. Negative selects it automatically: a grid centred on the collision energy recorded in the spectra is scored on a sample of confident PSMs and the best is kept. The instrument's own value is only a starting point -- the model's NCE scale does not coincide with it.");
+    defaults_.setValue("nce_grid_halfwidth", 6.0, "Half-width of the automatic NCE search grid around its centre.", {"advanced"});
+    defaults_.setMinFloat("nce_grid_halfwidth", 0.0);
+    defaults_.setValue("nce_grid_step", 2.0, "Step size of the automatic NCE search grid.", {"advanced"});
+    defaults_.setMinFloat("nce_grid_step", 0.1);
+    defaults_.setValue("nce_fallback", 30.0, "NCE grid centre used when the spectra do not record a collision energy.", {"advanced"});
+    defaults_.setValue("nce_sample_size", 2000, "Number of confident PSMs scored per candidate NCE.", {"advanced"});
+    defaults_.setMinInt("nce_sample_size", 50);
+
+    defaults_.setValue("calibration_quantile", 0.5, "Fraction of PSMs, ranked by search score, held out of the calibration sets. 0.5 fits on the better-scoring half. Selection uses the search score rather than spectral similarity, so the RT feature stays independent of the MS2 features.", {"advanced"});
+    defaults_.setMinFloat("calibration_quantile", 0.0);
+    defaults_.setMaxFloat("calibration_quantile", 0.99);
+
+    defaults_.setValue("rt_model_type", "b_spline", "Model mapping predicted onto observed retention time.");
+    defaults_.setValidStrings("rt_model_type", {"b_spline", "lowess", "linear"});
+    defaults_.setValue("rt_num_nodes", 5, "Number of B-spline nodes for the retention-time calibration. Fewer means smoother; an over-flexible fit tracks the calibration set instead of the gradient.", {"advanced"});
+    defaults_.setMinInt("rt_num_nodes", 2);
+
+    defaults_.setValue("ms2_min_ordinal", 1, "Ignore predicted fragments below this ordinal.", {"advanced"});
+    defaults_.setMinInt("ms2_min_ordinal", 1);
+    defaults_.setValue("ms2_strong_fraction", 0.05, "An ion counts as confidently predicted, for ms2_frac_pred_found, above this fraction of the peptide's most intense predicted ion.", {"advanced"});
+    defaults_.setMinFloat("ms2_strong_fraction", 0.0);
+    defaults_.setMaxFloat("ms2_strong_fraction", 1.0);
+
+    defaults_.setValue("batch_size", 500, "Peptides per ONNX inference call.", {"advanced"});
+    defaults_.setMinInt("batch_size", 1);
+    defaults_.setValue("threads", 4, "ONNX intra-op threads.", {"advanced"});
+    defaults_.setMinInt("threads", 1);
+
+    defaultsToParam_();
+  }
+
+  PeptDeepRescoring::~PeptDeepRescoring() = default;
+
+  void PeptDeepRescoring::updateMembers_()
+  {
+    ms2_model_ = param_.getValue("ms2_model").toString();
+    rt_model_ = param_.getValue("rt_model").toString();
+    instrument_ = param_.getValue("instrument").toString();
+    nce_ = param_.getValue("nce");
+    nce_grid_halfwidth_ = param_.getValue("nce_grid_halfwidth");
+    nce_grid_step_ = param_.getValue("nce_grid_step");
+    nce_fallback_ = param_.getValue("nce_fallback");
+    nce_sample_size_ = static_cast<Size>((int)param_.getValue("nce_sample_size"));
+    calibration_quantile_ = param_.getValue("calibration_quantile");
+    rt_model_type_ = param_.getValue("rt_model_type").toString();
+    rt_num_nodes_ = static_cast<Size>((int)param_.getValue("rt_num_nodes"));
+    ms2_min_ordinal_ = (int)param_.getValue("ms2_min_ordinal");
+    ms2_strong_fraction_ = param_.getValue("ms2_strong_fraction");
+    batch_size_ = static_cast<Size>((int)param_.getValue("batch_size"));
+    threads_ = (int)param_.getValue("threads");
+  }
+
+  StringList PeptDeepRescoring::featureNames()
+  {
+    return {Constants::UserParam::MS2_COSINE,
+            Constants::UserParam::MS2_SPECTRAL_ANGLE,
+            Constants::UserParam::MS2_PEARSON,
+            Constants::UserParam::MS2_FRAC_PRED_FOUND,
+            Constants::UserParam::RT_ABS_ERROR};
+  }
+
+  double PeptDeepRescoring::getUsedNCE() const { return used_nce_; }
+
+  double PeptDeepRescoring::getRTCalibrationError() const { return rt_calibration_error_; }
+
+  void PeptDeepRescoring::annotate(const PeakMap& spectra,
+                                   std::vector<ProteinIdentification>& protein_ids,
+                                   PeptideIdentificationList& peptide_ids)
+  {
+    if (ms2_model_.empty() || rt_model_.empty())
+    {
+      throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "PeptDeepRescoring needs both 'ms2_model' and 'rt_model' to be set.");
+    }
+    for (const std::string& m : {ms2_model_, rt_model_})
+    {
+      if (!File::exists(m))
+      {
+        throw Exception::FileNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, m);
+      }
+    }
+    if (peptide_ids.empty()) { return; }
+
+    // ---- gather the PSMs, and the distinct (sequence, charge) pairs to predict ----
+    struct Row { Size pi, hit; Size len; Size key; double score; };
+    std::vector<Row> rows;
+    std::map<std::pair<std::string, int>, Size> seen;
+    std::vector<std::string> uniq_seq;
+    std::vector<float> uniq_charge;
+    Size n_with_annotations = 0;
+
+    for (Size pi = 0; pi < peptide_ids.size(); ++pi)
+    {
+      const std::vector<PeptideHit>& hits = peptide_ids[pi].getHits();
+      for (Size h = 0; h < hits.size(); ++h)
+      {
+        const AASequence& seq = hits[h].getSequence();
+        if (seq.empty()) { continue; }
+        if (!hits[h].getPeakAnnotations().empty()) { ++n_with_annotations; }
+        const std::string str = seq.toString();
+        int z = hits[h].getCharge();
+        if (z <= 0) { z = 2; }
+        const auto key = std::make_pair(str, z);
+        auto it = seen.find(key);
+        if (it == seen.end())
+        {
+          it = seen.emplace(key, uniq_seq.size()).first;
+          uniq_seq.push_back(str);
+          uniq_charge.push_back(static_cast<float>(z));
+        }
+        rows.push_back(Row{pi, h, seq.size(), it->second, hits[h].getScore()});
+      }
+    }
+    if (rows.empty()) { return; }
+    if (n_with_annotations == 0)
+    {
+      throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "No PSM carries peak annotations, so every MS2 feature would be zero. Re-run the "
+        "search with fragment annotation enabled (ProSE: annotate:PSM contains 'ALL' or "
+        "'fragment_annotation').");
+    }
+
+    // Confident PSMs, used both to score NCE candidates and to fit the RT calibration.
+    // Ranking by search score keeps this independent of the MS2 features themselves.
+    const bool higher_better = peptide_ids[0].isHigherScoreBetter();
+    std::vector<Size> by_score(rows.size());
+    std::iota(by_score.begin(), by_score.end(), 0);
+    std::sort(by_score.begin(), by_score.end(), [&](Size a, Size b)
+      { return higher_better ? rows[a].score > rows[b].score : rows[a].score < rows[b].score; });
+    const Size n_conf = std::max<Size>(1, static_cast<Size>(rows.size() * (1.0 - calibration_quantile_)));
+    std::vector<char> is_confident(rows.size(), 0);
+    for (Size i = 0; i < n_conf; ++i) { is_confident[by_score[i]] = 1; }
+
+    PeptDeepMS2Inference ms2(ms2_model_, threads_, batch_size_);
+
+    // ---- normalised collision energy ----
+    const int64_t instrument = instrumentIndex_(instrument_);
+    if (nce_ > 0.0)
+    {
+      used_nce_ = nce_;
+    }
+    else
+    {
+      // Centre the grid on what the instrument recorded, when it recorded anything.
+      std::vector<double> ces;
+      for (const MSSpectrum& s : spectra)
+      {
+        if (s.getMSLevel() != 2 || s.getPrecursors().empty()) { continue; }
+        const Precursor& prec = s.getPrecursors()[0];
+        if (prec.metaValueExists("collision energy"))
+        {
+          ces.push_back(static_cast<double>(prec.getMetaValue("collision energy")));
+        }
+      }
+      double centre = nce_fallback_;
+      if (!ces.empty())
+      {
+        std::nth_element(ces.begin(), ces.begin() + ces.size() / 2, ces.end());
+        centre = ces[ces.size() / 2];
+      }
+
+      std::vector<double> grid;
+      for (double x = centre - nce_grid_halfwidth_; x <= centre + nce_grid_halfwidth_ + 1e-9; x += nce_grid_step_)
+      {
+        if (x > 0.0) { grid.push_back(x); }
+      }
+      if (grid.empty()) { grid.push_back(centre); }
+
+      // Score each candidate on a sample of confident PSMs and keep the best.
+      std::vector<Size> sample;
+      for (Size i : by_score)
+      {
+        if (sample.size() >= nce_sample_size_) { break; }
+        sample.push_back(i);
+      }
+      std::vector<std::string> s_seq;
+      std::vector<float> s_charge;
+      s_seq.reserve(sample.size()); s_charge.reserve(sample.size());
+      for (Size i : sample) { s_seq.push_back(uniq_seq[rows[i].key]); s_charge.push_back(uniq_charge[rows[i].key]); }
+
+      double best_median = -1.0;
+      used_nce_ = centre;
+      startProgress(0, grid.size(), "Selecting collision energy...");
+      Size done = 0;
+      for (double cand : grid)
+      {
+        const std::vector<float> s_nce(s_seq.size(), static_cast<float>(cand));
+        const std::vector<int64_t> s_inst(s_seq.size(), instrument);
+        const std::vector<std::vector<float>> pred = ms2.predictMS2(s_seq, s_charge, s_nce, s_inst);
+
+        std::vector<double> cosines;
+        cosines.reserve(sample.size());
+        for (Size k = 0; k < sample.size(); ++k)
+        {
+          const Row& r = rows[sample[k]];
+          const Size channels = r.len > 1 ? pred[k].size() / (r.len - 1) : DEFAULT_ION_CHANNELS;
+          const PeptideHit& hit = peptide_ids[r.pi].getHits()[r.hit];
+          cosines.push_back(similarity_(predictedIons_(pred[k], r.len, channels ? channels : DEFAULT_ION_CHANNELS),
+                                        observedIons_(hit), ms2_min_ordinal_, r.len, ms2_strong_fraction_).cosine);
+        }
+        std::nth_element(cosines.begin(), cosines.begin() + cosines.size() / 2, cosines.end());
+        const double med = cosines[cosines.size() / 2];
+        OPENMS_LOG_DEBUG << "[PeptDeepRescoring] NCE " << cand << " -> median cosine " << med << std::endl;
+        if (med > best_median) { best_median = med; used_nce_ = cand; }
+        setProgress(++done);
+      }
+      endProgress();
+      OPENMS_LOG_INFO << "[PeptDeepRescoring] NCE " << used_nce_ << " selected from a grid centred on "
+                      << centre << " (median cosine " << best_median << ")" << std::endl;
+    }
+
+    // ---- predictions for every distinct peptide ----
+    startProgress(0, 2, "Predicting fragment intensities and retention times...");
+    const std::vector<float> nces(uniq_seq.size(), static_cast<float>(used_nce_));
+    const std::vector<int64_t> instruments(uniq_seq.size(), instrument);
+    const std::vector<std::vector<float>> ms2_pred = ms2.predictMS2(uniq_seq, uniq_charge, nces, instruments);
+    setProgress(1);
+    PeptDeepRTInference rt(rt_model_, threads_, batch_size_);
+    const std::vector<float> rt_pred_uniq = rt.predictRT(uniq_seq);
+    setProgress(2);
+    endProgress();
+
+    // ---- MS2 agreement ----
+    std::vector<Similarity> sims(rows.size());
+    for (Size i = 0; i < rows.size(); ++i)
+    {
+      const Row& r = rows[i];
+      const std::vector<float>& pred = ms2_pred[r.key];
+      Size channels = (r.len > 1 && !pred.empty()) ? pred.size() / (r.len - 1) : DEFAULT_ION_CHANNELS;
+      if (channels == 0) { channels = DEFAULT_ION_CHANNELS; }
+      const PeptideHit& hit = peptide_ids[r.pi].getHits()[r.hit];
+      sims[i] = similarity_(predictedIons_(pred, r.len, channels), observedIons_(hit),
+                            ms2_min_ordinal_, r.len, ms2_strong_fraction_);
+    }
+
+    // ---- retention time calibration ----
+    // Predicted RT is in the model's own units; map it onto this run's gradient before
+    // taking a residual, otherwise the feature measures the unit mismatch.
+    TransformationModel::DataPoints points;
+    points.reserve(n_conf);
+    for (Size i = 0; i < rows.size(); ++i)
+    {
+      if (!is_confident[i]) { continue; }
+      points.emplace_back(static_cast<double>(rt_pred_uniq[rows[i].key]), peptide_ids[rows[i].pi].getRT());
+    }
+
+    std::vector<double> rt_err(rows.size(), 0.0);
+    std::unique_ptr<TransformationModel> model;
+    if (points.size() >= 4)
+    {
+      Param mp;
+      try
+      {
+        if (rt_model_type_ == "b_spline")
+        {
+          TransformationModelBSpline::getDefaultParameters(mp);
+          mp.setValue("num_nodes", static_cast<int>(rt_num_nodes_));
+          model = std::make_unique<TransformationModelBSpline>(points, mp);
+        }
+        else if (rt_model_type_ == "lowess")
+        {
+          TransformationModelLowess::getDefaultParameters(mp);
+          model = std::make_unique<TransformationModelLowess>(points, mp);
+        }
+        else
+        {
+          TransformationModelLinear::getDefaultParameters(mp);
+          model = std::make_unique<TransformationModelLinear>(points, mp);
+        }
+      }
+      catch (Exception::BaseException& e)
+      {
+        OPENMS_LOG_WARN << "[PeptDeepRescoring] retention-time calibration (" << rt_model_type_
+                        << ") failed (" << e.getName() << "); falling back to a linear fit." << std::endl;
+        model.reset();
+      }
+      if (!model)
+      {
+        Param lp;
+        TransformationModelLinear::getDefaultParameters(lp);
+        model = std::make_unique<TransformationModelLinear>(points, lp);
+      }
+
+      std::vector<double> conf_residuals;
+      conf_residuals.reserve(points.size());
+      for (Size i = 0; i < rows.size(); ++i)
+      {
+        const double fitted = model->evaluate(static_cast<double>(rt_pred_uniq[rows[i].key]));
+        rt_err[i] = std::abs(peptide_ids[rows[i].pi].getRT() - fitted);
+        if (is_confident[i]) { conf_residuals.push_back(rt_err[i]); }
+      }
+      if (!conf_residuals.empty())
+      {
+        std::nth_element(conf_residuals.begin(), conf_residuals.begin() + conf_residuals.size() / 2, conf_residuals.end());
+        rt_calibration_error_ = conf_residuals[conf_residuals.size() / 2];
+      }
+      OPENMS_LOG_INFO << "[PeptDeepRescoring] retention-time calibration (" << rt_model_type_ << ") on "
+                      << points.size() << " PSMs, median residual " << rt_calibration_error_ << " s" << std::endl;
+    }
+    else
+    {
+      OPENMS_LOG_WARN << "[PeptDeepRescoring] too few PSMs to calibrate retention time; "
+                      << Constants::UserParam::RT_ABS_ERROR << " will be 0 for every PSM." << std::endl;
+    }
+
+    // ---- write the features back ----
+    // Every hit gets every feature: a feature present on only some PSMs of a run is
+    // dropped for all of them by the Percolator feature-set check.
+    std::map<std::pair<Size, Size>, Size> row_of;
+    for (Size i = 0; i < rows.size(); ++i) { row_of[{rows[i].pi, rows[i].hit}] = i; }
+
+    for (Size pi = 0; pi < peptide_ids.size(); ++pi)
+    {
+      std::vector<PeptideHit> hits = peptide_ids[pi].getHits();
+      for (Size h = 0; h < hits.size(); ++h)
+      {
+        const auto it = row_of.find({pi, h});
+        const Similarity s = (it == row_of.end()) ? Similarity{} : sims[it->second];
+        const double e = (it == row_of.end()) ? 0.0 : rt_err[it->second];
+        hits[h].setMetaValue(Constants::UserParam::MS2_COSINE, s.cosine);
+        hits[h].setMetaValue(Constants::UserParam::MS2_SPECTRAL_ANGLE, s.spectral_angle);
+        hits[h].setMetaValue(Constants::UserParam::MS2_PEARSON, s.pearson);
+        hits[h].setMetaValue(Constants::UserParam::MS2_FRAC_PRED_FOUND, s.frac_found);
+        hits[h].setMetaValue(Constants::UserParam::RT_ABS_ERROR, e);
+      }
+      peptide_ids[pi].setHits(std::move(hits));
+    }
+
+    if (!protein_ids.empty())
+    {
+      ProteinIdentification::SearchParameters sp = protein_ids[0].getSearchParameters();
+      StringList features = sp.metaValueExists("extra_features")
+        ? ListUtils::create<std::string>(sp.getMetaValue("extra_features").toString(), ',')
+        : StringList();
+      for (const std::string& f : featureNames())
+      {
+        if (std::find(features.begin(), features.end(), f) == features.end()) { features.push_back(f); }
+      }
+      sp.setMetaValue("extra_features", ListUtils::concatenate(features, ","));
+      protein_ids[0].setSearchParameters(sp);
+    }
+  }
+
+} // namespace OpenMS

--- a/src/openms/source/ANALYSIS/ID/PeptDeepRescoring.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptDeepRescoring.cpp
@@ -298,7 +298,18 @@ namespace OpenMS
         "'fragment_annotation').");
     }
 
-    const bool higher_better = peptide_ids[0].isHigherScoreBetter();
+    // Collision energy per spectrum, keyed by native ID so each run can pick out its
+    // own spectra. Built once; the PeakMap is not otherwise needed below.
+    std::map<std::string, double> collision_energies;
+    for (const MSSpectrum& sp : spectra)
+    {
+      if (sp.getMSLevel() != 2 || sp.getPrecursors().empty()) { continue; }
+      const Precursor& prec = sp.getPrecursors()[0];
+      if (prec.metaValueExists("collision energy"))
+      {
+        collision_energies[sp.getNativeID()] = static_cast<double>(prec.getMetaValue("collision energy"));
+      }
+    }
 
     // Loading a model is expensive, so both sessions are created once and reused by
     // every run.
@@ -312,7 +323,12 @@ namespace OpenMS
     }
     for (const auto& [run_id, run_rows] : rows_by_run)
     {
-      annotateRun_(spectra, peptide_ids, rows, run_rows, uniq_seq, uniq_charge, higher_better, ms2, rt);
+      // Score orientation is a property of the run, not of the container: a merged file
+      // can hold runs from engines that disagree on it, and picking the wrong direction
+      // would calibrate on the *worst* PSMs.
+      const bool higher_better = peptide_ids[rows[run_rows.front()].pi].isHigherScoreBetter();
+      annotateRun_(collision_energies, peptide_ids, rows, run_rows, uniq_seq, uniq_charge,
+                   higher_better, ms2, rt);
     }
 
     // ---- register the features for rescoring, per run ----
@@ -352,7 +368,7 @@ namespace OpenMS
     }
   }
 
-  void PeptDeepRescoring::annotateRun_(const PeakMap& spectra,
+  void PeptDeepRescoring::annotateRun_(const std::map<std::string, double>& collision_energies,
                                        PeptideIdentificationList& peptide_ids,
                                        const std::vector<Row>& rows,
                                        const std::vector<Size>& run_rows,
@@ -378,16 +394,20 @@ namespace OpenMS
     double nce = nce_;
     if (nce <= 0.0)
     {
-      // Centre the grid on what the instrument recorded, when it recorded anything.
+      // Centre the grid on what the instrument recorded for *this run's* spectra.
+      // Runs acquired at different collision energies otherwise share a grid that can
+      // exclude one of their optima.
       std::vector<double> ces;
-      for (const MSSpectrum& s : spectra)
+      for (Size i : run_rows)
       {
-        if (s.getMSLevel() != 2 || s.getPrecursors().empty()) { continue; }
-        const Precursor& prec = s.getPrecursors()[0];
-        if (prec.metaValueExists("collision energy"))
-        {
-          ces.push_back(static_cast<double>(prec.getMetaValue("collision energy")));
-        }
+        const auto it = collision_energies.find(peptide_ids[rows[i].pi].getSpectrumReference());
+        if (it != collision_energies.end()) { ces.push_back(it->second); }
+      }
+      if (ces.empty())
+      {
+        // No usable spectrum references (older files, or identifications not linked to
+        // these spectra): fall back to every collision energy we saw.
+        for (const auto& [ref, ce] : collision_energies) { (void)ref; ces.push_back(ce); }
       }
       double centre = nce_fallback_;
       if (!ces.empty())

--- a/src/openms/source/ANALYSIS/ID/PeptDeepRescoring.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptDeepRescoring.cpp
@@ -30,6 +30,7 @@
 #include <cmath>
 #include <map>
 #include <memory>
+#include <set>
 #include <numeric>
 #include <string>
 #include <tuple>
@@ -300,15 +301,29 @@ namespace OpenMS
 
     // Collision energy per spectrum, keyed by native ID so each run can pick out its
     // own spectra. Built once; the PeakMap is not otherwise needed below.
+    //
+    // Native IDs are unique within a run, not across runs -- scan numbering restarts
+    // per file -- so a PeakMap spanning several runs can hold the same ID twice. Where
+    // two such spectra disagree on the collision energy there is no way to tell which
+    // run a PSM's reference meant, so the entry is dropped rather than resolved
+    // arbitrarily; those runs then fall back to the median over everything observed.
     std::map<std::string, double> collision_energies;
+    std::set<std::string> ambiguous_ids;
     for (const MSSpectrum& sp : spectra)
     {
       if (sp.getMSLevel() != 2 || sp.getPrecursors().empty()) { continue; }
       const Precursor& prec = sp.getPrecursors()[0];
-      if (prec.metaValueExists("collision energy"))
-      {
-        collision_energies[sp.getNativeID()] = static_cast<double>(prec.getMetaValue("collision energy"));
-      }
+      if (!prec.metaValueExists("collision energy")) { continue; }
+      const double ce = static_cast<double>(prec.getMetaValue("collision energy"));
+      const auto [it, inserted] = collision_energies.emplace(sp.getNativeID(), ce);
+      if (!inserted && std::abs(it->second - ce) > 1e-6) { ambiguous_ids.insert(sp.getNativeID()); }
+    }
+    for (const std::string& id : ambiguous_ids) { collision_energies.erase(id); }
+    if (!ambiguous_ids.empty())
+    {
+      OPENMS_LOG_WARN << "[PeptDeepRescoring] " << ambiguous_ids.size()
+                      << " spectrum identifiers occur more than once with differing collision "
+                         "energies; those spectra are excluded from collision-energy selection." << '\n';
     }
 
     // Loading a model is expensive, so both sessions are created once and reused by

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -512,7 +512,7 @@ namespace OpenMS
     (void)spectra; (void)protein_ids; (void)peptide_ids;
     OPENMS_LOG_WARN << "[ProSE] 'peptdeep:ms2_model'/'peptdeep:rt_model' are set, but this "
                        "OpenMS was built without ONNX support (WITH_ONNX=OFF); the "
-                       "prediction-based rescoring features are not added." << std::endl;
+                       "prediction-based rescoring features are not added." << '\n';
 #endif
   }
 

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -170,8 +170,10 @@ namespace OpenMS
 
     defaults_.setSectionDescription("annotate", "Annotation Options");
 
-    defaults_.setValue("peptdeep:ms2_model", "", "Path to a PeptDeep MS2 fragment-intensity ONNX model. Setting this together with 'peptdeep:rt_model' adds prediction-based rescoring features (ms2_cosine, ms2_spectral_angle, ms2_pearson, ms2_frac_pred_found, rt_abs_error) to every PSM. Requires an OpenMS built with ONNX support.");
-    defaults_.setValue("peptdeep:rt_model", "", "Path to a PeptDeep retention-time ONNX model. See 'peptdeep:ms2_model'.");
+    defaults_.setValue("peptdeep:enable", "false", "Add PeptDeep prediction-based rescoring features (ms2_cosine, ms2_spectral_angle, ms2_pearson, ms2_frac_pred_found, rt_abs_error) to every PSM. Uses the models shipped in OpenMS' 'share/OpenMS/models' unless 'peptdeep:ms2_model'/'peptdeep:rt_model' name others. Requires an OpenMS built with ONNX support.");
+    defaults_.setValidStrings("peptdeep:enable", {"true", "false"});
+    defaults_.setValue("peptdeep:ms2_model", "models/peptdeep_ms2_dynamic.onnx", "PeptDeep MS2 fragment-intensity ONNX model, used when 'peptdeep:enable' is true. A relative name is resolved against OpenMS' shared-data directory; an absolute path is used as given.");
+    defaults_.setValue("peptdeep:rt_model", "models/peptdeep_rt_dynamic.onnx", "PeptDeep retention-time ONNX model. See 'peptdeep:ms2_model'.");
     defaults_.setValue("peptdeep:instrument", "QE", "Instrument class passed to the PeptDeep MS2 model.");
     defaults_.setValidStrings("peptdeep:instrument", {"Lumos", "QE", "timsTOF", "SciexTOF"});
     defaults_.setValue("peptdeep:nce", -1.0, "Normalised collision energy for the PeptDeep MS2 model. Negative selects it automatically from the collision energy recorded in the spectra, refined by scoring a small grid on confident PSMs.");
@@ -294,6 +296,7 @@ namespace OpenMS
     precursor_min_charge_ = param_.getValue("precursor:min_charge");
     precursor_max_charge_ = param_.getValue("precursor:max_charge");
 
+    peptdeep_enable_ = param_.getValue("peptdeep:enable").toString() == "true";
     peptdeep_ms2_model_ = param_.getValue("peptdeep:ms2_model").toString();
     peptdeep_rt_model_ = param_.getValue("peptdeep:rt_model").toString();
     peptdeep_instrument_ = param_.getValue("peptdeep:instrument").toString();
@@ -494,13 +497,18 @@ namespace OpenMS
       std::vector<ProteinIdentification>& protein_ids,
       PeptideIdentificationList& peptide_ids) const
   {
-    if (peptdeep_ms2_model_.empty() || peptdeep_rt_model_.empty()) { return; }
+    if (!peptdeep_enable_) { return; }
 #ifdef WITH_ONNX
     startProgress(0, 1, "Adding PeptDeep rescoring features...");
     PeptDeepRescoring rescoring;
     Param p = rescoring.getParameters();
-    p.setValue("ms2_model", peptdeep_ms2_model_);
-    p.setValue("rt_model", peptdeep_rt_model_);
+    // A bare name resolves against share/OpenMS, an absolute path is returned unchanged.
+    // The models are downloaded to the build tree's share/OpenMS/models, which is not the
+    // compiled-in data path, so search relative to the executable as well: '../share/OpenMS'
+    // holds them both in a build tree (bin/../share) and in an install tree.
+    const StringList model_dirs = {File::getExecutablePath() + "../share/OpenMS"};
+    p.setValue("ms2_model", File::find(peptdeep_ms2_model_, model_dirs));
+    p.setValue("rt_model", File::find(peptdeep_rt_model_, model_dirs));
     p.setValue("instrument", peptdeep_instrument_);
     p.setValue("nce", peptdeep_nce_);
     p.setValue("rt_model_type", peptdeep_rt_model_type_);
@@ -510,9 +518,9 @@ namespace OpenMS
     endProgress();
 #else
     (void)spectra; (void)protein_ids; (void)peptide_ids;
-    OPENMS_LOG_WARN << "[ProSE] 'peptdeep:ms2_model'/'peptdeep:rt_model' are set, but this "
-                       "OpenMS was built without ONNX support (WITH_ONNX=OFF); the "
-                       "prediction-based rescoring features are not added." << '\n';
+    OPENMS_LOG_WARN << "[ProSE] 'peptdeep:enable' is set, but this OpenMS was built without "
+                       "ONNX support (WITH_ONNX=OFF); the prediction-based rescoring features "
+                       "are not added." << '\n';
 #endif
   }
 

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -15,6 +15,9 @@
 #include <OpenMS/ANALYSIS/ID/PeptideIndexing.h>
 #include <OpenMS/ANALYSIS/ID/HyperScore.h>
 #include <OpenMS/ANALYSIS/ID/OpenSearchModificationAnalysis.h>
+#ifdef WITH_ONNX
+#include <OpenMS/ANALYSIS/ID/PeptDeepRescoring.h>
+#endif
 #include <OpenMS/CHEMISTRY/DecoyGenerator.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
@@ -167,6 +170,15 @@ namespace OpenMS
 
     defaults_.setSectionDescription("annotate", "Annotation Options");
 
+    defaults_.setValue("peptdeep:ms2_model", "", "Path to a PeptDeep MS2 fragment-intensity ONNX model. Setting this together with 'peptdeep:rt_model' adds prediction-based rescoring features (ms2_cosine, ms2_spectral_angle, ms2_pearson, ms2_frac_pred_found, rt_abs_error) to every PSM. Requires an OpenMS built with ONNX support.");
+    defaults_.setValue("peptdeep:rt_model", "", "Path to a PeptDeep retention-time ONNX model. See 'peptdeep:ms2_model'.");
+    defaults_.setValue("peptdeep:instrument", "QE", "Instrument class passed to the PeptDeep MS2 model.");
+    defaults_.setValidStrings("peptdeep:instrument", {"Lumos", "QE", "timsTOF", "SciexTOF"});
+    defaults_.setValue("peptdeep:nce", -1.0, "Normalised collision energy for the PeptDeep MS2 model. Negative selects it automatically from the collision energy recorded in the spectra, refined by scoring a small grid on confident PSMs.");
+    defaults_.setValue("peptdeep:rt_model_type", "b_spline", "Model mapping predicted onto observed retention time.", {"advanced"});
+    defaults_.setValidStrings("peptdeep:rt_model_type", {"b_spline", "lowess", "linear"});
+    defaults_.setSectionDescription("peptdeep", "PeptDeep (ONNX) prediction-based rescoring features");
+
     defaults_.setValue("peptide:min_size", 7, "Minimum size a peptide must have after digestion to be considered in the search.");
     defaults_.setValue("peptide:max_size", 40, "Maximum size a peptide must have after digestion to be considered in the search (0 = disabled).");
     defaults_.setValue("peptide:missed_cleavages", 1, "Number of missed cleavages.");
@@ -281,6 +293,12 @@ namespace OpenMS
 
     precursor_min_charge_ = param_.getValue("precursor:min_charge");
     precursor_max_charge_ = param_.getValue("precursor:max_charge");
+
+    peptdeep_ms2_model_ = param_.getValue("peptdeep:ms2_model").toString();
+    peptdeep_rt_model_ = param_.getValue("peptdeep:rt_model").toString();
+    peptdeep_instrument_ = param_.getValue("peptdeep:instrument").toString();
+    peptdeep_nce_ = param_.getValue("peptdeep:nce");
+    peptdeep_rt_model_type_ = param_.getValue("peptdeep:rt_model_type").toString();
 
     precursor_isotopes_ = param_.getValue("precursor:isotopes");
     peaks_keep_n_ = (Size)(int)param_.getValue("peaks:keep_n");
@@ -470,6 +488,32 @@ namespace OpenMS
     const double var = std::max(0.0, sumsq / n - mean * mean);
     if (var <= 0.0) return 0.0; // every candidate scored the same: the best one is not an outlier
     return (best - mean) / std::sqrt(var);
+  }
+
+  void ProSEAlgorithm::annotatePeptDeepFeatures_(const PeakMap& spectra,
+      std::vector<ProteinIdentification>& protein_ids,
+      PeptideIdentificationList& peptide_ids) const
+  {
+    if (peptdeep_ms2_model_.empty() || peptdeep_rt_model_.empty()) { return; }
+#ifdef WITH_ONNX
+    startProgress(0, 1, "Adding PeptDeep rescoring features...");
+    PeptDeepRescoring rescoring;
+    Param p = rescoring.getParameters();
+    p.setValue("ms2_model", peptdeep_ms2_model_);
+    p.setValue("rt_model", peptdeep_rt_model_);
+    p.setValue("instrument", peptdeep_instrument_);
+    p.setValue("nce", peptdeep_nce_);
+    p.setValue("rt_model_type", peptdeep_rt_model_type_);
+    rescoring.setParameters(p);
+    rescoring.setLogType(getLogType());
+    rescoring.annotate(spectra, protein_ids, peptide_ids);
+    endProgress();
+#else
+    (void)spectra; (void)protein_ids; (void)peptide_ids;
+    OPENMS_LOG_WARN << "[ProSE] 'peptdeep:ms2_model'/'peptdeep:rt_model' are set, but this "
+                       "OpenMS was built without ONNX support (WITH_ONNX=OFF); the "
+                       "prediction-based rescoring features are not added." << std::endl;
+#endif
   }
 
   void ProSEAlgorithm::postProcessHits_(const PeakMap& exp,
@@ -1610,6 +1654,8 @@ namespace OpenMS
       );
     endProgress();
 
+    annotatePeptDeepFeatures_(spectra, protein_ids, peptide_ids);
+
     // 7. PeptideIndexing against the FULL database (not per-chunk).
     PeptideIndexing indexer;
     Param param_pi = indexer.getParameters();
@@ -1870,6 +1916,8 @@ namespace OpenMS
       "" // no database filename for in-memory search
       );
     endProgress();
+
+    annotatePeptDeepFeatures_(spectra, protein_ids, peptide_ids);
     sw_search.stop();
     last_run_stats_.seconds_search = sw_search.getClockTime();
 
@@ -2464,6 +2512,8 @@ namespace OpenMS
           per_file_cal[i].effective_fragment_tol,
           precursor_mass_tolerance_unit_, fragment_mass_tolerance_unit_,
           precursor_min_charge_, precursor_max_charge_, enzyme_, "");
+
+        annotatePeptDeepFeatures_(all_spectra[i], result.protein_ids, result.peptide_ids);
 
         PeptideIndexing indexer;
         Param param_pi = indexer.getParameters();

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -2532,6 +2532,9 @@ namespace OpenMS
           precursor_mass_tolerance_unit_, fragment_mass_tolerance_unit_,
           precursor_min_charge_, precursor_max_charge_, enzyme_, "");
 
+        // Per input file, while each file is still its own identification run. Moving this
+        // after the merge below would leave one run to calibrate NCE and RT on, which are
+        // per-run quantities; see the note on PeptDeepRescoring::annotate().
         annotatePeptDeepFeatures_(all_spectra[i], result.protein_ids, result.peptide_ids);
 
         PeptideIndexing indexer;

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -179,6 +179,8 @@ namespace OpenMS
     defaults_.setValue("peptdeep:nce", -1.0, "Normalised collision energy for the PeptDeep MS2 model. Negative selects it automatically from the collision energy recorded in the spectra, refined by scoring a small grid on confident PSMs.");
     defaults_.setValue("peptdeep:rt_model_type", "b_spline", "Model mapping predicted onto observed retention time.", {"advanced"});
     defaults_.setValidStrings("peptdeep:rt_model_type", {"b_spline", "lowess", "linear"});
+    defaults_.setValue("peptdeep:batch_size", 500, "Peptides per ONNX inference call.", {"advanced"});
+    defaults_.setMinInt("peptdeep:batch_size", 1);
     defaults_.setSectionDescription("peptdeep", "PeptDeep (ONNX) prediction-based rescoring features");
 
     defaults_.setValue("peptide:min_size", 7, "Minimum size a peptide must have after digestion to be considered in the search.");
@@ -302,6 +304,7 @@ namespace OpenMS
     peptdeep_instrument_ = param_.getValue("peptdeep:instrument").toString();
     peptdeep_nce_ = param_.getValue("peptdeep:nce");
     peptdeep_rt_model_type_ = param_.getValue("peptdeep:rt_model_type").toString();
+    peptdeep_batch_size_ = param_.getValue("peptdeep:batch_size");
 
     precursor_isotopes_ = param_.getValue("precursor:isotopes");
     peaks_keep_n_ = (Size)(int)param_.getValue("peaks:keep_n");
@@ -512,6 +515,14 @@ namespace OpenMS
     p.setValue("instrument", peptdeep_instrument_);
     p.setValue("nce", peptdeep_nce_);
     p.setValue("rt_model_type", peptdeep_rt_model_type_);
+    p.setValue("batch_size", peptdeep_batch_size_);
+    // Inference otherwise runs at its own default while the search around it scales with
+    // the thread count the user actually asked for.
+#ifdef _OPENMP
+    p.setValue("threads", std::max(1, omp_get_max_threads()));
+#else
+    p.setValue("threads", 1);
+#endif
     rescoring.setParameters(p);
     rescoring.setLogType(getLogType());
     rescoring.annotate(spectra, protein_ids, peptide_ids);

--- a/src/tests/class_tests/openms/data/PeptDeepRescoring_test.txt
+++ b/src/tests/class_tests/openms/data/PeptDeepRescoring_test.txt
@@ -1,0 +1,1 @@
+placeholder model file for the existence check

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -656,6 +656,10 @@ if(WITH_WNETALIGN)
   list(APPEND analysis_executables_list FeatureGroupingAlgorithmWNet_test WNetMatcher_test)
 endif()
 
+if(WITH_ONNX)
+  list(APPEND analysis_executables_list PeptDeepRescoring_test)
+endif()
+
 set(applications_executables_list
   INIUpdater_test
   #MapAlignerBase_test

--- a/src/tests/class_tests/openms/source/PeptDeepRescoring_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptDeepRescoring_test.cpp
@@ -16,11 +16,57 @@
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/METADATA/PeptideIdentificationList.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/SYSTEM/File.h>
+
+#include <cmath>
 
 ///////////////////////////
 
 using namespace OpenMS;
 using namespace std;
+
+// The models the build downloads for the ONNX tests; the class-test CMake copies them
+// next to this test's data. Same files PeptDeepInference_test loads.
+const std::string ms2_model_path = "data/peptdeep_ms2_dynamic.onnx";
+const std::string rt_model_path = "data/peptdeep_rt_dynamic.onnx";
+
+namespace
+{
+  /// A PSM whose peak annotations are the b/y ions of @p seq, so the observed side is a
+  /// plausible spectrum for it rather than noise.
+  PeptideHit makeHit_(const std::string& seq, int charge, double score,
+                      const std::vector<std::pair<std::string, double>>& peaks)
+  {
+    PeptideHit hit;
+    hit.setSequence(AASequence::fromString(seq));
+    hit.setCharge(charge);
+    hit.setScore(score);
+    std::vector<PeptideHit::PeakAnnotation> anns;
+    for (const auto& [name, intensity] : peaks)
+    {
+      PeptideHit::PeakAnnotation pa;
+      pa.annotation = name;
+      pa.charge = 1;
+      pa.mz = 100.0 + anns.size();
+      pa.intensity = intensity;
+      anns.push_back(pa);
+    }
+    hit.setPeakAnnotations(anns);
+    return hit;
+  }
+
+  PeptideIdentification makeId_(const std::string& run_id, double rt, const PeptideHit& hit)
+  {
+    PeptideIdentification pi;
+    pi.setIdentifier(run_id);
+    pi.setRT(rt);
+    pi.setHigherScoreBetter(true);
+    pi.setHits({hit});
+    return pi;
+  }
+}
 
 START_TEST(PeptDeepRescoring, "$Id$")
 
@@ -107,6 +153,198 @@ START_SECTION([EXTRA] annotate() is a no-op on empty input)
   // are never actually loaded.
   r.annotate(exp, prot, peps);
   TEST_EQUAL(peps.size(), 0)
+}
+END_SECTION
+
+START_SECTION([EXTRA] annotate() writes every feature and registers them per run)
+{
+  // Skip rather than fail if the downloaded models are not beside the test binary: the
+  // build normally provides them, but a hand-run binary may not see them.
+  if (!File::exists(ms2_model_path) || !File::exists(rt_model_path))
+  {
+    STATUS("PeptDeep ONNX models not found next to the test; skipping the end-to-end section.")
+  }
+  else
+  {
+    // Two runs, so the per-run grouping, calibration and feature registration are all
+    // exercised rather than assumed.
+    const std::vector<std::pair<std::string, double>> peaks =
+      {{"b2", 500.0}, {"y3", 900.0}, {"y4", 750.0}, {"b3", 300.0}, {"y5", 620.0}, {"y6", 410.0}};
+
+    PeptideIdentificationList peps;
+    // Enough PSMs that each run's confident half (calibration_quantile 0.5) still clears
+    // the four points the retention-time fit needs -- otherwise calibration is skipped
+    // and rt_abs_error is a constant zero that asserts nothing.
+    const std::vector<std::string> seqs =
+      {"PEPTIDEK", "TESTPEPTIDER", "ELVISLIVESK", "SAMPLERPEPTIDEK",
+       "LNGGKPVDEK", "VATVSLPRK", "AGGDLSTVEK", "YLDGTSLSPK",
+       "IADPEHLVK", "GFTVSGNLTK", "SLYPQEDVK", "NVLDTGAPIK",
+       "TFSDLPHLDK", "QALEGSVTLK", "MDSTEPPYSQK", "HVLTSIGEK",
+       "WGADLSPVEK", "CFAENGTLVK", "RPLDSNVTEK", "DYSAQLTPGK"};
+    for (Size i = 0; i < seqs.size(); ++i)
+    {
+      const std::string run = (i % 2 == 0) ? "run_A" : "run_B";
+      // Retention times increase with index so the calibration has a real trend to fit.
+      peps.push_back(makeId_(run, 100.0 + 40.0 * i, makeHit_(seqs[i], 2, 20.0 - i, peaks)));
+    }
+
+    std::vector<ProteinIdentification> prot(2);
+    prot[0].setIdentifier("run_A");
+    prot[1].setIdentifier("run_B");
+
+    PeptDeepRescoring r;
+    Param p = r.getParameters();
+    p.setValue("ms2_model", ms2_model_path);
+    p.setValue("rt_model", rt_model_path);
+    // Fixing the NCE keeps the test off the grid scan, which would otherwise dominate
+    // its runtime for no extra coverage of the write-back path.
+    p.setValue("nce", 30.0);
+    p.setValue("rt_model_type", "linear");
+    r.setParameters(p);
+
+    PeakMap exp;
+    r.annotate(exp, prot, peps);
+
+    // Every hit carries every feature. A feature present on only some PSMs of a run is
+    // dropped for all of them by Percolator, so partial annotation is a real failure.
+    for (const PeptideIdentification& pi : peps)
+    {
+      for (const PeptideHit& hit : pi.getHits())
+      {
+        for (const std::string& f : PeptDeepRescoring::featureNames())
+        {
+          TEST_EQUAL(hit.metaValueExists(f), true)
+        }
+      }
+    }
+
+    // Both runs must be told about the features, not just the first ProteinIdentification.
+    for (const ProteinIdentification& prot_run : prot)
+    {
+      const ProteinIdentification::SearchParameters& sp = prot_run.getSearchParameters();
+      TEST_EQUAL(sp.metaValueExists("extra_features"), true)
+      StringList registered =
+        ListUtils::create<std::string>(sp.getMetaValue("extra_features").toString(), ',');
+      for (const std::string& f : PeptDeepRescoring::featureNames())
+      {
+        TEST_EQUAL(std::find(registered.begin(), registered.end(), f) != registered.end(), true)
+      }
+    }
+
+    // The fixed NCE must be reported back rather than a stale or unset value.
+    TEST_REAL_SIMILAR(r.getUsedNCE(), 30.0)
+
+    // A negative calibration error means the fit was skipped, which would leave
+    // rt_abs_error a constant zero and make the checks below vacuous.
+    TEST_EQUAL(r.getRTCalibrationError() >= 0.0, true)
+
+    // Cosine is a similarity, so it has to stay in range whatever the model emits.
+    for (const PeptideIdentification& pi : peps)
+    {
+      const double cos = pi.getHits()[0].getMetaValue(Constants::UserParam::MS2_COSINE);
+      TEST_EQUAL(cos >= -1.0 && cos <= 1.0, true)
+      const double frac = pi.getHits()[0].getMetaValue(Constants::UserParam::MS2_FRAC_PRED_FOUND);
+      TEST_EQUAL(frac >= 0.0 && frac <= 1.0, true)
+      const double rt_err = pi.getHits()[0].getMetaValue(Constants::UserParam::RT_ABS_ERROR);
+      TEST_EQUAL(rt_err >= 0.0, true)
+    }
+  }
+}
+END_SECTION
+
+START_SECTION([EXTRA] automatic NCE selection scans the grid and reports its choice)
+{
+  if (!File::exists(ms2_model_path) || !File::exists(rt_model_path))
+  {
+    STATUS("PeptDeep ONNX models not found next to the test; skipping the NCE section.")
+  }
+  else
+  {
+    // No collision energy anywhere (the PeakMap is empty), so the grid centres on
+    // nce_fallback and the scan runs over centre +/- halfwidth. This is the only section
+    // that reaches the candidate loop; a fixed NCE skips it entirely.
+    const std::vector<std::pair<std::string, double>> peaks =
+      {{"b2", 400.0}, {"y3", 900.0}, {"y4", 650.0}, {"b3", 280.0}, {"y5", 520.0}};
+
+    PeptideIdentificationList peps;
+    const std::vector<std::string> seqs =
+      {"PEPTIDEK", "TESTPEPTIDER", "ELVISLIVESK", "LNGGKPVDEK",
+       "VATVSLPRK", "AGGDLSTVEK", "YLDGTSLSPK", "IADPEHLVK"};
+    for (Size i = 0; i < seqs.size(); ++i)
+    {
+      peps.push_back(makeId_("run_A", 200.0 + 30.0 * i, makeHit_(seqs[i], 2, 20.0 - i, peaks)));
+    }
+
+    std::vector<ProteinIdentification> prot(1);
+    prot[0].setIdentifier("run_A");
+
+    PeptDeepRescoring r;
+    Param p = r.getParameters();
+    p.setValue("ms2_model", ms2_model_path);
+    p.setValue("rt_model", rt_model_path);
+    p.setValue("nce", -1.0);            // negative: select from the data
+    p.setValue("nce_fallback", 30.0);
+    p.setValue("nce_grid_halfwidth", 6.0);
+    p.setValue("nce_grid_step", 2.0);
+    p.setValue("rt_model_type", "linear");
+    r.setParameters(p);
+
+    PeakMap exp;
+    r.annotate(exp, prot, peps);
+
+    // Whatever it picked has to come from the grid it was given.
+    const double used = r.getUsedNCE();
+    TEST_EQUAL(used >= 24.0 && used <= 36.0, true)
+    // And it must be a grid point, not an interpolation.
+    TEST_REAL_SIMILAR(std::fmod(used - 24.0, 2.0), 0.0)
+  }
+}
+END_SECTION
+
+START_SECTION([EXTRA] a matching peptide scores a higher cosine than a mismatched one)
+{
+  if (!File::exists(ms2_model_path) || !File::exists(rt_model_path))
+  {
+    STATUS("PeptDeep ONNX models not found next to the test; skipping the discrimination section.")
+  }
+  else
+  {
+    // Give both hits the annotations of the SAME observed spectrum. Only the first hit's
+    // sequence produced it, so its prediction should agree with it better than the other's.
+    // This is what the feature exists to do; if it fails, the ion mapping is wrong.
+    const std::string observed_seq = "SAMPLERPEPTIDEK";
+    const std::vector<std::pair<std::string, double>> peaks =
+      {{"y2", 800.0}, {"y3", 950.0}, {"y4", 700.0}, {"y5", 500.0},
+       {"b2", 300.0}, {"b3", 450.0}, {"b4", 260.0}};
+
+    PeptideIdentificationList peps;
+    peps.push_back(makeId_("run_A", 300.0, makeHit_(observed_seq, 2, 20.0, peaks)));
+    peps.push_back(makeId_("run_A", 300.0, makeHit_("KEDITPEPRELPMAS", 2, 19.0, peaks)));
+    // A few more so the run has enough points to calibrate at all.
+    const std::vector<std::string> filler = {"PEPTIDEK", "TESTPEPTIDER", "ELVISLIVESK", "AGGDLSTVEK"};
+    for (Size i = 0; i < filler.size(); ++i)
+    {
+      peps.push_back(makeId_("run_A", 400.0 + 50.0 * i, makeHit_(filler[i], 2, 18.0 - i, peaks)));
+    }
+
+    std::vector<ProteinIdentification> prot(1);
+    prot[0].setIdentifier("run_A");
+
+    PeptDeepRescoring r;
+    Param p = r.getParameters();
+    p.setValue("ms2_model", ms2_model_path);
+    p.setValue("rt_model", rt_model_path);
+    p.setValue("nce", 30.0);
+    p.setValue("rt_model_type", "linear");
+    r.setParameters(p);
+
+    PeakMap exp;
+    r.annotate(exp, prot, peps);
+
+    const double matched = peps[0].getHits()[0].getMetaValue(Constants::UserParam::MS2_COSINE);
+    const double mismatched = peps[1].getHits()[0].getMetaValue(Constants::UserParam::MS2_COSINE);
+    TEST_EQUAL(matched > mismatched, true)
+  }
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/PeptDeepRescoring_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptDeepRescoring_test.cpp
@@ -252,6 +252,91 @@ START_SECTION([EXTRA] annotate() writes every feature and registers them per run
 }
 END_SECTION
 
+START_SECTION([EXTRA] a run without peak annotations is reported rather than silently zeroed)
+{
+  if (!File::exists(ms2_model_path) || !File::exists(rt_model_path))
+  {
+    STATUS("PeptDeep ONNX models not found next to the test; skipping the mixed-annotation section.")
+  }
+  else
+  {
+    // run_A carries annotations, run_B does not. The global "no PSM has annotations"
+    // guard does not fire here, so without a per-run check run_B would receive four
+    // MS2 features that are exactly zero for every PSM -- a constant block Percolator
+    // reads as a run separator rather than as evidence.
+    const std::vector<std::pair<std::string, double>> peaks =
+      {{"b2", 400.0}, {"y3", 900.0}, {"y4", 650.0}, {"b3", 280.0}, {"y5", 520.0}};
+    const std::vector<std::pair<std::string, double>> none;
+
+    PeptideIdentificationList peps;
+    const std::vector<std::string> seqs =
+      {"PEPTIDEK", "TESTPEPTIDER", "ELVISLIVESK", "LNGGKPVDEK",
+       "VATVSLPRK", "AGGDLSTVEK", "YLDGTSLSPK", "IADPEHLVK"};
+    for (Size i = 0; i < seqs.size(); ++i)
+    {
+      const bool run_a = (i % 2 == 0);
+      peps.push_back(makeId_(run_a ? "run_A" : "run_B", 150.0 + 35.0 * i,
+                             makeHit_(seqs[i], 2, 20.0 - i, run_a ? peaks : none)));
+    }
+
+    std::vector<ProteinIdentification> prot(2);
+    prot[0].setIdentifier("run_A");
+    prot[1].setIdentifier("run_B");
+
+    PeptDeepRescoring r;
+    Param p = r.getParameters();
+    p.setValue("ms2_model", ms2_model_path);
+    p.setValue("rt_model", rt_model_path);
+    p.setValue("nce", 30.0);
+    p.setValue("rt_model_type", "linear");
+    r.setParameters(p);
+
+    PeakMap exp;
+    // Must not throw: one run is annotated, so the input is usable -- the unannotated
+    // run is a warning, not a fatal error.
+    r.annotate(exp, prot, peps);
+
+    // The features are still written everywhere (dropping them for one run would leave
+    // Percolator with a ragged feature set), but run_B's MS2 values are all zero and
+    // run_A's are not. That asymmetry is exactly what the warning exists to announce.
+    double run_a_cosine_sum = 0.0, run_b_cosine_sum = 0.0;
+    for (const PeptideIdentification& pi : peps)
+    {
+      for (const PeptideHit& hit : pi.getHits())
+      {
+        TEST_EQUAL(hit.metaValueExists(Constants::UserParam::MS2_COSINE), true)
+        const double c = hit.getMetaValue(Constants::UserParam::MS2_COSINE);
+        if (pi.getIdentifier() == "run_A") { run_a_cosine_sum += c; } else { run_b_cosine_sum += c; }
+      }
+    }
+    TEST_REAL_SIMILAR(run_b_cosine_sum, 0.0)
+    TEST_EQUAL(run_a_cosine_sum > 0.0, true)
+  }
+}
+END_SECTION
+
+START_SECTION([EXTRA] every run lacking annotations is still a hard error)
+{
+  PeptDeepRescoring r;
+  Param p = r.getParameters();
+  p.setValue("ms2_model", ms2_model_path);
+  p.setValue("rt_model", rt_model_path);
+  r.setParameters(p);
+
+  // Two runs, neither annotated: nothing can be computed, so this must still throw
+  // rather than degrade to a file of zeros.
+  PeptideIdentificationList peps;
+  peps.push_back(makeId_("run_A", 100.0, makeHit_("PEPTIDEK", 2, 20.0, {})));
+  peps.push_back(makeId_("run_B", 200.0, makeHit_("TESTPEPTIDER", 2, 19.0, {})));
+  std::vector<ProteinIdentification> prot(2);
+  prot[0].setIdentifier("run_A");
+  prot[1].setIdentifier("run_B");
+
+  PeakMap exp;
+  TEST_EXCEPTION(Exception::MissingInformation, r.annotate(exp, prot, peps))
+}
+END_SECTION
+
 START_SECTION([EXTRA] automatic NCE selection scans the grid and reports its choice)
 {
   if (!File::exists(ms2_model_path) || !File::exists(rt_model_path))

--- a/src/tests/class_tests/openms/source/PeptDeepRescoring_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptDeepRescoring_test.cpp
@@ -1,0 +1,114 @@
+// Copyright (c) 2002-present, OpenMS Team -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/ANALYSIS/ID/PeptDeepRescoring.h>
+#include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/METADATA/PeptideIdentificationList.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
+
+///////////////////////////
+
+using namespace OpenMS;
+using namespace std;
+
+START_TEST(PeptDeepRescoring, "$Id$")
+
+/////////////////////////////////////////////////////////////
+
+PeptDeepRescoring* ptr = nullptr;
+PeptDeepRescoring* null_ptr = nullptr;
+
+START_SECTION((PeptDeepRescoring()))
+  ptr = new PeptDeepRescoring();
+  TEST_NOT_EQUAL(ptr, null_ptr)
+END_SECTION
+
+START_SECTION((~PeptDeepRescoring()))
+  delete ptr;
+END_SECTION
+
+START_SECTION((static StringList featureNames()))
+{
+  StringList names = PeptDeepRescoring::featureNames();
+  TEST_EQUAL(names.size(), 5)
+  // The order is part of the contract: it is what gets appended to extra_features.
+  TEST_STRING_EQUAL(names[0], Constants::UserParam::MS2_COSINE)
+  TEST_STRING_EQUAL(names[1], Constants::UserParam::MS2_SPECTRAL_ANGLE)
+  TEST_STRING_EQUAL(names[2], Constants::UserParam::MS2_PEARSON)
+  TEST_STRING_EQUAL(names[3], Constants::UserParam::MS2_FRAC_PRED_FOUND)
+  TEST_STRING_EQUAL(names[4], Constants::UserParam::RT_ABS_ERROR)
+}
+END_SECTION
+
+START_SECTION([EXTRA] default parameters)
+{
+  PeptDeepRescoring r;
+  Param p = r.getParameters();
+  // Models have no sensible default, so they start empty and annotate() refuses to run.
+  TEST_STRING_EQUAL(p.getValue("ms2_model").toString(), "")
+  TEST_STRING_EQUAL(p.getValue("rt_model").toString(), "")
+  // A negative NCE means "select it from the data".
+  TEST_REAL_SIMILAR((double)p.getValue("nce"), -1.0)
+  TEST_STRING_EQUAL(p.getValue("rt_model_type").toString(), "b_spline")
+  TEST_STRING_EQUAL(p.getValue("instrument").toString(), "QE")
+  // Nothing has been run yet.
+  TEST_REAL_SIMILAR(r.getUsedNCE(), -1.0)
+}
+END_SECTION
+
+START_SECTION([EXTRA] annotate() refuses to run without models)
+{
+  PeptDeepRescoring r;
+  PeakMap exp;
+  vector<ProteinIdentification> prot(1);
+  PeptideIdentificationList peps;
+  PeptideIdentification pi;
+  PeptideHit hit;
+  hit.setSequence(AASequence::fromString("PEPTIDEK"));
+  hit.setCharge(2);
+  pi.setHits({hit});
+  peps.push_back(pi);
+
+  // Both model paths empty: the features cannot be computed at all.
+  TEST_EXCEPTION(Exception::MissingInformation, r.annotate(exp, prot, peps))
+
+  // A configured but absent model must fail loudly rather than silently emit zeros.
+  Param p = r.getParameters();
+  p.setValue("ms2_model", "does_not_exist_ms2.onnx");
+  p.setValue("rt_model", "does_not_exist_rt.onnx");
+  r.setParameters(p);
+  TEST_EXCEPTION(Exception::FileNotFound, r.annotate(exp, prot, peps))
+}
+END_SECTION
+
+START_SECTION([EXTRA] annotate() is a no-op on empty input)
+{
+  PeptDeepRescoring r;
+  Param p = r.getParameters();
+  p.setValue("ms2_model", OPENMS_GET_TEST_DATA_PATH("PeptDeepRescoring_test.txt"));
+  p.setValue("rt_model", OPENMS_GET_TEST_DATA_PATH("PeptDeepRescoring_test.txt"));
+  r.setParameters(p);
+
+  PeakMap exp;
+  vector<ProteinIdentification> prot(1);
+  PeptideIdentificationList peps;
+  // No PSMs: returns before touching the ONNX runtime, so the placeholder files above
+  // are never actually loaded.
+  r.annotate(exp, prot, peps);
+  TEST_EQUAL(peps.size(), 0)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+END_TEST


### PR DESCRIPTION
I did a quick attempt with AI:

there are several questions we need to address.
- how to properly test it (in CI)?
- how to deploy models (package vs. download)
- does it work correctly with multi file runs/merged runs


## Description

Adds `PeptDeepRescoring`, which compares every PSM against an AlphaPeptDeep prediction of the same peptide and stores the agreement as five per-hit features, registered in `extra_features` so `PercolatorAdapter` picks them up:

| feature | what it measures |
|---|---|
| `ms2_cosine`, `ms2_spectral_angle`, `ms2_pearson` | predicted versus observed fragment intensities |
| `ms2_frac_pred_found` | fraction of confidently predicted ions that were actually observed |
| `rt_abs_error` | observed retention time versus a per-run calibration of the predicted retention time |

Observed intensities come from the PSM's own peak annotations, so no second pass over the spectra is needed. Predicted ions that were not matched contribute zero on the observed side, which is what makes a wrong peptide score badly rather than simply score on fewer ions.

ProSE gains `peptdeep:*` parameters and calls this from all three search paths. The step is skipped unless both model paths are set, so default behaviour is unchanged. Built only with `WITH_ONNX`, which now also defines `WITH_ONNX=1` publicly so dependent code can compile the calls out — matching how `WITH_OPENTIMS` and `WITH_THERMO_RAW` are handled. On a build without ONNX, an ini file requesting the models still runs and warns rather than failing.

### Two quantities are calibrated from the data

Neither has a safe global default, and both are properties of the run:

**Collision energy.** The mzML value (`Precursor` meta value `"collision energy"`, which is where OpenMS puts `MS:1000045`) is used only as the centre of a small search grid; each candidate is scored on a sample of confident PSMs and the best median cosine wins. Reading the file alone is not enough — the model's NCE scale does not coincide with the instrument's number:

| | instrument reports | best by prediction quality |
|---|---|---|
| Q Exactive HF | 27 | **31** (scan), 30 (manual) |
| Orbitrap Astral | 30 | 27–30 |

On the Q Exactive HF run, NCE 27 gives target/decoy cosine separation +0.6522 against +0.6539 at 30 — the instrument's own value is measurably not the optimum. Setting `peptdeep:nce` to a positive value skips the scan.

**Retention time.** Predicted RT is in the model's own iRT-like units, so it is mapped onto the run's gradient with an OpenMS `TransformationModel` before the residual is taken. `b_spline` (5 nodes) is the default; `lowess` and `linear` are selectable.

Confident PSMs are selected by search score rather than by spectral similarity, which would otherwise tie the RT feature to the MS2 features.

### Evaluation

Two DDA runs from archive.openms.de, ProSE's built-in in-process Percolator, target PSMs at 1% FDR, five Percolator seeds, Welch *t*. Baseline is the 14-feature default set from #9970.

| | Q Exactive HF | Orbitrap Astral |
|---|---|---|
| default 14 features | 56655.0 ± 19.9 | 30841.4 ± 103.7 |
| + 4 MS2 similarity | +1362.8 (t = 97.4) | +2990.6 (t = 62.9) |
| + `rt_abs_error` | +1759.2 (t = 160.0) | +2976.0 (t = 61.4) |
| **+ all five** | **+2076.8 (+3.67%), t = 205.0** | **+4615.6 (+14.97%), t = 96.0** |

For scale, all four hand-crafted features in #9970 were worth +247 PSMs on the same Q Exactive HF run; these are roughly eight times that.

Both prior modification support and the earlier prototype's handling of it matter here. #9765 made `PeptDeepInputBuilder` modification-aware, and its `mod_x` output was checked against `peptdeep`'s own `parse_mod_feature` for Carbamidomethyl, Oxidation, Phospho, a two-modification peptide and an N-terminal Acetyl — all five match exactly. That is what lets these features be computed for every PSM: 22.9% of target and 30.4% of decoy PSMs carry a modification, so assigning them a fixed value would leak "is modified" into the features as a decoy proxy.

### Measured but not adopted

- **A single similarity metric instead of four.** `ms2_cosine` alone with RT reaches 58685.8 against 58731.8 for all four; the difference is small but real (+46.0, t = 5.26), so the block is kept. `ms2_spectral_angle` alone is equivalent to `ms2_cosine` alone (t = 1.95).
- **The RT calibration model.** All three are statistically indistinguishable on the Q Exactive HF run: `b_spline` −3.8 (t = −0.43), `lowess` −3.2 (t = −0.44), `linear` +5.6 (t = +1.01) against a degree-3 polynomial prototype; `b_spline` versus `linear` is −9.4 (t = −1.21). What matters is calibrating at all, not the form. `b_spline` is kept as the default for gradients where the iRT-to-RT mapping is not linear, but on this data linear would do as well.
- An unconstrained smoothing spline *did* regress (−17.8, t = −2.99) by tracking the calibration set; the node-limited fit this PR uses does not.

<sub>A SCIEX TripleTOF 6600 run (PXD060911) was also attempted as a vendor-independent third dataset and discarded without being scored: its converted mzML carries no precursor charge annotation at all, so ProSE must guess charges and the search collapses (1210 PSMs from 66709 spectra, target:decoy 1.17).</sub>

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

`ctest -R 'ProSE|PeptDeep|FragmentIndex|PercolatorAdapter'`: 43/43 pass, including the new `PeptDeepRescoring_test`. The ProSE golden files are unchanged, because the step is inert unless model paths are given. No pyOpenMS update was needed: the new class is only present in ONNX-enabled builds, so exposing it would make the bindings depend on the build configuration.

CHANGELOG is left unticked — happy to add an entry if you'd like one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPU24wdJgjAoyWYVuUU5FA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional PeptDeep-based rescoring for peptide-spectrum matches.
  * Added MS2 similarity and retention-time error features to search results.
  * Added automatic collision-energy and retention-time calibration.
  * Added configurable model paths, instrument, collision energy, and retention-time settings.
  * Features are available when ONNX support is enabled; otherwise processing continues with a warning.

* **Tests**
  * Added coverage for default settings, feature names, validation errors, and empty inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->