### PR TITLE
[FIX] ProteomicsLFQ: actually shuffle the quant-score SVM training sample

### DIFF
--- a/src/topp/ProteomicsLFQ.cpp
+++ b/src/topp/ProteomicsLFQ.cpp
@@ -1229,9 +1229,18 @@ protected:
         size_t current_row = 0;
         size_t quant_target {}, quant_decoy {};
 
-        Math::RandomShuffler shuffler;
+        // Draw the (up to) 1000 target and 1000 decoy training examples from a
+        // random subset instead of the head of the FeatureMap, which is ordered
+        // by RT and would otherwise bias the SVM towards early-eluting features.
+        // The seed is fixed so the selection stays reproducible across runs.
+        // Note: the predictor rows are filled in this shuffled order and the
+        // predictions are written back by iterating the same index vector, so
+        // row i of 'predictors'/'labels'/'predictions' always refers to
+        // fm[randomized_indices[i]].
+        Math::RandomShuffler shuffler(42);
         std::vector<size_t> randomized_indices(fm.size());
         std::iota(randomized_indices.begin(), randomized_indices.end(), 0);
+        shuffler.portable_random_shuffle(randomized_indices.begin(), randomized_indices.end());
 
         for (auto& i : randomized_indices)
         {


### PR DESCRIPTION
Fixes #9981

## Problem

In `ProteomicsLFQ`'s quantification-score SVM filter, `Math::RandomShuffler shuffler;` was constructed but never called. `randomized_indices` was `iota`-filled and then iterated in `FeatureMap` order:

```cpp
Math::RandomShuffler shuffler;                 // no call site
std::vector<size_t> randomized_indices(fm.size());
std::iota(randomized_indices.begin(), randomized_indices.end(), 0);

for (auto& i : randomized_indices) { ... }
```

The loop caps the SVM training set at 1000 targets and 1000 decoys, so without the shuffle those were simply the first 1000 of each in `FeatureMap` (RT) order, biasing training towards early-eluting features instead of a random subsample.

## Fix

Shuffle the index vector before use, with an explicit fixed seed:

```cpp
Math::RandomShuffler shuffler(42);
std::vector<size_t> randomized_indices(fm.size());
std::iota(randomized_indices.begin(), randomized_indices.end(), 0);
shuffler.portable_random_shuffle(randomized_indices.begin(), randomized_indices.end());
```

Same pattern as `FFIDAlgoExternalIDHandler::getRandomSample_`, which does exactly this for its SVM training selection.

## On determinism

The issue flagged that fixing this could make the path non-deterministic. It does not: `RandomShuffler`'s default ctor is `= default`, so `rng_` was already a default-seeded `boost::mt19937_64`. Passing `42` explicitly just documents that (cf. `ProSEAlgorithm.cpp:1123`) and keeps the selection reproducible across runs.

## Index consistency

The shuffle permutes both sides consistently, so there is no row/feature desync:

- `predictors` and `labels` rows are filled while iterating `randomized_indices`;
- `SimpleSVM::predict(predictions)` with an empty index list returns one prediction per observation **in row order** (`src/openms/source/ML/SVM/SimpleSVM.cpp`);
- the write-back loop iterates the same `randomized_indices`.

So row `i` of `predictors`/`labels`/`predictions` always refers to `fm[randomized_indices[i]]`. A comment in the code records this invariant.

## Test impact

None. The path is gated on `filter_by_quant_scores`, i.e. `-feature_with_id_min_score > 0` (default `0.0`). No test or `.ini` under `src/tests/` or `share/` sets `feature_with_id_min_score` or `feature_without_id_min_score`, so all existing reference outputs are produced with this branch disabled.

Verified to compile cleanly (`-fsyntax-only` with the target's real build flags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made training-example selection reproducible across runs while preserving randomized sampling.
  * Reduced potential bias from selecting examples solely according to retention-time order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->