### PR TITLE
[FIX,TOPP,TEST] ProteomicsLFQ: make the fraction's link FWHM a median, not the last file's

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -442,6 +442,15 @@ TOPP tools:
         right after peptide indexing, so the filter found nothing to keep; it is now preserved for that
         setting. Proteins left without evidence are dropped and the remaining ones are reported as
         singleton groups, which the quantification and all exporters need (#9979)
+      - The chromatographic FWHM the feature linker derives its RT tolerance from is now the median
+        over the runs of a fraction. It used to be whichever run the per-file loop happened to end
+        on, so the tolerance depended on the order the files were given in. Feature detection is
+        unaffected: each run still uses its own FWHM for the FFID peak width. Related: a run that
+        cannot measure one (.d/IM_PEAK without seeds) now falls back to the documented 30 s default
+        instead of inheriting the previous run's value, and a decoy affix that differs between input
+        files is reported rather than silently letting the last file decide the one picked protein
+        FDR uses. On the shipped fixtures the fraction values move (8.64/7.78/7.12 s: 7.12 -> 7.78)
+        without changing any output, since the tolerance is dominated by the alignment term
       - Identifications are now reduced to one per (spectrum, peptidoform, charge) when the input
         carries several of them -- the shape produced by concatenating search engine results rather
         than combining them (e.g. PSMFeatureExtractor -multiple_search_engines -concat, or

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -4260,6 +4260,46 @@ set_tests_properties("TOPP_ProteomicsLFQ_strictly_unique" PROPERTIES FAIL_REGULA
 add_test("TOPP_ProteomicsLFQ_strictly_unique_out_1" ${DIFF} -whitelist "software" "location" "InferenceEngineVersion" "TOPPProteinInference q-value" -in1 ${TESTS_TEMP_DIR}/BSA_strictly_unique.tmp.mzTab -in2 ${DATA_DIR_TOPP}/ProteomicsLFQ_strictly_unique_out.mzTab )
 set_tests_properties("TOPP_ProteomicsLFQ_strictly_unique_out_1" PROPERTIES DEPENDS "TOPP_ProteomicsLFQ_strictly_unique")
 
+# The feature linker's RT tolerance is derived from a fraction-level chromatographic FWHM, which
+# is the median over the fraction's runs rather than whichever run the loop ended on. On these
+# fixtures the two differ (fraction 1: runs 8.64/7.78/7.12, last-wins 7.12 vs median 7.78) but
+# the tolerance is dominated by 2*max_alignment_diff, floored at 120 s, so no output changes.
+# Nothing else would notice a silent revert to last-file-wins, hence this assertion on the log.
+# Note: PASS_REGULAR_EXPRESSION makes ctest ignore the exit code, so this test only pins the
+# aggregation; TOPP_ProteomicsLFQ_1_subset above is what checks the run actually succeeds.
+add_test("TOPP_ProteomicsLFQ_fraction_fwhm" ${TOPP_BIN_PATH}/ProteomicsLFQ
+         -in
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA1_F1.mzML
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA1_F2.mzML
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA2_F1.mzML
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA2_F2.mzML
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA3_F1.mzML
+         -ids
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA1_F1.idXML
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA1_F2.idXML
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA2_F1.idXML
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA2_F2.idXML
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA3_F1.idXML
+         -design
+         ${DATA_DIR_SHARE}/examples/FRACTIONS/BSA_design_onetable_nonconsec.tsv
+         -Alignment:align_algorithm:max_rt_shift 0
+         -fasta
+         ${DATA_DIR_SHARE}/examples/TOPPAS/data/BSA_Identification/18Protein_SoCe_Tr_detergents_trace_target_decoy.fasta
+         -targeted_only true
+         -mass_recalibration false
+         -out ${TESTS_TEMP_DIR}/BSA_fraction_fwhm.tmp.mzTab
+         -threads 1
+         -proteinFDR 0.3
+         -test
+         )
+# PASS pins that the aggregation happens at all (a revert would delete it); FAIL pins that the
+# reported value is not the last run's 7.115, i.e. that it is genuinely aggregated rather than
+# inherited. Deliberately matched on "7.1" rather than on the median itself, so the assertion
+# does not become brittle to platform differences in the FWHM estimate.
+set_tests_properties("TOPP_ProteomicsLFQ_fraction_fwhm" PROPERTIES
+  PASS_REGULAR_EXPRESSION "Median chromatographic FWHM across the 3 runs of this fraction"
+  FAIL_REGULAR_EXPRESSION "across the 3 runs of this fraction: 7\\.1")
+
 # QPX Parquet export test (reuses subset test input data)
   # Clear the output directory first. ctest never cleans tmp_path, so without this a
   # producer that crashed - or that legitimately stopped writing a file - would leave the

--- a/src/topp/ProteomicsLFQ.cpp
+++ b/src/topp/ProteomicsLFQ.cpp
@@ -819,8 +819,28 @@ protected:
       FASTAContainer<TFI_File> fasta_db(in_db);
       PeptideIndexing::ExitCodes indexer_exit = indexer.run(fasta_db, protein_ids, peptide_ids);
 
-      picked_decoy_string_ = indexer.getDecoyString();
-      picked_decoy_prefix_ = indexer.isPrefix();
+      // Picked protein FDR uses a single decoy affix for the whole study, but this runs once per
+      // input file and used to simply overwrite, so the last file silently decided it. The affix
+      // is a property of the FASTA, hence identical for every file in a well-formed run; if two
+      // files disagree, one of them was searched against a different database and the picked FDR
+      // would be computed against an affix that does not match half the accessions.
+      const std::string run_decoy_string = indexer.getDecoyString();
+      const bool run_decoy_prefix = indexer.isPrefix();
+      if (!picked_decoy_seen_)
+      {
+        picked_decoy_string_ = run_decoy_string;
+        picked_decoy_prefix_ = run_decoy_prefix;
+        picked_decoy_seen_ = true;
+      }
+      else if (run_decoy_string != picked_decoy_string_ || run_decoy_prefix != picked_decoy_prefix_)
+      {
+        OPENMS_LOG_WARN << "Warning: decoy affix inferred from " << id_file_abs_path << " ('"
+                        << run_decoy_string << "', " << (run_decoy_prefix ? "prefix" : "suffix")
+                        << ") differs from the one inferred from earlier input ('" << picked_decoy_string_
+                        << "', " << (picked_decoy_prefix_ ? "prefix" : "suffix")
+                        << "). Keeping the first. Picked protein FDR assumes one affix for the whole "
+                           "study - check that all inputs were searched against the same database.\n";
+      }
       if ((indexer_exit != PeptideIndexing::ExitCodes::EXECUTION_OK) && (indexer_exit != PeptideIndexing::ExitCodes::PEPTIDE_IDS_EMPTY))
       {
         if (indexer_exit == PeptideIndexing::ExitCodes::DATABASE_EMPTY) { return INPUT_FILE_EMPTY; }
@@ -1032,7 +1052,6 @@ protected:
     const pair<UInt, std::vector<std::string> > & ms_files,
     const map<std::string, std::string>& mzfile2idfile,
     const std::string& in_db,
-    double median_fwhm,
     ConsensusMap & consensus_fraction,
     set<std::string>& fixed_modifications,
     set<std::string>& variable_modifications)
@@ -1047,6 +1066,12 @@ protected:
     StringList id_MS_run_ref;
     StringList in_MS_run = ms_files.second;
     const auto& path_label_to_fractiongroup = design_.getPathLabelToFractionGroupMapping(true);
+
+    // One chromatographic FWHM per MS run of this fraction. The linker's RT tolerance is a
+    // property of the fraction, so it is derived from all of them (below) rather than from
+    // whichever run the loop happened to end on.
+    std::vector<double> run_fwhms;
+    run_fwhms.reserve(ms_files.second.size());
 
     for (std::string const & mz_file : ms_files.second)
     {
@@ -1067,6 +1092,11 @@ protected:
       MSExperiment ms_centroided;
       bool is_im_peak_data = false;
       const bool mass_recalibration = (getStringOption_("mass_recalibration") == "true");
+
+      // Chromatographic FWHM of THIS run. Scoped to the iteration so that a run which cannot
+      // measure one (IM_PEAK without seeds) falls back to the documented default instead of
+      // silently inheriting the previous run's value.
+      double median_fwhm = 0.0;
 
       {
         ExitCodes e = loadAndPreprocess_(mz_file, ms_centroided, is_im_peak_data);
@@ -1177,6 +1207,10 @@ protected:
           FileHandler().storeFeatures("debug_seeds_fraction_" + StringUtils::toStr(ms_files.first) + "_" + StringUtils::toStr(fraction_group) + ".featureXML", seeds, {FileTypes::FEATUREXML}, log_type_);
         }
       }
+
+      // median_fwhm is final for this run: measured from the raw data, from the Biosaur2
+      // seeds, or defaulted. Record it for the fraction-level linking window below.
+      run_fwhms.push_back(median_fwhm);
 
       /////////////////////////////////////////////////
       // Feature detection
@@ -1389,7 +1423,24 @@ protected:
         break;
     }
 
-    alignAndLink_(feature_maps, consensus_fraction, transformations, median_fwhm);
+    // The linker derives its RT tolerance from this (2*max_alignment_diff + 2*fraction_fwhm,
+    // and PIP-ECHO's local_rt window). It describes the fraction as a whole, so take the median
+    // over its runs. Previously this read whatever the per-run variable happened to hold after
+    // the loop, i.e. the last run's value, which made the tolerance depend on input order.
+    double fraction_fwhm = 0.0;
+    if (!run_fwhms.empty())
+    {
+      fraction_fwhm = Math::median(run_fwhms.begin(), run_fwhms.end());
+      if (run_fwhms.size() > 1)
+      {
+        const auto minmax = std::minmax_element(run_fwhms.begin(), run_fwhms.end());
+        OPENMS_LOG_INFO << "Median chromatographic FWHM across the " << run_fwhms.size()
+                        << " runs of this fraction: " << fraction_fwhm
+                        << " s (range " << *minmax.first << " - " << *minmax.second << " s)\n";
+      }
+    }
+
+    alignAndLink_(feature_maps, consensus_fraction, transformations, fraction_fwhm);
 
     if (feature_maps.size() > 1)
     {
@@ -1775,12 +1826,11 @@ protected:
     if (getStringOption_("quantification_method") == "feature_intensity")
     {
       OPENMS_LOG_INFO << "Performing feature intensity-based quantification." << endl;
-      double median_fwhm(0);
       for (auto const& ms_files : frac2ms) // for each fraction->ms file(s)
       {
         ConsensusMap consensus_fraction; // quantitative result for this fraction identifier
 
-        ExitCodes e = quantifyFraction_(ms_files, mzfile2idfile, in_db, median_fwhm, consensus_fraction, fixed_modifications, variable_modifications);
+        ExitCodes e = quantifyFraction_(ms_files, mzfile2idfile, in_db, consensus_fraction, fixed_modifications, variable_modifications);
 
         if (e != EXECUTION_OK) { return e; }
 
@@ -2040,6 +2090,7 @@ protected:
   }
   std::string picked_decoy_string_;
   bool picked_decoy_prefix_ = true;
+  bool picked_decoy_seen_ = false; ///< has an affix been inferred from an input file yet?
   ExperimentalDesign design_;
 };
 


### PR DESCRIPTION
## What

The feature linker's RT tolerance is derived from a chromatographic FWHM
(`distance_RT:max_difference = 2*max_alignment_diff + 2*fwhm`, and PIP-ECHO's `local_rt` window).
That FWHM describes the fraction, but `quantifyFraction_` computed it into a variable scoped to
the whole function and read it again *after* the per-file loop had finished — so it was whichever
run the loop ended on, and the tolerance depended on the order the files were passed in.

It is now the median over the fraction's runs. **Feature detection is untouched**:
`detect:peak_width` still uses the current run's own FWHM, which is a genuinely per-run quantity.
Only the fraction-level use changes.

## Two related defects with the same shape

- **The per-run value is now scoped to the loop iteration.** The "no seed-based estimate
  available, use 30 s" fallback for `.d`/IM_PEAK fires on `== 0.0`, so it only ever fired for the
  *first* file; a later IM_PEAK run in a fraction that also contained a non-IM run silently
  inherited that run's measured FWHM instead.
- **`picked_decoy_string_`/`picked_decoy_prefix_` were overwritten by every input file**, so the
  last one silently decided the affix used for picked protein FDR across the whole study. The
  first is now kept and a disagreement is reported: the affix is a property of the FASTA, so two
  files disagreeing means one was searched against a different database and the picked FDR would
  be computed against an affix that does not match half the accessions.

## Effect on output

None, on the shipped fixtures — and the values genuinely do move, so this is not vacuous:

| fraction | per-run FWHMs (s) | before (last run) | after (median) |
|---|---|---|---|
| 1 | 8.64 / 7.78 / 7.12 | 7.12 | 7.78 |
| 2 | 8.68 / 8.77 | 8.77 | 8.73 |

No grouping decision changes, because the tolerance is dominated by `2*max_alignment_diff`, which
is floored at 120 s: a ~1.4 s shift in a ~255 s window moves nothing. So the change is justified
by the definition rather than by an observed delta, and the fixtures are not sensitive enough to
show one. No reference file is touched.

## Test

Since nothing in the outputs would notice a silent revert to last-file-wins,
`TOPP_ProteomicsLFQ_fraction_fwhm` asserts the aggregation on the log:
`PASS_REGULAR_EXPRESSION` pins that it happens over the fraction's 3 runs,
`FAIL_REGULAR_EXPRESSION` pins that the reported value is not the last run's `7.1x`. Matched on
`7.1` rather than on the median itself so it does not become brittle to platform differences in
the FWHM estimate.

Verified to fail for its stated reason: with `Math::median(...)` replaced by `run_fwhms.back()`,
it reports `7.11529` and goes red; green again on revert.

`ctest -R TOPP_ProteomicsLFQ`: **72/72 pass** (rebased onto develop after #9979/#9982/#9984, so
this includes the new `strictly_unique` tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fraction-level retention-time tolerance calculations by using the median chromatographic FWHM across runs.
  * Runs without measurable FWHM now use the standard 30-second fallback consistently.
  * Added warnings when input files specify inconsistent decoy affixes.

* **Tests**
  * Added coverage verifying that median FWHM aggregation is correctly reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->