### PR TITLE
Update CHANGELOG: fraction FWHM PR reference and missing SVM shuffle fix entry

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -450,7 +450,13 @@ TOPP tools:
         instead of inheriting the previous run's value, and a decoy affix that differs between input
         files is reported rather than silently letting the last file decide the one picked protein
         FDR uses. On the shipped fixtures the fraction values move (8.64/7.78/7.12 s: 7.12 -> 7.78)
-        without changing any output, since the tolerance is dominated by the alignment term
+        without changing any output, since the tolerance is dominated by the alignment term (#9985)
+      - Fix: the quantification-score SVM filter (-feature_with_id_min_score /
+        -feature_without_id_min_score) now actually shuffles its training sample before capping it
+        at 1000 targets and 1000 decoys; a constructed-but-never-called RandomShuffler left the cap
+        applied to the first 1000 of each in RT order, biasing training towards early-eluting
+        features. Shuffling uses a fixed seed, so the selection stays reproducible across runs. No
+        effect unless one of those two parameters is set above its default of 0.0 (#9981, #9982)
       - Identifications are now reduced to one per (spectrum, peptidoform, charge) when the input
         carries several of them -- the shape produced by concatenating search engine results rather
         than combining them (e.g. PSMFeatureExtractor -multiple_search_engines -concat, or


### PR DESCRIPTION
## Description

Two small CHANGELOG gaps found while auditing recently merged PRs against the changelog:

- The `ProteomicsLFQ` "fraction FWHM is now the median" entry (added by #9985) was missing its own PR citation — it ended with a plain sentence instead of `(#9985)` like every other entry in that section.
- #9982 (fixes #9981) — the quant-score SVM training filter actually shuffling its sample before capping at 1000 targets/decoys, fixing a bias toward early-eluting features — had no CHANGELOG entry at all.

Added the missing PR reference and a new entry for #9981/#9982 under the `ProteomicsLFQ` TOPP tools section, matching the existing style.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A, docs-only change)
- [ ] New and existing unit tests pass locally with my changes (N/A, docs-only change)
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)


---
_Generated by [Claude Code](https://claude.ai/code/session_011BcssmGej97WFDdDWW7LhW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quantification-score filtering by shuffling training samples before limiting their size, reducing retention-time bias toward early-eluting features.
  * Ensured shuffling remains reproducible across runs.
* **Documentation**
  * Added the relevant pull request reference to the FWHM changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->