### PR TITLE
Fix Windows NSIS packaging: invalid CMake escape breaks nightly build

### DIFF
--- a/cmake/package_nsis.cmake
+++ b/cmake/package_nsis.cmake
@@ -59,7 +59,11 @@ install(CODE "
 ## (picked up automatically by include(CPack) below). We used to !include it via a hardcoded "..\..\..\"
 ## relative path from CPack's NSIS staging directory, which silently breaks whenever CPACK_PACKAGE_DIRECTORY
 ## is redirected elsewhere (e.g. to a short path on Windows to avoid MAX_PATH issues).
-file(TO_NATIVE_PATH "${PROJECT_BINARY_DIR}/Cfg_Settings.nsh" CPACK_OPENMS_CFG_SETTINGS_FILE)
+## Keep forward slashes here (like CPack's own CPACK_TOPLEVEL_DIRECTORY et al.): CPack re-serializes this
+## variable into a quoted string in the generated CPackConfig.cmake, and a native Windows path's backslashes
+## (e.g. "\a" in "D:\a\...", GitHub Actions' checkout root) are parsed as invalid CMake escape sequences there.
+## NSIS itself accepts forward slashes in !include paths just fine.
+set(CPACK_OPENMS_CFG_SETTINGS_FILE "${PROJECT_BINARY_DIR}/Cfg_Settings.nsh")
 
 ## Remove the next three lines if you use the NSIS autogeneration feature at some point!
 ## For now it makes sure everything is merged into the usual folders bin/share/include


### PR DESCRIPTION
## Description

The nightly `Release` workflow's Windows (`cl.exe`) packaging job has been failing every night since a prior fix (159f6f1, merged via #9985... actually via develop directly on 2026-08-28) changed how `CPACK_OPENMS_CFG_SETTINGS_FILE` is computed:

```
CMake Error at .../CPackConfig.cmake:36 (set):
  Syntax error in cmake code at
    .../CPackConfig.cmake:36
  when parsing string
    D:\a\OpenMS\OpenMS\build\windows-x64-ci\Cfg_Settings.nsh
  Invalid character escape '\a'.
```

Root cause: `cmake/package_nsis.cmake` used `file(TO_NATIVE_PATH ...)` to compute the absolute path to the generated `Cfg_Settings.nsh`, producing a Windows path with literal backslashes (GitHub Actions checks out the repo under `D:\a\<owner>\<repo>`, so the path contains `\a\OpenMS\...`). This value is a `CPACK_`-prefixed variable, so CPack re-serializes it into a quoted CMake string literal inside the generated `CPackConfig.cmake`. CMake's string parser does not recognize `\a` as a valid escape sequence, so parsing that generated file fails outright, which fails the whole packaging step on every matrix job that produces an NSIS installer (the nightly `Release` workflow on `windows-2025`/`cl.exe`).

Fix: build the path with forward slashes instead (`"${PROJECT_BINARY_DIR}/Cfg_Settings.nsh"`), the same convention already used by CPack's own path variables (e.g. `CPACK_TOPLEVEL_DIRECTORY`) in the same NSIS template (`cmake/Windows/NSIS.template.in`). NSIS's `!include` accepts forward-slash paths just fine, so this avoids the backslash-escaping problem entirely without reintroducing the original bug (a hardcoded relative `!include` path that broke when `CPACK_PACKAGE_DIRECTORY` is redirected to a short path).

This is not a workaround (skipping the packaging step, disabling the check, etc.) — it fixes the actual path being generated so `cpack -G NSIS` can parse its own generated config file.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes (no unit tests cover CPack/NSIS packaging; validated by reasoning through CPack's variable serialization and by reproducing the exact log context)
- [x] Updated or added python bindings for changed or new classes (not applicable — build/packaging script only, no Python-bound classes changed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VpxwBU1rrrxSkouRMHW8XC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows installer packaging by ensuring configuration files are referenced with valid paths.
  * Prevented packaging failures caused by incorrectly escaped Windows paths during installer generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->