### PR TITLE
[FIX,FEATUREFINDER,TEST] FeatureFinderIdentification: initialise the peptide counters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -687,6 +687,14 @@ TOPP tools:
         shorter in RT than the dominant trace they belong with: 'isotope_rt_overlap_reference'
         (longer|shorter) and 'min_isotope_rt_overlap' (default 0.7) for FeatureFindingMetabo, with a
         matching option for MetaboliteFeatureDeconvolution (#4483, #9711)
+    FeatureFinderIdentification (and the FeatureFinderIdentificationAlgorithm library class):
+      - Fix: the run summary reported a garbage count of external peptides ("12 peptides identified
+        (12 internal, 140724733953152 additional external)"). n_external_peps_ was assigned only when
+        external identifications were supplied, but read unconditionally, so without them statistics_()
+        formatted an uninitialised member -- undefined behaviour, and visible in every ProteomicsLFQ
+        and FeatureFinderIdentification run that does not use external IDs. Both peptide counters are
+        now initialised, and the external one is reset per run rather than only inside that branch, so
+        a reused algorithm object cannot carry the previous run's count into the next one
     FeatureFinderMetaboIdent:
       - Added an optional "Adduct" column to the TSV input; m/z is computed via AdductInfo from any
         supported notation (e.g. [M+Na]+, [M-H]-, [2M+H]+) and features are annotated with the adduct.

--- a/src/openms/include/OpenMS/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.h
+++ b/src/openms/include/OpenMS/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.h
@@ -181,8 +181,8 @@ protected:
 
   PeptideMap peptide_map_;
 
-  Size n_internal_peps_; ///< number of internal peptide
-  Size n_external_peps_; ///< number of external peptides
+  Size n_internal_peps_ = 0; ///< number of internal peptide
+  Size n_external_peps_ = 0; ///< number of external peptides
 
   Size batch_size_; ///< nr of peptides to use at the same time during chromatogram extraction
   double rt_window_; ///< RT window width

--- a/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
@@ -792,6 +792,10 @@ namespace OpenMS
     }
 
     n_internal_peps_ = peptide_map_.size();
+    // Reset alongside the internal count, not only inside the branch below: without external IDs
+    // nothing assigned this, so statistics_() read whatever the member happened to hold -- an
+    // uninitialised value on the first run, the previous run's count on a reused algorithm object.
+    n_external_peps_ = 0;
 
     if (with_external_ids)
     {

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -437,6 +437,13 @@ set_tests_properties("TOPP_FeatureFinderLFQ_1_out1" PROPERTIES DEPENDS "TOPP_Fea
 add_test("TOPP_FeatureFinderIdentification_1" ${TOPP_BIN_PATH}/FeatureFinderIdentification -test -in ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_input.mzML -id ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_input.idXML -out ${TESTS_TEMP_DIR}/FeatureFinderIdentification_1.tmp.featureXML -extract:mz_window 0.1 -detect:peak_width 60 -model:type none)
 add_test("TOPP_FeatureFinderIdentification_1_out1" ${DIFF} -whitelist "spectra_data" "featureMap" -in1 ${TESTS_TEMP_DIR}/FeatureFinderIdentification_1.tmp.featureXML -in2 ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_output.featureXML)
 set_tests_properties("TOPP_FeatureFinderIdentification_1_out1" PROPERTIES DEPENDS "TOPP_FeatureFinderIdentification_1")
+## The run summary must report a real external-peptide count, not an uninitialised member. Without
+## -id_ext nothing assigned n_external_peps_, so this line printed whatever memory held. Matched with
+## the leading comma and space, so a genuine count of 10 or 20 cannot satisfy it. Own invocation
+## rather than a property on the test above: PASS_REGULAR_EXPRESSION makes ctest ignore the exit
+## code, which would weaken that test's check that the tool succeeded.
+add_test("TOPP_FeatureFinderIdentification_no_ext_count" ${TOPP_BIN_PATH}/FeatureFinderIdentification -test -in ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_input.mzML -id ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_input.idXML -out ${TESTS_TEMP_DIR}/FeatureFinderIdentification_no_ext_count.tmp.featureXML -extract:mz_window 0.1 -detect:peak_width 60 -model:type none)
+set_tests_properties("TOPP_FeatureFinderIdentification_no_ext_count" PROPERTIES PASS_REGULAR_EXPRESSION ", 0 additional external")
 ## with (faked) external IDs; fix SVM parameters to avoid randomness:
 ## test currently produces different results on Windows, Mac, and Linux
 # add_test("TOPP_FeatureFinderIdentification_2" ${TOPP_BIN_PATH}/FeatureFinderIdentification -test -in ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_input.mzML -id ${DATA_DIR_TOPP}/FeatureFinderIdentification_2_input.idXML -id_ext ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_input.idXML -out ${TESTS_TEMP_DIR}/FeatureFinderIdentification_2.tmp.featureXML -extract:mz_window 0.1 -detect:peak_width 60 -svm:no_selection -svm:log2_C 1 -svm:log2_gamma 1 -model:type none)


### PR DESCRIPTION
## The bug

`FeatureFinderIdentification` and `ProteomicsLFQ` print a garbage external-peptide count in the run summary:

```
12 peptides identified (12 internal, 140724733953152 additional external)
4 peptides without features (4 internal, 130499712 external)
```

`runSingleGroup_()` assigns `n_external_peps_` only inside `if (with_external_ids)`, but `statistics_()` reads it unconditionally. A run given no external identifications therefore formats an **uninitialised member** — undefined behaviour. `n_missing_external` is derived from the same value, so the third line of the summary is wrong too.

This is not an edge case: it happens on every `ProteomicsLFQ` run, and on every `FeatureFinderIdentification` run without `-id_ext`.

## The fix

Both counters get in-class initialisers, and `n_external_peps_` is reset next to `n_internal_peps_` rather than only inside that branch. An initialiser alone would fix the first run but leave a reused algorithm object reporting the previous run's count.

After:

```
12 peptides identified (12 internal, 0 additional external)
4 peptides without features (4 internal, 0 external)
```

## Why nothing caught it

`TOPP_FeatureFinderIdentification_2` is the only test that passes `-id_ext`, and it has been commented out for producing different results across platforms — so the external-ID bookkeeping has no coverage at all.

Added `TOPP_FeatureFinderIdentification_no_ext_count`, which asserts the summary reports a real count. Matched as `, 0 additional external` — anchored on the comma and space so a genuine count of 10 or 20 cannot satisfy it — and given its own invocation rather than a property on the existing test, since `PASS_REGULAR_EXPRESSION` makes ctest ignore the exit code and would have weakened that test's check that the tool succeeded.

One honest caveat: because the old behaviour was UB, uninitialised memory could in principle happen to be 0 on some platform, and the test would then pass spuriously against the unfixed code. It still pins the contract going forward.

Found while reviewing #9989; unrelated to that PR's changes, hence separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected FeatureFinderIdentification run summaries to report zero additional external peptides when no external identifications are provided.
  * Prevented external peptide counts from carrying over between consecutive runs.

* **Tests**
  * Added coverage verifying accurate reporting when external identifications are omitted.

* **Documentation**
  * Updated the development changelog with details of the reporting correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->