### PR TITLE
[TEST,CLEANUP] Cover SignalToNoiseEstimatorMedianRapid empty-window fallback, drop unused boost includes

### DIFF
--- a/src/openms/source/PROCESSING/NOISEESTIMATION/SignalToNoiseEstimatorMedianRapid.cpp
+++ b/src/openms/source/PROCESSING/NOISEESTIMATION/SignalToNoiseEstimatorMedianRapid.cpp
@@ -9,16 +9,9 @@
 #include <OpenMS/PROCESSING/NOISEESTIMATION/SignalToNoiseEstimatorMedianRapid.h>
 
 #include <algorithm>
+#include <cmath>
+#include <iterator>
 #include <numeric>
-
-// array_wrapper needs to be included before it is used
-// only in boost1.64+. See issue #2790
-#if OPENMS_BOOST_VERSION_MINOR >= 64
-#include <boost/serialization/array_wrapper.hpp>
-#endif
-#include <boost/accumulators/accumulators.hpp>
-#include <boost/accumulators/statistics/mean.hpp>
-#include <boost/accumulators/statistics/variance.hpp>
 
 namespace OpenMS
 {

--- a/src/tests/class_tests/openms/source/SignalToNoiseEstimatorMedianRapid_test.cpp
+++ b/src/tests/class_tests/openms/source/SignalToNoiseEstimatorMedianRapid_test.cpp
@@ -119,6 +119,52 @@ START_SECTION( (NoiseEstimator estimateNoise(std::vector<double>& mz_array, std:
     TEST_REAL_SIMILAR(e.get_noise_even(550), 4.909  ) // numpy.median( int[33:] )
   }
 
+  // Empty windows: a gap in the m/z array leaves a window without any data point.
+  // computeMedian_ returns 0 for such a window, which triggers the imputed
+  // fallback value (mean + 3*stdev)/60 computed over the *whole* intensity array.
+  {
+    // m/z 200..290 and 400..490 are populated, so the window [300, 400) is empty.
+    static const double arr_mz[] =
+    {
+      200, 210, 220, 230, 240, 250, 260, 270, 280, 290,
+      400, 410, 420, 430, 440, 450, 460, 470, 480, 490
+    };
+    static const double arr_int[] =
+    {
+      5, 3, 7, 9, 1, 4, 6, 8, 2, 10,
+      5, 3, 7, 9, 1, 4, 6, 8, 2, 10
+    };
+    std::vector<double> mz_gap (arr_mz, arr_mz + sizeof(arr_mz) / sizeof(arr_mz[0]) );
+    std::vector<double> int_gap (arr_int, arr_int + sizeof(arr_int) / sizeof(arr_int[0]) );
+
+    // mean = 5.5, stdev = 2.8722813233, fallback = (5.5 + 3*2.8722813233)/60
+    SignalToNoiseEstimatorMedianRapid sne(100);
+    SignalToNoiseEstimatorMedianRapid::NoiseEstimator e = sne.estimateNoise(mz_gap, int_gap);
+    TEST_REAL_SIMILAR(e.get_noise_even(250), 5.5)           // median of the first block
+    TEST_REAL_SIMILAR(e.get_noise_even(350), 0.23528073283) // empty window -> imputed fallback
+    TEST_REAL_SIMILAR(e.get_noise_even(450), 5.5)           // median of the second block
+    TEST_REAL_SIMILAR(e.get_noise_odd(350), 5.0)
+    TEST_REAL_SIMILAR(e.get_noise_value(350), (0.23528073283 + 5.0) / 2.0)
+  }
+
+  // All intensities zero: every median is 0, so the fallback is imputed - but the
+  // fallback itself evaluates to 0 here. Guards against a fallback cache that uses
+  // the value (instead of a flag) as its "already computed" sentinel, and against a
+  // division by zero in clients, since get_noise_value clamps to 1.0.
+  {
+    std::vector<double> mz_zero, int_zero;
+    for (size_t i = 0; i < 20; ++i)
+    {
+      mz_zero.push_back(200.0 + 10.0 * i);
+      int_zero.push_back(0.0);
+    }
+
+    SignalToNoiseEstimatorMedianRapid sne(100);
+    SignalToNoiseEstimatorMedianRapid::NoiseEstimator e = sne.estimateNoise(mz_zero, int_zero);
+    TEST_REAL_SIMILAR(e.get_noise_even(250), 0.0)
+    TEST_REAL_SIMILAR(e.get_noise_value(250), 1.0)
+  }
+
 }
 END_SECTION
 


### PR DESCRIPTION
## Description

Two independent follow-ups to the review of #9782, split out so they can land on their own.

Both changes were written against `develop` and hold **before and after** the speedup in #9782, so they are regression guards rather than a codification of new behaviour. Merging them first gives #9782 a safety net for the exact code path it reworks.

### 1. Test coverage for the zero-median fallback

`computeNoiseInWindows_` imputes `(mean + 3*stdev)/60` whenever a window's median is exactly 0. **No existing test ever executed that branch**: the class test's intensity array contains no zeros and its m/z grid is uniform, so no window is ever empty. The whole fallback path could be broken and CI would stay green.

Two cases are added to the existing `estimateNoise` section:

- **m/z gap** — points at 200–290 and 400–490 with `window_length = 100`, leaving `[300, 400)` without any data point. `computeMedian_` returns 0 and the imputed value `0.23528073283` is stored. The odd-grid value and `get_noise_value` at the same position are asserted too, so the even/odd averaging over an imputed window is covered.
- **all-zero intensities** — here the imputed fallback is itself `0.0`. This distinguishes a fallback cache keyed on a flag from one keyed on the value: a `if (fallback == 0.0)` sentinel would silently recompute mean/stdev for every window and nothing would catch it. It also pins `get_noise_value` clamping to `1.0`, so clients dividing by the noise estimate stay safe.

This matters for #9782, which makes that branch stateful and cached.

### 2. Remove unused boost includes

No `boost::accumulators` symbol appears anywhere in the translation unit — mean and stdev are computed with `std::accumulate` / `std::inner_product`. The `boost/serialization/array_wrapper.hpp` include and its `OPENMS_BOOST_VERSION_MINOR` guard (the issue #2790 workaround) existed only to support the accumulators headers, so all four go.

:warning: Those headers were also **transitively supplying `<cmath>`**. Removing them without compensating breaks the build on the `std::sqrt` used for the stdev:

```
error: 'sqrt' is not a member of 'std'; did you mean 'sort'?
```

So `<cmath>` is added explicitly, along with `<iterator>` for `std::distance` / `std::advance` / `std::iterator_traits`, which were likewise only incidentally available. The translation unit is now self-contained.

### Verification

Compiled the real translation unit against the real header with `-Wall -Wextra` — clean, no warnings — then linked it into a harness running the new assertions plus all 25 pre-existing ones from the class test, against **this branch's** (i.e. `develop`'s) implementation:

```
empty-window block:    5/5 OK
all-zero block:        2/2 OK
existing assertions:  25/25 OK
ALL PASS (0 failures)
```

The same 32 assertions also pass against the #9782 head, which is what makes these safe to merge in either order.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file <!-- n/a: test coverage + removal of unused includes, no user-facing change -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.) <!-- no API change -->

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfBYxKS6C1aUUhgSUSycQA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfBYxKS6C1aUUhgSUSycQA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signal-to-noise estimation when data contains gaps, ensuring empty measurement windows receive a valid fallback estimate.
  * Improved handling of spectra with entirely zero intensities, preventing invalid noise values and applying the minimum supported noise level.

* **Tests**
  * Added coverage for gapped m/z data and all-zero intensity arrays to verify reliable noise estimation in these edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->