### PR TITLE
[FIX,TEST] Biosaur2Algorithm: preserve MS data on the FAIMS path (crashes ProteomicsLFQ)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1087,7 +1087,9 @@ Fixes:
     experiment. ProteomicsLFQ with -Seeding:algorithm biosaur2 passed exactly that on to
     FeatureFinderIdentification, which crashed on the zero-spectrum experiment (its chromatogram
     extraction indexes the PeakMap unconditionally). The spectra and chromatograms are now reassembled
-    in acquisition order, so both Biosaur2 paths leave the same processed experiment behind, and
+    in acquisition order (profile-mode centroiding likewise no longer replaces the whole experiment,
+    which dropped the chromatograms and experimental settings before the split saw them), so both
+    Biosaur2 paths leave the same processed experiment behind, and
     FeatureFinderIdentificationAlgorithm::run() rejects MS data without spectra instead of reading out
     of bounds (#9980)
   - Fix: ExperimentalDesign's Sample* mappings disagreed about their key, so any design whose sample names

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1057,6 +1057,14 @@ OpenMS Library:
     - Iterator patterns, container checks and memory allocation optimized in hot paths (#8656)
 
 Fixes:
+  - Fix: Biosaur2Algorithm::run() left the stored MS data empty on FAIMS input -- the per-CV split moves
+    the spectra out of ms_data_ and nothing put them back, so getMSData() handed the caller a cleared
+    experiment. ProteomicsLFQ with -Seeding:algorithm biosaur2 passed exactly that on to
+    FeatureFinderIdentification, which crashed on the zero-spectrum experiment (its chromatogram
+    extraction indexes the PeakMap unconditionally). The spectra and chromatograms are now reassembled
+    in acquisition order, so both Biosaur2 paths leave the same processed experiment behind, and
+    FeatureFinderIdentificationAlgorithm::run() rejects MS data without spectra instead of reading out
+    of bounds (#9980)
   - Fix: ExperimentalDesign's Sample* mappings disagreed about their key, so any design whose sample names
     are not "0", "1", ... crashed with a bare std::out_of_range. getSampleToPrefractionationMapping() was
     keyed by sample name while the condition and path-label mappings used the stringified zero-based row

--- a/src/openms/include/OpenMS/FEATUREFINDER/Biosaur2Algorithm.h
+++ b/src/openms/include/OpenMS/FEATUREFINDER/Biosaur2Algorithm.h
@@ -186,12 +186,12 @@ public:
     @param[out] peptide_features Output container storing intermediate peptide feature representations before conversion to FeatureMap entries
 
     @note The input MS data must be set via setMSData() before calling this method.
-    @note <b>This method destructively consumes the stored MS data.</b> It modifies the internal
-          experiment in place (all spectra with MS level != 1 are removed; if profile_mode is enabled the
-          remaining spectra are centroided with PeakPickerHiRes; if tof_mode is enabled TOF intensity
-          filtering is applied). On data containing FAIMS compensation voltages the stored experiment is
-          additionally moved out, so getMSData() afterwards returns an emptied/moved-from experiment.
-          run() is therefore not idempotent — call setMSData() again before re-running.
+    @note <b>This method modifies the stored MS data.</b> All spectra with MS level != 1 are removed;
+          if profile_mode is enabled the remaining spectra are centroided with PeakPickerHiRes; if
+          tof_mode is enabled TOF intensity filtering is applied. Data containing FAIMS compensation
+          voltages is split by CV internally and reassembled afterwards, so getMSData() returns the
+          same kind of processed experiment on both paths. run() is therefore not idempotent — call
+          setMSData() again before re-running.
   */
   void run(FeatureMap& feature_map,
            std::vector<Hill>& hills,

--- a/src/openms/source/FEATUREFINDER/Biosaur2Algorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/Biosaur2Algorithm.cpp
@@ -279,7 +279,11 @@ void Biosaur2Algorithm::run(FeatureMap& feature_map,
   }
   else
   {
-    // FAIMS: split by CV (moves ms_data_), process groups in parallel, merge
+    // FAIMS: split by CV (moves ms_data_), process groups in parallel, merge.
+    // splitByFAIMSCV() only redistributes spectra, so the chromatograms are kept
+    // aside here and put back together with the spectra below.
+    std::vector<MSChromatogram> chromatograms = std::move(ms_data_.getChromatograms());
+
     std::vector<std::pair<double, MSExperiment>> groups =
       IMDataConverter::splitByFAIMSCV(std::move(ms_data_));
 
@@ -321,6 +325,34 @@ void Biosaur2Algorithm::run(FeatureMap& feature_map,
         feature_map.insert(feature_map.end(), gm.begin(), gm.end());
       }
     }
+
+    // Reassemble ms_data_ from the per-CV groups. Without this, getMSData() would
+    // return the experiment splitByFAIMSCV() emptied, and a caller that reuses the
+    // data after run() (e.g. ProteomicsLFQ handing it to FeatureFinderIdentification)
+    // would silently continue on zero spectra. The spectra are moved back, so this
+    // costs no additional peak memory, and the result matches what the in-place path
+    // above leaves behind: MS1 only, centroided/TOF-filtered as configured.
+    if (!groups.empty())
+    {
+      Size n_spectra = 0;
+      for (const auto& group_pair : groups)
+      {
+        n_spectra += group_pair.second.size();
+      }
+      ms_data_.getExperimentalSettings() = groups.front().second.getExperimentalSettings();
+      ms_data_.reserveSpaceSpectra(n_spectra);
+      for (auto& group_pair : groups)
+      {
+        for (MSSpectrum& spec : group_pair.second)
+        {
+          ms_data_.addSpectrum(std::move(spec));
+        }
+        group_pair.second.clear(true);
+      }
+      // the groups are ordered by CV, so restore acquisition order across them
+      ms_data_.sortSpectra(false);
+    }
+    ms_data_.setChromatograms(std::move(chromatograms));
 
     // Optionally merge features representing the same analyte at different FAIMS CV values
     if (faims_merge_features_)

--- a/src/openms/source/FEATUREFINDER/Biosaur2Algorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/Biosaur2Algorithm.cpp
@@ -909,7 +909,9 @@ void Biosaur2Algorithm::centroidProfileSpectra_(MSExperiment& exp) const
     total_peaks_after += centroided_spectrum.size();
   }
 
-  exp = centroided_exp;
+  // Replace only the spectra: assigning the whole experiment would drop the
+  // experimental settings and the chromatograms, which centroiding does not touch.
+  exp.setSpectra(std::move(centroided_exp.getSpectra()));
   OPENMS_LOG_INFO << "Centroiding: " << total_peaks_before
                   << " profile points -> " << total_peaks_after << " centroided peaks" << endl;
 }

--- a/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
@@ -575,6 +575,20 @@ namespace OpenMS
     const std::string& spectra_file
     )
   {
+    // Without spectra there is nothing to extract chromatograms from, and the
+    // extraction below indexes the experiment unconditionally. Fail with a usable
+    // message instead of reading out of bounds.
+    if (ms_data_.empty())
+    {
+      throw Exception::IllegalArgument(
+        __FILE__,
+        __LINE__,
+        OPENMS_PRETTY_FUNCTION,
+        "No spectra in the MS data passed to FeatureFinderIdentification. Set the MS data via "
+        "setMSData() before calling run(); note that an experiment consumed by another algorithm "
+        "may have been left empty.");
+    }
+
     // Check for FAIMS data
     auto faims_groups = IMDataConverter::splitByFAIMSCV(std::move(ms_data_));
     const bool has_faims = faims_groups.size() > 1 || !std::isnan(faims_groups[0].first);

--- a/src/tests/class_tests/openms/source/Biosaur2Algorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/Biosaur2Algorithm_test.cpp
@@ -13,6 +13,7 @@
 #include <OpenMS/FEATUREFINDER/Biosaur2Algorithm.h>
 ///////////////////////////
 
+#include <OpenMS/IONMOBILITY/FAIMSHelper.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
@@ -200,6 +201,118 @@ START_SECTION(void run(FeatureMap& feature_map, std::vector<Hill>& hills, std::v
   TEST_EQUAL(hills.size() >= 1, true);
   // We might not get a feature if it doesn't have isotopes or charge state, 
   // but we should at least get a hill.
+}
+END_SECTION
+
+START_SECTION([EXTRA] run() preserves the stored MS data on the FAIMS path)
+{
+  // The FAIMS path splits ms_data_ by compensation voltage. It has to put the
+  // spectra back afterwards, otherwise getMSData() hands the caller an emptied
+  // experiment and a downstream algorithm silently works on nothing
+  // (https://github.com/OpenMS/OpenMS/issues/9980).
+  Biosaur2Algorithm algo;
+  MSExperiment exp;
+
+  // two CV groups, interleaved in acquisition order
+  const double cvs[2] = {-45.0, -65.0};
+  for (int i = 0; i < 10; ++i)
+  {
+    for (int g = 0; g < 2; ++g)
+    {
+      MSSpectrum spec;
+      spec.setRT(i * 2.0 + g);
+      spec.setMSLevel(1);
+      spec.setDriftTime(cvs[g]);
+      spec.setDriftTimeUnit(DriftTimeUnit::FAIMS_COMPENSATION_VOLTAGE);
+
+      Peak1D p1;
+      p1.setMZ(500.0 + g);
+      p1.setIntensity(10000.0);
+      spec.push_back(p1);
+
+      Peak1D p2;
+      p2.setMZ(500.0 + g + 1.003355);
+      p2.setIntensity(5000.0);
+      spec.push_back(p2);
+
+      exp.addSpectrum(spec);
+    }
+  }
+  // an MS2 spectrum and a chromatogram, neither of which should reappear as MS1
+  MSSpectrum ms2;
+  ms2.setRT(1.5);
+  ms2.setMSLevel(2);
+  ms2.setDriftTime(cvs[0]);
+  ms2.setDriftTimeUnit(DriftTimeUnit::FAIMS_COMPENSATION_VOLTAGE);
+  ms2.push_back(Peak1D(300.0, 100.0));
+  exp.addSpectrum(ms2);
+
+  MSChromatogram chrom;
+  chrom.setNativeID("TIC");
+  exp.addChromatogram(chrom);
+
+  TEST_EQUAL(FAIMSHelper::getCompensationVoltages(exp).size(), 2)
+
+  algo.setMSData(exp);
+
+  Param p = algo.getParameters();
+  p.setValue("minmz", 400.0);
+  p.setValue("maxmz", 600.0);
+  p.setValue("mini", 100.0);
+  algo.setParameters(p);
+
+  FeatureMap fmap;
+  algo.run(fmap);
+
+  // the 20 MS1 spectra are back (the MS2 spectrum is dropped by run(), as on the
+  // non-FAIMS path), and so is the chromatogram
+  const MSExperiment& back = algo.getMSData();
+  TEST_EQUAL(back.size(), 20)
+  TEST_EQUAL(back.getChromatograms().size(), 1)
+
+  // both CV groups are represented, and acquisition (RT) order is restored
+  // rather than left grouped by CV
+  TEST_EQUAL(FAIMSHelper::getCompensationVoltages(back).size(), 2)
+  bool rt_sorted = true;
+  for (Size i = 1; i < back.size(); ++i)
+  {
+    if (back[i].getRT() < back[i - 1].getRT()) { rt_sorted = false; }
+  }
+  TEST_EQUAL(rt_sorted, true)
+  TEST_REAL_SIMILAR(back[0].getRT(), 0.0)
+  TEST_REAL_SIMILAR(back[back.size() - 1].getRT(), 19.0)
+}
+END_SECTION
+
+START_SECTION([EXTRA] run() preserves the stored MS data on the non-FAIMS path)
+{
+  // the counterpart of the section above: both paths must leave getMSData() usable
+  Biosaur2Algorithm algo;
+  MSExperiment exp;
+  for (int i = 0; i < 10; ++i)
+  {
+    MSSpectrum spec;
+    spec.setRT(i * 1.0);
+    spec.setMSLevel(1);
+    Peak1D p1;
+    p1.setMZ(500.0);
+    p1.setIntensity(10000.0);
+    spec.push_back(p1);
+    exp.addSpectrum(spec);
+  }
+  TEST_EQUAL(FAIMSHelper::getCompensationVoltages(exp).empty(), true)
+
+  algo.setMSData(exp);
+  Param p = algo.getParameters();
+  p.setValue("minmz", 400.0);
+  p.setValue("maxmz", 600.0);
+  p.setValue("mini", 100.0);
+  algo.setParameters(p);
+
+  FeatureMap fmap;
+  algo.run(fmap);
+
+  TEST_EQUAL(algo.getMSData().size(), 10)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/Biosaur2Algorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/Biosaur2Algorithm_test.cpp
@@ -13,11 +13,14 @@
 #include <OpenMS/FEATUREFINDER/Biosaur2Algorithm.h>
 ///////////////////////////
 
+#include <OpenMS/DATASTRUCTURES/DateTime.h>
 #include <OpenMS/IONMOBILITY/FAIMSHelper.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/KERNEL/Feature.h>
+
+#include <cmath>
 
 using namespace OpenMS;
 using namespace std;
@@ -281,6 +284,63 @@ START_SECTION([EXTRA] run() preserves the stored MS data on the FAIMS path)
   TEST_EQUAL(rt_sorted, true)
   TEST_REAL_SIMILAR(back[0].getRT(), 0.0)
   TEST_REAL_SIMILAR(back[back.size() - 1].getRT(), 19.0)
+}
+END_SECTION
+
+START_SECTION([EXTRA] run() preserves chromatograms and settings on the FAIMS profile-mode path)
+{
+  // profile_mode centroids into a fresh experiment; replacing the whole experiment
+  // would drop the chromatograms and experimental settings before the FAIMS split
+  // ever saw them, so the reassembly above would have nothing to put back.
+  Biosaur2Algorithm algo;
+  MSExperiment exp;
+
+  const double cvs[2] = {-45.0, -65.0};
+  for (int i = 0; i < 10; ++i)
+  {
+    for (int g = 0; g < 2; ++g)
+    {
+      MSSpectrum spec;
+      spec.setRT(i * 2.0 + g);
+      spec.setMSLevel(1);
+      spec.setType(SpectrumSettings::SpectrumType::PROFILE);
+      spec.setDriftTime(cvs[g]);
+      spec.setDriftTimeUnit(DriftTimeUnit::FAIMS_COMPENSATION_VOLTAGE);
+      // a small profile peak shape around 500 + g
+      for (int k = -3; k <= 3; ++k)
+      {
+        Peak1D p;
+        p.setMZ(500.0 + g + k * 0.01);
+        p.setIntensity(10000.0f * static_cast<float>(std::exp(-0.5 * k * k)));
+        spec.push_back(p);
+      }
+      exp.addSpectrum(spec);
+    }
+  }
+
+  MSChromatogram chrom;
+  chrom.setNativeID("TIC");
+  exp.addChromatogram(chrom);
+  exp.getExperimentalSettings().setDateTime(DateTime::fromString("2019-09-07T09:40:04"));
+
+  algo.setMSData(exp);
+
+  Param p = algo.getParameters();
+  p.setValue("profile", "true");
+  p.setValue("minmz", 400.0);
+  p.setValue("maxmz", 600.0);
+  p.setValue("mini", 100.0);
+  algo.setParameters(p);
+
+  FeatureMap fmap;
+  algo.run(fmap);
+
+  const MSExperiment& back = algo.getMSData();
+  TEST_EQUAL(back.size(), 20)
+  TEST_EQUAL(back.getChromatograms().size(), 1)
+  TEST_EQUAL(back.getExperimentalSettings().getDateTime().toString(), "2019-09-07T09:40:04")
+  // centroiding must not strip the FAIMS annotation, or the split never happens
+  TEST_EQUAL(FAIMSHelper::getCompensationVoltages(back).size(), 2)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/FeatureFinderIdentificationAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureFinderIdentificationAlgorithm_test.cpp
@@ -12,6 +12,13 @@
 #include <OpenMS/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.h>
 ///////////////////////////
 
+#include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/KERNEL/FeatureMap.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
+#include <OpenMS/METADATA/PeptideIdentificationList.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
+
 using namespace OpenMS;
 using namespace std;
 
@@ -35,6 +42,37 @@ START_SECTION(~FeatureFinderIdentificationAlgorithm())
 }
 END_SECTION
 
+
+START_SECTION([EXTRA] run() rejects MS data without spectra)
+{
+  // Chromatogram extraction indexes the experiment unconditionally, so running on an
+  // empty experiment used to read out of bounds instead of reporting the problem
+  // (https://github.com/OpenMS/OpenMS/issues/9980).
+  FeatureFinderIdentificationAlgorithm algo;
+
+  ProteinIdentification protein;
+  protein.setIdentifier("run0");
+  vector<ProteinIdentification> proteins{protein};
+
+  PeptideIdentification peptide;
+  peptide.setIdentifier("run0");
+  peptide.setRT(100.0);
+  peptide.setMZ(500.0);
+  PeptideHit hit;
+  hit.setSequence(AASequence::fromString("PEPTIDEK"));
+  hit.setCharge(2);
+  peptide.setHits({hit});
+  PeptideIdentificationList peptides{peptide};
+
+  FeatureMap features;
+  FeatureMap seeds;
+
+  TEST_EQUAL(algo.getMSData().empty(), true)
+  TEST_EXCEPTION(Exception::IllegalArgument,
+                 algo.run(peptides, proteins, PeptideIdentificationList(), vector<ProteinIdentification>(),
+                          features, seeds, ""))
+}
+END_SECTION
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////

--- a/src/topp/ProteomicsLFQ.cpp
+++ b/src/topp/ProteomicsLFQ.cpp
@@ -1182,10 +1182,9 @@ protected:
         Biosaur2Algorithm bio;
         Param bio_param = getParam_().copy("Seeding:Biosaur2:", true);
         bio.setParameters(bio_param);
-        // For non-FAIMS data (including .d), Biosaur2 processes ms_data_ in-place
-        // without moving it, so we can use move here and retrieve it after run().
-        // For FAIMS data, ms_data_ is consumed (split by CV), but ProteomicsLFQ's
-        // FAIMS path uses FFId's own FAIMS splitting, so this is not an issue.
+        // Biosaur2 leaves the processed spectra in ms_data_ on both its paths
+        // (in-place for non-FAIMS, reassembled after the per-CV split for FAIMS),
+        // so we can move here and retrieve the data after run().
         bio.setMSData(std::move(ms_centroided));
 
         bio.run(seeds);
@@ -1219,7 +1218,7 @@ protected:
           OPENMS_LOG_INFO << "Median chromatographic FWHM (from Biosaur2): " << median_fwhm << "\n";
         }
 
-        // Retrieve ms_data_ back from Biosaur2 (non-FAIMS path preserves it in-place)
+        // Retrieve ms_data_ back from Biosaur2 (preserved on both the FAIMS and non-FAIMS paths)
         ms_centroided = std::move(bio.getMSData());
       }
       else


### PR DESCRIPTION
## Description

Fixes #9980. `Biosaur2Algorithm::run()` had two paths with different postconditions, and the FAIMS one
silently threw the input data away.

The non-FAIMS path processes `ms_data_` in place, so a caller can keep using it after `run()`. The
FAIMS path moved `ms_data_` into `IMDataConverter::splitByFAIMSCV()` — which clears it
(`IMDataConverter.cpp:83`) — and never put the spectra back, so `getMSData()` returned an emptied
experiment. The header documented this as expected behaviour rather than treating it as a defect.

`ProteomicsLFQ` moves that result back into `ms_centroided` and hands it to
`FeatureFinderIdentification`. The comment above the call argued the FAIMS case was safe because
"ProteomicsLFQ's FAIMS path uses FFId's own FAIMS splitting" — but FFId splits whatever it was given,
and on this path it was given nothing. With zero spectra it finds no compensation voltages, takes its
single-group branch (`FeatureFinderIdentificationAlgorithm.cpp:581`) and reaches the unguarded
`(*shared)[0]` in the chromatogram extraction (line 866).

Conditions: FAIMS mzML **and** `-Seeding:algorithm biosaur2` **and** `-targeted_only false`. Not the
default (`Seeding:algorithm` defaults to `multiplex`); Bruker `.d`/PASEF forces `biosaur2` but is not
FAIMS, so it takes the in-place branch and is unaffected.

### The symptom is a crash, not a low feature count

The issue was filed from code inspection and guessed at "zero or near-zero features". Run against
`archive.openms.de/openms/testfiles/FAIMS/ExplorisFAIMS-DDA-LFQ.mzML` (4 compensation voltages
−65/−55/−45/0, 9399 MS1 spectra), it is an out-of-bounds read:

| | before | after |
|---|---|---|
| spectra into `run()` | 9399 | 9399 |
| Biosaur2 seeds | 115825 | 115825 |
| spectra out of `getMSData()` | **0** | **9399**, RT-ordered, 4 CVs |
| FFId on that experiment | **SIGSEGV** | runs |

The segfault was isolated with a controlled comparison — identical peptide IDs and parameters, only
the experiment differing: empty → `SIGSEGV` in `MetaInfoInterface`'s copy ctor under
`runSingleGroup_`; 765 real MS1 spectra from the same file → completes normally.

### The fix

Two places lost data, both now fixed.

**1. The FAIMS split (`c90acf9`).** `Biosaur2Algorithm` reassembles `ms_data_` from the per-CV groups
after processing: spectra are moved back (so no additional peak memory) and re-sorted into
acquisition order, since the groups are ordered by CV; chromatograms are set aside before the split
and restored after, as `splitByFAIMSCV()` only redistributes spectra. Both paths now leave the same
processed experiment behind — MS1 only, centroided/TOF-filtered as configured.

Of the three options the issue lists (skip the move-back in `ProteomicsLFQ`, reassemble in
`Biosaur2Algorithm`, or reject the combination), this is the second: it removes the footgun at its
source and fixes every caller rather than teaching one caller to work around a surprising
postcondition. The seed count is unchanged, so this restores discarded data without perturbing
detection.

`splitByFAIMSCV()` has no inverse in the codebase (the only FAIMS "merge",
`FeatureOverlapFilter::mergeFAIMSFeatures`, operates on the output `FeatureMap` and is already called
a few lines below), so the reassembly is new code — but it needs no side-band bookkeeping: the split
never clears the per-spectrum drift time or unit, so every spectrum still carries its own CV and the
grouping is recoverable from the spectra themselves.

**2. Profile-mode centroiding (`be3a846`, found by CodeRabbit).** `centroidProfileSpectra_` collected
the picked spectra into a fresh `MSExperiment` and assigned it over the input, replacing the
experiment wholesale. In profile mode that dropped the chromatograms **and** the experimental settings
*before* the split ran, so the reassembly above had nothing left to restore — and the in-place path
lost them too. It now replaces only the spectra via `MSExperiment::setSpectra()`.

The per-spectrum metadata was already safe there: `PeakPickerHiRes::pick()` calls
`copySpectrumMeta()`, which carries over the drift time *and its unit*, so the FAIMS annotation
survives picking and `FAIMSHelper::getCompensationVoltages()` still sees the voltages.

**3. The unguarded index.** Independently,
`FeatureFinderIdentificationAlgorithm::run()` now rejects MS data without spectra up front with
`Exception::IllegalArgument`, so a caller passing a consumed experiment gets a usable error instead of
an out-of-bounds read. That guard is worth having whatever else changes upstream.

`ProteomicsLFQ.cpp` changes are comments only — the two that asserted the old, incorrect reasoning.

### Tests

Four new sections, each with a negative control to show they are not vacuous:

- `Biosaur2Algorithm`: FAIMS path preserves the MS data — two CVs interleaved in RT, asserting
  spectrum count, both CVs still present, RT order restored, chromatogram kept, MS2 still dropped.
- `Biosaur2Algorithm`: profile-mode FAIMS — the chromatogram, the experimental settings and both CVs
  survive `run()`.
- `Biosaur2Algorithm`: the non-FAIMS counterpart, so both postconditions stay pinned.
- `FeatureFinderIdentificationAlgorithm`: `run()` throws on spectrum-less MS data.

Reverting each fix makes its section fail exactly where the bug lives — `back.size()` got `0`,
expected `20` for the split; chromatograms `0` and an emptied `getDateTime()` for profile mode —
while the unrelated sections keep passing.

Locally: full `libOpenMS` build clean (834/834), and 7/7 passing across `Biosaur2Algorithm`,
`FeatureFinderIdentificationAlgorithm`, `IMDataConverter`, `FAIMSHelper`, `MSExperiment`,
`OnDiscMSExperiment`, `MultiplexFilteredMSExperiment`. The `TOPP_ProteomicsLFQ` suite was not run
locally (it needs the full tool set built) — CI covers it, and it is green on ubuntu g++/clang++,
ubuntu-arm and macOS.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.) — no public signatures changed, only a corrected `@note`; the existing `Biosaur2Algorithm` bindings pick the fix up unchanged

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>

- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds

</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNXuYhS47vR4DMJFLqSi8a

## Summary by CodeRabbit

- **Bug Fixes**
  - FAIMS processing now preserves spectra, chromatograms, acquisition order, and experiment settings.
  - Feature identification now reports a clear error for empty experiments.
- **Documentation**
  - Added OpenMS 3.6.0 changelog entries describing these updates.