### PR TITLE
[FIX] FAIMS: preserve identifications when merging features, accept ln(hyperscore), recompute ranges

### DIFF
--- a/src/openms/include/OpenMS/MATH/STATISTICS/PosteriorErrorProbabilityModel.h
+++ b/src/openms/include/OpenMS/MATH/STATISTICS/PosteriorErrorProbabilityModel.h
@@ -65,7 +65,9 @@ public:
        * @param[in] target_decoy_available whether target decoy information is stored as meta value
        * @param[in] fdr_for_targets_smaller fdr threshold for targets
        * @return engine (and optional charge state) id -> vector of triplets (score, target, decoy)
-       * @note supported engines are: XTandem,OMSSA,MASCOT,SpectraST,MyriMatch,SimTandem,MSGFPlus,MS-GF+,Comet,Sage
+       * @note supported engines are: XTandem,OMSSA,MASCOT,SpectraST,MyriMatch,SimTandem,MSGFPlus,MS-GF+,Comet,MSFragger,Sage,SimpleSearchEngine,ProSE -- i.e. those with a branch in
+       *       transformScore_(). Identifications from OpenMS/ConsensusID_* runs are resolved to
+       *       their ConsensusIDBaseSearch engine, which must itself be one of the above.
        */
       static std::map<std::string, std::vector<std::vector<double>>> extractAndTransformScores(
         const std::vector<ProteinIdentification> & protein_ids,
@@ -86,7 +88,9 @@ public:
        * @param[in,out] peptide_ids the peptide identifications
        * @param[out] unable_to_fit_data there was a problem fitting the data (probabilities are all smaller 0 or larger 1)
        * @param[out] data_might_not_be_well_fit fit was successful but of bad quality (probabilities are all smaller 0.8 and larger 0.2)
-       * @note supported engines are: XTandem,OMSSA,MASCOT,SpectraST,MyriMatch,SimTandem,MSGFPlus,MS-GF+,Comet
+       * @note supported engines are: XTandem,OMSSA,MASCOT,SpectraST,MyriMatch,SimTandem,MSGFPlus,MS-GF+,Comet,MSFragger,Sage,SimpleSearchEngine,ProSE -- i.e. those with a branch in
+       *       transformScore_(). Identifications from OpenMS/ConsensusID_* runs are resolved to
+       *       their ConsensusIDBaseSearch engine, which must itself be one of the above.
        */
       static void updateScores(
         const PosteriorErrorProbabilityModel & PEP_model,

--- a/src/openms/source/FEATUREFINDER/Biosaur2Algorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/Biosaur2Algorithm.cpp
@@ -367,6 +367,12 @@ void Biosaur2Algorithm::run(FeatureMap& feature_map,
     }
   }
 
+  // Both paths leave the stored experiment changed: MS1-only, and centroided/TOF-filtered
+  // as configured. The FAIMS path additionally goes through splitByFAIMSCV(), whose
+  // exp.clear(true) drops the ranges outright. Recompute once here so getMSData() reports
+  // ranges that describe the spectra it hands back, the same way on either path.
+  ms_data_.updateRanges();
+
   // Restore original paseftol_ value for subsequent calls.
   paseftol_ = original_paseftol;
   feature_map.applyMemberFunction(&UniqueIdInterface::ensureUniqueId);

--- a/src/openms/source/MATH/STATISTICS/PosteriorErrorProbabilityModel.cpp
+++ b/src/openms/source/MATH/STATISTICS/PosteriorErrorProbabilityModel.cpp
@@ -939,9 +939,12 @@ namespace OpenMS::Math
       {
         return (-1) * log10(getScore_({"MS:1002257","expect"}, hit, current_score_type));
       }
-      else if (engine == "SIMPLESEARCHENGINE")
+      else if ((engine == "SIMPLESEARCHENGINE") || (engine == "PROSE"))
       {
-        return getScore_({"hyperscore"}, hit, current_score_type); //TODO evaluate transformations
+        // Both score with HyperScore, which already returns the log-space value
+        // (HyperScore.cpp: log1p(dot_product) + log-factorials) and label it
+        // "ln(hyperscore)"; "hyperscore" is the older name for the same quantity.
+        return getScore_({"hyperscore", "ln(hyperscore)"}, hit, current_score_type); //TODO evaluate transformations
       }
       else if (engine == "SAGE")
       {
@@ -966,7 +969,7 @@ namespace OpenMS::Math
       std::set<Int> charges;
       const StringList search_engines = {"XTandem","OMSSA","MASCOT","SpectraST","MyriMatch",
                                          "SimTandem","MSGFPlus","MS-GF+","Comet","MSFragger",
-                                         "tide-search","Sage","SimpleSearchEngine",
+                                         "tide-search","Sage","SimpleSearchEngine","ProSE",
                                          "OpenMS/ConsensusID_best","OpenMS/ConsensusID_worst","OpenMS/ConsensusID_average"};
 
       if (split_charge)

--- a/src/openms/source/PROCESSING/FEATURE/FeatureOverlapFilter.cpp
+++ b/src/openms/source/PROCESSING/FEATURE/FeatureOverlapFilter.cpp
@@ -511,8 +511,11 @@ namespace OpenMS
              tolerances);
     }
 
-    // Combine back: merged FAIMS features + untouched non-FAIMS features
-    feature_map.clear();
+    // Combine back: merged FAIMS features + untouched non-FAIMS features.
+    // clear(false): only the feature container is refilled here -- the default
+    // clear(true) would also wipe protein/peptide identifications, data processing
+    // and the unique id that the caller set before calling us.
+    feature_map.clear(false);
     for (auto& f : faims_features)
     {
       feature_map.push_back(std::move(f));

--- a/src/tests/class_tests/openms/source/Biosaur2Algorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/Biosaur2Algorithm_test.cpp
@@ -284,6 +284,14 @@ START_SECTION([EXTRA] run() preserves the stored MS data on the FAIMS path)
   TEST_EQUAL(rt_sorted, true)
   TEST_REAL_SIMILAR(back[0].getRT(), 0.0)
   TEST_REAL_SIMILAR(back[back.size() - 1].getRT(), 19.0)
+  // The ranges have to describe the restored data: splitByFAIMSCV() ends in
+  // exp.clear(true), which clears them, so they are only correct if recomputed.
+  // getMinMZ() is deliberately not asserted: MSExperiment::updateRanges() folds each
+  // chromatogram's m/z into the combined range, and the TIC above carries no precursor,
+  // so the minimum is that chromatogram's 0 rather than the lowest peak.
+  TEST_REAL_SIMILAR(back.getMinRT(), 0.0)
+  TEST_REAL_SIMILAR(back.getMaxRT(), 19.0)
+  TEST_REAL_SIMILAR(back.getMaxMZ(), 502.003355)
 }
 END_SECTION
 
@@ -344,6 +352,61 @@ START_SECTION([EXTRA] run() preserves chromatograms and settings on the FAIMS pr
 }
 END_SECTION
 
+START_SECTION([EXTRA] run() refreshes ranges on the non-FAIMS profile-mode path)
+{
+  // The in-place path rewrites the spectra too: centroidProfileSpectra_ replaces every
+  // peak, so ranges cached before run() describe data that no longer exists. This is the
+  // non-FAIMS counterpart to the range assertions in the FAIMS section above.
+  Biosaur2Algorithm algo;
+  MSExperiment exp;
+
+  for (int i = 0; i < 10; ++i)
+  {
+    MSSpectrum spec;
+    spec.setRT(i * 1.0);
+    spec.setMSLevel(1);
+    spec.setType(SpectrumSettings::SpectrumType::PROFILE);
+    for (int k = -3; k <= 3; ++k)
+    {
+      Peak1D p;
+      p.setMZ(500.0 + k * 0.01);
+      p.setIntensity(10000.0f * static_cast<float>(std::exp(-0.5 * k * k)));
+      spec.push_back(p);
+    }
+    exp.addSpectrum(spec);
+  }
+  exp.updateRanges(); // ranges describing the *profile* peaks, stale once centroided
+
+  algo.setMSData(exp);
+
+  Param p = algo.getParameters();
+  p.setValue("profile", "true");
+  p.setValue("minmz", 400.0);
+  p.setValue("maxmz", 600.0);
+  p.setValue("mini", 100.0);
+  algo.setParameters(p);
+
+  FeatureMap fmap;
+  algo.run(fmap);
+
+  const MSExperiment& back = algo.getMSData();
+  TEST_EQUAL(back.size(), 10)
+  TEST_EQUAL(FAIMSHelper::getCompensationVoltages(back).empty(), true)
+  TEST_REAL_SIMILAR(back.getMinRT(), 0.0)
+  TEST_REAL_SIMILAR(back.getMaxRT(), 9.0)
+  // Compare the cached ranges against ones recomputed from the very same spectra: this
+  // fails whenever the cache is stale, whatever the values happen to be. Asserting a
+  // window around the peak would not -- the pre-centroiding profile span lies inside any
+  // window wide enough to hold the centroid, so a stale cache would satisfy it.
+  MSExperiment recomputed = back;
+  recomputed.updateRanges();
+  TEST_REAL_SIMILAR(back.getMinMZ(), recomputed.getMinMZ())
+  TEST_REAL_SIMILAR(back.getMaxMZ(), recomputed.getMaxMZ())
+  TEST_REAL_SIMILAR(back.getMinRT(), recomputed.getMinRT())
+  TEST_REAL_SIMILAR(back.getMaxRT(), recomputed.getMaxRT())
+}
+END_SECTION
+
 START_SECTION([EXTRA] run() preserves the stored MS data on the non-FAIMS path)
 {
   // the counterpart of the section above: both paths must leave getMSData() usable
@@ -373,6 +436,9 @@ START_SECTION([EXTRA] run() preserves the stored MS data on the non-FAIMS path)
   algo.run(fmap);
 
   TEST_EQUAL(algo.getMSData().size(), 10)
+  // ranges describe the returned spectra here too, not just on the FAIMS path
+  TEST_REAL_SIMILAR(algo.getMSData().getMinRT(), 0.0)
+  TEST_REAL_SIMILAR(algo.getMSData().getMaxRT(), 9.0)
 }
 END_SECTION
 


### PR DESCRIPTION
## Description

Rebased onto develop and rescoped. This PR originally fixed #9980, but #9996 landed an independent fix for that first, so the duplicate commits have been dropped. What remains is three defects that #9996 did not cover, all found while verifying #9980 end-to-end on a real Exploris FAIMS DDA-LFQ run (3 compensation voltages -45/-55/-65, 10325 PSMs).

### 1. `FeatureOverlapFilter::mergeFAIMSFeatures` wipes identifications — `5b72ded`

`feature_map.clear()` was called to empty the container before re-filling it with merged features, but `FeatureMap::clear()` defaults to `clear_meta_data = true`, which also drops `protein_identifications_`, `unassigned_peptide_identifications_`, `data_processing_` and `id_data_`. Now `clear(false)`.

Measured consequence: `FeatureFinderIdentificationAlgorithm`'s FAIMS path copies protein IDs in, then merges, and returned a FeatureMap with 3397 features and **zero** IdentificationRuns. `MapConversion::convert` copies that empty vector into the ConsensusMap, and `ConsensusMapMergerAlgorithm::mergeAllIDRuns` guards only `size() == 1`, so `size() == 0` fell through to `getProteinIdentifications()[0]` and segfaulted. This hit FAIMS data regardless of seeding algorithm, and silently dropped unassigned PSMs even where it did not crash. `FeatureFinderAlgorithmMetaboIdent` makes the same call and was equally affected.

### 2. `IDPosteriorErrorProbability` rejects `ln(hyperscore)` — `00ef7e3`

`SimpleSearchEngineAlgorithm` and `ProSEAlgorithm` both label their main score `"ln(hyperscore)"`, but the `SIMPLESEARCHENGINE` branch of `transformScore_` requested only `"hyperscore"`, and `ProSE` was absent from the engine list entirely. Neither engine writes a `hyperscore` meta value, so `getScore_()`'s meta-value fallback could not rescue the lookup:

- `SimpleSearchEngine` → `UnableToFit` ("None of the expected score types hyperscore for search engine found"), not bypassable with `-force`
- `ProSE` → `INPUT_FILE_EMPTY` with "No data collected. Check whether search engine is supported."

Both names denote the same quantity: `HyperScore::computeWithDetail` returns the log-space value, `Scores.cpp` lists both as RAW score names, and the `Sage` branch already accepts both for exactly this reason. ProSE scores via the same `HyperScore` call, so both engines share one branch.

Verified: the resulting posterior error probabilities are **byte-identical** to those obtained by relabelling the score type by hand, so no numbers change for anyone.

### 3. FAIMS restore leaves stale ranges — `966c482`

Follow-up to #9996. Its restore moves the per-CV spectra back and re-sorts them, but `splitByFAIMSCV()` ends in `exp.clear(true)`, which calls `clearRanges()`, and nothing recomputes them. After `run()` on FAIMS input `getMSData()` therefore held the spectra while `getMinRT()`/`getMaxRT()`/`getMaxMZ()` still reported the cleared state — which does not match "what the in-place path above leaves behind", the stated goal of that restore. Adds `updateRanges()` and asserts the ranges in the existing FAIMS regression section.

### Also included — `d407e30`

The `@note supported engines` entries on `extractAndTransformScores` and `updateScores` were stale: the first omitted `SimpleSearchEngine`, `MSFragger` and `tide-search`, the second also omitted `Sage`. They now list the engines `transformScore_` actually implements — deliberately *not* the `search_engines` list, which additionally names `tide-search` (no `transformScore_` branch, so it throws) and three `OpenMS/ConsensusID_*` entries (never matched, since the loop substitutes `ConsensusIDBaseSearch` first).

### Verification

Each fix was confirmed by reverting only that change and reproducing the original failure:

| Change | Reverted (control) | With fix |
|---|---|---|
| `5b72ded` | SIGSEGV in `ConsensusMapMergerAlgorithm::mergeAllIDRuns` | completes, identifications preserved |
| `00ef7e3` | `UnableToFit` (exit 8) / `INPUT_FILE_EMPTY` (exit 4) | exit 0, byte-identical PEPs |

End-to-end after the rebase: ProteomicsLFQ on the real FAIMS data with `-Seeding:algorithm biosaur2` yields **6437 consensus features**, unchanged from before the rebase. `Biosaur2Algorithm_test` passes, including the added range assertions.

### Known gap, not fixed here

`tide-search` is listed in `search_engines` but has no `transformScore_` branch, so `IDPosteriorErrorProbability` throws on Crux/Tide input — the same shape as defect 2. Fixing it requires knowing which score type Tide reports, so it is left for a separate change rather than guessed at.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

No public signatures changed, so no binding updates were needed. AUTHORS/CHANGELOG left for a maintainer to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtmMpvoaqZCoUDyRKsmoAb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved FAIMS and non-FAIMS processing so experiment retention-time and mass-to-charge ranges remain accurate.
  - Preserved protein and peptide identifications and related metadata when merging overlapping FAIMS features.
  - Added support for ProSE search results, including hyperscore and log-transformed hyperscore values.

- **Documentation**
  - Updated documentation for supported search engines and score formats.

- **Tests**
  - Added regression coverage for range recalculation, FAIMS processing, and profile-mode centroiding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->