### PR TITLE
[FIX,IO,TEST] Warn on imzML-dropped integer/string arrays, move the aux snapshot

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -843,6 +843,8 @@ OpenMS Library:
         never filled on read; getIMPeakType() is set to IM_PROFILE and getIMUnit() resolves the unit from
         the PSI-MS ontology (1/K0 for MS:1003006, not milliseconds). OnDiscImzMLExperiment now also
         rejects zlib-compressed m/z/intensity arrays like the in-memory loader (#9908)
+      - imzML export warns about per-peak Integer/StringDataArrays (e.g. a "charge array" carried over
+        from mzML): the format stores only FloatDataArrays, so they were silently dropped before
     - Native Parquet I/O for identifications, features and consensus maps:
       - PSMArrowIO reads/writes the .idparquet directory bundle (psms/proteins/protein_groups/
         search_params.parquet), lossless round-trip from PeptideIdentificationList and

--- a/src/openms/source/FORMAT/HANDLERS/ImzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ImzMLHandler.cpp
@@ -20,6 +20,7 @@
 #include <cstring>
 #include <limits>
 #include <stdexcept>
+#include <utility>
 
 namespace OpenMS
 {
@@ -583,9 +584,12 @@ void ImzMLHandler::onEndElement(const char16_t* qname)
       snap.z        = cur_z_;
       snap.mz_meta  = cur_mz_meta_;
       snap.int_meta = cur_int_meta_;
-      snap.aux_meta = cur_aux_metas_;
-      snap.inline_aux_names = cur_inline_aux_names_;
-      spec_ims_.push_back(snap);
+      // Safe to move: both vectors are cleared unconditionally below, and nothing
+      // between here and that reset reads them. Saves a per-spectrum copy of the
+      // aux name/accession/unit strings on datasets with a pixel per spectrum.
+      snap.aux_meta = std::move(cur_aux_metas_);
+      snap.inline_aux_names = std::move(cur_inline_aux_names_);
+      spec_ims_.push_back(std::move(snap));
     }
 
     // imzML peak data lives in the companion .ibd, so the inline <binary> arrays are

--- a/src/openms/source/FORMAT/HANDLERS/ImzMLWriter.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ImzMLWriter.cpp
@@ -272,6 +272,70 @@ namespace
     }
   }
 
+  /// imzML carries per-peak data only as FloatDataArrays (written as external .ibd
+  /// arrays), so Integer/StringDataArrays — e.g. a "charge array" carried over from
+  /// mzML — have no representation and are dropped. Warn once per store, not once per
+  /// pixel, and cap the listing so the line cannot grow with the dataset.
+  void warnOnDroppedDataArrays_(const MSExperiment& exp)
+  {
+    const Size max_listed = 20;
+    std::vector<std::string> names;
+    bool more_names = false;
+    Size dropped = 0;
+
+    auto collect = [&](const auto& arrays) {
+      for (const auto& array : arrays)
+      {
+        if (array.empty())
+        {
+          continue;
+        }
+        ++dropped;
+        if (std::find(names.begin(), names.end(), array.getName()) != names.end())
+        {
+          continue;
+        }
+        if (names.size() < max_listed)
+        {
+          names.push_back(array.getName());
+        }
+        else
+        {
+          more_names = true;
+        }
+      }
+    };
+
+    for (const MSSpectrum& spec : exp.getSpectra())
+    {
+      collect(spec.getIntegerDataArrays());
+      collect(spec.getStringDataArrays());
+    }
+
+    if (dropped == 0)
+    {
+      return;
+    }
+
+    std::string listed;
+    for (Size k = 0; k < names.size(); ++k)
+    {
+      if (k > 0)
+      {
+        listed += ", ";
+      }
+      listed += "'" + names[k] + "'";
+    }
+    if (more_names)
+    {
+      listed += ", ...";
+    }
+    OPENMS_LOG_WARN << "imzML stores per-peak data only as FloatDataArrays: dropping "
+                    << dropped << " integer/string data array(s) across " << exp.size()
+                    << " spectra. Affected array names: " << listed
+                    << "." << std::endl; // std::endl: OPENMS_LOG_* only distributes a line on flush
+  }
+
   ImzMLMeta extractMeta_(const MSExperiment& exp)
   {
     ImzMLMeta meta;
@@ -1344,6 +1408,7 @@ void ImzMLWriter::store(const std::string& imzml_path,
   }
 
   validatePixelMetadataForStore_(work);
+  warnOnDroppedDataArrays_(work);
 
   ImzMLMeta meta = extractMeta_(work);
   const bool continuous = isContinuousMode_(work, meta);

--- a/src/tests/class_tests/openms/source/ImzMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ImzMLFile_test.cpp
@@ -1677,6 +1677,54 @@ START_SECTION(void store skips FloatDataArrays named after the peak arrays)
 END_SECTION
 
 
+START_SECTION(void store drops integer and string data arrays)
+{
+  // imzML has no external representation for per-peak integer/string arrays, so they
+  // are dropped (with a warning) instead of failing the store. FloatDataArrays on the
+  // same spectrum must still round-trip.
+  MSExperiment original;
+  MSSpectrum s = makePixelSpectrum_(1, 1, 100.0, 10.0f);
+  MSSpectrum::FloatDataArray im;
+  im.setName("mean inverse reduced ion mobility array");
+  im.push_back(0.85f);
+  s.getFloatDataArrays().push_back(im);
+  MSSpectrum::IntegerDataArray charges;
+  charges.setName("charge array");
+  charges.push_back(2);
+  s.getIntegerDataArrays().push_back(charges);
+  MSSpectrum::StringDataArray labels;
+  labels.setName("annotation array");
+  labels.push_back("peak0");
+  s.getStringDataArrays().push_back(labels);
+  original.addSpectrum(s);
+  original.setMetaValue("imzml:imaging_mode", "processed");
+
+  ImzMLFile f;
+  std::string tmp_imzml;
+  NEW_TMP_FILE_EXT(tmp_imzml, ".imzML");
+  f.store(tmp_imzml, original);
+
+  MSExperiment mem = loadImzMLExperiment_(tmp_imzml);
+  TEST_EQUAL(mem[0].size(), 1)
+  TEST_REAL_SIMILAR(mem[0][0].getMZ(), 100.0)
+  TEST_EQUAL(mem[0].getIntegerDataArrays().size(), 0)
+  TEST_EQUAL(mem[0].getStringDataArrays().size(), 0)
+  TEST_EQUAL(mem[0].getFloatDataArrays().size(), 1)
+  TEST_EQUAL(mem[0].getFloatDataArrays()[0].getName(), "mean inverse reduced ion mobility array")
+  TEST_REAL_SIMILAR(mem[0].getFloatDataArrays()[0][0], 0.85)
+
+  OnDiscImzMLExperiment od;
+  od.open(tmp_imzml);
+  const MSSpectrum disc = od.getSpectrum(0);
+  TEST_EQUAL(disc.getIntegerDataArrays().size(), 0)
+  TEST_EQUAL(disc.getStringDataArrays().size(), 0)
+  TEST_EQUAL(disc.getFloatDataArrays().size(), 1)
+  od.close();
+  remove(ibdPathFor_(tmp_imzml).c_str());
+}
+END_SECTION
+
+
 START_SECTION(void load and OnDisc skip aux array without a supported binary data type)
 {
   MSExperiment original;


### PR DESCRIPTION
## Description

Two cheap follow-ups from the review of #9908 (merged). No behavior change beyond one new warning.

**1. imzML export silently dropped per-peak Integer/StringDataArrays.** The format stores per-peak data only as `FloatDataArray`s (written as external `.ibd` arrays), so an `IntegerDataArray` such as a `"charge array"` carried over from mzML vanishes on export. Unnamed and length-mismatched `FloatDataArray`s already warn, so this was the one silent loss left — users only discovered it downstream. `warnOnDroppedDataArrays_` now warns once per `store()`, not once per pixel (a million-pixel dataset must not emit a million lines), and caps the listed array names at 20 with a `, ...` marker so the line cannot grow with the dataset — the same bounded-listing shape as the existing duplicate-pixel warning. Nothing is written differently; the arrays are still dropped.

**2. The per-spectrum IMS snapshot deep-copied two vectors it could move.** `ImzMLHandler::onEndElement` copied `cur_aux_metas_` (three strings per aux array) and `cur_inline_aux_names_` into the snapshot, then cleared both unconditionally a few lines later. Moving them — and the snapshot into `spec_ims_` — removes a per-spectrum allocation on datasets that have one spectrum per pixel. Nothing reads either vector between the move and the reset, so the moved-from state is never observed.

### Testing

Added `store drops integer and string data arrays`: stores a spectrum carrying an IM `FloatDataArray` plus an integer and a string array, then asserts both loaders return the peaks and the IM array with zero integer/string arrays. The helper's counting, de-duplication and cap logic was also checked standalone (empty arrays and metadata-only stores produce no warning; duplicate names across spectra are listed once).

The change could not be built in the environment it was written in (no Xerces/Boost, no configured build), so it went to CI unbuilt. CI has since covered that: `build-and-test` is green on all five platforms (Ubuntu g++/clang++, Ubuntu ARM g++, macOS xcode, Windows cl.exe), along with `cppcheck-test` and the wheel builds.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file <!-- no new author: existing file maintainers -->
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes <!-- verified by CI rather than locally; see Testing -->
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.) <!-- internal helpers only, no API change -->

## Remaining follow-ups from the #9908 review (not in this PR)

Left out deliberately — each needs a design decision rather than a cheap fix:

- `MS:1003441` (ion mobility centroid frame) peak type diverges between loaders for third-party files: `ImzMLSpectrumIndex` records no peak type, so on-disc returns `IM_PROFILE` where in-memory keeps `IM_CENTROIDED`.
- The writer derives units from the CV term only and ignores an existing `unit_accession` MetaValue, so declared units on multi-unit or `MS:1000786` arrays are dropped on imzML export while surviving mzML export.
- Hybrid spectra (inline peaks + external aux) can misassign per-peak IM when the inline peaks are unsorted and sorting is on.
- The cvParam `name` attribute is stored in every `CvEntry` and forwarded through `applyRefGroup_`, but `handleIMSCvParam_` ignores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHpfx4xEGqkzAr6hhj5GHR