### PR TITLE
[FIX] Unknown mass-shift modifications: sign the serialised bracket (#10006) and key them on the base residue (#10007)

### DIFF
--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -1479,7 +1479,7 @@ namespace OpenMS
     if (mod == nullptr)
     {
       OPENMS_LOG_WARN << "Modification with monoisotopic mass diff. of " << diffMonoMassStr << " not found in databases with tolerance " << tol << ". Adding unknown modification.\n";
-      mod = ResidueModification::createUnknownFromMassString(StringUtils::toStr(diffMonoMass),
+      mod = ResidueModification::createUnknownFromMassString(ResidueModification::getDiffMonoMassString(diffMonoMass),
                                                                         diffMonoMass,
                                                                         true,
                                                                         ResidueModification::ANYWHERE,
@@ -1619,7 +1619,7 @@ namespace OpenMS
     {
 
       OPENMS_LOG_WARN << "Modification with monoisotopic mass diff. of " << diffMonoMassStr << " not found in databases with tolerance " << tol << ". Adding unknown modification.\n";
-      n_term_mod_ = ResidueModification::createUnknownFromMassString(StringUtils::toStr(diffMonoMass),
+      n_term_mod_ = ResidueModification::createUnknownFromMassString(ResidueModification::getDiffMonoMassString(diffMonoMass),
                                                                         diffMonoMass,
                                                                         true,
                                                                         term);
@@ -1649,7 +1649,7 @@ namespace OpenMS
     {
 
       OPENMS_LOG_WARN << "Modification with monoisotopic mass diff. of " << diffMonoMassStr << " not found in databases with tolerance " << tol << ". Adding unknown modification.\n";
-      n_term_mod_ = ResidueModification::createUnknownFromMassString(StringUtils::toStr(diffMonoMass),
+      n_term_mod_ = ResidueModification::createUnknownFromMassString(ResidueModification::getDiffMonoMassString(diffMonoMass),
                                                                         diffMonoMass,
                                                                         true,
                                                                         term);

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -1466,26 +1466,34 @@ namespace OpenMS
       throw Exception::IndexOverflow(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, index, peptide_.size());
     }
 
+    const ResidueDB* residue_db = ResidueDB::getInstance();
+    const Residue* base_residue = residue_db->getResidue(peptide_[index]->getOneLetterCode());
+    const bool has_existing_modification = peptide_[index]->isModified();
+    const double combined_diff_mono_mass =
+      diffMonoMass + (has_existing_modification ? peptide_[index]->getMonoWeight() - base_residue->getMonoWeight() : 0.0);
+
     const ModificationsDB* mod_db = ModificationsDB::getInstance();
     bool multimatch = false;
     // quickly check for user-defined modification added by createUnknownFromMassString (e.g. M[+12321])
-    std::string diffMonoMassStr = ResidueModification::getDiffMonoMassWithBracket(diffMonoMass);
-    const ResidueModification* mod = mod_db->searchModificationsFast(peptide_[index]->getOneLetterCode() + diffMonoMassStr, multimatch);
+    const std::string diff_mono_mass_str = ResidueModification::getDiffMonoMassWithBracket(combined_diff_mono_mass);
+    const ResidueModification* mod = mod_db->searchModificationsFast(base_residue->getOneLetterCode() + diff_mono_mass_str, multimatch);
     const double tol = 0.002;
-    if (mod == nullptr)
+    if (mod == nullptr && !has_existing_modification)
     {
-      mod = mod_db->getBestModificationByDiffMonoMass(diffMonoMass, tol, peptide_[index]->getOneLetterCode(), ResidueModification::ANYWHERE);
+      mod = mod_db->getBestModificationByDiffMonoMass(combined_diff_mono_mass, tol, base_residue->getOneLetterCode(), ResidueModification::ANYWHERE);
     }
     if (mod == nullptr)
     {
-      OPENMS_LOG_WARN << "Modification with monoisotopic mass diff. of " << diffMonoMassStr << " not found in databases with tolerance " << tol << ". Adding unknown modification.\n";
-      mod = ResidueModification::createUnknownFromMassString(ResidueModification::getDiffMonoMassString(diffMonoMass),
-                                                                        diffMonoMass,
-                                                                        true,
-                                                                        ResidueModification::ANYWHERE,
-                                                                        peptide_[index]);
+      OPENMS_LOG_WARN << "Modification with monoisotopic mass diff. of " << diff_mono_mass_str << " not found in databases with tolerance " << tol
+                      << ". Adding unknown modification.\n";
+      mod = ResidueModification::createUnknownFromMassString(
+        ResidueModification::getDiffMonoMassString(combined_diff_mono_mass),
+        combined_diff_mono_mass,
+        true,
+        ResidueModification::ANYWHERE,
+        base_residue);
     }
-    peptide_[index] = ResidueDB::getInstance()->getModifiedResidue(peptide_[index], mod);
+    peptide_[index] = residue_db->getModifiedResidue(base_residue, mod);
   }
 
   void AASequence::setModification(Size index, const Residue* modification)

--- a/src/openms/source/CHEMISTRY/Residue.cpp
+++ b/src/openms/source/CHEMISTRY/Residue.cpp
@@ -455,7 +455,7 @@ namespace OpenMS
     if (mod == nullptr)
     {
       OPENMS_LOG_WARN << "Modification with monoisotopic mass diff. of " << diffMonoMassStr << " not found in databases with tolerance " << tol << ". Adding unknown modification." << std::endl;
-      mod = ResidueModification::createUnknownFromMassString(StringUtils::toStr(diffMonoMass),
+      mod = ResidueModification::createUnknownFromMassString(ResidueModification::getDiffMonoMassString(diffMonoMass),
                                                                         diffMonoMass,
                                                                         true,
                                                                         ResidueModification::ANYWHERE,

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -310,7 +310,7 @@ namespace OpenMS
         // r will be nullptr if not found. The next line handles it.
         const Residue* r = ResidueDB::getInstance()->getResidue(aminoacid_[0]);
         //TODO check if it is better to create from mass or massdiff
-        registered_mod_ = ResidueModification::createUnknownFromMassString(StringUtils::toStr(massdiff_),
+        registered_mod_ = ResidueModification::createUnknownFromMassString(ResidueModification::getDiffMonoMassString(massdiff_),
                                                                                  massdiff_,
                                                                                  true,
                                                                                  term_spec_,

--- a/src/tests/class_tests/openms/source/AASequence_test.cpp
+++ b/src/tests/class_tests/openms/source/AASequence_test.cpp
@@ -656,6 +656,18 @@ START_SECTION(void setModification(Size index, const std::string &modification))
   TEST_STRING_EQUAL(seq1.toString(), "AC[-1.234]DE[-1.234]FN(Deamidated)E[-1.234]K")
 END_SECTION
 
+START_SECTION(void setModificationByDiffMonoMass(Size index, double diffMonoMass))
+  const double mass_shift = 306.025304840900048;
+  AASequence modified = AASequence::fromString("AEADNLDDKK");
+  modified.setModificationByDiffMonoMass(8, mass_shift);
+
+  const std::string serialized = modified.toString();
+  TEST_TRUE(serialized.find("K[+") != std::string::npos)
+
+  const AASequence round_tripped = AASequence::fromString(serialized);
+  TEST_REAL_SIMILAR(round_tripped.getMonoWeight(), modified.getMonoWeight())
+END_SECTION
+
 START_SECTION(void setNTerminalModification(const std::string &modification))
   AASequence seq1 = AASequence::fromString("DFPIANGER");
   AASequence seq2 = AASequence::fromString("(MOD:00051)DFPIANGER");

--- a/src/tests/class_tests/openms/source/AASequence_test.cpp
+++ b/src/tests/class_tests/openms/source/AASequence_test.cpp
@@ -666,6 +666,30 @@ START_SECTION(void setModificationByDiffMonoMass(Size index, double diffMonoMass
 
   const AASequence round_tripped = AASequence::fromString(serialized);
   TEST_REAL_SIMILAR(round_tripped.getMonoWeight(), modified.getMonoWeight())
+
+  // Use distinct unknown-modification IDs so both cache insertion orders can
+  // be tested independently in the process-global ModificationsDB.
+  const double reverse_order_mass_shift = mass_shift + 1.0;
+  AASequence oxidized_first = AASequence::fromString("M(Oxidation)PEPTIDE");
+  AASequence plain_second = AASequence::fromString("MPEPTIDE");
+  const double oxidized_weight = oxidized_first.getMonoWeight();
+  const double plain_weight = plain_second.getMonoWeight();
+  oxidized_first.setModificationByDiffMonoMass(0, mass_shift);
+  plain_second.setModificationByDiffMonoMass(0, mass_shift);
+
+  AASequence plain_first = AASequence::fromString("MPEPTIDE");
+  AASequence oxidized_second = AASequence::fromString("M(Oxidation)PEPTIDE");
+  plain_first.setModificationByDiffMonoMass(0, reverse_order_mass_shift);
+  oxidized_second.setModificationByDiffMonoMass(0, reverse_order_mass_shift);
+
+  TEST_REAL_SIMILAR(oxidized_first.getMonoWeight() - mass_shift, oxidized_weight)
+  TEST_REAL_SIMILAR(plain_second.getMonoWeight() - mass_shift, plain_weight)
+  TEST_REAL_SIMILAR(plain_first.getMonoWeight() - reverse_order_mass_shift, plain_weight)
+  TEST_REAL_SIMILAR(oxidized_second.getMonoWeight() - reverse_order_mass_shift, oxidized_weight)
+  TEST_REAL_SIMILAR(oxidized_first.getMonoWeight() - mass_shift, oxidized_second.getMonoWeight() - reverse_order_mass_shift)
+  TEST_REAL_SIMILAR(plain_second.getMonoWeight() - mass_shift, plain_first.getMonoWeight() - reverse_order_mass_shift)
+  TEST_FALSE(oxidized_first.toString() == plain_second.toString())
+  TEST_FALSE(oxidized_second.toString() == plain_first.toString())
 END_SECTION
 
 START_SECTION(void setNTerminalModification(const std::string &modification))

--- a/src/tests/class_tests/openms/source/PepXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/PepXMLFile_test.cpp
@@ -159,14 +159,14 @@ START_SECTION(void load(const std::string& filename, std::vector<ProteinIdentifi
   TEST_EQUAL(var_mods[2], "Oxidation (M)")
   TEST_EQUAL(var_mods[3], "Gln->pyro-Glu (N-term Q)")
 
-  TEST_EQUAL(var_mods[4], "M[1.0]")
-  TEST_EQUAL(var_mods[5], ".n[2.0]")
-  TEST_EQUAL(var_mods[6], ".c[2.0]")
-  TEST_EQUAL(var_mods[7], ".n[2.5]")
-  TEST_EQUAL(var_mods[8], ".n[2.5]")
+  TEST_EQUAL(var_mods[4], "M[+1.0]")
+  TEST_EQUAL(var_mods[5], ".n[+2.0]")
+  TEST_EQUAL(var_mods[6], ".c[+2.0]")
+  TEST_EQUAL(var_mods[7], ".n[+2.5]")
+  TEST_EQUAL(var_mods[8], ".n[+2.5]")
   TEST_EQUAL(var_mods[9], ".n[-2.5]")
-  TEST_EQUAL(var_mods[10], ".n[2.5]")
-  TEST_EQUAL(var_mods[11], ".c[3.4]")
+  TEST_EQUAL(var_mods[10], ".n[+2.5]")
+  TEST_EQUAL(var_mods[11], ".c[+3.4]")
 
   /* TODO Probably would be nicer to have the following as fullID for readability
    *  (with the other notation you can't see if it has AA restrictions or if it is protein term)


### PR DESCRIPTION
Fixes #10006 and #10007 — two independent defects in how OpenMS represents an unknown (mass-shift-only) modification. Both were found while auditing a proposed OpenNuXL change under #9992, but neither is NuXL-specific, and **the first one already corrupts output that ships today**.

## #10006 — an unsigned mass bracket does not round-trip

`AASequence::setModificationByDiffMonoMass` built its `ModificationsDB` lookup key *with* a sign, via `getDiffMonoMassWithBracket()`, but created the modification from a bare `StringUtils::toStr(diffMonoMass)`. So it registered `K[306.0253…]` while the lookup asked for `K[+306.0253…]`.

Two consequences:

- the fast lookup could never match what the same function had just created, so every call re-entered creation and logged `Modification not found`;
- the emitted bracket was unsigned, and `AASequence::fromString` reads an unsigned bracket as the residue's **absolute** mass, not a delta.

```
in-process:                    AEADNLDDK[306.025304840900048]K   1423.5504
reloaded from idXML, new proc: AEADNLDDK[306.025304840900048]K   1295.4555   (off by the K residue mass)
```

**This affects shipping output.** `FeatureFinderIdentificationAlgorithm::addPeptideToMap_` applies its `CalcMass` correction through this path. On a real run (PRIDE PXD048145, E. coli UV RNA cross-linking, adducts 306–669 Da), the featureXML written by standalone `FeatureFinderIdentification` contained **424 mass brackets, none signed**, and for all **184/184** cross-linked features the mass recomputed from the reloaded sequence disagreed with the m/z stored in that same feature (median −99 Da). The feature positions are right; the peptidoform written next to them decodes to a different molecule.

Fixed at all five call sites that pass a delta (three in `AASequence`, one in `Residue`, one in `PepXMLFile`) by using the existing signed `ResidueModification::getDiffMonoMassString()`.

**The parser is deliberately untouched.** An unsigned bracket meaning absolute residue mass is supported notation (`M[147]`); only the writing side was wrong.

## #10007 — order-dependent conflation of modified and unmodified residues

Applying an unknown mass shift to a residue that already carried a modification *replaced* that modification, and the result was interned process-wide under an id built from the residue's **one-letter code** — which cannot distinguish oxidized M from plain M. `createUnknownFromMassString` takes the absolute `MonoMass` from whichever residue it is first called with, and `ResidueDB::getModifiedResidue` rebuilds from the unmodified table.

| processed first | oxidized M gets | plain M gets |
|---|---|---|
| oxidized | +306.0253 ✓ | **+322.0202** — inherits the oxidation |
| plain | **+290.0304** — loses it | +306.0253 ✓ |

Both stringified identically. Not a consequence of the missing sign: it reproduced with the signed spelling too.

`setModificationByDiffMonoMass` now resolves the unmodified base residue, folds any existing modification's mass into a cumulative delta, and interns on that — plain M becomes `M[+306.025304840900048]`, oxidized M becomes `M[+322.02021984090004]`. Distinct entries, order-independent, each with the correct total mass.

The approximate 0.002 Da match against known modifications is skipped when the residue is already modified, so a cumulative mass cannot snap onto an unrelated database entry. Unmodified residues keep the previous behaviour, which is why no reference files change.

### Known limitations (also recorded on #10007)

- A `Residue` holds a single `ResidueModification`, so an existing **named** modification is absorbed into the cumulative bracket mass; its name/formula identity is not retained. The mass is now correct and stable, which it was not.
- `createUnknownFromMassString` is deliberately left unchanged: its callers pass a mix of incremental and already-combined deltas, and composing there could double-count `combineMods` results. Consequently `Residue::setModificationByDiffMonoMass` called directly on an already-modified standalone `Residue` can still show the old behaviour, and can pre-seed an inconsistent global entry.

## Testing

Regression tests in `AASequence_test.cpp`: a sign + round-trip assertion for #10006, and an order-independence test for #10007 exercising both orders with separated sentinel shifts (the modification database is process-global, so the orders must not share an id). Both were **proven red before the fix** — oxidized-first left the plain peptide with an extra 15.994915 Da, plain-first left the oxidized peptide short by the same amount.

`PepXMLFile_test` expectations change from `M[1.0]` to `M[+1.0]` and similar. Only the spelling changes, the masses are identical — and the already-correct `.n[-2.5]` line is untouched, which is precisely the asymmetry this bug produced: negative deltas always carried their sign from `toStr`, positive ones never did.

Full suite: **2834 / 2843**. All nine failures are environmental or pre-existing — six `TOPP_CometAdapter_*_out1` (version string), `TOPP_PercolatorAdapter_1_subprocess_out` (external percolator numerics), `Doxygen_Warning_test` (no Graphviz), and `pyopenms_unittests`, which fails **identically on pristine `develop`** (verified by differential build: the same six `test_mutable_references.py` cases, which assert mutable references against the copy semantics deliberately restored in 778b7109ff / #9792). No reference files changed anywhere.

The first commit was built and tested standalone (6/6) so that a bisect landing on it finds a working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of mass-based residue modifications when a residue already has a modification.
  * Unknown modifications now use consistent, precise mass-difference formatting across sequence and PepXML workflows.
  * Positive mass shifts are displayed with an explicit `+` sign for clearer modification notation.

* **Tests**
  * Added coverage confirming modified sequences preserve their expected monoisotopic weights and remain consistent across repeated use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->