### PR TITLE
[FIX,TEST] FFId: call run() with the current signature, unbreaking develop

### DIFF
--- a/src/tests/class_tests/openms/source/FeatureFinderIdentificationAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureFinderIdentificationAlgorithm_test.cpp
@@ -69,8 +69,7 @@ START_SECTION([EXTRA] run() rejects MS data without spectra)
 
   TEST_EQUAL(algo.getMSData().empty(), true)
   TEST_EXCEPTION(Exception::IllegalArgument,
-                 algo.run(peptides, proteins, PeptideIdentificationList(), vector<ProteinIdentification>(),
-                          features, seeds, ""))
+                 algo.run(peptides, proteins, features, seeds, ""))
 }
 END_SECTION
 


### PR DESCRIPTION
`develop` does not compile. Every `build-and-test` job on every platform fails at the same line.

## Cause

Two commits landed in an incompatible order:

- **`9858b8963b`** (#9995) removed FeatureFinderIdentification's external peptide ID path, changing the signature to
  ```cpp
  void run(PeptideIdentificationList peptides, const std::vector<ProteinIdentification>& proteins,
           FeatureMap& features, const FeatureMap& seeds = FeatureMap(), const std::string& spectra_file = "");
  ```
- **`c90acf92fd`** ("guard FFId against empty MS data", #9980) added a test call using the previous **seven-argument** form:
  ```cpp
  algo.run(peptides, proteins, PeptideIdentificationList(), vector<ProteinIdentification>(), features, seeds, "")
  ```

Neither is wrong on its own; together they are inconsistent. On `develop` HEAD (`13047432ae`):

```
src/tests/class_tests/openms/source/FeatureFinderIdentificationAlgorithm_test.cpp:72:26: error:
no matching function for call to 'OpenMS::FeatureFinderIdentificationAlgorithm::run(
  OpenMS::PeptideIdentificationList&, std::vector<OpenMS::ProteinIdentification>&,
  OpenMS::PeptideIdentificationList, std::vector<OpenMS::ProteinIdentification>,
  OpenMS::FeatureMap&, OpenMS::FeatureMap&, const char [1])'
```

## Why it went unnoticed

The most recent full **Build and Test** run on `develop` is `14da2d038`, which predates both merges. Everything green on `develop` since then has been `cppcheck` only, which does not compile the class tests. The breakage surfaced on the next PR to be built against the merged state (#10010), where it is the sole compiler error across the whole job and touches none of that PR's files.

## The change

Drop the two removed arguments from the call. Nothing else — the test's purpose is unchanged and still holds: `run()` must throw `IllegalArgument` when the MS data is empty, which is what #9980 added the guard for. Both `PeptideIdentificationList` and `vector<ProteinIdentification>` remain in use for the surviving arguments, so no includes become unused.

## Verification

Built and run against `develop` HEAD: `FeatureFinderIdentificationAlgorithm_test` compiles and passes (1/1). The guard still fires through the five-argument entry point, so the regression #9980 added is still covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage to use the current two-argument identification algorithm interface.
  * Preserved validation of the algorithm’s behavior with empty peptide and protein identification data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->