### PR TITLE
[FIX] AASequence: terminal setModificationByDiffMonoMass never applied anything (shadowed member)

### DIFF
--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -1616,18 +1616,18 @@ namespace OpenMS
     // quickly check for user-defined modification added by createUnknownFromMassString (e.g. M[+12321])
     std::string diffMonoMassStr = ResidueModification::getDiffMonoMassWithBracket(diffMonoMass);
     // TODO make a distinction in the FullID about protein vs peptide term??
-    const ResidueModification* n_term_mod_ = mod_db->searchModificationsFast(".c"+diffMonoMassStr, multimatch);
+    c_term_mod_ = mod_db->searchModificationsFast(".c"+diffMonoMassStr, multimatch);
     std::string residue;
-    if (n_term_mod_ == nullptr)
+    if (c_term_mod_ == nullptr)
     {
-        n_term_mod_ = ModificationsDB::getInstance()
+        c_term_mod_ = ModificationsDB::getInstance()
           ->getBestModificationByDiffMonoMass(diffMonoMass, tol, residue, term);
     }
-    if (n_term_mod_ == nullptr)
+    if (c_term_mod_ == nullptr)
     {
 
       OPENMS_LOG_WARN << "Modification with monoisotopic mass diff. of " << diffMonoMassStr << " not found in databases with tolerance " << tol << ". Adding unknown modification.\n";
-      n_term_mod_ = ResidueModification::createUnknownFromMassString(ResidueModification::getDiffMonoMassString(diffMonoMass),
+      c_term_mod_ = ResidueModification::createUnknownFromMassString(ResidueModification::getDiffMonoMassString(diffMonoMass),
                                                                         diffMonoMass,
                                                                         true,
                                                                         term);
@@ -1646,7 +1646,7 @@ namespace OpenMS
     // quickly check for user-defined modification added by createUnknownFromMassString (e.g. M[+12321])
     std::string diffMonoMassStr = ResidueModification::getDiffMonoMassWithBracket(diffMonoMass);
     // TODO make a distinction in the FullID about protein vs peptide term??
-    const ResidueModification* n_term_mod_ = mod_db->searchModificationsFast(".n"+diffMonoMassStr, multimatch);
+    n_term_mod_ = mod_db->searchModificationsFast(".n"+diffMonoMassStr, multimatch);
     std::string residue;
     if (n_term_mod_ == nullptr)
     {

--- a/src/tests/class_tests/openms/source/AASequence_test.cpp
+++ b/src/tests/class_tests/openms/source/AASequence_test.cpp
@@ -692,6 +692,33 @@ START_SECTION(void setModificationByDiffMonoMass(Size index, double diffMonoMass
   TEST_FALSE(oxidized_second.toString() == plain_first.toString())
 END_SECTION
 
+START_SECTION(void setNTerminalModificationByDiffMonoMass(double diffMonoMass, bool protein_term))
+  const double shift = 306.025304840900048;
+  AASequence seq = AASequence::fromString("AEADNLDDKK");
+  const double unmodified = seq.getMonoWeight();
+  seq.setNTerminalModificationByDiffMonoMass(shift, false);
+
+  // the modification must actually be applied, not assigned to a shadowing local
+  TEST_TRUE(seq.hasNTerminalModification())
+  TEST_FALSE(seq.hasCTerminalModification())
+  TEST_REAL_SIMILAR(seq.getMonoWeight() - unmodified, shift)
+  TEST_REAL_SIMILAR(AASequence::fromString(seq.toString()).getMonoWeight(), seq.getMonoWeight())
+END_SECTION
+
+START_SECTION(void setCTerminalModificationByDiffMonoMass(double diffMonoMass, bool protein_term))
+  const double shift = 306.025304840900048;
+  AASequence seq = AASequence::fromString("AEADNLDDKK");
+  const double unmodified = seq.getMonoWeight();
+  seq.setCTerminalModificationByDiffMonoMass(shift, false);
+
+  // must land on the C-terminus - the C-terminal overload used to write the
+  // N-terminal member name, so a naive de-shadowing would modify the wrong end
+  TEST_TRUE(seq.hasCTerminalModification())
+  TEST_FALSE(seq.hasNTerminalModification())
+  TEST_REAL_SIMILAR(seq.getMonoWeight() - unmodified, shift)
+  TEST_REAL_SIMILAR(AASequence::fromString(seq.toString()).getMonoWeight(), seq.getMonoWeight())
+END_SECTION
+
 START_SECTION(void setNTerminalModification(const std::string &modification))
   AASequence seq1 = AASequence::fromString("DFPIANGER");
   AASequence seq2 = AASequence::fromString("(MOD:00051)DFPIANGER");


### PR DESCRIPTION
`AASequence::setNTerminalModificationByDiffMonoMass` and `setCTerminalModificationByDiffMonoMass` are silent no-ops. Both return without having modified the sequence, without throwing and without warning.

## Cause

Each function opens by declaring a local pointer whose name **shadows the member it is supposed to write**:

```cpp
void AASequence::setNTerminalModificationByDiffMonoMass(double diffMonoMass, bool protein_term)
{
  ...
  const ResidueModification* n_term_mod_ = mod_db->searchModificationsFast(".n" + diffMonoMassStr, multimatch);
  //                       ^^^ new local, shadows the member declared in AASequence.h:624
```

Every later mention of `n_term_mod_` in the body resolves to the local. So the function performs all of its logic — the fast lookup for an existing user-defined modification, the 0.002 Da tolerance search, creating an unknown modification when neither matches — assigns the result to the local, and drops it at the closing brace. The member keeps its previous value.

```
AEADNLDDKK  +306.025304840900048 on the N-terminus
  before: mono = 1117.5251
  after : mono = 1117.5251     (applied delta +0.0000)
```

## The C-terminal overload has a second slip

It is the N-terminal function copied with only `".n"` changed to `".c"`. Its local is still named `n_term_mod_`, so de-shadowing it naively — by deleting the type — would have written the **N-terminal** member and silently applied a C-terminal modification to the wrong end of the peptide. Its body is retargeted to `c_term_mod_` throughout.

## Why this survived

Neither function has a caller anywhere in the codebase, so nothing exercised them and no test covered them. The residue-level sibling, `setModificationByDiffMonoMass`, *is* used (by `FeatureFinderIdentification`) and has had recent attention in #10010; these two terminal variants were never reached.

Found while evaluating whether an unlocalised modification could be represented on a terminus (#9992) — the API that approach would build on does not currently work.

## Tests

Regression sections added for both overloads. They assert that the modification is applied, that it lands on the **correct terminus** (which is what catches the copy-paste slip — a fix that wrote the wrong member would still pass a mass-only assertion), that the monoisotopic weight changes by the requested delta, and that the result survives a `toString()` / `fromString()` round trip.

Proven to fail before the fix — `hasNTerminalModification()` and `hasCTerminalModification()` both returned false — and to pass after.

`AASequence`, `Residue`, `ResidueDB`, `ResidueModification`, `ModificationsDB`, `PepXMLFile` and `TheoreticalSpectrumGenerator` class tests: 7/7 pass. No reference files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal modification handling when applying mass-based N-terminal or C-terminal changes.
  * Ensured the selected modifications are correctly retained and reflected in sequence mass calculations and serialization.

* **Tests**
  * Added regression coverage for terminal mass shifts, assignment, mass deltas, and serialization round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->