### PR TITLE
[FIX] pyopenms-wheels: retry artifact download when a wheel goes missing

### DIFF
--- a/.github/workflows/pyopenms-wheels-cibuildwheel.yml
+++ b/.github/workflows/pyopenms-wheels-cibuildwheel.yml
@@ -510,6 +510,37 @@ jobs:
           name: ${{ matrix.artifact }}
           path: wheelhouse
 
+      # actions/download-artifact@v4 can report success on a run where several
+      # test-wheels jobs download the same multi-platform-python artifact
+      # concurrently, yet leave the extracted directory missing a wheel (seen
+      # e.g. on run 33348103665, job "test-wheels (3.13, macos-15)": the
+      # download step itself was marked successful, but wheelhouse/*cp313*.whl
+      # was absent while the sibling cp310/cp311/cp312/cp314 jobs downloading
+      # the identical artifact all extracted it fine). Re-download rather than
+      # silently failing the pip install with an unglobbed literal filename.
+      - name: Verify wheel was downloaded, retry on a corrupt/incomplete extract
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PYVER=$(echo "${{ matrix.python-version }}" | tr -d '.')
+          echo "PYVER=${PYVER}" >> "$GITHUB_ENV"
+          for attempt in 1 2 3; do
+            if compgen -G "wheelhouse/*cp${PYVER}*.whl" > /dev/null; then
+              echo "Found the cp${PYVER} wheel on attempt ${attempt}."
+              exit 0
+            fi
+            echo "::warning::cp${PYVER} wheel missing from '${{ matrix.artifact }}' after download attempt ${attempt}; re-downloading."
+            rm -rf wheelhouse
+            gh run download "${{ github.run_id }}" \
+              --repo "${{ github.repository }}" \
+              --name "${{ matrix.artifact }}" \
+              --dir wheelhouse
+          done
+          echo "::error::cp${PYVER} wheel still missing from '${{ matrix.artifact }}' after ${attempt} download attempts."
+          ls -la wheelhouse || true
+          exit 1
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -519,7 +550,6 @@ jobs:
         shell: bash
         run: |
           # Install the wheel matching this Python version
-          PYVER=$(echo "${{ matrix.python-version }}" | tr -d '.')
           pip install wheelhouse/*cp${PYVER}*.whl
           python -c "import pyopenms; print('pyopenms version:', pyopenms.__version__)"
           python -c "import pyopenms; print(pyopenms.EmpiricalFormula('C6H12O6').getMonoWeight())"


### PR DESCRIPTION
## Summary

Today's nightly `pyopenms-wheels-cibuildwheel` run failed
([run 33348103665](https://github.com/OpenMS/OpenMS/actions/runs/33348103665)),
which in turn skipped the PyPI/Tuebingen/archive.openms.de publish jobs for
the whole nightly build.

Root cause: the `test-wheels` job runs one job per `(python-version, os)`
pair, and every macOS job downloads the same `wheels-macos-arm64` artifact
concurrently. In this run, `actions/download-artifact@v4` reported
**success** in all five macos-15 jobs, but only the `test-wheels (3.13,
macos-15)` job ended up with an incomplete extraction: `wheelhouse/` was
missing the cp313 wheel, while the sibling cp310/cp311/cp312/cp314 jobs -
downloading the identical artifact in parallel - all extracted theirs fine.
The wheel *had* been built and uploaded correctly (`build-wheels-macos`'s
upload step reports "5 files uploaded" and the cp313 wheel is listed as
built), so this is a download/extraction-side hiccup, not a build issue.

Because the glob had no match, bash passed the literal pattern to pip:
```
WARNING: Requirement 'wheelhouse/*cp313*.whl' looks like a filename, but the file does not exist
ERROR: Invalid wheel filename (wrong number of parts): '*cp313*'
```

This is the first occurrence of this failure mode in the workflow's history
(191 prior runs), so it isn't a recurring/known issue - but the workflow had
no defense against a `download-artifact` step that reports success while
leaving a wheel behind.

## Fix

Add a verification step right after `actions/download-artifact@v4` in the
`test-wheels` job: check that the wheel matching the job's Python version is
actually present, and if not, re-download the same artifact via `gh run
download` (up to 3 attempts) before failing loudly with a clear error. A
genuinely missing/broken wheel still fails the job after the retries -
this only guards against the download step silently under-delivering.

## Test plan

- [x] Workflow YAML validated with `yaml.safe_load`
- [ ] Re-run `pyopenms-wheels-cibuildwheel` on `nightly`/`develop` to confirm the job passes end to end (cannot be exercised locally; this is a GitHub Actions workflow)


---
_Generated by [Claude Code](https://claude.ai/code/session_01E6DqSR1mqU9ZgLRqA11hNB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wheel testing reliability by detecting missing or incomplete downloads.
  * Automatically retries artifact downloads up to three times before reporting failure.
  * Prevents tests from proceeding when the expected wheel is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->