### PR TITLE
[FIX,TEST] File_test: stop asserting on a source-tree mtime (#10018)

### DIFF
--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -177,9 +177,11 @@ namespace OpenMS
     if (!File::exists(file)) return -1;
 
     // stat() rather than std::filesystem::last_write_time(): file_time_type's epoch is
-    // implementation-defined, and std::chrono::clock_cast -- the standard way to anchor it to the
-    // Unix epoch -- is still absent from Apple's libc++. st_mtime is seconds since the Unix epoch
-    // on POSIX and on MSVC alike, so it needs neither a conversion nor a per-platform offset.
+    // implementation-defined (2174 on libstdc++, 1601 on MSVC), and std::chrono::clock_cast -- the
+    // standard way to anchor it to the Unix epoch -- is not available across the toolchains this
+    // builds on: absent from Apple's libc++, and libstdc++ still reports __cpp_lib_chrono == 201611
+    // as of GCC 13, below the 201907L that clock_cast requires. st_mtime is seconds since the Unix
+    // epoch on POSIX and on MSVC alike, so it needs neither a conversion nor a per-platform offset.
     // to_path() first, so a UTF-8 path still resolves on Windows.
     const auto p = to_path(file);
 #ifdef OPENMS_WINDOWSPLATFORM

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -20,6 +20,7 @@
 #include <OpenMS/SYSTEM/File.h>
 
 #include <atomic>
+#include <ctime>
 #include <fstream>
 #include <filesystem>
 #include <thread>
@@ -58,18 +59,24 @@ END_SECTION
 START_SECTION((static Int64 getModificationTime(const std::string& file)))
   TEST_EQUAL(File::getModificationTime("does_not_exists.txt"), -1)
 
-  // Anchored to the Unix epoch, not to file_clock's implementation-defined one, so the value means
-  // the same thing to a reader on another platform. Checked loosely -- any plausible wall clock
-  // since 2020 -- rather than against a fixture's timestamp, which a checkout rewrites.
-  const Int64 t_repo = File::getModificationTime(OPENMS_GET_TEST_DATA_PATH("File_test_text.txt"));
-  TEST_EQUAL(t_repo > 1577836800LL, true)   // after 2020-01-01
-  TEST_EQUAL(t_repo < 4102444800LL, true)   // before 2100-01-01
-
-  // A file written now is not older than one written earlier.
+  // Bracketed by the wall clock around a file this test writes itself. That pins both properties
+  // the method promises: the number is that file's actual modification time, and it counts seconds
+  // from the Unix epoch rather than from file_clock's implementation-defined one -- 2174 on
+  // libstdc++, 1601 on MSVC -- so it means the same thing to a reader on another platform.
+  //
+  // Deliberately not read off a file in the source tree: distributions building reproducibly
+  // (Debian, Nix) normalise every source timestamp to the epoch, which is a property of the build
+  // environment and not of this method (see issue #10018). The few seconds of slack absorb coarse
+  // filesystem timestamp granularity; the errors this guards against are off by billions.
+  const Int64 t_before = static_cast<Int64>(std::time(nullptr));
   std::string tmp;
   NEW_TMP_FILE(tmp);
   { std::ofstream os(tmp.c_str()); os << "x"; }
-  TEST_EQUAL(File::getModificationTime(tmp) >= t_repo - 86400LL, true)
+  const Int64 t_after = static_cast<Int64>(std::time(nullptr));
+
+  const Int64 t_tmp = File::getModificationTime(tmp);
+  TEST_TRUE(t_tmp >= t_before - 5)
+  TEST_TRUE(t_tmp <= t_after + 5)
 END_SECTION
 
 START_SECTION((static bool remove(const std::string &file)))


### PR DESCRIPTION
Fixes #10018.

`File_test`'s `getModificationTime` section read the mtime of a checked-in fixture and asserted it fell between 2020 and 2100. Distributions that build reproducibly (Debian, Nix) normalise every source timestamp to the Unix epoch, so the lower bound fails there; a source tarball unpacked with preserved pre-2020 timestamps would fail the same way. The verdict of a test about `File` depended on how the tree had been unpacked.

Reproduced by forcing the fixture's mtime to 0 — exactly one assertion breaks:

```
checking (static Int64 getModificationTime(const std::string& file)) ...
 -  line 65 : TEST_EQUAL(t_repo > 1577836800LL,true): got '0', expected '1'
: failed
```

### The range was not vacuous

It caught precisely the bug the method was added to fix. For that same fixture:

| | value |
|---|---|
| `last_write_time().time_since_epoch()` (libstdc++, epoch 2174-01-01) | **−4669704535 s** |
| `st_mtime` | 1767959464 s |

An unconverted `file_clock` count is negative on libstdc++ and around 1.3e10 on MSVC (epoch 1601-01-01), so the lower and upper bound each rejected one platform. The property was worth asserting — reading it off a file the *build environment* owns was the defect.

### The change

The test now brackets the wall clock around a file it writes itself:

```cpp
const Int64 t_before = static_cast<Int64>(std::time(nullptr));
std::string tmp;
NEW_TMP_FILE(tmp);
{ std::ofstream os(tmp.c_str()); os << "x"; }
const Int64 t_after = static_cast<Int64>(std::time(nullptr));

const Int64 t_tmp = File::getModificationTime(tmp);
TEST_TRUE(t_tmp >= t_before - 5)
TEST_TRUE(t_tmp <= t_after + 5)
```

No source-tree timestamp is touched, and the assertion is strictly stronger: the return value is pinned to that file's actual modification time within seconds instead of to any moment in a 130-year window. That also closes the reporter's second objection — that the old check never established the value was the *real* mtime. The few seconds of slack absorb coarse filesystem timestamp granularity; the errors it guards against are off by billions.

Also corrects the comment in `File.cpp` explaining why `stat()` is used over `std::filesystem::last_write_time()`. It blamed only Apple's libc++ for the missing `std::chrono::clock_cast`; libstdc++ still reports `__cpp_lib_chrono == 201611` as of GCC 13 — below the 201907L `clock_cast` requires — under both `-std=c++20` and `-std=c++23`. The constraint is broader than the comment claimed.

### Verification

1. Passes with the fixture's mtime forced to 0.
2. Full `File_test` green (exit 0, zero failures) with the mtime restored.
3. Fails on purpose — reverting `getModificationTime` to the pre-fix `last_write_time().time_since_epoch()` expression yields `line 80: TEST_TRUE(t_tmp >= t_before - 5): failed`, confirming the new bounds still catch the epoch bug the old ones were guarding.

Test-only behaviour change; the `File.cpp` edit is a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of file modification timestamps to use reliable time boundaries, reducing the risk of platform-dependent test failures.

* **Documentation**
  * Added clarification about cross-platform timestamp behavior and compatibility considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->