### PR TITLE
Fix PercolatorAdapter to not require percolator binary for in-process backend

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -429,6 +429,11 @@ TOPP tools:
         write no longer crashes with "Invalid protein reference 'DECOY_...'" when target+decoy shared
         peptides are present (#9197, #9205)
     PercolatorAdapter:
+      - Fix: the tool aborted with "Executable not found (the executable 'percolator' could not be
+        found)" on machines without percolator installed, even for the default in-process backend that
+        never runs the binary. -percolator_executable carries the 'is_executable' tag, so reading it
+        resolves it on PATH; it is now read only when the subprocess path will actually be used, which
+        also restores the TOPP_PercolatorAdapter_1_inproc / _CalcMass tests in such builds (#10020)
       - Fix: an input CalcMass meta value (a search engine's way of stating that a PSM's precursor mass
         differs from its AASequence, which FeatureFinderIdentification's CalcMass correction consumes)
         was deleted along with the training-only PIN columns after in-process rescoring, even though

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -4200,12 +4200,7 @@ add_test("TOPP_PercolatorAdapter_1_inproc" ${TOPP_BIN_PATH}/PercolatorAdapter -t
 add_test("TOPP_PercolatorAdapter_1_inproc_out" ${DIFF} -in1 PercolatorAdapter_1_inproc_out.tmp.idXML -in2 ${DATA_DIR_TOPP}/THIRDPARTY/PercolatorAdapter_1_inproc_out.idXML -whitelist ${_topp_percolator_diff_whitelist})
 set_tests_properties("TOPP_PercolatorAdapter_1_inproc_out" PROPERTIES DEPENDS "TOPP_PercolatorAdapter_1_inproc")
 
-# The in-process backend must not resolve '-percolator_executable' at all: the
-# parameter carries the 'is_executable' tag, so reading it searches PATH and
-# aborts the tool when nothing is found (#10020). Pointing it at a path that
-# cannot exist reproduces a machine without percolator installed, so this guards
-# the regression on CI hosts that do have the binary. The output must still match
-# the in-process reference.
+# regression for in-process is wrongly dependent on '-percolator_executable'
 add_test("TOPP_PercolatorAdapter_1_inproc_no_binary" ${TOPP_BIN_PATH}/PercolatorAdapter -test -ini ${DATA_DIR_TOPP}/THIRDPARTY/PercolatorAdapter_1.ini -use_subprocess false -percolator_executable ${TESTS_TEMP_DIR}/this_percolator_does_not_exist -in ${DATA_DIR_TOPP}/THIRDPARTY/PercolatorAdapter_1.idXML -out PercolatorAdapter_1_inproc_no_binary_out.tmp.idXML -out_type idXML)
 add_test("TOPP_PercolatorAdapter_1_inproc_no_binary_out" ${DIFF} -in1 PercolatorAdapter_1_inproc_no_binary_out.tmp.idXML -in2 ${DATA_DIR_TOPP}/THIRDPARTY/PercolatorAdapter_1_inproc_out.idXML -whitelist ${_topp_percolator_diff_whitelist})
 set_tests_properties("TOPP_PercolatorAdapter_1_inproc_no_binary_out" PROPERTIES DEPENDS "TOPP_PercolatorAdapter_1_inproc_no_binary")

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -4200,6 +4200,16 @@ add_test("TOPP_PercolatorAdapter_1_inproc" ${TOPP_BIN_PATH}/PercolatorAdapter -t
 add_test("TOPP_PercolatorAdapter_1_inproc_out" ${DIFF} -in1 PercolatorAdapter_1_inproc_out.tmp.idXML -in2 ${DATA_DIR_TOPP}/THIRDPARTY/PercolatorAdapter_1_inproc_out.idXML -whitelist ${_topp_percolator_diff_whitelist})
 set_tests_properties("TOPP_PercolatorAdapter_1_inproc_out" PROPERTIES DEPENDS "TOPP_PercolatorAdapter_1_inproc")
 
+# The in-process backend must not resolve '-percolator_executable' at all: the
+# parameter carries the 'is_executable' tag, so reading it searches PATH and
+# aborts the tool when nothing is found (#10020). Pointing it at a path that
+# cannot exist reproduces a machine without percolator installed, so this guards
+# the regression on CI hosts that do have the binary. The output must still match
+# the in-process reference.
+add_test("TOPP_PercolatorAdapter_1_inproc_no_binary" ${TOPP_BIN_PATH}/PercolatorAdapter -test -ini ${DATA_DIR_TOPP}/THIRDPARTY/PercolatorAdapter_1.ini -use_subprocess false -percolator_executable ${TESTS_TEMP_DIR}/this_percolator_does_not_exist -in ${DATA_DIR_TOPP}/THIRDPARTY/PercolatorAdapter_1.idXML -out PercolatorAdapter_1_inproc_no_binary_out.tmp.idXML -out_type idXML)
+add_test("TOPP_PercolatorAdapter_1_inproc_no_binary_out" ${DIFF} -in1 PercolatorAdapter_1_inproc_no_binary_out.tmp.idXML -in2 ${DATA_DIR_TOPP}/THIRDPARTY/PercolatorAdapter_1_inproc_out.idXML -whitelist ${_topp_percolator_diff_whitelist})
+set_tests_properties("TOPP_PercolatorAdapter_1_inproc_no_binary_out" PROPERTIES DEPENDS "TOPP_PercolatorAdapter_1_inproc_no_binary")
+
 # An input CalcMass is search-engine data, whereas one synthesized for PIN training
 # is temporary; the in-process backend must preserve only the former (#9997). This
 # exercises the default in-process backend, which needs no external percolator, so

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -782,8 +782,6 @@ protected:
       return PARSE_ERROR;
     }
 
-    const std::string percolator_executable(getStringOption_("percolator_executable"));
-    
     if (in_list.empty() && in_osw.empty())
     {
       writeLogError_("Fatal error: no input file given (parameter 'in' or 'in_osw')");
@@ -823,6 +821,27 @@ protected:
     bool protein_level_fdrs = getFlag_("protein_level_fdrs");  
 
     Int description_of_correct = getIntOption_("doc");
+
+    // Decide up front whether the external 'percolator' binary is needed. The
+    // in-process backend covers the idXML/mzid + PSM-level FDR path; OSW input,
+    // protein-/peptide-level FDR, description-of-correct, initial weights, or an
+    // explicit -use_subprocess true all fall through to the subprocess path.
+    // '-percolator_executable' carries the 'is_executable' tag, so merely reading
+    // it resolves it on PATH and aborts when it is missing. Read it only when the
+    // subprocess will actually be run, so installations without percolator can
+    // still use the in-process backend (#10020).
+    const bool in_process_ok = getStringOption_("use_subprocess") != "true"
+                               && in_osw.empty()
+                               && !protein_level_fdrs
+                               && !peptide_level_fdrs
+                               && description_of_correct == 0
+                               && getStringOption_("init_weights").empty();
+
+    std::string percolator_executable;
+    if (!in_process_ok)
+    {
+      percolator_executable = getStringOption_("percolator_executable");
+    }
 
     double ipf_max_peakgroup_pep = getDoubleOption_("ipf_max_peakgroup_pep");
     double ipf_max_transition_isotope_overlap = getDoubleOption_("ipf_max_transition_isotope_overlap");
@@ -947,16 +966,10 @@ protected:
       feature_set.push_back("Proteins");
 
       // In-process path: handle the simple idXML/mzid + PSM-level FDR case
-      // without spawning the external 'percolator' binary. Falls through to
-      // the subprocess path for anything the in-process wrapper can't do
-      // (protein-level FDR, peptide-level FDR, init_weights, etc.).
-      const bool use_subprocess = (getStringOption_("use_subprocess") == "true");
-      const bool in_process_ok = !use_subprocess
-                                 && !protein_level_fdrs
-                                 && !peptide_level_fdrs
-                                 && description_of_correct == 0
-                                 && getStringOption_("init_weights").empty();
-
+      // without spawning the external 'percolator' binary (in_process_ok was
+      // determined above). Falls through to the subprocess path for anything
+      // the in-process wrapper can't do (protein-level FDR, peptide-level FDR,
+      // init_weights, etc.).
       if (in_process_ok)
       {
         // Stamp PIN meta values on all hits — this mirrors what the subprocess


### PR DESCRIPTION
## Description

Fixes issue #10020 where PercolatorAdapter would abort with "Executable not found" on machines without the percolator binary installed, even when using the default in-process backend that never executes the external binary.

The root cause is that the `-percolator_executable` parameter carries the `is_executable` tag, which causes OpenMS to resolve it on PATH immediately when read. This check was happening unconditionally at the start of the run method, before determining whether the subprocess path would actually be used.

### Changes

1. **PercolatorAdapter.cpp**: Moved the reading of `percolator_executable` to occur only when needed:
   - Added logic to determine upfront whether the in-process backend can handle the current configuration (no OSW input, no protein/peptide-level FDR, no description-of-correct, no init_weights, and use_subprocess != true)
   - Only read the `percolator_executable` parameter if the subprocess path will actually be used
   - Updated comments to clarify the decision logic
   - This allows installations without percolator to use the in-process backend without errors

2. **CMakeLists.txt**: Added a regression test that verifies the in-process backend works even when pointing `-percolator_executable` to a non-existent path, simulating a machine without percolator installed

3. **CHANGELOG**: Documented the fix

### Testing

- Existing test `TOPP_PercolatorAdapter_1_inproc` continues to pass
- New test `TOPP_PercolatorAdapter_1_inproc_no_binary` verifies the in-process backend works with a non-existent percolator executable path
- Output matches the in-process reference file, confirming correct behavior

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (N/A - no API changes)

https://claude.ai/code/session_01R6hiMB8cQC949JN6PKktgt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PercolatorAdapter no longer aborts with “Executable not found” during in-process execution on systems without Percolator installed.
  * The external executable is resolved only when the subprocess backend is selected.
  * In-process processing and mass-calculation tests now succeed without the Percolator binary.

* **Documentation**
  * Updated the OpenMS 3.6.0 release notes with details of this fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->