### PR TITLE
Update CHANGELOG: PeakPickerChromatogram S/N reporting and File_test mtime fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -658,6 +658,11 @@ TOPP tools:
       - IM-axis hill centroiding via -algorithm hill (see BrukerTimsFile/PASEFHillCentroider) (#9380)
     PeakPickerHiRes:
       - New parameter to allow peak cores with no leading flank peaks (#8649)
+    PeakPickerChromatogram:
+      - Added optional per-peak apex signal-to-noise reporting: the new 'report_sn' parameter (default
+        false) adds an "SN" FloatDataArray to the picked chromatogram, populated from the existing
+        SignalToNoiseEstimatorMedian pass; it can be enabled independently of the 'signal_to_noise'
+        boundary-extension threshold. Peaks without an available estimate report -1.0 (#9780)
     FileConverter:
       - Added MSP file format support (#8650) and OpenSwath sqMass to XIC Parquet conversion (#8829)
       - Bruker options exposed as -bruker:* (MS1 frame aggregation, centroiding algorithm, frame/RT range
@@ -1295,6 +1300,12 @@ Fixes:
     self-copy rejection in File::copyDirRecursively, the CopyOptions::SKIP notices and the
     File::findDatabase miss), which made a passing test run look like a broken build in packaging
     logs (#10019)
+  - Fix: File_test's getModificationTime() check asserted that a checked-in fixture's mtime fell between
+    2020 and 2100; distributions that normalise source timestamps for reproducible builds (Debian, Nix)
+    set it to the Unix epoch, failing the lower bound, and the same would happen for a source tarball
+    unpacked with preserved pre-2020 timestamps. The test now brackets the wall clock around a
+    temporary file it writes and checks itself, which no longer depends on how the tree was unpacked
+    while still catching the bug the original bounds guarded against (#10018)
 
 Documentation:
   - Comprehensive documentation for the Targeted Quantitation algorithms (#8588)


### PR DESCRIPTION
## Description

Audited recently merged PRs on `develop` against CHANGELOG. Most recent merges (LogSinkGuard fix #10024, PercolatorAdapter fix #10023, OpenNuXL adduct feature #10017) already carried their own CHANGELOG entries. Two did not:

- **#9780** — added optional per-peak apex signal-to-noise reporting to `PeakPickerChromatogram` (new `report_sn` parameter, `"SN"` FloatDataArray). The PR's own CHANGELOG checkbox was left unticked.
- **#10021** (fixing #10018) — `File_test`'s `getModificationTime()` check asserted a checked-in fixture's mtime fell in 2020-2100, which fails on distributions that normalise source timestamps for reproducible builds (Debian, Nix). The test now brackets the wall clock around a temp file it writes itself.

## Changes

- CHANGELOG: added a `PeakPickerChromatogram:` entry under `TOPP tools` for #9780
- CHANGELOG: added a `Fixes:` entry for the `File_test` mtime assertion fix (#10021 / #10018)

No code changes.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A - CHANGELOG only)
- [ ] New and existing unit tests pass locally with my changes (N/A - CHANGELOG only)
- [ ] Updated or added python bindings for changed or new classes (N/A - no API changes)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FZZyFcTsnwTanBEyVRfhxT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-peak signal-to-noise reporting for chromatogram peak picking.
  * Signal-to-noise estimates are available in the `SN` data output, with unavailable values marked as `-1.0`.

* **Tests**
  * Improved file modification-time validation using temporary files and current timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->