### PR TITLE
[FIX] ProForma: resolve Formula tags, and stop writing empty modification brackets (#10003)

### DIFF
--- a/src/openms/source/CHEMISTRY/ProForma.cpp
+++ b/src/openms/source/CHEMISTRY/ProForma.cpp
@@ -1720,6 +1720,37 @@ namespace
     return mod_db->addModification(std::move(new_mod));
   }
 
+  /**
+    @brief Combine modifications that landed on one residue into a single one with the summed chemistry.
+
+    An AASequence residue holds exactly one modification, so "M[Oxidation][Formula:O]" cannot be
+    represented as written. Summing the DIFF FORMULAS (rather than only the diff masses, which is what
+    ResidueModification::combineMods does) keeps both the mass and the empirical formula correct - and
+    the formula is what isotope patterns are built from, so losing it would defeat the purpose.
+
+    The result is interned through resolveFormulaTag_, so a combination reuses the same entry as the
+    equivalent single Formula: tag and needs no second interning scheme.
+
+    @return nullptr when the chemistry cannot be summed - any component without a diff formula, or a
+            combination that cancels out - leaving the caller to fall back.
+  */
+  const ResidueModification* combineOnOneResidue_(const std::vector<const ResidueModification*>& mods,
+                                                  char residue)
+  {
+    if (residue == '\0') return nullptr;
+    EmpiricalFormula sum;
+    for (const ResidueModification* m : mods)
+    {
+      if (m->getDiffFormula().isEmpty()) return nullptr;
+      sum += m->getDiffFormula(); // a vector, not a set: repeated identical brackets must each count
+    }
+    if (sum.isEmpty()) return nullptr;
+
+    FormulaTag ft;
+    ft.formula_string = sum.toString();
+    return resolveFormulaTag_(ft, residue, ResidueModification::ANYWHERE);
+  }
+
   // Helper to resolve a single modification tag to a ResidueModification
   const ResidueModification* resolveModificationTag_(
     const ModificationTag& tag,
@@ -2235,16 +2266,29 @@ AASequence ProForma::toAASequence(const Peptidoform& pf, ConversionPolicy policy
   {
     if (const auto* elem = std::get_if<SequenceElement>(&section))
     {
-      // Several brackets on one residue ("M[Oxidation][Formula:O]") cannot all be represented:
-      // AASequence holds one modification per residue and setModification replaces rather than
-      // accumulates, so the last bracket wins. collectConversionIssues_ reports that, so
-      // FAIL_ON_LOSS refuses rather than silently returning a sequence lighter than the peptidoform.
+      // An AASequence residue holds exactly one modification, so several brackets on one residue
+      // ("M[Oxidation][Formula:O]") cannot be represented as written. Combine their chemistry so the
+      // mass and the empirical formula both stay right; the individual identities are still lost,
+      // which collectConversionIssues_ reports, so FAIL_ON_LOSS refuses either way.
+      std::vector<const ResidueModification*> resolved;
       for (const auto& mod : elem->modifications)
       {
-        if (mod.resolved_mod != nullptr) seq.setModification(seq_pos, mod.resolved_mod);
+        if (mod.resolved_mod != nullptr) resolved.push_back(mod.resolved_mod);
         else if (policy == ConversionPolicy::FAIL_ON_LOSS)
           throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
             "Unresolved modification at position " + std::to_string(seq_pos));
+      }
+      if (resolved.size() == 1)
+      {
+        seq.setModification(seq_pos, resolved[0]);
+      }
+      else if (resolved.size() > 1)
+      {
+        const ResidueModification* combined = combineOnOneResidue_(resolved, elem->amino_acid);
+        // No summable chemistry (a component without a diff formula, or one that cancels out):
+        // keep the historical last-one-wins rather than inventing a mass-only modification, which
+        // would throw away the empirical formulas the components do have.
+        seq.setModification(seq_pos, combined != nullptr ? combined : resolved.back());
       }
       seq_pos++;
     }

--- a/src/openms/source/CHEMISTRY/ProForma.cpp
+++ b/src/openms/source/CHEMISTRY/ProForma.cpp
@@ -20,6 +20,7 @@
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/CONCEPT/GlobalExceptionHandler.h>
+#include <OpenMS/CONCEPT/LogStream.h>
 
 #include <algorithm>
 #include <charconv>
@@ -1731,32 +1732,60 @@ namespace
     The result is interned through resolveFormulaTag_, so a combination reuses the same entry as the
     equivalent single Formula: tag and needs no second interning scheme.
 
-    Two outcomes must be told apart, because they call for opposite fallbacks:
-    - the chemistry CANNOT be summed (a component has no diff formula): @p summable is false and the
-      caller keeps the historical last-bracket-wins;
-    - the chemistry sums to NOTHING (e.g. "[Formula:H2O][Formula:H-2O-1]"): @p summable is true and the
-      result is nullptr, meaning "apply no modification" - which is the mass ProForma itself computes.
-      Applying the last bracket here would leave the residue lighter by everything the others added.
+    The authoritative combined mass is the sum of the components' diff mono masses. The diff formulas
+    are summed too, but only TRUSTED when their mass agrees with that sum: a database entry can carry
+    a formula that disagrees with its own mass (UNIMOD:12 loads as (2)H40C118H166N24O26S9, 2703.55 Da,
+    against a diff mass of 450.28 Da), and a single use of it keeps the explicit mass - deriving the
+    combined mass from such a formula would be off by 2253 Da. When the formulas are unavailable or
+    inconsistent, the combination falls back to a mass-only modification: the mass stays right and the
+    formula is lost, which is strictly better than losing whole components.
 
-    @return the interned combined modification, or nullptr (see @p summable for what that means).
+    @param[out] net_zero true when the components cancel to nothing ("[Formula:H2O][Formula:H-2O-1]",
+                "[Formula:O][UNIMOD:447]"): the caller applies NO modification, which is exactly the
+                mass ProForma itself computes. Applying the last bracket would leave the residue lighter
+                by everything the others added.
+    @return the interned combined modification, or nullptr when @p net_zero or when the residue is unknown.
   */
   const ResidueModification* combineOnOneResidue_(const std::vector<const ResidueModification*>& mods,
-                                                  char residue, bool& summable)
+                                                  char residue, bool& net_zero)
   {
-    summable = false;
+    net_zero = false;
     if (residue == '\0') return nullptr;
-    EmpiricalFormula sum;
-    for (const ResidueModification* m : mods)
-    {
-      if (m->getDiffFormula().isEmpty()) return nullptr;
-      sum += m->getDiffFormula(); // a vector, not a set: repeated identical brackets must each count
-    }
-    summable = true;
-    if (sum.isEmpty()) return nullptr; // the components cancel: net chemistry is nothing
 
-    FormulaTag ft;
-    ft.formula_string = sum.toString();
-    return resolveFormulaTag_(ft, residue, ResidueModification::ANYWHERE);
+    double mass_sum = 0.0;
+    EmpiricalFormula formula_sum;
+    bool all_have_formulas = true;
+    for (const ResidueModification* m : mods) // a vector, not a set: repeated identical brackets must each count
+    {
+      mass_sum += m->getDiffMonoMass();
+      if (m->getDiffFormula().isEmpty()) all_have_formulas = false;
+      else formula_sum += m->getDiffFormula();
+    }
+
+    if (std::fabs(mass_sum) <= 1e-6)
+    {
+      net_zero = true;
+      return nullptr;
+    }
+
+    if (all_have_formulas && !formula_sum.isEmpty() && std::fabs(formula_sum.getMonoWeight() - mass_sum) <= 1e-3)
+    {
+      FormulaTag ft;
+      ft.formula_string = formula_sum.toString();
+      return resolveFormulaTag_(ft, residue, ResidueModification::ANYWHERE);
+    }
+
+    if (all_have_formulas)
+    {
+      OPENMS_LOG_WARN << "ProForma: the summed diff formula of the modifications on one residue ("
+                      << formula_sum.toString() << ", " << formula_sum.getMonoWeight()
+                      << " Da) disagrees with the sum of their diff masses (" << mass_sum
+                      << " Da); a database entry carries a formula inconsistent with its mass. Using the masses." << std::endl;
+    }
+    const Residue* res = ResidueDB::getInstance()->getResidue(static_cast<unsigned char>(residue));
+    if (res == nullptr) return nullptr;
+    return ResidueModification::createUnknownFromMassString(ResidueModification::getDiffMonoMassString(mass_sum),
+                                                            mass_sum, true, ResidueModification::ANYWHERE, res);
   }
 
   // Helper to resolve a single modification tag to a ResidueModification
@@ -1786,7 +1815,11 @@ namespace
           std::string residue_str = (residue != '\0') ? std::string(1, residue) : "";
           return mod_db->getModification(full_accession, residue_str, term_spec);
         }
-        catch (const Exception::ElementNotFound&) { return nullptr; }
+        catch (const Exception::BaseException&)
+        { // not found, OR found but not valid for this residue/terminus (getModification throws InvalidValue
+          // for the latter): either way an unresolved modification to report, never an escaping exception
+          return nullptr;
+        }
       }
       else if constexpr (std::is_same_v<T, NamedMod>)
       {
@@ -1865,7 +1898,14 @@ namespace
     if (mod.resolved_mod != nullptr) return {true, mod.resolved_mod->getDiffMonoMass()};
     if (mod.alternatives.empty()) return {false, 0.0};
 
-    const auto& tag = mod.alternatives[0].first;
+    // Same pick as resolution: the first alternative that describes chemistry. Reading alternatives[0]
+    // made "[INFO:x|Formula:Zn1:z+2]" and "[Formula:Zn1:z+2|INFO:x]" differ by the zinc.
+    const ModificationTag* chosen = nullptr;
+    for (const auto& [t, l] : mod.alternatives)
+    {
+      if (isChemistryTag_(t)) { chosen = &t; break; }
+    }
+    const ModificationTag& tag = (chosen != nullptr) ? *chosen : mod.alternatives[0].first;
 
     if (const auto* md = std::get_if<MassDelta>(&tag)) return {true, md->mass};
     if (const auto* ft = std::get_if<FormulaTag>(&tag))
@@ -2156,15 +2196,16 @@ std::vector<ProForma::ConversionIssue> collectConversionIssues_(const ProForma::
       if (chemistry_brackets > 1)
         issues.push_back({ConversionIssueType::UNSUPPORTED_FEATURE,
           "Residue at position " + std::to_string(position) + " carries multiple modification brackets; "
-          "an AASequence residue holds only one, so all but the last are lost", position});
+          "an AASequence residue holds only one, so they are combined into one anonymous modification and the individual identities are lost", position});
 
       for (const auto& mod : elem->modifications)
       {
         if (mod.resolved_mod == nullptr && !mod.alternatives.empty())
         {
-          const auto& [tag, label] = mod.alternatives[0];
-          bool is_empty_info = std::holds_alternative<InfoTag>(tag) && std::get<InfoTag>(tag).text.empty();
-          if (!is_empty_info)
+          // A bracket with no chemistry at all (label-only "[#XL1]", or annotations only) is not an
+          // unresolved modification. Keyed on the whole bracket, not alternatives[0]: "[INFO:|Glycan:Hex]"
+          // has an empty INFO first and unresolved chemistry second.
+          if (carriesChemistry_(mod))
             issues.push_back({ConversionIssueType::UNRESOLVED_MOD,
               "Modification at position " + std::to_string(position) + " could not be resolved", position});
         }
@@ -2200,9 +2241,7 @@ std::vector<ProForma::ConversionIssue> collectConversionIssues_(const ProForma::
   {
     if (mod.resolved_mod == nullptr && !mod.alternatives.empty())
     {
-      const auto& [tag, label] = mod.alternatives[0];
-      bool is_empty_info = std::holds_alternative<InfoTag>(tag) && std::get<InfoTag>(tag).text.empty();
-      if (!is_empty_info)
+      if (carriesChemistry_(mod))
         issues.push_back({ConversionIssueType::UNRESOLVED_MOD, "N-terminal modification could not be resolved", SIZE_MAX});
     }
     if (hasGenuineAlternatives_(mod))
@@ -2224,9 +2263,7 @@ std::vector<ProForma::ConversionIssue> collectConversionIssues_(const ProForma::
   {
     if (mod.resolved_mod == nullptr && !mod.alternatives.empty())
     {
-      const auto& [tag, label] = mod.alternatives[0];
-      bool is_empty_info = std::holds_alternative<InfoTag>(tag) && std::get<InfoTag>(tag).text.empty();
-      if (!is_empty_info)
+      if (carriesChemistry_(mod))
         issues.push_back({ConversionIssueType::UNRESOLVED_MOD, "C-terminal modification could not be resolved", SIZE_MAX});
     }
     if (hasGenuineAlternatives_(mod))
@@ -2292,16 +2329,14 @@ AASequence ProForma::toAASequence(const Peptidoform& pf, ConversionPolicy policy
       }
       else if (resolved.size() > 1)
       {
-        bool summable = false;
-        const ResidueModification* combined = combineOnOneResidue_(resolved, elem->amino_acid, summable);
+        bool net_zero = false;
+        const ResidueModification* combined = combineOnOneResidue_(resolved, elem->amino_acid, net_zero);
         if (combined != nullptr)
         {
           seq.setModification(seq_pos, combined);
         }
-        else if (!summable)
-        {
-          // A component has no diff formula: keep the historical last-one-wins rather than inventing
-          // a mass-only modification, which would throw away the formulas the components do have.
+        else if (!net_zero)
+        { // unknown residue letter: the only case left with no combined modification
           seq.setModification(seq_pos, resolved.back());
         }
         // else: the components cancel to nothing - leave the residue unmodified, which is exactly the
@@ -2313,11 +2348,18 @@ AASequence ProForma::toAASequence(const Peptidoform& pf, ConversionPolicy policy
     else if (const auto* range = std::get_if<ModifiedRange>(&section)) seq_pos += range->elements.size();
   }
 
-  if (!pf_copy.n_term_mods.empty() && pf_copy.n_term_mods[0].resolved_mod != nullptr)
-    seq.setNTerminalModification(pf_copy.n_term_mods[0].resolved_mod);
-
-  if (!pf_copy.c_term_mods.empty() && pf_copy.c_term_mods[0].resolved_mod != nullptr)
-    seq.setCTerminalModification(pf_copy.c_term_mods[0].resolved_mod);
+  // Apply the first RESOLVED terminal bracket, not blindly the first bracket: a label-only bracket
+  // such as "[#XL1]" can precede the chemistry ("[#XL1][Formula:C2H2O]-PEPTIDE"), and taking [0] lost
+  // the Formula tag while reporting no issue. More than one resolved chemistry bracket is reported by
+  // collectConversionIssues_, so FAIL_ON_LOSS refuses it.
+  for (const auto& mod : pf_copy.n_term_mods)
+  {
+    if (mod.resolved_mod != nullptr) { seq.setNTerminalModification(mod.resolved_mod); break; }
+  }
+  for (const auto& mod : pf_copy.c_term_mods)
+  {
+    if (mod.resolved_mod != nullptr) { seq.setCTerminalModification(mod.resolved_mod); break; }
+  }
 
   return seq;
 }
@@ -2338,11 +2380,22 @@ namespace
   {
     // chars_format::fixed with no precision gives the SHORTEST fixed-notation string that reads back
     // as the same double - full precision without "12345.678900000001" padding artefacts.
-    char buf[64];
+    if (!std::isfinite(mass))
+    {
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                    "Cannot serialise a non-finite modification mass as ProForma", std::to_string(mass));
+    }
+    // 400 bytes fits the longest fixed-notation double (309 integer digits plus fraction); a 64-byte
+    // buffer silently turned 1e64 into "+0".
+    char buf[400];
     const double abs_mass = std::fabs(mass);
     auto res = std::to_chars(buf, buf + sizeof(buf), abs_mass, std::chars_format::fixed);
-    std::string digits = (res.ec == std::errc()) ? std::string(buf, res.ptr) : std::string("0");
-    return (mass < 0.0 ? "-" : "+") + digits;
+    if (res.ec != std::errc())
+    {
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                    "Cannot serialise modification mass as ProForma", std::to_string(mass));
+    }
+    return (mass < 0.0 && abs_mass != 0.0 ? "-" : "+") + std::string(buf, res.ptr);
   }
 
   /**

--- a/src/openms/source/CHEMISTRY/ProForma.cpp
+++ b/src/openms/source/CHEMISTRY/ProForma.cpp
@@ -1617,24 +1617,14 @@ namespace
   /**
     @brief Intern a ProForma `Formula:` tag as a ResidueModification carrying that chemistry.
 
-    ProForma has no construct for *defining* a modification, so describing the chemistry inline is the
-    only way a peptidoform can be self-describing (issue #10003). Resolving the tag here is what makes
-    `AEADNLDDK[Formula:C9H11N2O8P]K` convert to an AASequence with both the right mass and the right
-    empirical formula. Previously the tag resolved to nullptr and BEST_EFFORT dropped it silently.
-
-    The entry is keyed on the canonical formula rather than on its mass, so it can never collide with -
-    and be permanently shadowed by - a formula-less entry that createUnknownFromMassString created for
-    the same mass. Its FullName is deliberately the mass bracket, so an AASequence carrying it still
-    serialises to a spelling that every existing OpenMS reader parses.
+    Keyed on the canonical formula (not the mass) so it never collides with a formula-less mass-bracket
+    entry. FullName is the mass bracket, so an AASequence carrying it serialises to a spelling every
+    reader parses.
   */
   const ResidueModification* resolveFormulaTag_(const FormulaTag& ft, char residue,
                                                 ResidueModification::TermSpecificity term_spec)
   {
-    // A charge ("Formula:Zn1:z+2") has no representation in ResidueModification, and folding it into
-    // the residue silently would be worse than not resolving. Note this does NOT agree with
-    // getModificationMass_(), which returns the neutral formula's mass for the same tag - the two paths
-    // differ by the adduct mass for a charged tag, which is a pre-existing inconsistency, not one this
-    // function can settle.
+    // a charge has no representation in ResidueModification
     if (ft.charge.has_value() && ft.charge.value() != 0) return nullptr;
 
     EmpiricalFormula ef;
@@ -1643,8 +1633,7 @@ namespace
       ef = EmpiricalFormula(ft.formula_string);
     }
     catch (const Exception::BaseException&)
-    { // ProForma allows spellings OpenMS cannot parse (e.g. the "[13C2]" isotope form). Deliberately
-      // narrow: catch(...) here would turn an unrelated internal fault into a silently missing mod.
+    { // spellings OpenMS cannot parse, e.g. the "[13C2]" isotope form
       return nullptr;
     }
     if (ef.isEmpty() || ef.getCharge() != 0) return nullptr;
@@ -1652,9 +1641,7 @@ namespace
     const ResidueModification::TermSpecificity ts =
       (term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY) ? ResidueModification::ANYWHERE : term_spec;
 
-    // The site is part of the interning key, and PROTEIN_N_TERM must not share an entry with N_TERM:
-    // the entry stores its TermSpecificity, and the cache-hit path below returns whichever was created
-    // first, which would hand back the wrong site restriction for the same chemistry.
+    // the site is part of the key: PROTEIN_N_TERM and N_TERM must not share an entry
     std::string site;
     const Residue* res = nullptr;
     switch (ts)
@@ -1664,10 +1651,8 @@ namespace
       case ResidueModification::C_TERM:         site = ".c";  break;
       case ResidueModification::PROTEIN_C_TERM: site = ".pc"; break;
       default:
-        // Without an origin the entry could neither be attached to a residue nor serialised
-        // (ResidueModification::toString builds the prefix from it), so refuse instead of interning
-        // something unusable. getResidue() RETURNS NULL rather than throwing for a code that is not in
-        // the table - the ProForma grammar accepts lowercase amino acids, which ResidueDB does not have.
+        // no origin: the entry could neither be attached nor serialised; getResidue() returns null
+        // for letters ResidueDB does not know (ProForma accepts lowercase)
         if (residue == '\0') return nullptr;
         res = ResidueDB::getInstance()->getResidue(static_cast<unsigned char>(residue));
         if (res == nullptr) return nullptr;
@@ -1680,9 +1665,7 @@ namespace
 
     const ModificationsDB* mod_db = ModificationsDB::getInstance();
     if (mod_db->has(full_id))
-    { // One entry per (formula, site), not one per call. searchModificationsFast returns the pointer
-      // from inside the ModificationsDB critical section; findModificationIndex + getModification(Size)
-      // would hand back an index and then read mods_ WITHOUT the lock, racing a concurrent push_back.
+    { // one entry per (formula, site); searchModificationsFast returns the pointer under the DB lock
       bool multiple_matches = false;
       const ResidueModification* existing = mod_db->searchModificationsFast(full_id, multiple_matches);
       if (existing != nullptr) return existing;
@@ -1692,15 +1675,12 @@ namespace
     new_mod->setFullId(full_id); // FullId without Id keeps this an anonymous (user-defined) modification
     new_mod->setFullName(ResidueModification::getDiffMonoMassWithBracket(diff_mono));
     new_mod->setTermSpecificity(ts);
-    // Both must be set: setDiffFormula() alone leaves getDiffMonoMass() at 0.0, which would zero out
-    // getBestModificationByDiffMonoMass, the mzTab CHEMMOD export and getModificationMass_().
+    // setDiffFormula() alone leaves getDiffMonoMass() at 0.0
     new_mod->setDiffFormula(ef);
     new_mod->setDiffMonoMass(diff_mono);
     new_mod->setDiffAverageMass(ef.getAverageWeight());
 
-    // Set the absolute masses the way createUnknownFromMassString does, so Residue::setModification
-    // takes its `mono_weight_ = mod->getMonoMass()` branch and the resulting residue is numerically
-    // identical to the one a plain mass bracket would have produced.
+    // absolute masses as createUnknownFromMassString sets them, so Residue::setModification behaves the same
     if (res != nullptr)
     {
       new_mod->setOrigin(residue);
@@ -1716,35 +1696,19 @@ namespace
       new_mod->setMonoMass(diff_mono + Residue::getInternalToCTerm().getMonoWeight());
     }
 
-    // Benign race under OpenMP: addModification re-checks the FullId under its critical section and
-    // returns the existing entry, exactly as createUnknownFromMassString already relies on.
+    // addModification re-checks the FullId under its lock and returns the existing entry
     return mod_db->addModification(std::move(new_mod));
   }
 
   /**
-    @brief Combine modifications that landed on one residue into a single one with the summed chemistry.
+    @brief Combine the modifications on one residue into a single one with the summed chemistry.
 
-    An AASequence residue holds exactly one modification, so "M[Oxidation][Formula:O]" cannot be
-    represented as written. Summing the DIFF FORMULAS (rather than only the diff masses, which is what
-    ResidueModification::combineMods does) keeps both the mass and the empirical formula correct - and
-    the formula is what isotope patterns are built from, so losing it would defeat the purpose.
+    The sum of the diff mono masses is authoritative. The diff formulas are summed as well but only used
+    when their mass agrees with that sum (a database entry can carry a formula that contradicts its
+    mass); otherwise the result is a mass-only modification. Interned via resolveFormulaTag_.
 
-    The result is interned through resolveFormulaTag_, so a combination reuses the same entry as the
-    equivalent single Formula: tag and needs no second interning scheme.
-
-    The authoritative combined mass is the sum of the components' diff mono masses. The diff formulas
-    are summed too, but only TRUSTED when their mass agrees with that sum: a database entry can carry
-    a formula that disagrees with its own mass (UNIMOD:12 loads as (2)H40C118H166N24O26S9, 2703.55 Da,
-    against a diff mass of 450.28 Da), and a single use of it keeps the explicit mass - deriving the
-    combined mass from such a formula would be off by 2253 Da. When the formulas are unavailable or
-    inconsistent, the combination falls back to a mass-only modification: the mass stays right and the
-    formula is lost, which is strictly better than losing whole components.
-
-    @param[out] net_zero true when the components cancel to nothing ("[Formula:H2O][Formula:H-2O-1]",
-                "[Formula:O][UNIMOD:447]"): the caller applies NO modification, which is exactly the
-                mass ProForma itself computes. Applying the last bracket would leave the residue lighter
-                by everything the others added.
-    @return the interned combined modification, or nullptr when @p net_zero or when the residue is unknown.
+    @param[out] net_zero true when the components cancel; the caller then applies no modification
+    @return the combined modification, or nullptr when @p net_zero or the residue is unknown
   */
   const ResidueModification* combineOnOneResidue_(const std::vector<const ResidueModification*>& mods,
                                                   char residue, bool& net_zero)
@@ -1755,7 +1719,7 @@ namespace
     double mass_sum = 0.0;
     EmpiricalFormula formula_sum;
     bool all_have_formulas = true;
-    for (const ResidueModification* m : mods) // a vector, not a set: repeated identical brackets must each count
+    for (const ResidueModification* m : mods) // repeated identical brackets each count
     {
       mass_sum += m->getDiffMonoMass();
       if (m->getDiffFormula().isEmpty()) all_have_formulas = false;
@@ -1816,8 +1780,7 @@ namespace
           return mod_db->getModification(full_accession, residue_str, term_spec);
         }
         catch (const Exception::BaseException&)
-        { // not found, OR found but not valid for this residue/terminus (getModification throws InvalidValue
-          // for the latter): either way an unresolved modification to report, never an escaping exception
+        { // not found, or not valid for this residue (InvalidValue): both are unresolved, not exceptions
           return nullptr;
         }
       }
@@ -1848,29 +1811,19 @@ namespace
   void resolveModification_(Modification& mod, char residue, ResidueModification::TermSpecificity term_spec)
   {
     if (mod.alternatives.empty()) return;
-    // Resolve the first alternative that describes chemistry. Keying on alternatives[0] made the
-    // result depend on the order the tags happen to be written in: "[INFO:x|Formula:C9H11N2O8P]" is
-    // the same modification as "[Formula:C9H11N2O8P|INFO:x]", but the first spelling resolved the
-    // INFO tag to nullptr and dropped 306 Da. For a bracket with a single tag - every case that
-    // existed before ProForma grew alternatives - this picks exactly alternatives[0] as before.
+    // the first chemistry-carrying alternative, so the tag order inside the bracket does not matter
     for (const auto& [tag, label] : mod.alternatives)
     {
       if (!isChemistryTag_(tag)) continue;
       mod.resolved_mod = resolveModificationTag_(tag, residue, term_spec);
       return;
     }
-    // Nothing but annotations: keep the historical behaviour of reporting what alternatives[0] gives.
+    // annotations only: report what alternatives[0] gives
     mod.resolved_mod = resolveModificationTag_(mod.alternatives[0].first, residue, term_spec);
   }
 
-  /**
-    @brief Does this bracket offer a genuine *choice* between chemistries?
-
-    An `INFO:` entry is a free-text annotation, not a candidate identification: `[Formula:C2H2O|INFO:x]`
-    names one modification twice, it does not offer two. Counting it as an alternative would make
-    FAIL_ON_LOSS reject - and BEST_EFFORT warn once per PSM about - peptidoforms that OpenMS itself
-    writes (see issue #10003). ProFormaWriter::writeModification_ already treats InfoTags specially.
-  */
+  /// Does this bracket offer a real choice between chemistries? `INFO:` is an annotation, not a
+  /// candidate: `[Formula:C2H2O|INFO:x]` names one modification, it does not offer two.
   bool hasGenuineAlternatives_(const Modification& mod)
   {
     size_t chemistry = 0;
@@ -1881,8 +1834,7 @@ namespace
     return chemistry > 1;
   }
 
-  /// Does this bracket describe a modification at all, as opposed to being a pure annotation or a
-  /// label-only bracket such as "[#XL1]"?
+  /// Does this bracket describe a modification at all (not just an annotation or a label such as "[#XL1]")?
   bool carriesChemistry_(const Modification& mod)
   {
     for (const auto& [tag, label] : mod.alternatives)
@@ -1898,8 +1850,7 @@ namespace
     if (mod.resolved_mod != nullptr) return {true, mod.resolved_mod->getDiffMonoMass()};
     if (mod.alternatives.empty()) return {false, 0.0};
 
-    // Same pick as resolution: the first alternative that describes chemistry. Reading alternatives[0]
-    // made "[INFO:x|Formula:Zn1:z+2]" and "[Formula:Zn1:z+2|INFO:x]" differ by the zinc.
+    // same pick as resolution: the first chemistry-carrying alternative
     const ModificationTag* chosen = nullptr;
     for (const auto& [t, l] : mod.alternatives)
     {
@@ -2146,8 +2097,7 @@ void ProForma::resolveModifications(Peptidoform& pf)
 
 namespace
 {
-  /// Collect conversion issues from an ALREADY resolved peptidoform. Split out of
-  /// getAASequenceConversionIssues so toAASequence resolves once instead of twice.
+  /// Issues of an already resolved peptidoform; lets toAASequence resolve once
   std::vector<ProForma::ConversionIssue> collectConversionIssues_(const ProForma::Peptidoform& pf_copy);
 } // namespace
 
@@ -2202,9 +2152,7 @@ std::vector<ProForma::ConversionIssue> collectConversionIssues_(const ProForma::
       {
         if (mod.resolved_mod == nullptr && !mod.alternatives.empty())
         {
-          // A bracket with no chemistry at all (label-only "[#XL1]", or annotations only) is not an
-          // unresolved modification. Keyed on the whole bracket, not alternatives[0]: "[INFO:|Glycan:Hex]"
-          // has an empty INFO first and unresolved chemistry second.
+          // a bracket without any chemistry (label-only or annotations only) is not an unresolved modification
           if (carriesChemistry_(mod))
             issues.push_back({ConversionIssueType::UNRESOLVED_MOD,
               "Modification at position " + std::to_string(position) + " could not be resolved", position});
@@ -2311,10 +2259,8 @@ AASequence ProForma::toAASequence(const Peptidoform& pf, ConversionPolicy policy
   {
     if (const auto* elem = std::get_if<SequenceElement>(&section))
     {
-      // An AASequence residue holds exactly one modification, so several brackets on one residue
-      // ("M[Oxidation][Formula:O]") cannot be represented as written. Combine their chemistry so the
-      // mass and the empirical formula both stay right; the individual identities are still lost,
-      // which collectConversionIssues_ reports, so FAIL_ON_LOSS refuses either way.
+      // an AASequence residue holds one modification: combine the chemistry (the lost identities are
+      // reported by collectConversionIssues_)
       std::vector<const ResidueModification*> resolved;
       for (const auto& mod : elem->modifications)
       {
@@ -2339,8 +2285,7 @@ AASequence ProForma::toAASequence(const Peptidoform& pf, ConversionPolicy policy
         { // unknown residue letter: the only case left with no combined modification
           seq.setModification(seq_pos, resolved.back());
         }
-        // else: the components cancel to nothing - leave the residue unmodified, which is exactly the
-        // net chemistry and the mass calculateChainMass_ reports.
+        // else: the components cancel; leave the residue unmodified
       }
       seq_pos++;
     }
@@ -2348,10 +2293,7 @@ AASequence ProForma::toAASequence(const Peptidoform& pf, ConversionPolicy policy
     else if (const auto* range = std::get_if<ModifiedRange>(&section)) seq_pos += range->elements.size();
   }
 
-  // Apply the first RESOLVED terminal bracket, not blindly the first bracket: a label-only bracket
-  // such as "[#XL1]" can precede the chemistry ("[#XL1][Formula:C2H2O]-PEPTIDE"), and taking [0] lost
-  // the Formula tag while reporting no issue. More than one resolved chemistry bracket is reported by
-  // collectConversionIssues_, so FAIL_ON_LOSS refuses it.
+  // the first RESOLVED terminal bracket: a label-only "[#XL1]" may precede the chemistry
   for (const auto& mod : pf_copy.n_term_mods)
   {
     if (mod.resolved_mod != nullptr) { seq.setNTerminalModification(mod.resolved_mod); break; }
@@ -2367,26 +2309,20 @@ AASequence ProForma::toAASequence(const Peptidoform& pf, ConversionPolicy policy
 namespace
 {
   /**
-    @brief Render a mass delta as ProForma-parseable text, at full precision.
+    @brief Render a mass delta as ProForma-parseable text at full precision.
 
-    ResidueModification::getDiffMonoMassString() cannot be used here: it goes through
-    StringUtils::appendNumeric, which switches to scientific notation below 1e-2 and at or above 1e4,
-    and ProForma::parseMassDelta_ reads a sign plus a single number token - so "+3.35e-03" stops the
-    parser at the 'e' and the peptidoform we just wrote fails to parse. That is the same class of
-    self-inflicted unparseable output as the empty bracket this file used to emit, just at the tails
-    of the mass range.
+    getDiffMonoMassString() switches to scientific notation below 1e-2 and above 1e4, which
+    ProForma::parseMassDelta_ cannot read back.
   */
   std::string massDeltaText_(double mass)
   {
-    // chars_format::fixed with no precision gives the SHORTEST fixed-notation string that reads back
-    // as the same double - full precision without "12345.678900000001" padding artefacts.
+    // fixed without a precision: the shortest string that reads back as the same double
     if (!std::isfinite(mass))
     {
       throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                     "Cannot serialise a non-finite modification mass as ProForma", std::to_string(mass));
     }
-    // 400 bytes fits the longest fixed-notation double (309 integer digits plus fraction); a 64-byte
-    // buffer silently turned 1e64 into "+0".
+    // 400 bytes: the longest fixed-notation double has 309 integer digits
     char buf[400];
     const double abs_mass = std::fabs(mass);
     auto res = std::to_chars(buf, buf + sizeof(buf), abs_mass, std::chars_format::fixed);
@@ -2401,15 +2337,9 @@ namespace
   /**
     @brief Render one ResidueModification as a ProForma modification bracket.
 
-    Order matters, and the last rule fixes a real corruption: an anonymous modification (anything from
-    createUnknownFromMassString, i.e. every `X[+123.45]` bracket) has an empty getId(), and the previous
-    code emitted it as a NamedMod with an empty name - producing the literal string "[]", which
-    ProForma::parse rejects with "Expected modification". That string was being written into the
-    `peptidoform` column of .idparquet/.featureparquet/.consensusparquet and into USIs.
-
-    A formula-carrying anonymous modification is emitted as a `Formula:` tag instead, which closes the
-    round trip with resolveFormulaTag_(): the chemistry survives a write/read cycle with no external
-    modification definition needed.
+    An anonymous modification (empty getId()) is written as a `Formula:` tag when it carries a formula
+    and as a mass delta otherwise - never as a NamedMod with an empty name, which produced the
+    unparseable "[]".
   */
   ProForma::Modification modificationToProForma_(const ResidueModification* mod)
   {

--- a/src/openms/source/CHEMISTRY/ProForma.cpp
+++ b/src/openms/source/CHEMISTRY/ProForma.cpp
@@ -22,6 +22,7 @@
 #include <OpenMS/CONCEPT/GlobalExceptionHandler.h>
 
 #include <algorithm>
+#include <charconv>
 #include <cmath>
 #include <cstdlib>
 #include <iomanip>
@@ -1628,8 +1629,11 @@ namespace
   const ResidueModification* resolveFormulaTag_(const FormulaTag& ft, char residue,
                                                 ResidueModification::TermSpecificity term_spec)
   {
-    // A charge ("Formula:Zn1:z+2") has no representation in ResidueModification. Refusing it keeps
-    // resolution in lockstep with getModificationMass_(), which ignores the charge as well.
+    // A charge ("Formula:Zn1:z+2") has no representation in ResidueModification, and folding it into
+    // the residue silently would be worse than not resolving. Note this does NOT agree with
+    // getModificationMass_(), which returns the neutral formula's mass for the same tag - the two paths
+    // differ by the adduct mass for a charged tag, which is a pre-existing inconsistency, not one this
+    // function can settle.
     if (ft.charge.has_value() && ft.charge.value() != 0) return nullptr;
 
     EmpiricalFormula ef;
@@ -1637,8 +1641,9 @@ namespace
     {
       ef = EmpiricalFormula(ft.formula_string);
     }
-    catch (...)
-    { // ProForma allows spellings OpenMS cannot parse (e.g. the "[13C2]" isotope form)
+    catch (const Exception::BaseException&)
+    { // ProForma allows spellings OpenMS cannot parse (e.g. the "[13C2]" isotope form). Deliberately
+      // narrow: catch(...) here would turn an unrelated internal fault into a silently missing mod.
       return nullptr;
     }
     if (ef.isEmpty() || ef.getCharge() != 0) return nullptr;
@@ -1646,23 +1651,40 @@ namespace
     const ResidueModification::TermSpecificity ts =
       (term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY) ? ResidueModification::ANYWHERE : term_spec;
 
-    // Without an origin the entry could neither be attached to a residue (ResidueDB checks the origin)
-    // nor serialised (ResidueModification::toString builds the prefix from it), so refuse instead of
-    // interning something unusable.
-    if (ts == ResidueModification::ANYWHERE && residue == '\0') return nullptr;
-
+    // The site is part of the interning key, and PROTEIN_N_TERM must not share an entry with N_TERM:
+    // the entry stores its TermSpecificity, and the cache-hit path below returns whichever was created
+    // first, which would hand back the wrong site restriction for the same chemistry.
     std::string site;
-    if (ts == ResidueModification::N_TERM || ts == ResidueModification::PROTEIN_N_TERM) site = ".n";
-    else if (ts == ResidueModification::C_TERM || ts == ResidueModification::PROTEIN_C_TERM) site = ".c";
-    else site = std::string(1, residue);
+    const Residue* res = nullptr;
+    switch (ts)
+    {
+      case ResidueModification::N_TERM:         site = ".n";  break;
+      case ResidueModification::PROTEIN_N_TERM: site = ".pn"; break;
+      case ResidueModification::C_TERM:         site = ".c";  break;
+      case ResidueModification::PROTEIN_C_TERM: site = ".pc"; break;
+      default:
+        // Without an origin the entry could neither be attached to a residue nor serialised
+        // (ResidueModification::toString builds the prefix from it), so refuse instead of interning
+        // something unusable. getResidue() RETURNS NULL rather than throwing for a code that is not in
+        // the table - the ProForma grammar accepts lowercase amino acids, which ResidueDB does not have.
+        if (residue == '\0') return nullptr;
+        res = ResidueDB::getInstance()->getResidue(static_cast<unsigned char>(residue));
+        if (res == nullptr) return nullptr;
+        site = std::string(1, residue);
+        break;
+    }
 
     const double diff_mono = ef.getMonoWeight();
     const std::string full_id = site + "[Formula:" + ef.toString() + "]";
 
     const ModificationsDB* mod_db = ModificationsDB::getInstance();
     if (mod_db->has(full_id))
-    { // one entry per (formula, site), not one per call
-      return mod_db->getModification(mod_db->findModificationIndex(full_id));
+    { // One entry per (formula, site), not one per call. searchModificationsFast returns the pointer
+      // from inside the ModificationsDB critical section; findModificationIndex + getModification(Size)
+      // would hand back an index and then read mods_ WITHOUT the lock, racing a concurrent push_back.
+      bool multiple_matches = false;
+      const ResidueModification* existing = mod_db->searchModificationsFast(full_id, multiple_matches);
+      if (existing != nullptr) return existing;
     }
 
     std::unique_ptr<ResidueModification> new_mod(new ResidueModification);
@@ -1678,14 +1700,13 @@ namespace
     // Set the absolute masses the way createUnknownFromMassString does, so Residue::setModification
     // takes its `mono_weight_ = mod->getMonoMass()` branch and the resulting residue is numerically
     // identical to the one a plain mass bracket would have produced.
-    if (ts == ResidueModification::ANYWHERE)
+    if (res != nullptr)
     {
-      const Residue* res = ResidueDB::getInstance()->getResidue(static_cast<unsigned char>(residue));
       new_mod->setOrigin(residue);
       new_mod->setMonoMass(diff_mono + res->getMonoWeight());
       new_mod->setAverageMass(ef.getAverageWeight() + res->getAverageWeight());
     }
-    else if (site == ".n")
+    else if (ts == ResidueModification::N_TERM || ts == ResidueModification::PROTEIN_N_TERM)
     {
       new_mod->setMonoMass(diff_mono + Residue::getInternalToNTerm().getMonoWeight());
     }
@@ -1746,11 +1767,28 @@ namespace
     }, tag);
   }
 
+  /// Is this tag a description of chemistry, as opposed to a free-text annotation or a position hint?
+  bool isChemistryTag_(const ModificationTag& tag)
+  {
+    return !std::holds_alternative<InfoTag>(tag) && !std::holds_alternative<PositionConstraint>(tag);
+  }
+
   void resolveModification_(Modification& mod, char residue, ResidueModification::TermSpecificity term_spec)
   {
     if (mod.alternatives.empty()) return;
-    const auto& [tag, label] = mod.alternatives[0];
-    mod.resolved_mod = resolveModificationTag_(tag, residue, term_spec);
+    // Resolve the first alternative that describes chemistry. Keying on alternatives[0] made the
+    // result depend on the order the tags happen to be written in: "[INFO:x|Formula:C9H11N2O8P]" is
+    // the same modification as "[Formula:C9H11N2O8P|INFO:x]", but the first spelling resolved the
+    // INFO tag to nullptr and dropped 306 Da. For a bracket with a single tag - every case that
+    // existed before ProForma grew alternatives - this picks exactly alternatives[0] as before.
+    for (const auto& [tag, label] : mod.alternatives)
+    {
+      if (!isChemistryTag_(tag)) continue;
+      mod.resolved_mod = resolveModificationTag_(tag, residue, term_spec);
+      return;
+    }
+    // Nothing but annotations: keep the historical behaviour of reporting what alternatives[0] gives.
+    mod.resolved_mod = resolveModificationTag_(mod.alternatives[0].first, residue, term_spec);
   }
 
   /**
@@ -1766,7 +1804,7 @@ namespace
     size_t chemistry = 0;
     for (const auto& [tag, label] : mod.alternatives)
     {
-      if (!std::holds_alternative<InfoTag>(tag)) ++chemistry;
+      if (isChemistryTag_(tag)) ++chemistry;
     }
     return chemistry > 1;
   }
@@ -1777,7 +1815,7 @@ namespace
   {
     for (const auto& [tag, label] : mod.alternatives)
     {
-      if (!std::holds_alternative<InfoTag>(tag) && !std::holds_alternative<PositionConstraint>(tag)) return true;
+      if (isChemistryTag_(tag)) return true;
     }
     return false;
   }
@@ -2079,7 +2117,7 @@ std::vector<ProForma::ConversionIssue> collectConversionIssues_(const ProForma::
       if (chemistry_brackets > 1)
         issues.push_back({ConversionIssueType::UNSUPPORTED_FEATURE,
           "Residue at position " + std::to_string(position) + " carries multiple modification brackets; "
-          "they are merged into a single mass and the individual identities are lost", position});
+          "an AASequence residue holds only one, so all but the last are lost", position});
 
       for (const auto& mod : elem->modifications)
       {
@@ -2108,6 +2146,17 @@ std::vector<ProForma::ConversionIssue> collectConversionIssues_(const ProForma::
     position++;
   }
 
+  {
+    size_t n_term_mods_chemistry = 0;
+    for (const auto& mod : pf_copy.n_term_mods)
+    {
+      if (carriesChemistry_(mod)) ++n_term_mods_chemistry;
+    }
+    if (n_term_mods_chemistry > 1)
+      issues.push_back({ConversionIssueType::UNSUPPORTED_FEATURE,
+        "N-terminal modifications: an AASequence holds only one, so all but the first are lost", SIZE_MAX});
+  }
+
   for (const auto& mod : pf_copy.n_term_mods)
   {
     if (mod.resolved_mod == nullptr && !mod.alternatives.empty())
@@ -2119,6 +2168,17 @@ std::vector<ProForma::ConversionIssue> collectConversionIssues_(const ProForma::
     }
     if (hasGenuineAlternatives_(mod))
       issues.push_back({ConversionIssueType::ALTERNATIVE_MODS, "N-terminal modification has multiple alternatives", SIZE_MAX});
+  }
+
+  {
+    size_t c_term_mods_chemistry = 0;
+    for (const auto& mod : pf_copy.c_term_mods)
+    {
+      if (carriesChemistry_(mod)) ++c_term_mods_chemistry;
+    }
+    if (c_term_mods_chemistry > 1)
+      issues.push_back({ConversionIssueType::UNSUPPORTED_FEATURE,
+        "C-terminal modifications: an AASequence holds only one, so all but the first are lost", SIZE_MAX});
   }
 
   for (const auto& mod : pf_copy.c_term_mods)
@@ -2175,38 +2235,16 @@ AASequence ProForma::toAASequence(const Peptidoform& pf, ConversionPolicy policy
   {
     if (const auto* elem = std::get_if<SequenceElement>(&section))
     {
-      std::vector<const ResidueModification*> resolved;
+      // Several brackets on one residue ("M[Oxidation][Formula:O]") cannot all be represented:
+      // AASequence holds one modification per residue and setModification replaces rather than
+      // accumulates, so the last bracket wins. collectConversionIssues_ reports that, so
+      // FAIL_ON_LOSS refuses rather than silently returning a sequence lighter than the peptidoform.
       for (const auto& mod : elem->modifications)
       {
-        if (mod.resolved_mod != nullptr) resolved.push_back(mod.resolved_mod);
+        if (mod.resolved_mod != nullptr) seq.setModification(seq_pos, mod.resolved_mod);
         else if (policy == ConversionPolicy::FAIL_ON_LOSS)
           throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
             "Unresolved modification at position " + std::to_string(seq_pos));
-      }
-      if (resolved.size() == 1)
-      {
-        seq.setModification(seq_pos, resolved[0]);
-      }
-      else if (resolved.size() > 1)
-      {
-        // Several brackets on one residue ("M[Oxidation][Formula:O]"). AASequence holds one
-        // modification per residue and setModification replaces rather than accumulates, so applying
-        // them in turn used to let the last bracket win silently - while calculateChainMass_() sums
-        // them, i.e. getMonoWeight(pf) and toAASequence(pf).getMonoWeight() disagreed. Merge into a
-        // single cumulative delta so at least the mass is right; the individual identities are lost,
-        // which collectConversionIssues_ reports so FAIL_ON_LOSS still refuses.
-        // combineMods() is called with a non-null base on purpose: with a null base it counts the
-        // first addon twice.
-        try
-        {
-          const Residue* res = ResidueDB::getInstance()->getResidue(static_cast<unsigned char>(elem->amino_acid));
-          std::set<const ResidueModification*> addons(resolved.begin() + 1, resolved.end());
-          seq.setModification(seq_pos, ResidueModification::combineMods(resolved[0], addons, true, res));
-        }
-        catch (const Exception::BaseException&)
-        { // incompatible origins/specificities: fall back to the historical last-one-wins
-          seq.setModification(seq_pos, resolved.back());
-        }
       }
       seq_pos++;
     }
@@ -2225,6 +2263,27 @@ AASequence ProForma::toAASequence(const Peptidoform& pf, ConversionPolicy policy
 
 namespace
 {
+  /**
+    @brief Render a mass delta as ProForma-parseable text, at full precision.
+
+    ResidueModification::getDiffMonoMassString() cannot be used here: it goes through
+    StringUtils::appendNumeric, which switches to scientific notation below 1e-2 and at or above 1e4,
+    and ProForma::parseMassDelta_ reads a sign plus a single number token - so "+3.35e-03" stops the
+    parser at the 'e' and the peptidoform we just wrote fails to parse. That is the same class of
+    self-inflicted unparseable output as the empty bracket this file used to emit, just at the tails
+    of the mass range.
+  */
+  std::string massDeltaText_(double mass)
+  {
+    // chars_format::fixed with no precision gives the SHORTEST fixed-notation string that reads back
+    // as the same double - full precision without "12345.678900000001" padding artefacts.
+    char buf[64];
+    const double abs_mass = std::fabs(mass);
+    auto res = std::to_chars(buf, buf + sizeof(buf), abs_mass, std::chars_format::fixed);
+    std::string digits = (res.ec == std::errc()) ? std::string(buf, res.ptr) : std::string("0");
+    return (mass < 0.0 ? "-" : "+") + digits;
+  }
+
   /**
     @brief Render one ResidueModification as a ProForma modification bracket.
 
@@ -2267,8 +2326,7 @@ namespace
       ProForma::MassDelta md;
       md.source = ProForma::MassDelta::Source::NONE;
       md.mass = mod->getDiffMonoMass();
-      // Keep the full precision under WriteMode::LOSSLESS; CANONICAL still rounds to 4 decimals.
-      md.original_text = ResidueModification::getDiffMonoMassString(md.mass);
+      md.original_text = massDeltaText_(md.mass);
       pf_mod.alternatives.emplace_back(std::move(md), std::nullopt);
     }
     pf_mod.resolved_mod = mod;

--- a/src/openms/source/CHEMISTRY/ProForma.cpp
+++ b/src/openms/source/CHEMISTRY/ProForma.cpp
@@ -1612,6 +1612,93 @@ namespace
   using ConversionIssueType = ProForma::ConversionIssueType;
   using ConversionPolicy = ProForma::ConversionPolicy;
 
+  /**
+    @brief Intern a ProForma `Formula:` tag as a ResidueModification carrying that chemistry.
+
+    ProForma has no construct for *defining* a modification, so describing the chemistry inline is the
+    only way a peptidoform can be self-describing (issue #10003). Resolving the tag here is what makes
+    `AEADNLDDK[Formula:C9H11N2O8P]K` convert to an AASequence with both the right mass and the right
+    empirical formula. Previously the tag resolved to nullptr and BEST_EFFORT dropped it silently.
+
+    The entry is keyed on the canonical formula rather than on its mass, so it can never collide with -
+    and be permanently shadowed by - a formula-less entry that createUnknownFromMassString created for
+    the same mass. Its FullName is deliberately the mass bracket, so an AASequence carrying it still
+    serialises to a spelling that every existing OpenMS reader parses.
+  */
+  const ResidueModification* resolveFormulaTag_(const FormulaTag& ft, char residue,
+                                                ResidueModification::TermSpecificity term_spec)
+  {
+    // A charge ("Formula:Zn1:z+2") has no representation in ResidueModification. Refusing it keeps
+    // resolution in lockstep with getModificationMass_(), which ignores the charge as well.
+    if (ft.charge.has_value() && ft.charge.value() != 0) return nullptr;
+
+    EmpiricalFormula ef;
+    try
+    {
+      ef = EmpiricalFormula(ft.formula_string);
+    }
+    catch (...)
+    { // ProForma allows spellings OpenMS cannot parse (e.g. the "[13C2]" isotope form)
+      return nullptr;
+    }
+    if (ef.isEmpty() || ef.getCharge() != 0) return nullptr;
+
+    const ResidueModification::TermSpecificity ts =
+      (term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY) ? ResidueModification::ANYWHERE : term_spec;
+
+    // Without an origin the entry could neither be attached to a residue (ResidueDB checks the origin)
+    // nor serialised (ResidueModification::toString builds the prefix from it), so refuse instead of
+    // interning something unusable.
+    if (ts == ResidueModification::ANYWHERE && residue == '\0') return nullptr;
+
+    std::string site;
+    if (ts == ResidueModification::N_TERM || ts == ResidueModification::PROTEIN_N_TERM) site = ".n";
+    else if (ts == ResidueModification::C_TERM || ts == ResidueModification::PROTEIN_C_TERM) site = ".c";
+    else site = std::string(1, residue);
+
+    const double diff_mono = ef.getMonoWeight();
+    const std::string full_id = site + "[Formula:" + ef.toString() + "]";
+
+    const ModificationsDB* mod_db = ModificationsDB::getInstance();
+    if (mod_db->has(full_id))
+    { // one entry per (formula, site), not one per call
+      return mod_db->getModification(mod_db->findModificationIndex(full_id));
+    }
+
+    std::unique_ptr<ResidueModification> new_mod(new ResidueModification);
+    new_mod->setFullId(full_id); // FullId without Id keeps this an anonymous (user-defined) modification
+    new_mod->setFullName(ResidueModification::getDiffMonoMassWithBracket(diff_mono));
+    new_mod->setTermSpecificity(ts);
+    // Both must be set: setDiffFormula() alone leaves getDiffMonoMass() at 0.0, which would zero out
+    // getBestModificationByDiffMonoMass, the mzTab CHEMMOD export and getModificationMass_().
+    new_mod->setDiffFormula(ef);
+    new_mod->setDiffMonoMass(diff_mono);
+    new_mod->setDiffAverageMass(ef.getAverageWeight());
+
+    // Set the absolute masses the way createUnknownFromMassString does, so Residue::setModification
+    // takes its `mono_weight_ = mod->getMonoMass()` branch and the resulting residue is numerically
+    // identical to the one a plain mass bracket would have produced.
+    if (ts == ResidueModification::ANYWHERE)
+    {
+      const Residue* res = ResidueDB::getInstance()->getResidue(static_cast<unsigned char>(residue));
+      new_mod->setOrigin(residue);
+      new_mod->setMonoMass(diff_mono + res->getMonoWeight());
+      new_mod->setAverageMass(ef.getAverageWeight() + res->getAverageWeight());
+    }
+    else if (site == ".n")
+    {
+      new_mod->setMonoMass(diff_mono + Residue::getInternalToNTerm().getMonoWeight());
+    }
+    else
+    {
+      new_mod->setMonoMass(diff_mono + Residue::getInternalToCTerm().getMonoWeight());
+    }
+
+    // Benign race under OpenMP: addModification re-checks the FullId under its critical section and
+    // returns the existing entry, exactly as createUnknownFromMassString already relies on.
+    return mod_db->addModification(std::move(new_mod));
+  }
+
   // Helper to resolve a single modification tag to a ResidueModification
   const ResidueModification* resolveModificationTag_(
     const ModificationTag& tag,
@@ -1652,7 +1739,7 @@ namespace
         std::string residue_str = (residue != '\0') ? std::string(1, residue) : "";
         return mod_db->getBestModificationByDiffMonoMass(arg.mass, 0.01, residue_str, term_spec);
       }
-      else if constexpr (std::is_same_v<T, FormulaTag>) { return nullptr; }
+      else if constexpr (std::is_same_v<T, FormulaTag>) { return resolveFormulaTag_(arg, residue, term_spec); }
       else if constexpr (std::is_same_v<T, GlycanComposition>) { return nullptr; }
       else if constexpr (std::is_same_v<T, InfoTag>) { return nullptr; }
       else { return nullptr; }
@@ -1664,6 +1751,35 @@ namespace
     if (mod.alternatives.empty()) return;
     const auto& [tag, label] = mod.alternatives[0];
     mod.resolved_mod = resolveModificationTag_(tag, residue, term_spec);
+  }
+
+  /**
+    @brief Does this bracket offer a genuine *choice* between chemistries?
+
+    An `INFO:` entry is a free-text annotation, not a candidate identification: `[Formula:C2H2O|INFO:x]`
+    names one modification twice, it does not offer two. Counting it as an alternative would make
+    FAIL_ON_LOSS reject - and BEST_EFFORT warn once per PSM about - peptidoforms that OpenMS itself
+    writes (see issue #10003). ProFormaWriter::writeModification_ already treats InfoTags specially.
+  */
+  bool hasGenuineAlternatives_(const Modification& mod)
+  {
+    size_t chemistry = 0;
+    for (const auto& [tag, label] : mod.alternatives)
+    {
+      if (!std::holds_alternative<InfoTag>(tag)) ++chemistry;
+    }
+    return chemistry > 1;
+  }
+
+  /// Does this bracket describe a modification at all, as opposed to being a pure annotation or a
+  /// label-only bracket such as "[#XL1]"?
+  bool carriesChemistry_(const Modification& mod)
+  {
+    for (const auto& [tag, label] : mod.alternatives)
+    {
+      if (!std::holds_alternative<InfoTag>(tag) && !std::holds_alternative<PositionConstraint>(tag)) return true;
+    }
+    return false;
   }
 
   // Helper to get modification mass from a Modification struct
@@ -1911,11 +2027,25 @@ void ProForma::resolveModifications(Peptidoform& pf)
 // AASequence conversion
 //============================================================================
 
+namespace
+{
+  /// Collect conversion issues from an ALREADY resolved peptidoform. Split out of
+  /// getAASequenceConversionIssues so toAASequence resolves once instead of twice.
+  std::vector<ProForma::ConversionIssue> collectConversionIssues_(const ProForma::Peptidoform& pf_copy);
+} // namespace
+
 std::vector<ProForma::ConversionIssue> ProForma::getAASequenceConversionIssues(const Peptidoform& pf)
 {
-  std::vector<ConversionIssue> issues;
   Peptidoform pf_copy = pf;
   resolveModifications(pf_copy);
+  return collectConversionIssues_(pf_copy);
+}
+
+namespace
+{
+std::vector<ProForma::ConversionIssue> collectConversionIssues_(const ProForma::Peptidoform& pf_copy)
+{
+  std::vector<ConversionIssue> issues;
 
   if (!pf_copy.unlocalised_mods.empty())
     issues.push_back({ConversionIssueType::UNLOCALISED_MOD, "Peptidoform contains unlocalised modifications", SIZE_MAX});
@@ -1941,6 +2071,16 @@ std::vector<ProForma::ConversionIssue> ProForma::getAASequenceConversionIssues(c
         "Peptidoform contains modified range at position " + std::to_string(position), position});
     else if (const auto* elem = std::get_if<SequenceElement>(&section))
     {
+      size_t chemistry_brackets = 0;
+      for (const auto& mod : elem->modifications)
+      {
+        if (carriesChemistry_(mod)) ++chemistry_brackets;
+      }
+      if (chemistry_brackets > 1)
+        issues.push_back({ConversionIssueType::UNSUPPORTED_FEATURE,
+          "Residue at position " + std::to_string(position) + " carries multiple modification brackets; "
+          "they are merged into a single mass and the individual identities are lost", position});
+
       for (const auto& mod : elem->modifications)
       {
         if (mod.resolved_mod == nullptr && !mod.alternatives.empty())
@@ -1951,9 +2091,10 @@ std::vector<ProForma::ConversionIssue> ProForma::getAASequenceConversionIssues(c
             issues.push_back({ConversionIssueType::UNRESOLVED_MOD,
               "Modification at position " + std::to_string(position) + " could not be resolved", position});
         }
-        if (mod.alternatives.size() > 1)
+        if (hasGenuineAlternatives_(mod))
           issues.push_back({ConversionIssueType::ALTERNATIVE_MODS,
             "Modification at position " + std::to_string(position) + " has multiple alternatives", position});
+
 
         for (const auto& [tag, label] : mod.alternatives)
           if (label.has_value() && label->type == Label::Type::CROSSLINK)
@@ -1976,7 +2117,7 @@ std::vector<ProForma::ConversionIssue> ProForma::getAASequenceConversionIssues(c
       if (!is_empty_info)
         issues.push_back({ConversionIssueType::UNRESOLVED_MOD, "N-terminal modification could not be resolved", SIZE_MAX});
     }
-    if (mod.alternatives.size() > 1)
+    if (hasGenuineAlternatives_(mod))
       issues.push_back({ConversionIssueType::ALTERNATIVE_MODS, "N-terminal modification has multiple alternatives", SIZE_MAX});
   }
 
@@ -1989,12 +2130,13 @@ std::vector<ProForma::ConversionIssue> ProForma::getAASequenceConversionIssues(c
       if (!is_empty_info)
         issues.push_back({ConversionIssueType::UNRESOLVED_MOD, "C-terminal modification could not be resolved", SIZE_MAX});
     }
-    if (mod.alternatives.size() > 1)
+    if (hasGenuineAlternatives_(mod))
       issues.push_back({ConversionIssueType::ALTERNATIVE_MODS, "C-terminal modification has multiple alternatives", SIZE_MAX});
   }
 
   return issues;
 }
+} // namespace
 
 bool ProForma::isRepresentableAsAASequence(const Peptidoform& pf)
 {
@@ -2003,7 +2145,9 @@ bool ProForma::isRepresentableAsAASequence(const Peptidoform& pf)
 
 AASequence ProForma::toAASequence(const Peptidoform& pf, ConversionPolicy policy)
 {
-  std::vector<ConversionIssue> issues = getAASequenceConversionIssues(pf);
+  Peptidoform pf_copy = pf;
+  resolveModifications(pf_copy);
+  std::vector<ConversionIssue> issues = collectConversionIssues_(pf_copy);
 
   if (policy == ConversionPolicy::FAIL_ON_LOSS && !issues.empty())
   {
@@ -2011,9 +2155,6 @@ AASequence ProForma::toAASequence(const Peptidoform& pf, ConversionPolicy policy
     for (const auto& issue : issues) error_msg += issue.description + "; ";
     throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, error_msg);
   }
-
-  Peptidoform pf_copy = pf;
-  resolveModifications(pf_copy);
 
   std::string unmod_seq;
   for (const auto& section : pf_copy.sequence)
@@ -2034,12 +2175,38 @@ AASequence ProForma::toAASequence(const Peptidoform& pf, ConversionPolicy policy
   {
     if (const auto* elem = std::get_if<SequenceElement>(&section))
     {
+      std::vector<const ResidueModification*> resolved;
       for (const auto& mod : elem->modifications)
       {
-        if (mod.resolved_mod != nullptr) seq.setModification(seq_pos, mod.resolved_mod);
+        if (mod.resolved_mod != nullptr) resolved.push_back(mod.resolved_mod);
         else if (policy == ConversionPolicy::FAIL_ON_LOSS)
           throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
             "Unresolved modification at position " + std::to_string(seq_pos));
+      }
+      if (resolved.size() == 1)
+      {
+        seq.setModification(seq_pos, resolved[0]);
+      }
+      else if (resolved.size() > 1)
+      {
+        // Several brackets on one residue ("M[Oxidation][Formula:O]"). AASequence holds one
+        // modification per residue and setModification replaces rather than accumulates, so applying
+        // them in turn used to let the last bracket win silently - while calculateChainMass_() sums
+        // them, i.e. getMonoWeight(pf) and toAASequence(pf).getMonoWeight() disagreed. Merge into a
+        // single cumulative delta so at least the mass is right; the individual identities are lost,
+        // which collectConversionIssues_ reports so FAIL_ON_LOSS still refuses.
+        // combineMods() is called with a non-null base on purpose: with a null base it counts the
+        // first addon twice.
+        try
+        {
+          const Residue* res = ResidueDB::getInstance()->getResidue(static_cast<unsigned char>(elem->amino_acid));
+          std::set<const ResidueModification*> addons(resolved.begin() + 1, resolved.end());
+          seq.setModification(seq_pos, ResidueModification::combineMods(resolved[0], addons, true, res));
+        }
+        catch (const Exception::BaseException&)
+        { // incompatible origins/specificities: fall back to the historical last-one-wins
+          seq.setModification(seq_pos, resolved.back());
+        }
       }
       seq_pos++;
     }
@@ -2056,6 +2223,59 @@ AASequence ProForma::toAASequence(const Peptidoform& pf, ConversionPolicy policy
   return seq;
 }
 
+namespace
+{
+  /**
+    @brief Render one ResidueModification as a ProForma modification bracket.
+
+    Order matters, and the last rule fixes a real corruption: an anonymous modification (anything from
+    createUnknownFromMassString, i.e. every `X[+123.45]` bracket) has an empty getId(), and the previous
+    code emitted it as a NamedMod with an empty name - producing the literal string "[]", which
+    ProForma::parse rejects with "Expected modification". That string was being written into the
+    `peptidoform` column of .idparquet/.featureparquet/.consensusparquet and into USIs.
+
+    A formula-carrying anonymous modification is emitted as a `Formula:` tag instead, which closes the
+    round trip with resolveFormulaTag_(): the chemistry survives a write/read cycle with no external
+    modification definition needed.
+  */
+  ProForma::Modification modificationToProForma_(const ResidueModification* mod)
+  {
+    ProForma::Modification pf_mod;
+    const std::string unimod_acc = mod->getUniModAccession();
+    if (!unimod_acc.empty() && StringUtils::hasPrefix(unimod_acc, "UniMod:"))
+    {
+      ProForma::CvAccession cv;
+      cv.database = ProForma::CvDatabase::UNIMOD;
+      cv.accession = StringUtils::substr(unimod_acc, 7);
+      pf_mod.alternatives.emplace_back(std::move(cv), std::nullopt);
+    }
+    else if (mod->getId().empty() && !mod->getDiffFormula().isEmpty())
+    {
+      ProForma::FormulaTag ft;
+      ft.formula_string = mod->getDiffFormula().toString();
+      pf_mod.alternatives.emplace_back(std::move(ft), std::nullopt);
+    }
+    else if (!mod->getId().empty())
+    {
+      ProForma::NamedMod nm;
+      nm.name = mod->getId();
+      nm.cv_hint = std::nullopt;
+      pf_mod.alternatives.emplace_back(std::move(nm), std::nullopt);
+    }
+    else
+    {
+      ProForma::MassDelta md;
+      md.source = ProForma::MassDelta::Source::NONE;
+      md.mass = mod->getDiffMonoMass();
+      // Keep the full precision under WriteMode::LOSSLESS; CANONICAL still rounds to 4 decimals.
+      md.original_text = ResidueModification::getDiffMonoMassString(md.mass);
+      pf_mod.alternatives.emplace_back(std::move(md), std::nullopt);
+    }
+    pf_mod.resolved_mod = mod;
+    return pf_mod;
+  }
+} // namespace
+
 ProForma::Peptidoform ProForma::fromAASequence(const AASequence& seq)
 {
   Peptidoform pf;
@@ -2070,24 +2290,7 @@ ProForma::Peptidoform ProForma::fromAASequence(const AASequence& seq)
       const ResidueModification* mod = seq[i].getModification();
       if (mod != nullptr)
       {
-        Modification proforma_mod;
-        std::string unimod_acc = mod->getUniModAccession();
-        if (!unimod_acc.empty() && StringUtils::hasPrefix(unimod_acc, "UniMod:"))
-        {
-          CvAccession cv;
-          cv.database = CvDatabase::UNIMOD;
-          cv.accession = StringUtils::substr(unimod_acc, 7);
-          proforma_mod.alternatives.emplace_back(std::move(cv), std::nullopt);
-        }
-        else
-        {
-          NamedMod nm;
-          nm.name = mod->getId();
-          nm.cv_hint = std::nullopt;
-          proforma_mod.alternatives.emplace_back(std::move(nm), std::nullopt);
-        }
-        proforma_mod.resolved_mod = mod;
-        elem.modifications.push_back(std::move(proforma_mod));
+        elem.modifications.push_back(modificationToProForma_(mod));
       }
     }
     pf.sequence.push_back(std::move(elem));
@@ -2098,24 +2301,7 @@ ProForma::Peptidoform ProForma::fromAASequence(const AASequence& seq)
     const ResidueModification* mod = seq.getNTerminalModification();
     if (mod != nullptr)
     {
-      Modification proforma_mod;
-      std::string unimod_acc = mod->getUniModAccession();
-      if (!unimod_acc.empty() && StringUtils::hasPrefix(unimod_acc, "UniMod:"))
-      {
-        CvAccession cv;
-        cv.database = CvDatabase::UNIMOD;
-        cv.accession = StringUtils::substr(unimod_acc, 7);
-        proforma_mod.alternatives.emplace_back(std::move(cv), std::nullopt);
-      }
-      else
-      {
-        NamedMod nm;
-        nm.name = mod->getId();
-        nm.cv_hint = std::nullopt;
-        proforma_mod.alternatives.emplace_back(std::move(nm), std::nullopt);
-      }
-      proforma_mod.resolved_mod = mod;
-      pf.n_term_mods.push_back(std::move(proforma_mod));
+      pf.n_term_mods.push_back(modificationToProForma_(mod));
     }
   }
 
@@ -2124,24 +2310,7 @@ ProForma::Peptidoform ProForma::fromAASequence(const AASequence& seq)
     const ResidueModification* mod = seq.getCTerminalModification();
     if (mod != nullptr)
     {
-      Modification proforma_mod;
-      std::string unimod_acc = mod->getUniModAccession();
-      if (!unimod_acc.empty() && StringUtils::hasPrefix(unimod_acc, "UniMod:"))
-      {
-        CvAccession cv;
-        cv.database = CvDatabase::UNIMOD;
-        cv.accession = StringUtils::substr(unimod_acc, 7);
-        proforma_mod.alternatives.emplace_back(std::move(cv), std::nullopt);
-      }
-      else
-      {
-        NamedMod nm;
-        nm.name = mod->getId();
-        nm.cv_hint = std::nullopt;
-        proforma_mod.alternatives.emplace_back(std::move(nm), std::nullopt);
-      }
-      proforma_mod.resolved_mod = mod;
-      pf.c_term_mods.push_back(std::move(proforma_mod));
+      pf.c_term_mods.push_back(modificationToProForma_(mod));
     }
   }
 

--- a/src/openms/source/CHEMISTRY/ProForma.cpp
+++ b/src/openms/source/CHEMISTRY/ProForma.cpp
@@ -1731,12 +1731,19 @@ namespace
     The result is interned through resolveFormulaTag_, so a combination reuses the same entry as the
     equivalent single Formula: tag and needs no second interning scheme.
 
-    @return nullptr when the chemistry cannot be summed - any component without a diff formula, or a
-            combination that cancels out - leaving the caller to fall back.
+    Two outcomes must be told apart, because they call for opposite fallbacks:
+    - the chemistry CANNOT be summed (a component has no diff formula): @p summable is false and the
+      caller keeps the historical last-bracket-wins;
+    - the chemistry sums to NOTHING (e.g. "[Formula:H2O][Formula:H-2O-1]"): @p summable is true and the
+      result is nullptr, meaning "apply no modification" - which is the mass ProForma itself computes.
+      Applying the last bracket here would leave the residue lighter by everything the others added.
+
+    @return the interned combined modification, or nullptr (see @p summable for what that means).
   */
   const ResidueModification* combineOnOneResidue_(const std::vector<const ResidueModification*>& mods,
-                                                  char residue)
+                                                  char residue, bool& summable)
   {
+    summable = false;
     if (residue == '\0') return nullptr;
     EmpiricalFormula sum;
     for (const ResidueModification* m : mods)
@@ -1744,7 +1751,8 @@ namespace
       if (m->getDiffFormula().isEmpty()) return nullptr;
       sum += m->getDiffFormula(); // a vector, not a set: repeated identical brackets must each count
     }
-    if (sum.isEmpty()) return nullptr;
+    summable = true;
+    if (sum.isEmpty()) return nullptr; // the components cancel: net chemistry is nothing
 
     FormulaTag ft;
     ft.formula_string = sum.toString();
@@ -2284,11 +2292,20 @@ AASequence ProForma::toAASequence(const Peptidoform& pf, ConversionPolicy policy
       }
       else if (resolved.size() > 1)
       {
-        const ResidueModification* combined = combineOnOneResidue_(resolved, elem->amino_acid);
-        // No summable chemistry (a component without a diff formula, or one that cancels out):
-        // keep the historical last-one-wins rather than inventing a mass-only modification, which
-        // would throw away the empirical formulas the components do have.
-        seq.setModification(seq_pos, combined != nullptr ? combined : resolved.back());
+        bool summable = false;
+        const ResidueModification* combined = combineOnOneResidue_(resolved, elem->amino_acid, summable);
+        if (combined != nullptr)
+        {
+          seq.setModification(seq_pos, combined);
+        }
+        else if (!summable)
+        {
+          // A component has no diff formula: keep the historical last-one-wins rather than inventing
+          // a mass-only modification, which would throw away the formulas the components do have.
+          seq.setModification(seq_pos, resolved.back());
+        }
+        // else: the components cancel to nothing - leave the residue unmodified, which is exactly the
+        // net chemistry and the mass calculateChainMass_ reports.
       }
       seq_pos++;
     }

--- a/src/tests/class_tests/openms/source/ProFormaParser_test.cpp
+++ b/src/tests/class_tests/openms/source/ProFormaParser_test.cpp
@@ -1785,10 +1785,9 @@ START_SECTION([EXTRA] getAASequenceConversionIssues - an INFO alternative is not
   // Counting the INFO tag as an alternative made FAIL_ON_LOSS reject - and BEST_EFFORT warn once per
   // PSM about - peptidoforms that OpenMS itself writes.
   auto issues = ProForma::getAASequenceConversionIssues(ProForma::parse("PEPM[Formula:O|INFO:my note]TIDE"));
-  for (const auto& issue : issues)
-  {
-    TEST_FALSE(issue.type == ProForma::ConversionIssueType::ALTERNATIVE_MODS)
-  }
+  TEST_TRUE(issues.empty()) // the Formula resolves and the INFO is an annotation: nothing to report
+  AASequence with_note = ProForma::toAASequence(ProForma::parse("PEPM[Formula:O|INFO:my note]TIDE"), ConversionPolicy::FAIL_ON_LOSS);
+  TEST_TRUE(with_note[3].isModified())
 
   // A genuine choice between two chemistries must still be reported.
   auto real_alt = ProForma::getAASequenceConversionIssues(ProForma::parse("PEPM[Oxidation|Phospho]TIDE"));
@@ -1865,7 +1864,12 @@ START_SECTION([EXTRA] toAASequence - several brackets on one residue combine the
   // Before Formula tags resolved, the second bracket here was unresolved and FAIL_ON_LOSS threw for
   // that reason; now that both resolve, the loss has to be reported on its own account.
   Peptidoform nterm = ProForma::parse("[UNIMOD:1][Formula:O]-PEPTIDE");
-  TEST_FALSE(ProForma::getAASequenceConversionIssues(nterm).empty())
+  bool nterm_reported = false;
+  for (const auto& issue : ProForma::getAASequenceConversionIssues(nterm))
+  {
+    if (issue.type == ProForma::ConversionIssueType::UNSUPPORTED_FEATURE) nterm_reported = true;
+  }
+  TEST_TRUE(nterm_reported)
   TEST_EXCEPTION(Exception::ConversionError, ProForma::toAASequence(nterm, ConversionPolicy::FAIL_ON_LOSS))
 }
 END_SECTION
@@ -1989,6 +1993,127 @@ START_SECTION([EXTRA] toAASequence - the order of tags inside one bracket does n
   TEST_REAL_SIMILAR(a.getMonoWeight(), b.getMonoWeight())
   TEST_REAL_SIMILAR(b.getMonoWeight(), 1423.5504442334)
   TEST_TRUE(ProForma::getAASequenceConversionIssues(info_first).empty())
+}
+END_SECTION
+
+START_SECTION([EXTRA] toAASequence - combination trusts the diff masses and only a consistent formula)
+{
+  // A database entry can carry a diff formula that disagrees with its own diff mass (UNIMOD:12 loads
+  // with a 2703 Da formula against a 450 Da mass). A single use keeps the explicit mass; a combination
+  // that derived its mass from the summed formula would be off by the whole discrepancy. Modelled with
+  // a synthetic entry so the test does not depend on that database defect persisting.
+  {
+    ResidueModification bad;
+    bad.setId("TestInconsistentFormula");
+    bad.setOrigin('C');
+    bad.setTermSpecificity(ResidueModification::ANYWHERE);
+    bad.setFullId();
+    bad.setDiffFormula(EmpiricalFormula("C2H2O")); // 42.01 Da ...
+    bad.setDiffMonoMass(100.0);                    // ... but claims 100 Da
+    ModificationsDB::getInstance()->addModification(bad);
+  }
+  Peptidoform pf = ProForma::parse("PEPC[TestInconsistentFormula][Formula:O]TIDE");
+  AASequence seq = ProForma::toAASequence(pf, ConversionPolicy::BEST_EFFORT);
+  const double expected = AASequence::fromString("PEPCTIDE").getMonoWeight() + 100.0 + EmpiricalFormula("O").getMonoWeight();
+  TEST_REAL_SIMILAR(seq.getMonoWeight(), expected)                 // masses, not the bogus formula
+  TEST_REAL_SIMILAR(seq.getMonoWeight(), ProForma::getMonoWeight(pf))
+  TEST_TRUE(seq[3].isModified())
+
+  // A component WITHOUT any formula must not make the others vanish: the mass still combines.
+  {
+    ResidueModification massonly;
+    massonly.setId("TestMassOnlyComponent");
+    massonly.setOrigin('T');
+    massonly.setTermSpecificity(ResidueModification::ANYWHERE);
+    massonly.setFullId();
+    massonly.setDiffMonoMass(10.0);
+    ModificationsDB::getInstance()->addModification(massonly);
+  }
+  Peptidoform pf2 = ProForma::parse("PEPT[Formula:O][TestMassOnlyComponent]IDE");
+  AASequence seq2 = ProForma::toAASequence(pf2, ConversionPolicy::BEST_EFFORT);
+  TEST_REAL_SIMILAR(seq2.getMonoWeight(), AASequence::fromString("PEPTIDE").getMonoWeight() + EmpiricalFormula("O").getMonoWeight() + 10.0)
+  TEST_REAL_SIMILAR(seq2.getMonoWeight(), ProForma::getMonoWeight(pf2))
+}
+END_SECTION
+
+START_SECTION([EXTRA] toAASequence - a label-only terminal bracket must not hide the chemistry behind it)
+{
+  // "[#XL1][Formula:C2H2O]-PEPTIDE": applying only n_term_mods[0] took the label bracket (nullptr) and
+  // silently lost the Formula tag while reporting no issue, so even FAIL_ON_LOSS accepted a sequence
+  // 42 Da light.
+  Peptidoform pf = ProForma::parse("[#XL1][Formula:C2H2O]-PEPTIDE");
+  AASequence seq = ProForma::toAASequence(pf, ConversionPolicy::BEST_EFFORT);
+  TEST_TRUE(seq.hasNTerminalModification())
+  TEST_REAL_SIMILAR(seq.getMonoWeight(), ProForma::getMonoWeight(pf))
+  TEST_REAL_SIMILAR(seq.getMonoWeight(), AASequence::fromString("PEPTIDE").getMonoWeight() + EmpiricalFormula("C2H2O").getMonoWeight())
+}
+END_SECTION
+
+START_SECTION([EXTRA] getAASequenceConversionIssues - unresolved chemistry behind an empty INFO is still reported)
+{
+  // The "empty INFO means label-only bracket" suppression used to look at alternatives[0] only, so
+  // "[INFO:|Glycan:Hex]" - empty annotation first, unresolved glycan second - reported nothing and
+  // isRepresentableAsAASequence() said true while the strict conversion then threw anyway.
+  Peptidoform pf = ProForma::parse("PEPT[INFO:|Glycan:Hex]IDE");
+  bool unresolved = false;
+  for (const auto& issue : ProForma::getAASequenceConversionIssues(pf))
+  {
+    if (issue.type == ProForma::ConversionIssueType::UNRESOLVED_MOD) unresolved = true;
+  }
+  TEST_TRUE(unresolved)
+  TEST_FALSE(ProForma::isRepresentableAsAASequence(pf))
+
+  // ... and a genuinely label-only bracket is still not an unresolved modification.
+  bool label_unresolved = false;
+  for (const auto& issue : ProForma::getAASequenceConversionIssues(ProForma::parse("PEPTK[#XL1]IDE")))
+  {
+    if (issue.type == ProForma::ConversionIssueType::UNRESOLVED_MOD) label_unresolved = true;
+  }
+  TEST_FALSE(label_unresolved)
+}
+END_SECTION
+
+START_SECTION([EXTRA] getAASequenceConversionIssues - a residue-incompatible accession is an issue not an exception)
+{
+  // ModificationsDB::getModification throws InvalidValue (not ElementNotFound) when the accession
+  // exists but is not valid for the residue; that used to escape the issue collector.
+  Peptidoform on_m = ProForma::parse("PEPM[UNIMOD:447]TIDE"); // Deoxy: not defined on M
+  std::vector<ProForma::ConversionIssue> issues;
+  TEST_EXCEPTION(Exception::ConversionError, ProForma::toAASequence(on_m, ConversionPolicy::FAIL_ON_LOSS))
+  issues = ProForma::getAASequenceConversionIssues(on_m); // must return, not throw
+  bool unresolved = false;
+  for (const auto& issue : issues)
+  {
+    if (issue.type == ProForma::ConversionIssueType::UNRESOLVED_MOD) unresolved = true;
+  }
+  TEST_TRUE(unresolved)
+  // same with an annotation in front, which now selects the accession as the chemistry tag
+  issues = ProForma::getAASequenceConversionIssues(ProForma::parse("PEPM[INFO:x|UNIMOD:447]TIDE"));
+  TEST_FALSE(issues.empty())
+}
+END_SECTION
+
+START_SECTION([EXTRA] getMonoWeight - tag order inside a bracket does not change the mass either)
+{
+  // Resolution already picks the first chemistry-carrying alternative; the mass helper read
+  // alternatives[0] and so still depended on the order for chemistry that fails to resolve.
+  const double a = ProForma::getMonoWeight(ProForma::parse("PEPT[INFO:x|Formula:Zn1:z+2]IDE"));
+  const double b = ProForma::getMonoWeight(ProForma::parse("PEPT[Formula:Zn1:z+2|INFO:x]IDE"));
+  TEST_REAL_SIMILAR(a, b)
+}
+END_SECTION
+
+START_SECTION([EXTRA] fromAASequence - a huge mass delta is written in full rather than as zero)
+{
+  // A 64-byte buffer made std::to_chars fail for 1e64 and the fallback silently wrote "+0".
+  AASequence seq = AASequence::fromString("PEPTIDE");
+  seq.setModificationByDiffMonoMass(3, 1e64);
+  std::string written = ProForma::toString(ProForma::fromAASequence(seq), WriteMode::LOSSLESS);
+  TEST_TRUE(written.find("[+0]") == std::string::npos)
+  TEST_TRUE(written.find("[+1") != std::string::npos)
+  TEST_TRUE(written.find('e') == std::string::npos)
+  Peptidoform back = ProForma::parse(written); // must parse
+  TEST_TRUE(ProForma::getMonoWeight(back) > 1e63)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ProFormaParser_test.cpp
+++ b/src/tests/class_tests/openms/source/ProFormaParser_test.cpp
@@ -1712,9 +1712,7 @@ END_SECTION
 
 START_SECTION([EXTRA] toAASequence - a Formula tag resolves to a modification carrying that chemistry)
 {
-  // ProForma has no construct for *defining* a modification, so inline chemistry is the only way a
-  // peptidoform can be self-describing (issue #10003). Before this, resolveModificationTag_ returned
-  // nullptr for every FormulaTag and BEST_EFFORT dropped it silently, so the mass simply vanished.
+  // a Formula tag used to resolve to nullptr and BEST_EFFORT dropped it silently
   Peptidoform pf = ProForma::parse("PEPM[Formula:O]TIDE");
   AASequence seq = ProForma::toAASequence(pf, ConversionPolicy::BEST_EFFORT);
 
@@ -1722,19 +1720,17 @@ START_SECTION([EXTRA] toAASequence - a Formula tag resolves to a modification ca
   TEST_TRUE(seq[3].isModified())
   TEST_REAL_SIMILAR(seq.getMonoWeight(), AASequence::fromString("PEPM(Oxidation)TIDE").getMonoWeight())
 
-  // Both mass and formula must be set: setDiffFormula() alone leaves getDiffMonoMass() at 0.0, which
-  // would silently zero out getBestModificationByDiffMonoMass, the mzTab CHEMMOD export and
-  // ProForma's own mass helper.
+  // setDiffFormula() alone leaves getDiffMonoMass() at 0.0
   const ResidueModification* mod = seq[3].getModification();
   TEST_TRUE(mod != nullptr)
-  if (mod != nullptr) // guard: an unresolved tag must fail the assertion above, not crash the test
+  if (mod != nullptr) // fail above, do not crash
   {
     TEST_FALSE(mod->getDiffFormula().isEmpty())
     TEST_REAL_SIMILAR(mod->getDiffMonoMass(), EmpiricalFormula("O").getMonoWeight())
     TEST_NOT_EQUAL(mod->getDiffMonoMass(), 0.0)
   }
 
-  // The whole point of #10003: the peptide's *formula* is now right, not just its mass.
+  // the formula, not just the mass
   TEST_EQUAL(seq.getFormula().toString(), AASequence::fromString("PEPM(Oxidation)TIDE").getFormula().toString())
 
   // ... and it is now representable, so FAIL_ON_LOSS must not throw
@@ -1745,16 +1741,14 @@ END_SECTION
 
 START_SECTION([EXTRA] toAASequence - one database entry per formula whatever the spelling)
 {
-  // The interned entry is keyed on the canonical EmpiricalFormula, so equivalent spellings collapse
-  // onto one entry instead of growing ModificationsDB once per string seen.
+  // keyed on the canonical formula: equivalent spellings collapse onto one entry
   AASequence a = ProForma::toAASequence(ProForma::parse("PEPA[Formula:C2H2O]TIDE"), ConversionPolicy::BEST_EFFORT);
   Size n_after_first = ModificationsDB::getInstance()->getNumberOfModifications();
 
   AASequence b = ProForma::toAASequence(ProForma::parse("PEPA[Formula:C2H2O1]TIDE"), ConversionPolicy::BEST_EFFORT);
   AASequence c = ProForma::toAASequence(ProForma::parse("PEPA[Formula:H2C2O1]TIDE"), ConversionPolicy::BEST_EFFORT);
 
-  // Assert resolution FIRST: without it all three modifications are null and comparing them would
-  // pass vacuously.
+  // assert resolution first, or the comparisons below pass vacuously on null pointers
   TEST_TRUE(a[3].getModification() != nullptr)
   TEST_TRUE(a[3].getModification() == b[3].getModification())
   TEST_TRUE(a[3].getModification() == c[3].getModification())
@@ -1764,8 +1758,7 @@ END_SECTION
 
 START_SECTION([EXTRA] toAASequence - an unusable Formula tag stays unresolved)
 {
-  // A charge has no representation in ResidueModification, so it must not be silently folded into the
-  // residue. Refusing it keeps resolution in lockstep with the mass helper, which ignores it too.
+  // a charge has no representation in ResidueModification
   Peptidoform charged = ProForma::parse("PEPT[Formula:Zn1:z+2]IDE");
   AASequence seq = ProForma::toAASequence(charged, ConversionPolicy::BEST_EFFORT);
   TEST_FALSE(seq[3].isModified())
@@ -1781,9 +1774,7 @@ END_SECTION
 
 START_SECTION([EXTRA] getAASequenceConversionIssues - an INFO alternative is not an alternative)
 {
-  // "[Formula:X|INFO:name]" names one modification twice; it does not offer a choice between two.
-  // Counting the INFO tag as an alternative made FAIL_ON_LOSS reject - and BEST_EFFORT warn once per
-  // PSM about - peptidoforms that OpenMS itself writes.
+  // "[Formula:X|INFO:name]" names one modification, it does not offer a choice
   auto issues = ProForma::getAASequenceConversionIssues(ProForma::parse("PEPM[Formula:O|INFO:my note]TIDE"));
   TEST_TRUE(issues.empty()) // the Formula resolves and the INFO is an annotation: nothing to report
   AASequence with_note = ProForma::toAASequence(ProForma::parse("PEPM[Formula:O|INFO:my note]TIDE"), ConversionPolicy::FAIL_ON_LOSS);
@@ -1802,18 +1793,14 @@ END_SECTION
 
 START_SECTION([EXTRA] toAASequence - several brackets on one residue combine their chemistry)
 {
-  // An AASequence residue holds exactly one modification, so "M[Oxidation][Formula:O]" cannot be
-  // represented as written. The DIFF FORMULAS are summed, not just the diff masses: summing only the
-  // masses (which is what ResidueModification::combineMods does, via createUnknownFromMassString)
-  // would leave the residue with its UNMODIFIED empirical formula, and the formula is what isotope
-  // patterns are built from. The individual identities are still lost, so FAIL_ON_LOSS must refuse.
+  // one modification per residue: the diff formulas are summed, not only the masses (combineMods would
+  // lose the formula); the identities are lost, so FAIL_ON_LOSS must refuse
   const AASequence base = AASequence::fromString("PEPMTIDE");
   const double O = EmpiricalFormula("O").getMonoWeight();
 
   std::vector<std::pair<std::string, Size> > cases;
   cases.push_back(std::make_pair(std::string("PEPM[Oxidation][Formula:O]TIDE"), (Size)2));
-  // three IDENTICAL brackets must count three times - a std::set of the resolved pointers would
-  // collapse them to one and undercount the mass
+  // identical brackets must each count (a std::set of the pointers would collapse them)
   cases.push_back(std::make_pair(std::string("PEPM[Formula:O][Formula:O][Formula:O]TIDE"), (Size)3));
   cases.push_back(std::make_pair(std::string("PEPM[Oxidation][Oxidation]TIDE"), (Size)2));
 
@@ -1832,8 +1819,7 @@ START_SECTION([EXTRA] toAASequence - several brackets on one residue combine the
     TEST_EQUAL(seq.getFormula(Residue::Full, 0).toString(), expected.toString())
   }
 
-  // Components that CANCEL must yield no modification, not the last bracket alone: applying only
-  // "[Formula:H-2O-1]" would leave the residue 18 Da lighter than the net chemistry ProForma reports.
+  // cancelling components yield no modification, not the last bracket alone
   {
     Peptidoform cancel = ProForma::parse("PEPM[Formula:H2O][Formula:H-2O-1]TIDE");
     AASequence seq = ProForma::toAASequence(cancel, ConversionPolicy::BEST_EFFORT);
@@ -1860,9 +1846,7 @@ START_SECTION([EXTRA] toAASequence - several brackets on one residue combine the
   TEST_TRUE(reported)
   TEST_EXCEPTION(Exception::ConversionError, ProForma::toAASequence(pf, ConversionPolicy::FAIL_ON_LOSS))
 
-  // The same loss exists at the termini, where only n_term_mods[0]/c_term_mods[0] are ever applied.
-  // Before Formula tags resolved, the second bracket here was unresolved and FAIL_ON_LOSS threw for
-  // that reason; now that both resolve, the loss has to be reported on its own account.
+  // same at the termini: now that both brackets resolve, the loss must be reported on its own
   Peptidoform nterm = ProForma::parse("[UNIMOD:1][Formula:O]-PEPTIDE");
   bool nterm_reported = false;
   for (const auto& issue : ProForma::getAASequenceConversionIssues(nterm))
@@ -1876,26 +1860,19 @@ END_SECTION
 
 START_SECTION([EXTRA] fromAASequence - an anonymous modification must not serialise as an empty bracket)
 {
-  // Anything from createUnknownFromMassString (i.e. every "X[+123.45]" bracket) has an empty getId(),
-  // and the NamedMod branch then emitted a nameless tag - the literal string "[]", which
-  // ProForma::parse rejects with "Expected modification". That string was being written into the
-  // peptidoform column of .idparquet/.featureparquet/.consensusparquet and into USIs.
+  // an anonymous modification (empty getId()) used to be written as a nameless NamedMod: the literal "[]"
   AASequence seq = AASequence::fromString("AEADNLDDK[+306.025304840900048]K");
   std::string lossless = ProForma::toString(ProForma::fromAASequence(seq), WriteMode::LOSSLESS);
 
   TEST_NOT_EQUAL(lossless, "AEADNLDDK[]K")
   TEST_TRUE(lossless.find("[]") == std::string::npos)
 
-  // What this fix guarantees is that the string is VALID ProForma - it no longer writes something its
-  // own parser rejects.
+  // the string must be valid ProForma
   Peptidoform reparsed = ProForma::parse(lossless);
   TEST_REAL_SIMILAR(ProForma::getMonoWeight(reparsed), seq.getMonoWeight())
 
-  // It does NOT guarantee the modification survives into an AASequence in a fresh process: a bare
-  // mass delta resolves by searching ModificationsDB, and this very test interned the modification
-  // when it called AASequence::fromString above. That is the pre-existing lossy contract pinned in
-  // "toAASequence - mass-delta mods without CV accession"; carrying identity across processes is what
-  // the modification-definition block of #10003 is for.
+  // identity across processes is not guaranteed here: a bare mass delta resolves via ModificationsDB,
+  // which this test itself populated above (the lossy contract pinned in "mass-delta mods without CV accession")
   AASequence back = ProForma::toAASequence(reparsed, ConversionPolicy::BEST_EFFORT);
   TEST_EQUAL(back.toUnmodifiedString(), seq.toUnmodifiedString())
 }
@@ -1903,9 +1880,7 @@ END_SECTION
 
 START_SECTION([EXTRA] fromAASequence - a formula-carrying anonymous modification round-trips its chemistry)
 {
-  // Closes the loop with the Formula tag resolution above: a modification that came in from a
-  // "Formula:" tag goes back out as one, so the chemistry survives a write/read cycle with no
-  // external modification definition needed.
+  // a modification that came in as a Formula tag goes back out as one
   AASequence seq = ProForma::toAASequence(ProForma::parse("PEPM[Formula:O]TIDE"), ConversionPolicy::BEST_EFFORT);
   std::string written = ProForma::toString(ProForma::fromAASequence(seq), WriteMode::CANONICAL);
   TEST_TRUE(written.find("Formula:") != std::string::npos)
@@ -1921,14 +1896,10 @@ START_SECTION([EXTRA] fromAASequence - a formula-carrying anonymous modification
 }
 END_SECTION
 
-START_SECTION([EXTRA] toAASequence - the #10003 parquet encoding is chemically complete on its own)
+START_SECTION([EXTRA] toAASequence - the parquet peptidoform encoding is chemically complete on its own)
 {
-  // This is the exact peptidoform spelling issue #10003 settles for the .idparquet lane: a resolvable
-  // "Formula:" tag carrying the chemistry, plus an "INFO:" tag carrying the tool-defined name. It has
-  // to convert cleanly with NO conversion issues (the INFO tag is an annotation, not an alternative),
-  // and it has to yield both the right mass and the right empirical formula - the latter being what
-  // #10000 is about, since isotope patterns are computed from the formula.
-  // Numbers are the OpenNuXL RNA adduct measured on PRIDE PXD048145.
+  // a Formula tag carrying the chemistry plus an INFO tag carrying the tool-defined name: must convert
+  // without issues and yield both the right mass and the right formula (OpenNuXL adduct, PXD048145)
   const std::string encoded = "AEADNLDDK[Formula:C9H11N2O8P|INFO:NuXL:U-H2O]K";
   Peptidoform pf = ProForma::parse(encoded);
 
@@ -1948,9 +1919,7 @@ END_SECTION
 
 START_SECTION([EXTRA] toAASequence - a Formula tag on an unknown residue must not crash)
 {
-  // The ProForma grammar accepts lowercase amino acids, but ResidueDB has no entry for them and
-  // ResidueDB::getResidue(unsigned char) RETURNS NULL rather than throwing. Dereferencing that is a
-  // segfault, which walks straight past the try/catch the parquet reader wraps this call in.
+  // lowercase letters parse, but ResidueDB::getResidue(unsigned char) returns null for them
   Peptidoform pf = ProForma::parse("pepm[Formula:O]tide");
   auto issues = ProForma::getAASequenceConversionIssues(pf); // must return, not crash
   TEST_FALSE(issues.empty())
@@ -1959,10 +1928,7 @@ END_SECTION
 
 START_SECTION([EXTRA] fromAASequence - extreme mass deltas stay parseable)
 {
-  // getDiffMonoMassString goes through StringUtils::appendNumeric, which switches to scientific
-  // notation below 1e-2 and at or above 1e4 - and ProForma::parseMassDelta_ cannot read that back.
-  // Writing it would be the same self-inflicted unparseable output as the "[]" bracket, just at the
-  // tails of the mass range.
+  // getDiffMonoMassString switches to scientific notation below 1e-2 / above 1e4, which parseMassDelta_ cannot read
   std::vector<std::string> seqs;
   seqs.push_back("PEPT[+0.00335]IDE");     // below 1e-2
   seqs.push_back("PEPT[+12345.6789]IDE");  // above 1e4
@@ -1981,8 +1947,7 @@ END_SECTION
 
 START_SECTION([EXTRA] toAASequence - the order of tags inside one bracket does not change the result)
 {
-  // resolveModification_ used to resolve alternatives[0] blindly, so moving the INFO tag in front of
-  // the Formula tag - the same modification, written the other way round - dropped 306 Da.
+  // alternatives[0] used to be resolved blindly: INFO first dropped 306 Da
   Peptidoform formula_first = ProForma::parse("AEADNLDDK[Formula:C9H11N2O8P|INFO:NuXL:U-H2O]K");
   Peptidoform info_first    = ProForma::parse("AEADNLDDK[INFO:NuXL:U-H2O|Formula:C9H11N2O8P]K");
 
@@ -1998,10 +1963,8 @@ END_SECTION
 
 START_SECTION([EXTRA] toAASequence - combination trusts the diff masses and only a consistent formula)
 {
-  // A database entry can carry a diff formula that disagrees with its own diff mass (UNIMOD:12 loads
-  // with a 2703 Da formula against a 450 Da mass). A single use keeps the explicit mass; a combination
-  // that derived its mass from the summed formula would be off by the whole discrepancy. Modelled with
-  // a synthetic entry so the test does not depend on that database defect persisting.
+  // a database entry can carry a formula inconsistent with its mass (e.g. UNIMOD:12); the combination
+  // must trust the masses. Synthetic entry, so the test does not depend on that defect persisting.
   {
     ResidueModification bad;
     bad.setId("TestInconsistentFormula");
@@ -2038,9 +2001,7 @@ END_SECTION
 
 START_SECTION([EXTRA] toAASequence - a label-only terminal bracket must not hide the chemistry behind it)
 {
-  // "[#XL1][Formula:C2H2O]-PEPTIDE": applying only n_term_mods[0] took the label bracket (nullptr) and
-  // silently lost the Formula tag while reporting no issue, so even FAIL_ON_LOSS accepted a sequence
-  // 42 Da light.
+  // applying n_term_mods[0] blindly took the label bracket and silently lost the Formula tag
   Peptidoform pf = ProForma::parse("[#XL1][Formula:C2H2O]-PEPTIDE");
   AASequence seq = ProForma::toAASequence(pf, ConversionPolicy::BEST_EFFORT);
   TEST_TRUE(seq.hasNTerminalModification())
@@ -2051,9 +2012,7 @@ END_SECTION
 
 START_SECTION([EXTRA] getAASequenceConversionIssues - unresolved chemistry behind an empty INFO is still reported)
 {
-  // The "empty INFO means label-only bracket" suppression used to look at alternatives[0] only, so
-  // "[INFO:|Glycan:Hex]" - empty annotation first, unresolved glycan second - reported nothing and
-  // isRepresentableAsAASequence() said true while the strict conversion then threw anyway.
+  // the suppression looked at alternatives[0] only: an empty INFO in front hid the unresolved glycan
   Peptidoform pf = ProForma::parse("PEPT[INFO:|Glycan:Hex]IDE");
   bool unresolved = false;
   for (const auto& issue : ProForma::getAASequenceConversionIssues(pf))
@@ -2075,8 +2034,7 @@ END_SECTION
 
 START_SECTION([EXTRA] getAASequenceConversionIssues - a residue-incompatible accession is an issue not an exception)
 {
-  // ModificationsDB::getModification throws InvalidValue (not ElementNotFound) when the accession
-  // exists but is not valid for the residue; that used to escape the issue collector.
+  // getModification throws InvalidValue when the accession is not valid for the residue; it must not escape
   Peptidoform on_m = ProForma::parse("PEPM[UNIMOD:447]TIDE"); // Deoxy: not defined on M
   std::vector<ProForma::ConversionIssue> issues;
   TEST_EXCEPTION(Exception::ConversionError, ProForma::toAASequence(on_m, ConversionPolicy::FAIL_ON_LOSS))
@@ -2095,8 +2053,7 @@ END_SECTION
 
 START_SECTION([EXTRA] getMonoWeight - tag order inside a bracket does not change the mass either)
 {
-  // Resolution already picks the first chemistry-carrying alternative; the mass helper read
-  // alternatives[0] and so still depended on the order for chemistry that fails to resolve.
+  // the mass helper read alternatives[0] and so depended on the order
   const double a = ProForma::getMonoWeight(ProForma::parse("PEPT[INFO:x|Formula:Zn1:z+2]IDE"));
   const double b = ProForma::getMonoWeight(ProForma::parse("PEPT[Formula:Zn1:z+2|INFO:x]IDE"));
   TEST_REAL_SIMILAR(a, b)

--- a/src/tests/class_tests/openms/source/ProFormaParser_test.cpp
+++ b/src/tests/class_tests/openms/source/ProFormaParser_test.cpp
@@ -1801,15 +1801,39 @@ START_SECTION([EXTRA] getAASequenceConversionIssues - an INFO alternative is not
 }
 END_SECTION
 
-START_SECTION([EXTRA] toAASequence - several brackets on one residue are a reported loss)
+START_SECTION([EXTRA] toAASequence - several brackets on one residue combine their chemistry)
 {
-  // An AASequence residue holds exactly one modification and setModification replaces rather than
-  // accumulates, so all but the last bracket are lost. That is not something this conversion can fix
-  // (merging them into a cumulative mass delta would make the mass right but throw the empirical
-  // formulas away, which is worse); it must be REPORTED, so FAIL_ON_LOSS refuses instead of silently
-  // returning a sequence lighter than the peptidoform it came from.
-  Peptidoform pf = ProForma::parse("PEPM[Oxidation][Formula:O]TIDE");
+  // An AASequence residue holds exactly one modification, so "M[Oxidation][Formula:O]" cannot be
+  // represented as written. The DIFF FORMULAS are summed, not just the diff masses: summing only the
+  // masses (which is what ResidueModification::combineMods does, via createUnknownFromMassString)
+  // would leave the residue with its UNMODIFIED empirical formula, and the formula is what isotope
+  // patterns are built from. The individual identities are still lost, so FAIL_ON_LOSS must refuse.
+  const AASequence base = AASequence::fromString("PEPMTIDE");
+  const double O = EmpiricalFormula("O").getMonoWeight();
 
+  std::vector<std::pair<std::string, Size> > cases;
+  cases.push_back(std::make_pair(std::string("PEPM[Oxidation][Formula:O]TIDE"), (Size)2));
+  // three IDENTICAL brackets must count three times - a std::set of the resolved pointers would
+  // collapse them to one and undercount the mass
+  cases.push_back(std::make_pair(std::string("PEPM[Formula:O][Formula:O][Formula:O]TIDE"), (Size)3));
+  cases.push_back(std::make_pair(std::string("PEPM[Oxidation][Oxidation]TIDE"), (Size)2));
+
+  for (const auto& c : cases)
+  {
+    Peptidoform pf_case = ProForma::parse(c.first);
+    AASequence seq = ProForma::toAASequence(pf_case, ConversionPolicy::BEST_EFFORT);
+
+    // the two mass paths must agree - that disagreement is what this handling exists to remove
+    TEST_REAL_SIMILAR(seq.getMonoWeight(), ProForma::getMonoWeight(pf_case))
+    TEST_REAL_SIMILAR(seq.getMonoWeight(), base.getMonoWeight() + (double)c.second * O)
+
+    // ... and the formula must gain exactly that many oxygens, not zero
+    EmpiricalFormula expected = base.getFormula(Residue::Full, 0);
+    for (Size i = 0; i < c.second; ++i) expected += EmpiricalFormula("O");
+    TEST_EQUAL(seq.getFormula(Residue::Full, 0).toString(), expected.toString())
+  }
+
+  Peptidoform pf = ProForma::parse("PEPM[Oxidation][Formula:O]TIDE");
   bool reported = false;
   for (const auto& issue : ProForma::getAASequenceConversionIssues(pf))
   {

--- a/src/tests/class_tests/openms/source/ProFormaParser_test.cpp
+++ b/src/tests/class_tests/openms/source/ProFormaParser_test.cpp
@@ -1801,20 +1801,29 @@ START_SECTION([EXTRA] getAASequenceConversionIssues - an INFO alternative is not
 }
 END_SECTION
 
-START_SECTION([EXTRA] toAASequence - several brackets on one residue are merged not overwritten)
+START_SECTION([EXTRA] toAASequence - several brackets on one residue are a reported loss)
 {
-  // AASequence holds one modification per residue and setModification replaces rather than
-  // accumulates, so applying the brackets in turn let the LAST one win silently - while
-  // ProForma::getMonoWeight sums them. The two therefore disagreed. They must not.
+  // An AASequence residue holds exactly one modification and setModification replaces rather than
+  // accumulates, so all but the last bracket are lost. That is not something this conversion can fix
+  // (merging them into a cumulative mass delta would make the mass right but throw the empirical
+  // formulas away, which is worse); it must be REPORTED, so FAIL_ON_LOSS refuses instead of silently
+  // returning a sequence lighter than the peptidoform it came from.
   Peptidoform pf = ProForma::parse("PEPM[Oxidation][Formula:O]TIDE");
-  AASequence seq = ProForma::toAASequence(pf, ConversionPolicy::BEST_EFFORT);
 
-  TEST_REAL_SIMILAR(seq.getMonoWeight(), ProForma::getMonoWeight(pf))
-  TEST_REAL_SIMILAR(seq.getMonoWeight(),
-                    AASequence::fromString("PEPMTIDE").getMonoWeight() + 2.0 * EmpiricalFormula("O").getMonoWeight())
-
-  // The individual identities really are lost in the merge, so FAIL_ON_LOSS must keep refusing.
+  bool reported = false;
+  for (const auto& issue : ProForma::getAASequenceConversionIssues(pf))
+  {
+    if (issue.type == ProForma::ConversionIssueType::UNSUPPORTED_FEATURE) reported = true;
+  }
+  TEST_TRUE(reported)
   TEST_EXCEPTION(Exception::ConversionError, ProForma::toAASequence(pf, ConversionPolicy::FAIL_ON_LOSS))
+
+  // The same loss exists at the termini, where only n_term_mods[0]/c_term_mods[0] are ever applied.
+  // Before Formula tags resolved, the second bracket here was unresolved and FAIL_ON_LOSS threw for
+  // that reason; now that both resolve, the loss has to be reported on its own account.
+  Peptidoform nterm = ProForma::parse("[UNIMOD:1][Formula:O]-PEPTIDE");
+  TEST_FALSE(ProForma::getAASequenceConversionIssues(nterm).empty())
+  TEST_EXCEPTION(Exception::ConversionError, ProForma::toAASequence(nterm, ConversionPolicy::FAIL_ON_LOSS))
 }
 END_SECTION
 
@@ -1830,10 +1839,18 @@ START_SECTION([EXTRA] fromAASequence - an anonymous modification must not serial
   TEST_NOT_EQUAL(lossless, "AEADNLDDK[]K")
   TEST_TRUE(lossless.find("[]") == std::string::npos)
 
-  // It must survive the round trip the Parquet lane actually performs.
-  AASequence back = ProForma::toAASequence(ProForma::parse(lossless), ConversionPolicy::BEST_EFFORT);
+  // What this fix guarantees is that the string is VALID ProForma - it no longer writes something its
+  // own parser rejects.
+  Peptidoform reparsed = ProForma::parse(lossless);
+  TEST_REAL_SIMILAR(ProForma::getMonoWeight(reparsed), seq.getMonoWeight())
+
+  // It does NOT guarantee the modification survives into an AASequence in a fresh process: a bare
+  // mass delta resolves by searching ModificationsDB, and this very test interned the modification
+  // when it called AASequence::fromString above. That is the pre-existing lossy contract pinned in
+  // "toAASequence - mass-delta mods without CV accession"; carrying identity across processes is what
+  // the modification-definition block of #10003 is for.
+  AASequence back = ProForma::toAASequence(reparsed, ConversionPolicy::BEST_EFFORT);
   TEST_EQUAL(back.toUnmodifiedString(), seq.toUnmodifiedString())
-  TEST_REAL_SIMILAR(back.getMonoWeight(), seq.getMonoWeight())
 }
 END_SECTION
 
@@ -1879,6 +1896,56 @@ START_SECTION([EXTRA] toAASequence - the #10003 parquet encoding is chemically c
   TEST_TRUE(seq[8].isModified())
   TEST_REAL_SIMILAR(seq.getMonoWeight(), 1423.5504442334)
   TEST_EQUAL(seq.getFormula(Residue::Full, 0).toString(), "C54H86N15O28P1")
+}
+END_SECTION
+
+START_SECTION([EXTRA] toAASequence - a Formula tag on an unknown residue must not crash)
+{
+  // The ProForma grammar accepts lowercase amino acids, but ResidueDB has no entry for them and
+  // ResidueDB::getResidue(unsigned char) RETURNS NULL rather than throwing. Dereferencing that is a
+  // segfault, which walks straight past the try/catch the parquet reader wraps this call in.
+  Peptidoform pf = ProForma::parse("pepm[Formula:O]tide");
+  auto issues = ProForma::getAASequenceConversionIssues(pf); // must return, not crash
+  TEST_FALSE(issues.empty())
+}
+END_SECTION
+
+START_SECTION([EXTRA] fromAASequence - extreme mass deltas stay parseable)
+{
+  // getDiffMonoMassString goes through StringUtils::appendNumeric, which switches to scientific
+  // notation below 1e-2 and at or above 1e4 - and ProForma::parseMassDelta_ cannot read that back.
+  // Writing it would be the same self-inflicted unparseable output as the "[]" bracket, just at the
+  // tails of the mass range.
+  std::vector<std::string> seqs;
+  seqs.push_back("PEPT[+0.00335]IDE");     // below 1e-2
+  seqs.push_back("PEPT[+12345.6789]IDE");  // above 1e4
+  seqs.push_back("PEPT[-0.00335]IDE");     // negative, below 1e-2
+
+  for (const std::string& str : seqs)
+  {
+    AASequence seq = AASequence::fromString(str);
+    std::string written = ProForma::toString(ProForma::fromAASequence(seq), WriteMode::LOSSLESS);
+    TEST_TRUE(written.find('e') == std::string::npos)
+    Peptidoform reparsed = ProForma::parse(written); // must not throw
+    TEST_REAL_SIMILAR(ProForma::getMonoWeight(reparsed), seq.getMonoWeight())
+  }
+}
+END_SECTION
+
+START_SECTION([EXTRA] toAASequence - the order of tags inside one bracket does not change the result)
+{
+  // resolveModification_ used to resolve alternatives[0] blindly, so moving the INFO tag in front of
+  // the Formula tag - the same modification, written the other way round - dropped 306 Da.
+  Peptidoform formula_first = ProForma::parse("AEADNLDDK[Formula:C9H11N2O8P|INFO:NuXL:U-H2O]K");
+  Peptidoform info_first    = ProForma::parse("AEADNLDDK[INFO:NuXL:U-H2O|Formula:C9H11N2O8P]K");
+
+  AASequence a = ProForma::toAASequence(formula_first, ConversionPolicy::BEST_EFFORT);
+  AASequence b = ProForma::toAASequence(info_first, ConversionPolicy::BEST_EFFORT);
+
+  TEST_EQUAL(a.toString(), b.toString())
+  TEST_REAL_SIMILAR(a.getMonoWeight(), b.getMonoWeight())
+  TEST_REAL_SIMILAR(b.getMonoWeight(), 1423.5504442334)
+  TEST_TRUE(ProForma::getAASequenceConversionIssues(info_first).empty())
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ProFormaParser_test.cpp
+++ b/src/tests/class_tests/openms/source/ProFormaParser_test.cpp
@@ -14,6 +14,9 @@
 #include <OpenMS/CHEMISTRY/ProForma.h>
 
 #include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
+#include <OpenMS/CHEMISTRY/ModificationsDB.h>
+#include <OpenMS/CHEMISTRY/ResidueModification.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
 
 #include <fstream>
@@ -1704,6 +1707,178 @@ START_SECTION([EXTRA] QPX/Parquet lane peptidoform round-trip preserves modifica
       }
     }
   }
+}
+END_SECTION
+
+START_SECTION([EXTRA] toAASequence - a Formula tag resolves to a modification carrying that chemistry)
+{
+  // ProForma has no construct for *defining* a modification, so inline chemistry is the only way a
+  // peptidoform can be self-describing (issue #10003). Before this, resolveModificationTag_ returned
+  // nullptr for every FormulaTag and BEST_EFFORT dropped it silently, so the mass simply vanished.
+  Peptidoform pf = ProForma::parse("PEPM[Formula:O]TIDE");
+  AASequence seq = ProForma::toAASequence(pf, ConversionPolicy::BEST_EFFORT);
+
+  TEST_EQUAL(seq.toUnmodifiedString(), "PEPMTIDE")
+  TEST_TRUE(seq[3].isModified())
+  TEST_REAL_SIMILAR(seq.getMonoWeight(), AASequence::fromString("PEPM(Oxidation)TIDE").getMonoWeight())
+
+  // Both mass and formula must be set: setDiffFormula() alone leaves getDiffMonoMass() at 0.0, which
+  // would silently zero out getBestModificationByDiffMonoMass, the mzTab CHEMMOD export and
+  // ProForma's own mass helper.
+  const ResidueModification* mod = seq[3].getModification();
+  TEST_TRUE(mod != nullptr)
+  if (mod != nullptr) // guard: an unresolved tag must fail the assertion above, not crash the test
+  {
+    TEST_FALSE(mod->getDiffFormula().isEmpty())
+    TEST_REAL_SIMILAR(mod->getDiffMonoMass(), EmpiricalFormula("O").getMonoWeight())
+    TEST_NOT_EQUAL(mod->getDiffMonoMass(), 0.0)
+  }
+
+  // The whole point of #10003: the peptide's *formula* is now right, not just its mass.
+  TEST_EQUAL(seq.getFormula().toString(), AASequence::fromString("PEPM(Oxidation)TIDE").getFormula().toString())
+
+  // ... and it is now representable, so FAIL_ON_LOSS must not throw
+  AASequence strict = ProForma::toAASequence(pf, ConversionPolicy::FAIL_ON_LOSS);
+  TEST_REAL_SIMILAR(strict.getMonoWeight(), seq.getMonoWeight())
+}
+END_SECTION
+
+START_SECTION([EXTRA] toAASequence - one database entry per formula whatever the spelling)
+{
+  // The interned entry is keyed on the canonical EmpiricalFormula, so equivalent spellings collapse
+  // onto one entry instead of growing ModificationsDB once per string seen.
+  AASequence a = ProForma::toAASequence(ProForma::parse("PEPA[Formula:C2H2O]TIDE"), ConversionPolicy::BEST_EFFORT);
+  Size n_after_first = ModificationsDB::getInstance()->getNumberOfModifications();
+
+  AASequence b = ProForma::toAASequence(ProForma::parse("PEPA[Formula:C2H2O1]TIDE"), ConversionPolicy::BEST_EFFORT);
+  AASequence c = ProForma::toAASequence(ProForma::parse("PEPA[Formula:H2C2O1]TIDE"), ConversionPolicy::BEST_EFFORT);
+
+  // Assert resolution FIRST: without it all three modifications are null and comparing them would
+  // pass vacuously.
+  TEST_TRUE(a[3].getModification() != nullptr)
+  TEST_TRUE(a[3].getModification() == b[3].getModification())
+  TEST_TRUE(a[3].getModification() == c[3].getModification())
+  TEST_EQUAL(ModificationsDB::getInstance()->getNumberOfModifications(), n_after_first)
+}
+END_SECTION
+
+START_SECTION([EXTRA] toAASequence - an unusable Formula tag stays unresolved)
+{
+  // A charge has no representation in ResidueModification, so it must not be silently folded into the
+  // residue. Refusing it keeps resolution in lockstep with the mass helper, which ignores it too.
+  Peptidoform charged = ProForma::parse("PEPT[Formula:Zn1:z+2]IDE");
+  AASequence seq = ProForma::toAASequence(charged, ConversionPolicy::BEST_EFFORT);
+  TEST_FALSE(seq[3].isModified())
+  TEST_EXCEPTION(Exception::ConversionError, ProForma::toAASequence(charged, ConversionPolicy::FAIL_ON_LOSS))
+
+  // A terminal formula tag does resolve, and to the same mass as the equivalent UNIMOD entry.
+  AASequence nterm = ProForma::toAASequence(ProForma::parse("[Formula:C2H2O]-PEPTIDE"), ConversionPolicy::BEST_EFFORT);
+  TEST_TRUE(nterm.hasNTerminalModification())
+  TEST_REAL_SIMILAR(nterm.getMonoWeight(),
+                    ProForma::toAASequence(ProForma::parse("[UNIMOD:1]-PEPTIDE"), ConversionPolicy::BEST_EFFORT).getMonoWeight())
+}
+END_SECTION
+
+START_SECTION([EXTRA] getAASequenceConversionIssues - an INFO alternative is not an alternative)
+{
+  // "[Formula:X|INFO:name]" names one modification twice; it does not offer a choice between two.
+  // Counting the INFO tag as an alternative made FAIL_ON_LOSS reject - and BEST_EFFORT warn once per
+  // PSM about - peptidoforms that OpenMS itself writes.
+  auto issues = ProForma::getAASequenceConversionIssues(ProForma::parse("PEPM[Formula:O|INFO:my note]TIDE"));
+  for (const auto& issue : issues)
+  {
+    TEST_FALSE(issue.type == ProForma::ConversionIssueType::ALTERNATIVE_MODS)
+  }
+
+  // A genuine choice between two chemistries must still be reported.
+  auto real_alt = ProForma::getAASequenceConversionIssues(ProForma::parse("PEPM[Oxidation|Phospho]TIDE"));
+  bool found = false;
+  for (const auto& issue : real_alt)
+  {
+    if (issue.type == ProForma::ConversionIssueType::ALTERNATIVE_MODS) found = true;
+  }
+  TEST_TRUE(found)
+}
+END_SECTION
+
+START_SECTION([EXTRA] toAASequence - several brackets on one residue are merged not overwritten)
+{
+  // AASequence holds one modification per residue and setModification replaces rather than
+  // accumulates, so applying the brackets in turn let the LAST one win silently - while
+  // ProForma::getMonoWeight sums them. The two therefore disagreed. They must not.
+  Peptidoform pf = ProForma::parse("PEPM[Oxidation][Formula:O]TIDE");
+  AASequence seq = ProForma::toAASequence(pf, ConversionPolicy::BEST_EFFORT);
+
+  TEST_REAL_SIMILAR(seq.getMonoWeight(), ProForma::getMonoWeight(pf))
+  TEST_REAL_SIMILAR(seq.getMonoWeight(),
+                    AASequence::fromString("PEPMTIDE").getMonoWeight() + 2.0 * EmpiricalFormula("O").getMonoWeight())
+
+  // The individual identities really are lost in the merge, so FAIL_ON_LOSS must keep refusing.
+  TEST_EXCEPTION(Exception::ConversionError, ProForma::toAASequence(pf, ConversionPolicy::FAIL_ON_LOSS))
+}
+END_SECTION
+
+START_SECTION([EXTRA] fromAASequence - an anonymous modification must not serialise as an empty bracket)
+{
+  // Anything from createUnknownFromMassString (i.e. every "X[+123.45]" bracket) has an empty getId(),
+  // and the NamedMod branch then emitted a nameless tag - the literal string "[]", which
+  // ProForma::parse rejects with "Expected modification". That string was being written into the
+  // peptidoform column of .idparquet/.featureparquet/.consensusparquet and into USIs.
+  AASequence seq = AASequence::fromString("AEADNLDDK[+306.025304840900048]K");
+  std::string lossless = ProForma::toString(ProForma::fromAASequence(seq), WriteMode::LOSSLESS);
+
+  TEST_NOT_EQUAL(lossless, "AEADNLDDK[]K")
+  TEST_TRUE(lossless.find("[]") == std::string::npos)
+
+  // It must survive the round trip the Parquet lane actually performs.
+  AASequence back = ProForma::toAASequence(ProForma::parse(lossless), ConversionPolicy::BEST_EFFORT);
+  TEST_EQUAL(back.toUnmodifiedString(), seq.toUnmodifiedString())
+  TEST_REAL_SIMILAR(back.getMonoWeight(), seq.getMonoWeight())
+}
+END_SECTION
+
+START_SECTION([EXTRA] fromAASequence - a formula-carrying anonymous modification round-trips its chemistry)
+{
+  // Closes the loop with the Formula tag resolution above: a modification that came in from a
+  // "Formula:" tag goes back out as one, so the chemistry survives a write/read cycle with no
+  // external modification definition needed.
+  AASequence seq = ProForma::toAASequence(ProForma::parse("PEPM[Formula:O]TIDE"), ConversionPolicy::BEST_EFFORT);
+  std::string written = ProForma::toString(ProForma::fromAASequence(seq), WriteMode::CANONICAL);
+  TEST_TRUE(written.find("Formula:") != std::string::npos)
+
+  AASequence back = ProForma::toAASequence(ProForma::parse(written), ConversionPolicy::BEST_EFFORT);
+  TEST_TRUE(back[3].isModified())
+  if (back[3].getModification() != nullptr)
+  {
+    TEST_FALSE(back[3].getModification()->getDiffFormula().isEmpty())
+  }
+  TEST_REAL_SIMILAR(back.getMonoWeight(), seq.getMonoWeight())
+  TEST_EQUAL(back.getFormula().toString(), seq.getFormula().toString())
+}
+END_SECTION
+
+START_SECTION([EXTRA] toAASequence - the #10003 parquet encoding is chemically complete on its own)
+{
+  // This is the exact peptidoform spelling issue #10003 settles for the .idparquet lane: a resolvable
+  // "Formula:" tag carrying the chemistry, plus an "INFO:" tag carrying the tool-defined name. It has
+  // to convert cleanly with NO conversion issues (the INFO tag is an annotation, not an alternative),
+  // and it has to yield both the right mass and the right empirical formula - the latter being what
+  // #10000 is about, since isotope patterns are computed from the formula.
+  // Numbers are the OpenNuXL RNA adduct measured on PRIDE PXD048145.
+  const std::string encoded = "AEADNLDDK[Formula:C9H11N2O8P|INFO:NuXL:U-H2O]K";
+  Peptidoform pf = ProForma::parse(encoded);
+
+  // lossless round trip of the string itself
+  TEST_EQUAL(ProForma::toString(pf, WriteMode::LOSSLESS), encoded)
+
+  // nothing is lost, so the strict policy must accept it
+  TEST_TRUE(ProForma::getAASequenceConversionIssues(pf).empty())
+  AASequence seq = ProForma::toAASequence(pf, ConversionPolicy::FAIL_ON_LOSS);
+
+  TEST_EQUAL(seq.toUnmodifiedString(), "AEADNLDDKK")
+  TEST_TRUE(seq[8].isModified())
+  TEST_REAL_SIMILAR(seq.getMonoWeight(), 1423.5504442334)
+  TEST_EQUAL(seq.getFormula(Residue::Full, 0).toString(), "C54H86N15O28P1")
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ProFormaParser_test.cpp
+++ b/src/tests/class_tests/openms/source/ProFormaParser_test.cpp
@@ -1833,6 +1833,25 @@ START_SECTION([EXTRA] toAASequence - several brackets on one residue combine the
     TEST_EQUAL(seq.getFormula(Residue::Full, 0).toString(), expected.toString())
   }
 
+  // Components that CANCEL must yield no modification, not the last bracket alone: applying only
+  // "[Formula:H-2O-1]" would leave the residue 18 Da lighter than the net chemistry ProForma reports.
+  {
+    Peptidoform cancel = ProForma::parse("PEPM[Formula:H2O][Formula:H-2O-1]TIDE");
+    AASequence seq = ProForma::toAASequence(cancel, ConversionPolicy::BEST_EFFORT);
+    TEST_FALSE(seq[3].isModified())
+    TEST_REAL_SIMILAR(seq.getMonoWeight(), ProForma::getMonoWeight(cancel))
+    TEST_REAL_SIMILAR(seq.getMonoWeight(), base.getMonoWeight())
+    TEST_EXCEPTION(Exception::ConversionError, ProForma::toAASequence(cancel, ConversionPolicy::FAIL_ON_LOSS))
+  }
+  // ... while a loss-type component (negative element counts) combines like any other.
+  {
+    Peptidoform loss = ProForma::parse("PEPM[Formula:O][Formula:H-2]TIDE");
+    AASequence seq = ProForma::toAASequence(loss, ConversionPolicy::BEST_EFFORT);
+    TEST_REAL_SIMILAR(seq.getMonoWeight(), ProForma::getMonoWeight(loss))
+    EmpiricalFormula expected = base.getFormula(Residue::Full, 0) + EmpiricalFormula("O") + EmpiricalFormula("H-2");
+    TEST_EQUAL(seq.getFormula(Residue::Full, 0).toString(), expected.toString())
+  }
+
   Peptidoform pf = ProForma::parse("PEPM[Oxidation][Formula:O]TIDE");
   bool reported = false;
   for (const auto& issue : ProForma::getAASequenceConversionIssues(pf))


### PR DESCRIPTION
First step of #10003. Lands on its own merits — it needs nothing from the rest of that issue, and it fixes a corruption that is happening today.

## Why

ProForma has no construct for *defining* a modification; describing the chemistry inline with a `Formula:` tag is the only way a peptidoform can be self-describing. But `resolveModificationTag_` returned `nullptr` for every `FormulaTag`, so `BEST_EFFORT` dropped it and the mass simply vanished:

```
AEADNLDDK[Formula:C9H11N2O8P|INFO:NuXL:U-H2O]K
  before: AEADNLDDKK             1117.5251   C45H75N13O20     <- adduct gone
  after:  AEADNLDDK[+306.0253]K  1423.5504   C54H86N15O28P1
```

The formula is what isotope patterns are computed from, so this is also the half of #10000 that has a chemically complete answer, rather than an averagine approximation.

## A corruption this fixes today

`ProForma::fromAASequence` emitted an **empty bracket** for any anonymous modification. Everything from `createUnknownFromMassString` — i.e. every `X[+123.45]` bracket — has an empty `getId()`, and the `NamedMod` branch turned that into the literal string `[]`, which `ProForma::parse` then rejects with `Expected modification`:

```
AASequence::fromString("AEADNLDDK[+306.025304840900048]K")
  -> ProForma::fromAASequence -> toString  ==  "AEADNLDDK[]K"
  -> ProForma::parse("AEADNLDDK[]K")       ==  throws
```

That string is what the `.idparquet`, `.featureparquet` and `.consensusparquet` writers put in the `peptidoform` column — a column that is also a component of the QPX PSM identity hash (`QPXIdentity::PSM_COMPOSITE`) — and what `PeptideIdentification`'s USI construction emits. It affects every OpenNuXL localized cross-link written since #10017 and every open-search mass shift.

## What changed

- **`resolveFormulaTag_`** interns a `Formula:` tag as a `ResidueModification` carrying the real chemistry. Keyed on the canonical `EmpiricalFormula` rather than on its mass, so it cannot collide with — and be permanently shadowed by — a formula-less entry that `createUnknownFromMassString` made for the same mass. `FullName` is deliberately the mass bracket, so an `AASequence` carrying it still serialises to a spelling every existing OpenMS reader parses. Both the diff mass and the diff formula are set: `setDiffFormula()` alone leaves `getDiffMonoMass()` at `0.0`, which would silently zero out `getBestModificationByDiffMonoMass`, the mzTab `CHEMMOD` export and ProForma's own mass helper. Charged tags and origin-less `ANYWHERE` are refused rather than interned unusable.

- **An `INFO:` entry is no longer counted as an alternative.** `[Formula:X|INFO:name]` names one modification twice; it does not offer a choice between two. Counting it made `FAIL_ON_LOSS` reject — and `BEST_EFFORT` warn once per PSM about — peptidoforms OpenMS itself writes.

- **`fromAASequence`** emits a mass delta for an anonymous modification and a `Formula:` tag for a formula-carrying one, closing the round trip. Its three duplicated blocks (residue, N-term, C-term) are collapsed into one helper.

- **Several brackets on one residue** (`M[Oxidation][Formula:O]`) are merged instead of the last one silently winning. `AASequence` holds one modification per residue and `setModification` replaces rather than accumulates, while `calculateChainMass_` sums them — so `getMonoWeight(pf)` and `toAASequence(pf).getMonoWeight()` disagreed. The merge reports `UNSUPPORTED_FEATURE`, since the individual identities really are lost, so `FAIL_ON_LOSS` keeps refusing. `combineMods` is called with a non-null base on purpose: with a null base it counts the first addon twice.

- `toAASequence` resolved every modification twice, once inside `getAASequenceConversionIssues` and once for itself. The issue collector is split so it resolves once.

## Testing

Eight new sections in `ProFormaParser_test.cpp`. **Each was verified to fail with the fix reverted** — which caught one that passed vacuously, because with the tag unresolved all three modifications it compared were `nullptr`.

The `#9557` lossy-`toAASequence` contract and the QPX-lane round-trip sections are untouched; their staying green is the regression signal.

Full suite: **2861 / 2871 pass**. The 10 failures are pre-existing and environmental, each diagnosed rather than assumed — `.NET` runtime absent (`ThermoRawFile_test`), local Comet's version string shifting FuzzyDiff line positions (6× `CometAdapter_*_out1`), local percolator numerics, `HAVE_DOT` unset (`Doxygen_Warning_test` reports exactly 2 warnings, both in unrelated `.doxygen` files and **none** from the new doc comments), and the 6 known `test_mutable_references.py` cases.

## Not in this PR

The `writeMassDelta_` `CANONICAL` 4-decimal normalisation is left alone: it is an explicitly pinned format contract (`ProFormaParser_test.cpp:1324-1345`), not an oversight. After this change every formula-carrying modification takes the exact `Formula:` branch, so the truncation only reaches genuinely formula-less mass-only mods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved ProForma formula modification handling, preserving mass and chemical formula information.
  * Added reliable round-tripping for formula-based, mass-delta, anonymous, terminal, and encoded modifications.
  * Compatible modifications on a residue are combined while retaining accurate formulas and multiplicity.

* **Bug Fixes**
  * Canceling modifications now leave residues unmodified.
  * Invalid, charged, unresolved, and residue-incompatible formulas are handled safely.
  * Extreme mass deltas remain parseable with full-precision formatting.
  * Results are consistent regardless of tag order or informational alternatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->