### PR TITLE
[FEATURE] ResidueModification: record where a modification's definition came from (#10003)

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
@@ -104,32 +104,20 @@ public:
     };
 
     /**
-      @brief Where the *definition* of this modification came from.
+      @brief Where the definition of this modification came from.
 
-      This matters when writing an identification file: a modification that no other process can look
-      up has to travel with its definition, and the writer needs to know which ones those are.
-
-      It is deliberately NOT SourceClassification, which records biological origin (artefact, natural,
-      post-translational, ...) and says nothing about where the description came from. It is also
-      deliberately not isUserDefined(), which means "anonymous - identified only by a mass string" and
-      guards the origin-'X' matching rule in ModificationsDB; a modification registered WITH an Id is
-      resolvable by name yet not user-defined, i.e. that predicate is false for exactly the
-      modifications that need serialising.
-
-      Provenance must not be inferred from the state of ModificationsDB. That database is a
-      process-global singleton which accumulates every definition a process has ever loaded, so
-      "everything beyond the startup baseline" is a property of process history rather than of the
-      data - a tool reading many files would attribute file 1's definitions to an output that never
-      references them. A mark carried on the modification survives read -> register -> write -> read.
+      File writers use this to decide which modifications must be stored together with their
+      definition. Distinct from SourceClassification (biological origin) and from isUserDefined()
+      (anonymous mass-string modifications). Carried on the object rather than derived from
+      ModificationsDB, which is process-global and accumulates the definitions of every file read.
     */
     enum Provenance
     {
-      /// Registered by a tool, or restored from a file's definition block. Must be serialised.
+      /// Registered by a tool or read from a file's definition block; must be serialised
       DEFINED = 0,
-      /// From a controlled vocabulary shipped with OpenMS (unimod.xml, custom_mods.xml, PSI-MOD.obo, XLMOD.obo).
+      /// From a controlled vocabulary shipped with OpenMS (Unimod, PSI-MOD, XLMOD, custom_mods.xml)
       CV,
-      /// Anonymous: reconstructible from its own serialised form (a mass bracket or an inline formula),
-      /// so it needs no definition to travel with it.
+      /// Anonymous mass or formula modification; reconstructible from its own serialised form
       MASS_ONLY,
       NUMBER_OF_PROVENANCE
     };
@@ -457,8 +445,7 @@ protected:
 
     std::vector<double> neutral_loss_average_masses_;
 
-    // Appended last on purpose: it leaves the layout of every existing member untouched.
-    // Deliberately absent from operator==, operator< and std::hash - see the note on operator==.
+    /// not part of operator==, operator< or std::hash (see operator==)
     Provenance provenance_;
   };
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
@@ -102,6 +102,37 @@ public:
       UNKNOWN,                ///< An unknown modification
       NUMBER_OF_SOURCE_CLASSIFICATIONS
     };
+
+    /**
+      @brief Where the *definition* of this modification came from.
+
+      This matters when writing an identification file: a modification that no other process can look
+      up has to travel with its definition, and the writer needs to know which ones those are.
+
+      It is deliberately NOT SourceClassification, which records biological origin (artefact, natural,
+      post-translational, ...) and says nothing about where the description came from. It is also
+      deliberately not isUserDefined(), which means "anonymous - identified only by a mass string" and
+      guards the origin-'X' matching rule in ModificationsDB; a modification registered WITH an Id is
+      resolvable by name yet not user-defined, i.e. that predicate is false for exactly the
+      modifications that need serialising.
+
+      Provenance must not be inferred from the state of ModificationsDB. That database is a
+      process-global singleton which accumulates every definition a process has ever loaded, so
+      "everything beyond the startup baseline" is a property of process history rather than of the
+      data - a tool reading many files would attribute file 1's definitions to an output that never
+      references them. A mark carried on the modification survives read -> register -> write -> read.
+    */
+    enum Provenance
+    {
+      /// Registered by a tool, or restored from a file's definition block. Must be serialised.
+      DEFINED = 0,
+      /// From a controlled vocabulary shipped with OpenMS (unimod.xml, custom_mods.xml, PSI-MOD.obo, XLMOD.obo).
+      CV,
+      /// Anonymous: reconstructible from its own serialised form (a mass bracket or an inline formula),
+      /// so it needs no definition to travel with it.
+      MASS_ONLY,
+      NUMBER_OF_PROVENANCE
+    };
     //@}
 
     /** @name Constructors and Destructors
@@ -240,6 +271,12 @@ public:
 
     /// returns the classification
     std::string getSourceClassificationName(SourceClassification classification = NUMBER_OF_SOURCE_CLASSIFICATIONS) const;
+
+    /// sets where the definition of this modification came from
+    void setProvenance(Provenance provenance);
+
+    /// returns where the definition of this modification came from
+    Provenance getProvenance() const;
 
     /// sets the average mass
     void setAverageMass(double mass);
@@ -419,6 +456,10 @@ protected:
     std::vector<double> neutral_loss_mono_masses_;
 
     std::vector<double> neutral_loss_average_masses_;
+
+    // Appended last on purpose: it leaves the layout of every existing member untouched.
+    // Deliberately absent from operator==, operator< and std::hash - see the note on operator==.
+    Provenance provenance_;
   };
 } // namespace OpenMS
 

--- a/src/openms/source/ANALYSIS/NUXL/NuXLParameterParsing.cpp
+++ b/src/openms/source/ANALYSIS/NUXL/NuXLParameterParsing.cpp
@@ -215,10 +215,7 @@ NuXLParameterParsing::getTargetNucleotideToFragmentAdducts(StringList fragment_a
       c_term->setFullId(name + " (C-term)");
       c_term->setTermSpecificity(ResidueModification::C_TERM);
       c_term->setDiffMonoMass(fad.mass);
-      // Invented at run time and named, so no other process can look it up: exactly what the
-      // definition block of #10003 has to carry. Stated explicitly rather than relying on the
-      // default, because this is the site a definition collector must pick up.
-      c_term->setProvenance(ResidueModification::DEFINED);
+      c_term->setProvenance(ResidueModification::DEFINED); // defined at run time, must be serialised
       ModificationsDB::getInstance()->addModification(std::move(c_term));
 
       std::unique_ptr<ResidueModification> n_term{new ResidueModification()};
@@ -227,10 +224,7 @@ NuXLParameterParsing::getTargetNucleotideToFragmentAdducts(StringList fragment_a
       n_term->setFullId(name + " (N-term)");
       n_term->setTermSpecificity(ResidueModification::N_TERM);
       n_term->setDiffMonoMass(fad.mass);
-      // Invented at run time and named, so no other process can look it up: exactly what the
-      // definition block of #10003 has to carry. Stated explicitly rather than relying on the
-      // default, because this is the site a definition collector must pick up.
-      n_term->setProvenance(ResidueModification::DEFINED);
+      n_term->setProvenance(ResidueModification::DEFINED); // defined at run time, must be serialised
       ModificationsDB::getInstance()->addModification(std::move(n_term));
     }
   }

--- a/src/openms/source/ANALYSIS/NUXL/NuXLParameterParsing.cpp
+++ b/src/openms/source/ANALYSIS/NUXL/NuXLParameterParsing.cpp
@@ -215,6 +215,10 @@ NuXLParameterParsing::getTargetNucleotideToFragmentAdducts(StringList fragment_a
       c_term->setFullId(name + " (C-term)");
       c_term->setTermSpecificity(ResidueModification::C_TERM);
       c_term->setDiffMonoMass(fad.mass);
+      // Invented at run time and named, so no other process can look it up: exactly what the
+      // definition block of #10003 has to carry. Stated explicitly rather than relying on the
+      // default, because this is the site a definition collector must pick up.
+      c_term->setProvenance(ResidueModification::DEFINED);
       ModificationsDB::getInstance()->addModification(std::move(c_term));
 
       std::unique_ptr<ResidueModification> n_term{new ResidueModification()};
@@ -223,6 +227,10 @@ NuXLParameterParsing::getTargetNucleotideToFragmentAdducts(StringList fragment_a
       n_term->setFullId(name + " (N-term)");
       n_term->setTermSpecificity(ResidueModification::N_TERM);
       n_term->setDiffMonoMass(fad.mass);
+      // Invented at run time and named, so no other process can look it up: exactly what the
+      // definition block of #10003 has to carry. Stated explicitly rather than relying on the
+      // default, because this is the site a definition collector must pick up.
+      n_term->setProvenance(ResidueModification::DEFINED);
       ModificationsDB::getInstance()->addModification(std::move(n_term));
     }
   }

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -203,8 +203,7 @@ namespace OpenMS
 
   const ResidueModification* ModificationsDB::getModification(Size index) const
   {
-    // Every other accessor takes this section; without it, reading mods_ races a concurrent
-    // addModification() whose push_back can reallocate the vector.
+    // a concurrent addModification() may reallocate mods_
     const ResidueModification* ret = nullptr;
     #pragma omp critical(OpenMS_ModificationsDB)
     {
@@ -498,9 +497,7 @@ namespace OpenMS
 
   const ResidueModification* ModificationsDB::addModification(const ResidueModification& new_mod) const
   {
-    // Held by a unique_ptr until it is actually stored: the copy used to be raw-newed before the
-    // duplicate check below, and on the duplicate path `ret` was reassigned to the existing entry,
-    // leaking it.
+    // owned until stored; the duplicate path below must not leak the copy
     std::unique_ptr<ResidueModification> owned(new ResidueModification(new_mod));
     const ResidueModification* ret = owned.get();
     #pragma omp critical(OpenMS_ModificationsDB)

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -10,6 +10,8 @@
 #include <OpenMS/CHEMISTRY/ResidueModification.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 
+#include <memory>
+
 #include <OpenMS/CHEMISTRY/Residue.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/Macros.h>
@@ -201,8 +203,15 @@ namespace OpenMS
 
   const ResidueModification* ModificationsDB::getModification(Size index) const
   {
-    OPENMS_PRECONDITION(index < mods_.size(), "Index out of bounds in ModificationsDB::getModification(Size index)." );
-    return mods_[index];
+    // Every other accessor takes this section; without it, reading mods_ races a concurrent
+    // addModification() whose push_back can reallocate the vector.
+    const ResidueModification* ret = nullptr;
+    #pragma omp critical(OpenMS_ModificationsDB)
+    {
+      OPENMS_PRECONDITION(index < mods_.size(), "Index out of bounds in ModificationsDB::getModification(Size index)." );
+      ret = mods_[index];
+    }
+    return ret;
   }
 
   void ModificationsDB::searchModifications(set<const ResidueModification*>& mods,
@@ -489,7 +498,11 @@ namespace OpenMS
 
   const ResidueModification* ModificationsDB::addModification(const ResidueModification& new_mod) const
   {
-    const ResidueModification* ret = new ResidueModification(new_mod);
+    // Held by a unique_ptr until it is actually stored: the copy used to be raw-newed before the
+    // duplicate check below, and on the duplicate path `ret` was reassigned to the existing entry,
+    // leaking it.
+    std::unique_ptr<ResidueModification> owned(new ResidueModification(new_mod));
+    const ResidueModification* ret = owned.get();
     #pragma omp critical(OpenMS_ModificationsDB)
     {
       auto it = modification_names_.find(new_mod.getFullId());
@@ -504,7 +517,7 @@ namespace OpenMS
         modification_names_[ret->getId()].insert(ret);
         modification_names_[ret->getFullName()].insert(ret);
         modification_names_[ret->getUniModAccession()].insert(ret);
-        mods_.push_back(const_cast<ResidueModification*>(ret));
+        mods_.push_back(owned.release());
         ret = mods_.back();
       }
     }

--- a/src/openms/source/CHEMISTRY/OBODataProvider.cpp
+++ b/src/openms/source/CHEMISTRY/OBODataProvider.cpp
@@ -292,7 +292,9 @@ namespace OpenMS
       // ModificationsDB's loadFromProviders_() will detect these and handle alias resolution.
       if (it->second.getUniModRecordId() > 0)
       {
-        result.push_back(make_unique<ResidueModification>(it->second));
+        auto alias_ptr = make_unique<ResidueModification>(it->second);
+        alias_ptr->setProvenance(ResidueModification::CV);
+        result.push_back(std::move(alias_ptr));
         continue;
       }
 
@@ -303,6 +305,7 @@ namespace OpenMS
            (it->second.getDiffMonoMass() != 0)))
       {
         auto mod_ptr = make_unique<ResidueModification>(it->second);
+        mod_ptr->setProvenance(ResidueModification::CV); // PSI-MOD / XLMOD are shipped vocabularies
 
         // full ID is auto-generated based on (short) ID, but we want the name instead:
         mod_ptr->setId(it->second.getFullName());

--- a/src/openms/source/CHEMISTRY/ResidueModification.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueModification.cpp
@@ -34,10 +34,7 @@ namespace OpenMS
     diff_mono_mass_(0.0),
     neutral_loss_mono_masses_(0),
     neutral_loss_average_masses_(0),
-    // DEFINED by default on purpose: over-emitting a definition is a no-op on read (the
-    // ModificationsDB dedup returns the existing entry), whereas under-emitting silently produces a
-    // file that cannot be read back. A missed stamp site fails in the harmless direction.
-    provenance_(DEFINED)
+    provenance_(DEFINED) // default: an unnecessary definition is harmless, a missing one is not
   {
   }
 
@@ -87,13 +84,9 @@ namespace OpenMS
   }
 
 
-  // provenance_ is deliberately NOT compared here, nor in operator< or std::hash. ModificationsDB::
-  // searchModification() requires a full operator== match and gates addNewModification_ - the
-  // NO-DEDUP inserter - reached from Residue::setModification and the AASequence setters. Were the
-  // mark compared, a caller holding a copy whose mark differs from the database entry's would miss
-  // and insert a SECOND entry under the same FullId, after which findModificationIndex() throws
-  // "More than one modification with name". Provenance describes where the description came from,
-  // not the chemistry, so two entries that agree on everything else are the same modification.
+  // provenance_ is intentionally not compared (nor in operator< / std::hash): searchModification()
+  // gates the no-dedup inserter on operator==, so a mismatch would create a second entry under the
+  // same FullId. Provenance describes the source of the definition, not the chemistry.
   bool ResidueModification::operator==(const ResidueModification& rhs) const
   {
     return id_ == rhs.id_ &&
@@ -594,7 +587,7 @@ namespace OpenMS
       {
         unique_ptr<ResidueModification> new_mod(new ResidueModification);
         new_mod->setFullId(residue_id); // setting FullId but not Id makes it a user-defined mod
-          new_mod->setProvenance(MASS_ONLY); // reconstructible from its own mass bracket
+        new_mod->setProvenance(MASS_ONLY);
         new_mod->setFullName(residue_name); // display name
         new_mod->setTermSpecificity(specificity);
 
@@ -632,7 +625,7 @@ namespace OpenMS
         {
           unique_ptr<ResidueModification> new_mod(new ResidueModification);
           new_mod->setFullId(residue_id); // setting FullId but not Id makes it a user-defined mod
-          new_mod->setProvenance(MASS_ONLY); // reconstructible from its own mass bracket
+          new_mod->setProvenance(MASS_ONLY);
           new_mod->setFullName(residue_name); // display name
           new_mod->setTermSpecificity(specificity);
 
@@ -672,7 +665,7 @@ namespace OpenMS
           // create new modification
           unique_ptr<ResidueModification> new_mod(new ResidueModification);
           new_mod->setFullId(residue_id); // setting FullId but not Id makes it a user-defined mod
-          new_mod->setProvenance(MASS_ONLY); // reconstructible from its own mass bracket
+          new_mod->setProvenance(MASS_ONLY);
           new_mod->setFullName(modification_name); // display name
 
           // We will set origin to make sure the same modification will be used

--- a/src/openms/source/CHEMISTRY/ResidueModification.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueModification.cpp
@@ -33,7 +33,11 @@ namespace OpenMS
     diff_average_mass_(0.0),
     diff_mono_mass_(0.0),
     neutral_loss_mono_masses_(0),
-    neutral_loss_average_masses_(0)
+    neutral_loss_average_masses_(0),
+    // DEFINED by default on purpose: over-emitting a definition is a no-op on read (the
+    // ModificationsDB dedup returns the existing entry), whereas under-emitting silently produces a
+    // file that cannot be read back. A missed stamp site fails in the harmless direction.
+    provenance_(DEFINED)
   {
   }
 
@@ -83,6 +87,13 @@ namespace OpenMS
   }
 
 
+  // provenance_ is deliberately NOT compared here, nor in operator< or std::hash. ModificationsDB::
+  // searchModification() requires a full operator== match and gates addNewModification_ - the
+  // NO-DEDUP inserter - reached from Residue::setModification and the AASequence setters. Were the
+  // mark compared, a caller holding a copy whose mark differs from the database entry's would miss
+  // and insert a SECOND entry under the same FullId, after which findModificationIndex() throws
+  // "More than one modification with name". Provenance describes where the description came from,
+  // not the chemistry, so two entries that agree on everything else are the same modification.
   bool ResidueModification::operator==(const ResidueModification& rhs) const
   {
     return id_ == rhs.id_ &&
@@ -431,6 +442,16 @@ namespace OpenMS
     }
   }
 
+  void ResidueModification::setProvenance(Provenance provenance)
+  {
+    provenance_ = provenance;
+  }
+
+  ResidueModification::Provenance ResidueModification::getProvenance() const
+  {
+    return provenance_;
+  }
+
   void ResidueModification::setAverageMass(double mass)
   {
     average_mass_ = mass;
@@ -573,6 +594,7 @@ namespace OpenMS
       {
         unique_ptr<ResidueModification> new_mod(new ResidueModification);
         new_mod->setFullId(residue_id); // setting FullId but not Id makes it a user-defined mod
+          new_mod->setProvenance(MASS_ONLY); // reconstructible from its own mass bracket
         new_mod->setFullName(residue_name); // display name
         new_mod->setTermSpecificity(specificity);
 
@@ -610,6 +632,7 @@ namespace OpenMS
         {
           unique_ptr<ResidueModification> new_mod(new ResidueModification);
           new_mod->setFullId(residue_id); // setting FullId but not Id makes it a user-defined mod
+          new_mod->setProvenance(MASS_ONLY); // reconstructible from its own mass bracket
           new_mod->setFullName(residue_name); // display name
           new_mod->setTermSpecificity(specificity);
 
@@ -649,6 +672,7 @@ namespace OpenMS
           // create new modification
           unique_ptr<ResidueModification> new_mod(new ResidueModification);
           new_mod->setFullId(residue_id); // setting FullId but not Id makes it a user-defined mod
+          new_mod->setProvenance(MASS_ONLY); // reconstructible from its own mass bracket
           new_mod->setFullName(modification_name); // display name
 
           // We will set origin to make sure the same modification will be used

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -2797,7 +2797,7 @@ namespace OpenMS::Internal
                       if (!mod_db->has(residue_id))
                       {
                         unique_ptr<ResidueModification> new_mod(new ResidueModification);
-                        new_mod->setFullId(residue_id); // FullId without Id makes this a user-defined mod
+                        new_mod->setFullId(residue_id); // setting FullId but not Id makes it a user-defined mod
                         new_mod->setProvenance(ResidueModification::MASS_ONLY);
                         new_mod->setFullName(residue_name); // display name
                         new_mod->setDiffMonoMass(mass_delta);
@@ -2817,14 +2817,11 @@ namespace OpenMS::Internal
                       std::string residue_id = ".c[" + mod + "]";
 
                       // Check if it already exists, if not create new modification, transfer
-                      // ownership to ModDB.
-                      // Guard on residue_id, which is what gets registered below: guarding on
-                      // residue_name (".[mod]" vs ".c[mod]") never matched, so every occurrence
-                      // re-entered addModification and logged a duplicate warning.
+                      // ownership to ModDB (check residue_id, which is what gets registered)
                       if (!mod_db->has(residue_id))
                       {
                         unique_ptr<ResidueModification> new_mod(new ResidueModification);
-                        new_mod->setFullId(residue_id); // FullId without Id makes this a user-defined mod
+                        new_mod->setFullId(residue_id); // setting FullId but not Id makes it a user-defined mod
                         new_mod->setProvenance(ResidueModification::MASS_ONLY);
                         new_mod->setFullName(residue_name); // display name
                         new_mod->setDiffMonoMass(mass_delta);

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -2797,7 +2797,8 @@ namespace OpenMS::Internal
                       if (!mod_db->has(residue_id))
                       {
                         unique_ptr<ResidueModification> new_mod(new ResidueModification);
-                        new_mod->setFullId(residue_id); // setting FullId but not Id makes it a user-defined mod
+                        new_mod->setFullId(residue_id); // FullId without Id makes this a user-defined mod
+                        new_mod->setProvenance(ResidueModification::MASS_ONLY);
                         new_mod->setFullName(residue_name); // display name
                         new_mod->setDiffMonoMass(mass_delta);
                         new_mod->setMonoMass(mass_delta + Residue::getInternalToNTerm().getMonoWeight());
@@ -2816,11 +2817,15 @@ namespace OpenMS::Internal
                       std::string residue_id = ".c[" + mod + "]";
 
                       // Check if it already exists, if not create new modification, transfer
-                      // ownership to ModDB
-                      if (!mod_db->has(residue_name))
+                      // ownership to ModDB.
+                      // Guard on residue_id, which is what gets registered below: guarding on
+                      // residue_name (".[mod]" vs ".c[mod]") never matched, so every occurrence
+                      // re-entered addModification and logged a duplicate warning.
+                      if (!mod_db->has(residue_id))
                       {
                         unique_ptr<ResidueModification> new_mod(new ResidueModification);
-                        new_mod->setFullId(residue_id); // setting FullId but not Id makes it a user-defined mod
+                        new_mod->setFullId(residue_id); // FullId without Id makes this a user-defined mod
+                        new_mod->setProvenance(ResidueModification::MASS_ONLY);
                         new_mod->setFullName(residue_name); // display name
                         new_mod->setDiffMonoMass(mass_delta);
                         new_mod->setMonoMass(mass_delta + Residue::getInternalToCTerm().getMonoWeight());
@@ -2843,6 +2848,7 @@ namespace OpenMS::Internal
                         // create new modification
                         unique_ptr<ResidueModification> new_mod(new ResidueModification);
                         new_mod->setFullId(residue_name); // setting FullId but not Id makes it a user-defined mod
+                        new_mod->setProvenance(ResidueModification::MASS_ONLY);
                         new_mod->setFullName(modification_name); // display name
 
                         // We will set origin to make sure the same modification will be used

--- a/src/openms/source/FORMAT/HANDLERS/UnimodXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/UnimodXMLHandler.cpp
@@ -37,6 +37,10 @@ namespace OpenMS::Internal
       {
         sites_.clear();
         modification_ = new ResidueModification();
+      // Covers unimod.xml AND custom_mods.xml: both go through this provider, which does not record
+      // which file an entry came from - and for provenance purposes they are the same thing, a CV
+      // shipped with OpenMS.
+      modification_->setProvenance(ResidueModification::CV);
         std::string title(attributeAsString_(attributes, "title"));
         modification_->setId(title);
 

--- a/src/openms/source/FORMAT/HANDLERS/UnimodXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/UnimodXMLHandler.cpp
@@ -37,10 +37,7 @@ namespace OpenMS::Internal
       {
         sites_.clear();
         modification_ = new ResidueModification();
-      // Covers unimod.xml AND custom_mods.xml: both go through this provider, which does not record
-      // which file an entry came from - and for provenance purposes they are the same thing, a CV
-      // shipped with OpenMS.
-      modification_->setProvenance(ResidueModification::CV);
+        modification_->setProvenance(ResidueModification::CV); // unimod.xml and custom_mods.xml
         std::string title(attributeAsString_(attributes, "title"));
         modification_->setId(title);
 

--- a/src/pyOpenMS/bindings/bind_chemistry.cpp
+++ b/src/pyOpenMS/bindings/bind_chemistry.cpp
@@ -1946,6 +1946,8 @@ Modified residues get created and added if getModifiedResidue is called.
         .def("getNeutralLossAverageMasses", [](const OpenMS::ResidueModification& self) { return self.getNeutralLossAverageMasses(); }, "Returns the neutral loss average weight")
         .def("hasNeutralLoss", [](const OpenMS::ResidueModification& self) { return self.hasNeutralLoss(); }, "Returns true if a neutral loss formula is set")
         .def("isUserDefined", [](const OpenMS::ResidueModification& self) { return self.isUserDefined(); }, "Returns true if it is a user-defined modification (empty id)")
+        .def("setProvenance", [](OpenMS::ResidueModification& self, OpenMS::ResidueModification::Provenance p) { self.setProvenance(p); }, "provenance"_a, "Sets where the definition of this modification came from")
+        .def("getProvenance", [](const OpenMS::ResidueModification& self) { return self.getProvenance(); }, "Returns where the definition of this modification came from")
         .def(nb::self == nb::self)
         .def(nb::self != nb::self)
         .def("__hash__", [](const OpenMS::ResidueModification& self) { return std::hash<OpenMS::ResidueModification>{}(self); })
@@ -1986,6 +1988,13 @@ Modified residues get created and added if getModifiedResidue is called.
         .value("OLINKED_GLYCOSYLATION", OpenMS::ResidueModification::SourceClassification::OLINKED_GLYCOSYLATION)
         .value("UNKNOWN", OpenMS::ResidueModification::SourceClassification::UNKNOWN)
         .value("NUMBER_OF_SOURCE_CLASSIFICATIONS", OpenMS::ResidueModification::SourceClassification::NUMBER_OF_SOURCE_CLASSIFICATIONS)
+        .export_values();
+    // Provenance enum nested under ResidueModification
+    nb::enum_<OpenMS::ResidueModification::Provenance>(residuemodification_class, "Provenance", nb::is_arithmetic())
+        .value("DEFINED", OpenMS::ResidueModification::Provenance::DEFINED)
+        .value("CV", OpenMS::ResidueModification::Provenance::CV)
+        .value("MASS_ONLY", OpenMS::ResidueModification::Provenance::MASS_ONLY)
+        .value("NUMBER_OF_PROVENANCE", OpenMS::ResidueModification::Provenance::NUMBER_OF_PROVENANCE)
         .export_values();
 
     // -----------------------------------------------------------------------

--- a/src/tests/class_tests/openms/source/ResidueModification_test.cpp
+++ b/src/tests/class_tests/openms/source/ResidueModification_test.cpp
@@ -640,14 +640,10 @@ END_SECTION
 
 START_SECTION([EXTRA] Provenance - default and the values set by the creation paths)
 {
-  // DEFINED by default on purpose: over-emitting a definition is a no-op on read, whereas
-  // under-emitting silently produces a file that cannot be read back, so a missed stamp site has to
-  // fail in the harmless direction.
   ResidueModification fresh;
   TEST_EQUAL(fresh.getProvenance(), ResidueModification::DEFINED)
 
-  // Anything from createUnknownFromMassString is reconstructible from its own mass bracket and needs
-  // no definition to travel with it.
+  // mass-string modifications
   const Residue* lysine = ResidueDB::getInstance()->getResidue("K");
   const ResidueModification* unknown =
     ResidueModification::createUnknownFromMassString("+306.0253048409", 306.0253048409, true,
@@ -658,7 +654,7 @@ START_SECTION([EXTRA] Provenance - default and the values set by the creation pa
     TEST_EQUAL(unknown->getProvenance(), ResidueModification::MASS_ONLY)
   }
 
-  // Entries loaded from the shipped vocabularies are CV.
+  // shipped vocabularies
   const ResidueModification* oxidation = ModificationsDB::getInstance()->getModification("Oxidation (M)");
   TEST_TRUE(oxidation != nullptr)
   if (oxidation != nullptr)
@@ -666,9 +662,7 @@ START_SECTION([EXTRA] Provenance - default and the values set by the creation pa
     TEST_EQUAL(oxidation->getProvenance(), ResidueModification::CV)
   }
 
-  // Provenance is orthogonal to isUserDefined(), which means "anonymous - identified only by a mass
-  // string". Reusing that predicate instead would be wrong in both directions, and would silently
-  // change the origin-'X' matching rule it guards in ModificationsDB.
+  // orthogonal to isUserDefined()
   if (unknown != nullptr && oxidation != nullptr)
   {
     TEST_TRUE(unknown->isUserDefined())
@@ -679,11 +673,7 @@ END_SECTION
 
 START_SECTION([EXTRA] Provenance - deliberately excluded from equality ordering and hash)
 {
-  // ModificationsDB::searchModification() requires a full operator== match and gates
-  // addNewModification_ - the NO-DEDUP inserter - reached from Residue::setModification and the
-  // AASequence setters. If the mark were compared, a caller holding a copy whose mark differs from
-  // the stored entry's would miss and insert a SECOND entry under the same FullId, after which
-  // findModificationIndex() throws "More than one modification with name".
+  // searchModification() gates the no-dedup inserter on operator==; comparing the mark would duplicate entries
   ResidueModification a;
   a.setId("TestProvenanceMod");
   a.setFullId("TestProvenanceMod (K)");
@@ -702,7 +692,7 @@ START_SECTION([EXTRA] Provenance - deliberately excluded from equality ordering 
   std::hash<ResidueModification> hasher;
   TEST_EQUAL(hasher(a), hasher(b))
 
-  // ... but the mark itself is still carried, and survives a copy.
+  // the mark itself is still carried and copied
   TEST_EQUAL(a.getProvenance(), ResidueModification::CV)
   ResidueModification c(a);
   TEST_EQUAL(c.getProvenance(), ResidueModification::CV)

--- a/src/tests/class_tests/openms/source/ResidueModification_test.cpp
+++ b/src/tests/class_tests/openms/source/ResidueModification_test.cpp
@@ -638,4 +638,75 @@ START_SECTION(([EXTRA] std::hash<ResidueModification>))
 }
 END_SECTION
 
+START_SECTION([EXTRA] Provenance - default and the values set by the creation paths)
+{
+  // DEFINED by default on purpose: over-emitting a definition is a no-op on read, whereas
+  // under-emitting silently produces a file that cannot be read back, so a missed stamp site has to
+  // fail in the harmless direction.
+  ResidueModification fresh;
+  TEST_EQUAL(fresh.getProvenance(), ResidueModification::DEFINED)
+
+  // Anything from createUnknownFromMassString is reconstructible from its own mass bracket and needs
+  // no definition to travel with it.
+  const Residue* lysine = ResidueDB::getInstance()->getResidue("K");
+  const ResidueModification* unknown =
+    ResidueModification::createUnknownFromMassString("+306.0253048409", 306.0253048409, true,
+                                                     ResidueModification::ANYWHERE, lysine);
+  TEST_TRUE(unknown != nullptr)
+  if (unknown != nullptr)
+  {
+    TEST_EQUAL(unknown->getProvenance(), ResidueModification::MASS_ONLY)
+  }
+
+  // Entries loaded from the shipped vocabularies are CV.
+  const ResidueModification* oxidation = ModificationsDB::getInstance()->getModification("Oxidation (M)");
+  TEST_TRUE(oxidation != nullptr)
+  if (oxidation != nullptr)
+  {
+    TEST_EQUAL(oxidation->getProvenance(), ResidueModification::CV)
+  }
+
+  // Provenance is orthogonal to isUserDefined(), which means "anonymous - identified only by a mass
+  // string". Reusing that predicate instead would be wrong in both directions, and would silently
+  // change the origin-'X' matching rule it guards in ModificationsDB.
+  if (unknown != nullptr && oxidation != nullptr)
+  {
+    TEST_TRUE(unknown->isUserDefined())
+    TEST_FALSE(oxidation->isUserDefined())
+  }
+}
+END_SECTION
+
+START_SECTION([EXTRA] Provenance - deliberately excluded from equality ordering and hash)
+{
+  // ModificationsDB::searchModification() requires a full operator== match and gates
+  // addNewModification_ - the NO-DEDUP inserter - reached from Residue::setModification and the
+  // AASequence setters. If the mark were compared, a caller holding a copy whose mark differs from
+  // the stored entry's would miss and insert a SECOND entry under the same FullId, after which
+  // findModificationIndex() throws "More than one modification with name".
+  ResidueModification a;
+  a.setId("TestProvenanceMod");
+  a.setFullId("TestProvenanceMod (K)");
+  a.setOrigin('K');
+  a.setDiffMonoMass(42.0);
+
+  ResidueModification b(a);
+  a.setProvenance(ResidueModification::CV);
+  b.setProvenance(ResidueModification::MASS_ONLY);
+
+  TEST_TRUE(a == b)
+  TEST_FALSE(a != b)
+  TEST_FALSE(a < b)
+  TEST_FALSE(b < a)
+
+  std::hash<ResidueModification> hasher;
+  TEST_EQUAL(hasher(a), hasher(b))
+
+  // ... but the mark itself is still carried, and survives a copy.
+  TEST_EQUAL(a.getProvenance(), ResidueModification::CV)
+  ResidueModification c(a);
+  TEST_EQUAL(c.getProvenance(), ResidueModification::CV)
+}
+END_SECTION
+
 END_TEST


### PR DESCRIPTION
Second step of #10003, independent of #10026 — both branch off `develop` and neither needs the other.

**Nothing reads the mark yet.** This only records it. Opened as a draft until the full suite finishes (it is an ABI change, so everything has to be rebuilt) and until #10026 has had a human look.

## Why

Writing an identification file another process can read back requires knowing which modifications are *not* in `ModificationsDB` and therefore have to travel with their definition. Nothing on `ResidueModification` says that today.

```cpp
enum Provenance {
  DEFINED = 0,  // registered by a tool, or restored from a file's definition block -- must be serialised
  CV,           // from a vocabulary shipped with OpenMS (unimod.xml, custom_mods.xml, PSI-MOD.obo, XLMOD.obo)
  MASS_ONLY,    // anonymous: reconstructible from its own serialised form, so it needs no definition
  NUMBER_OF_PROVENANCE
};
```

## Why marked, not inferred

`ModificationsDB` is a process-global singleton that accumulates every definition a process has ever loaded, so "everything beyond the startup baseline" is a property of **process history**, not of the data — a tool reading many identification files (ProteomicsLFQ reads N idXML) would attribute the first file's definitions to an output that never references them. A mark carried on the modification survives read → register → write → read.

## Why not an existing predicate

- `SourceClassification` records *biological* origin (artefact, natural, post-translational, …) and says nothing about where the description came from. No algorithm branches on it.
- `isUserDefined()` means *"anonymous — identified only by a mass string"* and guards the origin-`X` matching rule in `ModificationsDB::residuesMatch_`. It is also false for exactly the modifications that need serialising, since registering one *with* an `Id` is what makes it resolvable by name.

## The one decision worth reviewing

**The mark is deliberately absent from `operator==`, `operator<` and `std::hash`**, with the reason recorded above `operator==`. `ModificationsDB::searchModification()` requires a full `operator==` match and gates `addNewModification_` — the **no-dedup** inserter — reached from `Residue::setModification` and the `AASequence` setters. Were the mark compared, a caller holding a copy whose mark differs from the stored entry's would miss and insert a *second* entry under the same `FullId`, after which `findModificationIndex()` throws *"More than one modification with name"*.

The default is `DEFINED`, also on purpose: over-emitting a definition is a no-op on read (the dedup returns the existing entry), whereas under-emitting silently produces a file that cannot be read back. A missed stamp site fails in the harmless direction.

## Stamp sites

`CV` where the Unimod and OBO providers hand out entries; `MASS_ONLY` in the three `createUnknownFromMassString` branches and the three mzIdentML unknown-mass registrations; explicitly `DEFINED` for NuXL's runtime fragment adducts, which are invented at run time and named — the case a definition collector must pick up.

## Three drive-by fixes

In files this already touches. Happy to split them out if you would rather review them separately:

- `ModificationsDB::addModification(const&)` allocated its copy **before** the duplicate check and, on the duplicate path, reassigned the return pointer to the existing entry — leaking it. Now owned by a `unique_ptr` until stored.
- `ModificationsDB::getModification(Size)` read `mods_` **without** the `critical(OpenMS_ModificationsDB)` section every other accessor takes, racing a concurrent `addModification()` whose `push_back` can reallocate the vector.
- `MzIdentMLDOMHandler`'s C-terminal branch guarded on `residue_name` (`.[mod]`) but registered under `residue_id` (`.c[mod]`), so the guard never matched what it created and every occurrence re-entered `addModification` and logged a duplicate warning. The N-terminal branch above it already used `residue_id`.

## Testing

Two new sections in `ResidueModification_test.cpp`: the default and the values the creation paths set, and that the mark does not affect equality, ordering or hashing while still being carried across a copy. The exclusion assertion was verified non-vacuous by temporarily adding `provenance_` to `operator==` and confirming it fails on exactly those lines.

## ⚠ ABI

This grows `sizeof(ResidueModification)`, so the **`pyopenms` target must be rebuilt, not just `libOpenMS`** — a binding compiled against the old header reads the wrong object layout. Building this exposed the same hazard in C++: a stale test binary run against the new library aborted with `*** stack smashing detected ***` in an unrelated section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provenance information for residue modifications, distinguishing defined, controlled-vocabulary, and mass-only modifications.
  * Exposed provenance accessors and enum values through the Python API.
  * Automatically records provenance when loading or creating modifications.
  * Improved parsing of modification masses, formulas, and neutral-loss information.

* **Bug Fixes**
  * Improved reliability when accessing and registering modifications.
  * Prevented memory leaks and duplicate-registration warnings during modification handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->