### PR TITLE
[FEATURE] Modification definition records: serialise, register and collect tool-defined modifications (#10003)

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
@@ -170,27 +170,18 @@ public:
     const ResidueModification* addModification(const ResidueModification& new_mod) const;
 
     /**
-       @brief Register a modification definition read from a file (or supplied by a tool).
+       @brief Register a modification definition read from a file or supplied by a tool.
 
-       Policy: the same FullId is the same modification, and the first definition wins. Re-reading a
-       file in one process is therefore idempotent and silent. If an entry with this FullId already
-       exists but describes different chemistry (different diff formula, or diff mono masses more than
-       1e-6 Da apart), a warning is logged and the existing entry is kept - that is the one signal a
-       producer gets that two tools used one name for two things, so it is not downgraded to debug.
+       The same FullId is the same modification: the first definition wins, re-registration is silent,
+       and a different chemistry under an existing FullId logs a warning and keeps the existing entry.
+       The stored copy is marked Provenance::DEFINED.
 
-       The stored copy is marked Provenance::DEFINED regardless of the input's mark.
-
-       @return the ModificationsDB entry for this FullId (the pre-existing one if already present).
-       @throws Exception::MissingInformation if the definition has no Id.
+       @return the entry for this FullId (the pre-existing one if already present)
+       @throws Exception::MissingInformation if the definition has no Id
     */
     const ResidueModification* registerDefinition(const ResidueModification& definition) const;
 
-    /**
-       @brief Is @p name (an Id, FullId or FullName) registered with Provenance::DEFINED?
-
-       This is the question a reader asks before trusting a name found in a file: has()/searchModifications*
-       answer "is it known at all", which is also true for every shipped vocabulary entry.
-    */
+    /// Is @p name (an Id, FullId or FullName) registered with Provenance::DEFINED? Unlike has(), false for vocabulary entries.
     bool hasDefinedModification(const std::string& name) const;
 
     /**

--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
@@ -170,6 +170,30 @@ public:
     const ResidueModification* addModification(const ResidueModification& new_mod) const;
 
     /**
+       @brief Register a modification definition read from a file (or supplied by a tool).
+
+       Policy: the same FullId is the same modification, and the first definition wins. Re-reading a
+       file in one process is therefore idempotent and silent. If an entry with this FullId already
+       exists but describes different chemistry (different diff formula, or diff mono masses more than
+       1e-6 Da apart), a warning is logged and the existing entry is kept - that is the one signal a
+       producer gets that two tools used one name for two things, so it is not downgraded to debug.
+
+       The stored copy is marked Provenance::DEFINED regardless of the input's mark.
+
+       @return the ModificationsDB entry for this FullId (the pre-existing one if already present).
+       @throws Exception::MissingInformation if the definition has no Id.
+    */
+    const ResidueModification* registerDefinition(const ResidueModification& definition) const;
+
+    /**
+       @brief Is @p name (an Id, FullId or FullName) registered with Provenance::DEFINED?
+
+       This is the question a reader asks before trusting a name found in a file: has()/searchModifications*
+       answer "is it known at all", which is also true for every shipped vocabulary entry.
+    */
+    bool hasDefinedModification(const std::string& name) const;
+
+    /**
        @brief Returns the index of the modification in the mods_ vector; a unique name must be given
 
        return numeric_limits<Size>::max() if not exactly one matching modification was found

--- a/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
@@ -407,30 +407,17 @@ public:
 
     /** @name Definition records
 
-      A definition record is the portable description of a modification that is NOT in the shipped
-      vocabularies, so that a file carrying a peptidoform such as `AEADNLDDK(NuXL:U-H2O)K` can be read by
-      a process which never saw the tool that invented `NuXL:U-H2O`. One record describes exactly one
-      ModificationsDB entry, i.e. one (Id, origin, term specificity) triple; a name used on several
-      residues is several records.
+      Portable description of a modification that is not in the shipped vocabularies, so that a file
+      naming it can be read by another process. One record per ModificationsDB entry, i.e. per
+      (Id, origin, term specificity).
 
-      Format (version 1), fields separated by '|', records by ';', each field escaped with '\\' for
-      '\\', '|' and ';':
+      Version 1; fields separated by '|', records by ';', '\\' escapes '\\', '|' and ';':
       @code
       1|Id|FullId|FullName|origin|term_spec|diff_formula|diff_mono_mass|diff_average_mass|neutral_loss_formulas
       @endcode
-      - Id is the resolution key and is required.
-      - FullId is the ModificationsDB dedup key; it is derivable from Id, origin and term_spec but
-        carried so the round trip is exact.
-      - term_spec uses the names of getTermSpecificityName(): none, N-term, C-term, Protein N-term,
-        Protein C-term.
-      - diff_mono_mass is carried even when diff_formula is present: setDiffFormula() does not derive it.
-      - neutral_loss_formulas is a ','-joined list of empirical formulas and may be empty. It is part
-        of the record because Residue::setModification copies the losses onto the residue and the
-        theoretical spectrum generator consumes them there.
-      - The absolute masses are deliberately NOT carried: Residue::setModification takes getMonoMass()
-        as the residue's absolute weight when non-zero, and that value is per-residue.
-      Unknown versions and trailing extra fields are the reader's business: skip the record, ignore the
-      fields.
+      Id is required; term_spec uses the names of getTermSpecificityName(); neutral_loss_formulas is a
+      ','-joined list and may be empty. Absolute masses are not carried (they are per residue).
+      Readers ignore trailing extra fields.
     */
     //@{
     /// Serialise this modification as a version-1 definition record. @throws Exception::MissingInformation if Id is empty.

--- a/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
@@ -405,6 +405,45 @@ public:
     /// return a string of the form '[&gt;mass&lt;]
     static std::string getMonoMassWithBracket(const double mono_mass);
 
+    /** @name Definition records
+
+      A definition record is the portable description of a modification that is NOT in the shipped
+      vocabularies, so that a file carrying a peptidoform such as `AEADNLDDK(NuXL:U-H2O)K` can be read by
+      a process which never saw the tool that invented `NuXL:U-H2O`. One record describes exactly one
+      ModificationsDB entry, i.e. one (Id, origin, term specificity) triple; a name used on several
+      residues is several records.
+
+      Format (version 1), fields separated by '|', records by ';', each field escaped with '\\' for
+      '\\', '|' and ';':
+      @code
+      1|Id|FullId|FullName|origin|term_spec|diff_formula|diff_mono_mass|diff_average_mass|neutral_loss_formulas
+      @endcode
+      - Id is the resolution key and is required.
+      - FullId is the ModificationsDB dedup key; it is derivable from Id, origin and term_spec but
+        carried so the round trip is exact.
+      - term_spec uses the names of getTermSpecificityName(): none, N-term, C-term, Protein N-term,
+        Protein C-term.
+      - diff_mono_mass is carried even when diff_formula is present: setDiffFormula() does not derive it.
+      - neutral_loss_formulas is a ','-joined list of empirical formulas and may be empty. It is part
+        of the record because Residue::setModification copies the losses onto the residue and the
+        theoretical spectrum generator consumes them there.
+      - The absolute masses are deliberately NOT carried: Residue::setModification takes getMonoMass()
+        as the residue's absolute weight when non-zero, and that value is per-residue.
+      Unknown versions and trailing extra fields are the reader's business: skip the record, ignore the
+      fields.
+    */
+    //@{
+    /// Serialise this modification as a version-1 definition record. @throws Exception::MissingInformation if Id is empty.
+    std::string toDefinitionString() const;
+
+    /// Parse a definition record. Does not touch ModificationsDB; provenance of the result is DEFINED.
+    /// @throws Exception::ParseError on a malformed record or an unsupported version.
+    static ResidueModification fromDefinitionString(const std::string& record);
+
+    /// Split a ';'-joined sequence of records, honouring '\\' escapes. Empty input yields no records.
+    static std::vector<std::string> splitDefinitionRecords(const std::string& records);
+    //@}
+
 protected:
     std::string id_;
 

--- a/src/openms/include/OpenMS/CONCEPT/Constants.h
+++ b/src/openms/include/OpenMS/CONCEPT/Constants.h
@@ -678,6 +678,14 @@ namespace OpenMS
               String
       */
       inline const std::string   NUM_PEAKS = "num_peaks";
+
+      /** SearchParameters meta value carrying the definitions of modifications that are not in the
+          shipped vocabularies, so a file naming them can be read by another process.
+              String: ';'-joined ResidueModification definition records (see
+              ResidueModification::toDefinitionString). Deliberately a single string and not a
+              stringList - the .idparquet meta-value codec splits lists on ',' without escaping.
+      */
+      inline const std::string   MODIFICATION_DEFINITIONS = "modification_definitions";
     }
 
     //@}

--- a/src/openms/include/OpenMS/CONCEPT/Constants.h
+++ b/src/openms/include/OpenMS/CONCEPT/Constants.h
@@ -679,11 +679,9 @@ namespace OpenMS
       */
       inline const std::string   NUM_PEAKS = "num_peaks";
 
-      /** SearchParameters meta value carrying the definitions of modifications that are not in the
-          shipped vocabularies, so a file naming them can be read by another process.
-              String: ';'-joined ResidueModification definition records (see
-              ResidueModification::toDefinitionString). Deliberately a single string and not a
-              stringList - the .idparquet meta-value codec splits lists on ',' without escaping.
+      /** SearchParameters meta value carrying the definitions of modifications not in the shipped vocabularies.
+              String: ';'-joined ResidueModification definition records. A single string, not a
+              stringList: the parquet meta-value codec splits lists on ',' without escaping.
       */
       inline const std::string   MODIFICATION_DEFINITIONS = "modification_definitions";
     }

--- a/src/openms/include/OpenMS/FORMAT/ModificationDefinitionIO.h
+++ b/src/openms/include/OpenMS/FORMAT/ModificationDefinitionIO.h
@@ -26,22 +26,10 @@ namespace OpenMS
   /**
     @brief Collect, serialise and re-register the definitions of tool-defined modifications.
 
-    A modification that is not in the shipped vocabularies (a run-time adduct, a custom search space)
-    can be written into an identification file only by name, and no other process can resolve that
-    name. This class carries the definitions alongside the identifications, as the
-    Constants::UserParam::MODIFICATION_DEFINITIONS meta value on ProteinIdentification::SearchParameters
-    - the one structure that idXML, featureXML, consensusXML and .idparquet all already serialise, so no
-    format needs a schema change.
-
-    Writers call collect() + attach() (or encode()); readers call registerFrom() as soon as the
-    SearchParameters are available and BEFORE any peptide sequence is parsed, because
-    AASequence::fromString throws on an unknown name.
-
-    What is serialised is decided per modification by isDefinition(): provenance DEFINED and a
-    non-empty Id. It is deliberately not "everything in ModificationsDB beyond the startup baseline":
-    the database is process-global and accumulates every definition a process has ever loaded, so a
-    tool reading many files would otherwise attribute the first file's definitions to an output that
-    never references them.
+    The definitions travel as the Constants::UserParam::MODIFICATION_DEFINITIONS meta value on
+    ProteinIdentification::SearchParameters, which idXML, featureXML, consensusXML and .idparquet all
+    serialise. Writers call collect() + attach(); readers call registerFrom() before parsing any
+    peptide sequence. isDefinition() selects what is serialised: provenance DEFINED and a non-empty Id.
 
     @ingroup FileIO
   */
@@ -52,12 +40,10 @@ namespace OpenMS
     static bool isDefinition(const ResidueModification* mod);
 
     /**
-      @brief Walk the identifications and collect, per run identifier, the definitions they reference.
+      @brief Collect, per run identifier, the definitions the identifications reference.
 
-      Looks at every hit's N-terminal, residue and C-terminal modifications, plus the names in each
-      run's fixed_modifications / variable_modifications (so a defined variable modification that
-      happens to occur in no hit keeps its definition). O(hits). Runs referencing no definition do not
-      appear in the result.
+      Covers every hit's terminal and residue modifications plus each run's fixed/variable modification
+      names. Runs referencing no definition do not appear.
     */
     static std::map<std::string, std::set<const ResidueModification*>> collect(
       const std::vector<ProteinIdentification>& protein_ids,
@@ -66,22 +52,13 @@ namespace OpenMS
     /// Serialise @p defs into one ';'-joined string. Deterministic: records are sorted.
     static std::string encode(const std::set<const ResidueModification*>& defs);
 
-    /**
-      @brief Store @p defs on @p sp under Constants::UserParam::MODIFICATION_DEFINITIONS.
-
-      Unions with whatever the meta value already holds rather than overwriting it, so a filter tool
-      that drops every hit of a defined modification does not silently drop its definition too.
-      A no-op when @p defs is empty and nothing was stored before.
-    */
+    /// Store @p defs on @p sp under Constants::UserParam::MODIFICATION_DEFINITIONS, unioned with
+    /// what the meta value already holds. No-op when there is nothing to store.
     static void attach(ProteinIdentification::SearchParameters& sp,
                        const std::set<const ResidueModification*>& defs);
 
-    /**
-      @brief Register every record in @p records into ModificationsDB.
-
-      A malformed record is logged and skipped - a bad definition degrades to "unresolvable name", the
-      pre-existing behaviour, and must not abort the whole file. @return the number of records registered.
-    */
+    /// Register every record in @p records into ModificationsDB; a malformed record is logged and
+    /// skipped. @return the number of records registered
     static Size registerFrom(const std::string& records);
 
     /// Convenience: registerFrom() on the meta value of @p sp, if present. @return records registered.

--- a/src/openms/include/OpenMS/FORMAT/ModificationDefinitionIO.h
+++ b/src/openms/include/OpenMS/FORMAT/ModificationDefinitionIO.h
@@ -1,0 +1,90 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/config.h>
+
+#include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/METADATA/PeptideIdentificationList.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace OpenMS
+{
+  class ResidueModification;
+
+  /**
+    @brief Collect, serialise and re-register the definitions of tool-defined modifications.
+
+    A modification that is not in the shipped vocabularies (a run-time adduct, a custom search space)
+    can be written into an identification file only by name, and no other process can resolve that
+    name. This class carries the definitions alongside the identifications, as the
+    Constants::UserParam::MODIFICATION_DEFINITIONS meta value on ProteinIdentification::SearchParameters
+    - the one structure that idXML, featureXML, consensusXML and .idparquet all already serialise, so no
+    format needs a schema change.
+
+    Writers call collect() + attach() (or encode()); readers call registerFrom() as soon as the
+    SearchParameters are available and BEFORE any peptide sequence is parsed, because
+    AASequence::fromString throws on an unknown name.
+
+    What is serialised is decided per modification by isDefinition(): provenance DEFINED and a
+    non-empty Id. It is deliberately not "everything in ModificationsDB beyond the startup baseline":
+    the database is process-global and accumulates every definition a process has ever loaded, so a
+    tool reading many files would otherwise attribute the first file's definitions to an output that
+    never references them.
+
+    @ingroup FileIO
+  */
+  class OPENMS_DLLAPI ModificationDefinitionIO
+  {
+  public:
+    /// The selection predicate: a named modification whose definition must travel with the file.
+    static bool isDefinition(const ResidueModification* mod);
+
+    /**
+      @brief Walk the identifications and collect, per run identifier, the definitions they reference.
+
+      Looks at every hit's N-terminal, residue and C-terminal modifications, plus the names in each
+      run's fixed_modifications / variable_modifications (so a defined variable modification that
+      happens to occur in no hit keeps its definition). O(hits). Runs referencing no definition do not
+      appear in the result.
+    */
+    static std::map<std::string, std::set<const ResidueModification*>> collect(
+      const std::vector<ProteinIdentification>& protein_ids,
+      const PeptideIdentificationList& peptide_ids);
+
+    /// Serialise @p defs into one ';'-joined string. Deterministic: records are sorted.
+    static std::string encode(const std::set<const ResidueModification*>& defs);
+
+    /**
+      @brief Store @p defs on @p sp under Constants::UserParam::MODIFICATION_DEFINITIONS.
+
+      Unions with whatever the meta value already holds rather than overwriting it, so a filter tool
+      that drops every hit of a defined modification does not silently drop its definition too.
+      A no-op when @p defs is empty and nothing was stored before.
+    */
+    static void attach(ProteinIdentification::SearchParameters& sp,
+                       const std::set<const ResidueModification*>& defs);
+
+    /**
+      @brief Register every record in @p records into ModificationsDB.
+
+      A malformed record is logged and skipped - a bad definition degrades to "unresolvable name", the
+      pre-existing behaviour, and must not abort the whole file. @return the number of records registered.
+    */
+    static Size registerFrom(const std::string& records);
+
+    /// Convenience: registerFrom() on the meta value of @p sp, if present. @return records registered.
+    static Size registerFrom(const ProteinIdentification::SearchParameters& sp);
+  };
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/FORMAT/sources.cmake
+++ b/src/openms/include/OpenMS/FORMAT/sources.cmake
@@ -137,6 +137,7 @@ list(APPEND sources_list_h ProteinIdentificationArrowIO.h)
 list(APPEND sources_list_h FeatureMapArrowIO.h)
 list(APPEND sources_list_h ConsensusMapArrowIO.h)
 list(APPEND sources_list_h PSMArrowIO.h)
+list(APPEND sources_list_h ModificationDefinitionIO.h)
 
 if (WITH_OPENTIMS)
   list(APPEND sources_list_h BrukerTimsFile.h)

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -19,6 +19,7 @@
 #include <OpenMS/CHEMISTRY/UnimodXMLDataProvider.h>
 #include <OpenMS/CHEMISTRY/OBODataProvider.h>
 
+#include <cmath>
 #include <fstream>
 #include <limits>
 #include <utility>
@@ -543,6 +544,67 @@ namespace OpenMS
     return ret;
   }
 
+  namespace
+  {
+    bool sameChemistry_(const ResidueModification& a, const ResidueModification& b)
+    {
+      if (!a.getDiffFormula().isEmpty() && !b.getDiffFormula().isEmpty())
+      {
+        return a.getDiffFormula() == b.getDiffFormula();
+      }
+      return std::fabs(a.getDiffMonoMass() - b.getDiffMonoMass()) <= 1e-6;
+    }
+  } // namespace
+
+  const ResidueModification* ModificationsDB::registerDefinition(const ResidueModification& definition) const
+  {
+    if (definition.getId().empty())
+    {
+      throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "Cannot register a modification definition without an Id.");
+    }
+    // Do NOT wrap the calls below in a critical section of our own: has(), searchModificationsFast()
+    // and addModification() each take critical(OpenMS_ModificationsDB), and OpenMP critical regions
+    // with the same name are not reentrant. The check-then-add race is benign - addModification
+    // re-checks the FullId under its lock and returns the existing entry to the loser.
+    if (has(definition.getFullId()))
+    {
+      bool multiple_matches = false;
+      const ResidueModification* existing = searchModificationsFast(definition.getFullId(), multiple_matches);
+      if (existing != nullptr)
+      {
+        if (!sameChemistry_(*existing, definition))
+        {
+          OPENMS_LOG_WARN << "Modification definition '" << definition.getFullId()
+                          << "' disagrees with the one already registered (registered: "
+                          << existing->getDiffFormula().toString() << " / " << existing->getDiffMonoMass()
+                          << " Da; new: " << definition.getDiffFormula().toString() << " / "
+                          << definition.getDiffMonoMass() << " Da). Keeping the registered one." << std::endl;
+        }
+        return existing;
+      }
+    }
+    std::unique_ptr<ResidueModification> copy(new ResidueModification(definition));
+    copy->setProvenance(ResidueModification::DEFINED);
+    return addModification(std::move(copy));
+  }
+
+  bool ModificationsDB::hasDefinedModification(const std::string& name) const
+  {
+    bool found = false;
+    #pragma omp critical(OpenMS_ModificationsDB)
+    {
+      auto it = modification_names_.find(name);
+      if (it != modification_names_.end())
+      {
+        for (const ResidueModification* m : it->second)
+        {
+          if (m->getProvenance() == ResidueModification::DEFINED) { found = true; break; }
+        }
+      }
+    }
+    return found;
+  }
   const ResidueModification* ModificationsDB::addNewModification_(const ResidueModification& new_mod) const
   {
     const ResidueModification* ret = new ResidueModification(new_mod);

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -546,11 +546,12 @@ namespace OpenMS
 
   namespace
   {
+    // the mono mass is compared even when the formulas agree: it is what a modified residue weighs
     bool sameChemistry_(const ResidueModification& a, const ResidueModification& b)
     {
-      if (!a.getDiffFormula().isEmpty() && !b.getDiffFormula().isEmpty())
+      if (!a.getDiffFormula().isEmpty() && !b.getDiffFormula().isEmpty() && a.getDiffFormula() != b.getDiffFormula())
       {
-        return a.getDiffFormula() == b.getDiffFormula();
+        return false;
       }
       return std::fabs(a.getDiffMonoMass() - b.getDiffMonoMass()) <= 1e-6;
     }

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -563,10 +563,8 @@ namespace OpenMS
       throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
         "Cannot register a modification definition without an Id.");
     }
-    // Do NOT wrap the calls below in a critical section of our own: has(), searchModificationsFast()
-    // and addModification() each take critical(OpenMS_ModificationsDB), and OpenMP critical regions
-    // with the same name are not reentrant. The check-then-add race is benign - addModification
-    // re-checks the FullId under its lock and returns the existing entry to the loser.
+    // no critical section here: has(), searchModificationsFast() and addModification() each take the
+    // (non-reentrant) OpenMS_ModificationsDB critical; addModification re-checks the FullId under it
     if (has(definition.getFullId()))
     {
       bool multiple_matches = false;

--- a/src/openms/source/CHEMISTRY/ResidueModification.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueModification.cpp
@@ -799,7 +799,12 @@ namespace OpenMS
     {
       char buf[64];
       const auto res = std::to_chars(buf, buf + sizeof(buf), d); // shortest exact round trip
-      return (res.ec == std::errc()) ? std::string(buf, res.ptr) : std::string("0");
+      if (res.ec != std::errc())
+      {
+        throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                         "Cannot write the mass " + std::to_string(d) + " into a modification definition record");
+      }
+      return std::string(buf, res.ptr);
     }
 
     double recordToDouble_(const std::string& field, const std::string& record)
@@ -887,13 +892,19 @@ namespace OpenMS
     if (f.size() > 9 && !f[9].empty())
     {
       std::vector<EmpiricalFormula> losses;
+      std::vector<double> loss_mono, loss_avg;
       std::stringstream ss(f[9]);
       std::string item;
       while (std::getline(ss, item, ','))
       {
-        if (!item.empty()) losses.emplace_back(item);
+        if (item.empty()) continue;
+        losses.emplace_back(item);
+        loss_mono.push_back(losses.back().getMonoWeight());
+        loss_avg.push_back(losses.back().getAverageWeight());
       }
       mod.setNeutralLossDiffFormulas(losses);
+      mod.setNeutralLossMonoMasses(loss_mono); // the record carries formulas only; keep the object consistent
+      mod.setNeutralLossAverageMasses(loss_avg);
     }
 
     // the record's FullId is authoritative (dedup key) but should agree with the derived one

--- a/src/openms/source/CHEMISTRY/ResidueModification.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueModification.cpp
@@ -894,8 +894,7 @@ namespace OpenMS
       mod.setNeutralLossDiffFormulas(losses);
     }
 
-    // The FullId from the record is authoritative (it is the dedup key), but it must agree with what
-    // Id + site would derive; a disagreement means the producer wrote an inconsistent record.
+    // the record's FullId is authoritative (dedup key) but should agree with the derived one
     ResidueModification derived(mod);
     derived.setFullId();
     if (f[2].empty())
@@ -920,8 +919,7 @@ namespace OpenMS
   {
     if (records.empty()) return {};
     std::vector<std::string> out;
-    // Split on unescaped ';' WITHOUT unescaping: each record is unescaped field-wise by
-    // fromDefinitionString, which needs to see the '|' escapes intact.
+    // split on unescaped ';' without unescaping; fromDefinitionString needs the escapes intact
     std::string cur;
     for (std::size_t i = 0; i < records.size(); ++i)
     {

--- a/src/openms/source/CHEMISTRY/ResidueModification.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueModification.cpp
@@ -14,9 +14,12 @@
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 
+#include <charconv>
 #include <cmath>
 #include <iostream>
+#include <sstream>
 #include <utility>
+#include <vector>
 
 using namespace std;
 
@@ -751,6 +754,195 @@ namespace OpenMS
                                                        residue);
 
     return mod_sum;
+  }
+
+  namespace
+  {
+    // Escape a definition-record field: the three characters that have structural meaning.
+    std::string escapeField_(const std::string& in)
+    {
+      std::string out;
+      out.reserve(in.size());
+      for (const char c : in)
+      {
+        if (c == '\\' || c == '|' || c == ';') out += '\\';
+        out += c;
+      }
+      return out;
+    }
+
+    // Split on an unescaped separator, unescaping as we go. A trailing lone backslash is kept literally.
+    std::vector<std::string> splitEscaped_(const std::string& in, const char sep)
+    {
+      std::vector<std::string> parts(1);
+      for (std::size_t i = 0; i < in.size(); ++i)
+      {
+        const char c = in[i];
+        if (c == '\\' && i + 1 < in.size())
+        {
+          parts.back() += in[++i];
+        }
+        else if (c == sep)
+        {
+          parts.emplace_back();
+        }
+        else
+        {
+          parts.back() += c;
+        }
+      }
+      return parts;
+    }
+
+    std::string doubleToRecord_(const double d)
+    {
+      char buf[64];
+      const auto res = std::to_chars(buf, buf + sizeof(buf), d); // shortest exact round trip
+      return (res.ec == std::errc()) ? std::string(buf, res.ptr) : std::string("0");
+    }
+
+    double recordToDouble_(const std::string& field, const std::string& record)
+    {
+      if (field.empty()) return 0.0;
+      double d = 0.0;
+      const auto res = std::from_chars(field.data(), field.data() + field.size(), d);
+      if (res.ec != std::errc() || res.ptr != field.data() + field.size())
+      {
+        throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, record,
+                                    "Modification definition record has a malformed number: '" + field + "'");
+      }
+      return d;
+    }
+  } // namespace
+
+  std::string ResidueModification::toDefinitionString() const
+  {
+    if (id_.empty())
+    {
+      throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "Cannot write a definition record for a modification without an Id: resolution goes through the name.");
+    }
+    std::string losses;
+    for (const EmpiricalFormula& f : neutral_loss_diff_formulas_)
+    {
+      if (!losses.empty()) losses += ',';
+      losses += f.toString();
+    }
+    const std::string fields[] = {
+      "1",
+      id_,
+      full_id_,
+      full_name_,
+      std::string(1, origin_),
+      getTermSpecificityName(term_spec_),
+      diff_formula_.isEmpty() ? std::string() : diff_formula_.toString(),
+      doubleToRecord_(diff_mono_mass_),
+      doubleToRecord_(diff_average_mass_),
+      losses
+    };
+    std::string out;
+    for (const std::string& f : fields)
+    {
+      if (!out.empty()) out += '|';
+      out += escapeField_(f);
+    }
+    return out;
+  }
+
+  ResidueModification ResidueModification::fromDefinitionString(const std::string& record)
+  {
+    const std::vector<std::string> f = splitEscaped_(record, '|');
+    // version | Id | FullId | FullName | origin | term_spec | diff_formula | diff_mono | diff_avg [| losses [| ...]]
+    if (f.size() < 9)
+    {
+      throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, record,
+                                  "Modification definition record has " + std::to_string(f.size()) + " fields, expected at least 9");
+    }
+    if (f[0] != "1")
+    {
+      throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, record,
+                                  "Unsupported modification definition record version '" + f[0] + "'");
+    }
+    if (f[1].empty())
+    {
+      throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, record,
+                                  "Modification definition record has an empty Id");
+    }
+    if (f[4].size() != 1)
+    {
+      throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, record,
+                                  "Modification definition record origin must be a single residue letter, got '" + f[4] + "'");
+    }
+
+    ResidueModification mod;
+    mod.setId(f[1]);
+    mod.setFullName(f[3]);
+    mod.setTermSpecificity(f[5]); // throws InvalidValue on an unknown name
+    mod.setOrigin(f[4][0]);       // throws InvalidValue on a non-residue letter
+    if (!f[6].empty()) mod.setDiffFormula(EmpiricalFormula(f[6]));
+    mod.setDiffMonoMass(recordToDouble_(f[7], record));
+    mod.setDiffAverageMass(recordToDouble_(f[8], record));
+    if (f.size() > 9 && !f[9].empty())
+    {
+      std::vector<EmpiricalFormula> losses;
+      std::stringstream ss(f[9]);
+      std::string item;
+      while (std::getline(ss, item, ','))
+      {
+        if (!item.empty()) losses.emplace_back(item);
+      }
+      mod.setNeutralLossDiffFormulas(losses);
+    }
+
+    // The FullId from the record is authoritative (it is the dedup key), but it must agree with what
+    // Id + site would derive; a disagreement means the producer wrote an inconsistent record.
+    ResidueModification derived(mod);
+    derived.setFullId();
+    if (f[2].empty())
+    {
+      mod.setFullId(derived.getFullId());
+    }
+    else
+    {
+      mod.setFullId(f[2]);
+      if (f[2] != derived.getFullId())
+      {
+        OPENMS_LOG_WARN << "Modification definition '" << f[1] << "': FullId '" << f[2]
+                        << "' does not match the one derived from its site ('" << derived.getFullId()
+                        << "'); keeping the record's." << std::endl;
+      }
+    }
+    mod.setProvenance(DEFINED);
+    return mod;
+  }
+
+  std::vector<std::string> ResidueModification::splitDefinitionRecords(const std::string& records)
+  {
+    if (records.empty()) return {};
+    std::vector<std::string> out;
+    // Split on unescaped ';' WITHOUT unescaping: each record is unescaped field-wise by
+    // fromDefinitionString, which needs to see the '|' escapes intact.
+    std::string cur;
+    for (std::size_t i = 0; i < records.size(); ++i)
+    {
+      const char c = records[i];
+      if (c == '\\' && i + 1 < records.size())
+      {
+        cur += c;
+        cur += records[++i];
+      }
+      else if (c == ';')
+      {
+        if (!cur.empty()) out.push_back(cur);
+        cur.clear();
+      }
+      else
+      {
+        cur += c;
+      }
+    }
+    if (!cur.empty()) out.push_back(cur);
+    return out;
   }
 
   std::string ResidueModification::toString() const

--- a/src/openms/source/CHEMISTRY/ResidueModification.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueModification.cpp
@@ -13,6 +13,7 @@
 #include <OpenMS/CHEMISTRY/Residue.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/DATASTRUCTURES/StringUtils.h>
 
 #include <charconv>
 #include <cmath>
@@ -804,14 +805,15 @@ namespace OpenMS
     double recordToDouble_(const std::string& field, const std::string& record)
     {
       if (field.empty()) return 0.0;
-      double d = 0.0;
-      const auto res = std::from_chars(field.data(), field.data() + field.size(), d);
-      if (res.ec != std::errc() || res.ptr != field.data() + field.size())
+      try
+      {
+        return StringUtils::toDouble(field); // libc++ has no floating-point std::from_chars
+      }
+      catch (const Exception::ConversionError&)
       {
         throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, record,
                                     "Modification definition record has a malformed number: '" + field + "'");
       }
-      return d;
     }
   } // namespace
 

--- a/src/openms/source/FORMAT/ModificationDefinitionIO.cpp
+++ b/src/openms/source/FORMAT/ModificationDefinitionIO.cpp
@@ -21,8 +21,7 @@ namespace OpenMS
 {
   bool ModificationDefinitionIO::isDefinition(const ResidueModification* mod)
   {
-    // The Id guard prunes anything mass-shift-shaped that merely inherited the DEFINED default:
-    // those are reconstructible from their own bracket and have no name to serialise anyway.
+    // the Id guard excludes anonymous mass shifts that merely inherited the DEFINED default
     return mod != nullptr && mod->getProvenance() == ResidueModification::DEFINED && !mod->getId().empty();
   }
 
@@ -78,8 +77,7 @@ namespace OpenMS
 
   std::string ModificationDefinitionIO::encode(const std::set<const ResidueModification*>& defs)
   {
-    // A set of pointers has no stable order across processes; sort the records so the same
-    // definitions always produce the same bytes.
+    // sorted, so the same definitions always produce the same bytes
     std::vector<std::string> records;
     records.reserve(defs.size());
     for (const ResidueModification* mod : defs)

--- a/src/openms/source/FORMAT/ModificationDefinitionIO.cpp
+++ b/src/openms/source/FORMAT/ModificationDefinitionIO.cpp
@@ -40,10 +40,13 @@ namespace OpenMS
       {
         for (const std::string& name : *names)
         {
-          if (!db->has(name)) continue; // has() is silent; searchModificationsFast logs on a miss
-          bool multiple_matches = false;
-          const ResidueModification* mod = db->searchModificationsFast(name, multiple_matches);
-          if (isDefinition(mod)) out[prot.getIdentifier()].insert(mod);
+          if (!db->has(name)) continue; // has() is silent; searchModifications logs on a miss
+          std::set<const ResidueModification*> matches; // a bare Id names every site it is defined on
+          db->searchModifications(matches, name);
+          for (const ResidueModification* mod : matches)
+          {
+            if (isDefinition(mod)) out[prot.getIdentifier()].insert(mod);
+          }
         }
       }
     }

--- a/src/openms/source/FORMAT/ModificationDefinitionIO.cpp
+++ b/src/openms/source/FORMAT/ModificationDefinitionIO.cpp
@@ -1,0 +1,151 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/FORMAT/ModificationDefinitionIO.h>
+
+#include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CHEMISTRY/ModificationsDB.h>
+#include <OpenMS/CHEMISTRY/ResidueModification.h>
+#include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+
+#include <algorithm>
+
+namespace OpenMS
+{
+  bool ModificationDefinitionIO::isDefinition(const ResidueModification* mod)
+  {
+    // The Id guard prunes anything mass-shift-shaped that merely inherited the DEFINED default:
+    // those are reconstructible from their own bracket and have no name to serialise anyway.
+    return mod != nullptr && mod->getProvenance() == ResidueModification::DEFINED && !mod->getId().empty();
+  }
+
+  std::map<std::string, std::set<const ResidueModification*>> ModificationDefinitionIO::collect(
+    const std::vector<ProteinIdentification>& protein_ids,
+    const PeptideIdentificationList& peptide_ids)
+  {
+    std::map<std::string, std::set<const ResidueModification*>> out;
+    const ModificationsDB* db = ModificationsDB::getInstance();
+
+    // Definitions named by the search space, whether or not any hit carries them.
+    for (const ProteinIdentification& prot : protein_ids)
+    {
+      const ProteinIdentification::SearchParameters& sp = prot.getSearchParameters();
+      for (const std::vector<std::string>* names : {&sp.fixed_modifications, &sp.variable_modifications})
+      {
+        for (const std::string& name : *names)
+        {
+          if (!db->has(name)) continue; // has() is silent; searchModificationsFast logs on a miss
+          bool multiple_matches = false;
+          const ResidueModification* mod = db->searchModificationsFast(name, multiple_matches);
+          if (isDefinition(mod)) out[prot.getIdentifier()].insert(mod);
+        }
+      }
+    }
+
+    // Definitions actually sitting on peptidoforms.
+    for (const PeptideIdentification& pep : peptide_ids)
+    {
+      const std::string& run = pep.getIdentifier();
+      for (const PeptideHit& hit : pep.getHits())
+      {
+        const AASequence& seq = hit.getSequence();
+        if (seq.hasNTerminalModification() && isDefinition(seq.getNTerminalModification()))
+        {
+          out[run].insert(seq.getNTerminalModification());
+        }
+        for (Size i = 0; i < seq.size(); ++i)
+        {
+          if (seq[i].isModified() && isDefinition(seq[i].getModification()))
+          {
+            out[run].insert(seq[i].getModification());
+          }
+        }
+        if (seq.hasCTerminalModification() && isDefinition(seq.getCTerminalModification()))
+        {
+          out[run].insert(seq.getCTerminalModification());
+        }
+      }
+    }
+    return out;
+  }
+
+  std::string ModificationDefinitionIO::encode(const std::set<const ResidueModification*>& defs)
+  {
+    // A set of pointers has no stable order across processes; sort the records so the same
+    // definitions always produce the same bytes.
+    std::vector<std::string> records;
+    records.reserve(defs.size());
+    for (const ResidueModification* mod : defs)
+    {
+      records.push_back(mod->toDefinitionString());
+    }
+    std::sort(records.begin(), records.end());
+    std::string out;
+    for (const std::string& r : records)
+    {
+      if (!out.empty()) out += ';';
+      out += r;
+    }
+    return out;
+  }
+
+  void ModificationDefinitionIO::attach(ProteinIdentification::SearchParameters& sp,
+                                        const std::set<const ResidueModification*>& defs)
+  {
+    const std::string& key = Constants::UserParam::MODIFICATION_DEFINITIONS;
+    std::set<std::string> records;
+    if (sp.metaValueExists(key))
+    {
+      for (const std::string& r : ResidueModification::splitDefinitionRecords(sp.getMetaValue(key).toString()))
+      {
+        records.insert(r);
+      }
+    }
+    for (const ResidueModification* mod : defs)
+    {
+      records.insert(mod->toDefinitionString());
+    }
+    if (records.empty()) return;
+    std::string out;
+    for (const std::string& r : records) // std::set iterates sorted: deterministic
+    {
+      if (!out.empty()) out += ';';
+      out += r;
+    }
+    sp.setMetaValue(key, out);
+  }
+
+  Size ModificationDefinitionIO::registerFrom(const std::string& records)
+  {
+    const ModificationsDB* db = ModificationsDB::getInstance();
+    Size n = 0;
+    for (const std::string& record : ResidueModification::splitDefinitionRecords(records))
+    {
+      try
+      {
+        db->registerDefinition(ResidueModification::fromDefinitionString(record));
+        ++n;
+      }
+      catch (const Exception::BaseException& e)
+      {
+        OPENMS_LOG_WARN << "Skipping an unreadable modification definition record (" << e.getMessage()
+                        << "): '" << record << "'" << std::endl;
+      }
+    }
+    return n;
+  }
+
+  Size ModificationDefinitionIO::registerFrom(const ProteinIdentification::SearchParameters& sp)
+  {
+    const std::string& key = Constants::UserParam::MODIFICATION_DEFINITIONS;
+    if (!sp.metaValueExists(key)) return 0;
+    return registerFrom(sp.getMetaValue(key).toString());
+  }
+} // namespace OpenMS

--- a/src/openms/source/FORMAT/sources.cmake
+++ b/src/openms/source/FORMAT/sources.cmake
@@ -129,6 +129,7 @@ list(APPEND sources_list ProteinIdentificationArrowIO.cpp)
 list(APPEND sources_list FeatureMapArrowIO.cpp)
 list(APPEND sources_list ConsensusMapArrowIO.cpp)
 list(APPEND sources_list PSMArrowIO.cpp)
+list(APPEND sources_list ModificationDefinitionIO.cpp)
 list(APPEND sources_list ArrowSchemaRegistry.cpp)
 list(APPEND sources_list ArrowIOHelpers.cpp)
 

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -348,6 +348,7 @@ list(APPEND format_executables_list Arrow_test MSExperimentArrowExport_test Cons
   FeatureMapArrowIO_test
   ConsensusMapArrowIO_test
   PSMArrowIO_test
+  ModificationDefinitionIO_test
   ArrowSchemaRegistry_test
   ArrowIOHelpers_test
   ParquetTableComparator_test)

--- a/src/tests/class_tests/openms/source/ModificationDefinitionIO_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationDefinitionIO_test.cpp
@@ -88,6 +88,22 @@ START_SECTION([EXTRA] collect - only the DEFINED named modifications a run refer
   {
     TEST_FALSE(m->getId() == "Oxidation")
   }
+
+  // a bare Id in the search parameters names every site it is defined on
+  const ResidueModification* on_k = define("TestIO:TwoSites", 'K', "C2H2O");
+  const ResidueModification* on_y = define("TestIO:TwoSites", 'Y', "C2H2O");
+  TEST_TRUE(on_k != nullptr && on_y != nullptr && on_k != on_y)
+  ProteinIdentification two;
+  two.setIdentifier("run3");
+  ProteinIdentification::SearchParameters sp_two;
+  sp_two.variable_modifications.push_back("TestIO:TwoSites");
+  two.setSearchParameters(sp_two);
+  std::vector<ProteinIdentification> prots_two;
+  prots_two.push_back(two);
+  auto defs_two = ModificationDefinitionIO::collect(prots_two, PeptideIdentificationList());
+  TEST_EQUAL(defs_two["run3"].size(), 2)
+  TEST_EQUAL(defs_two["run3"].count(on_k), 1)
+  TEST_EQUAL(defs_two["run3"].count(on_y), 1)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ModificationDefinitionIO_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationDefinitionIO_test.cpp
@@ -1,0 +1,181 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+#include <OpenMS/FORMAT/ModificationDefinitionIO.h>
+///////////////////////////
+
+#include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
+#include <OpenMS/CHEMISTRY/ModificationsDB.h>
+#include <OpenMS/CHEMISTRY/ResidueModification.h>
+#include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
+
+using namespace OpenMS;
+using namespace std;
+
+namespace
+{
+  // A defined modification with a formula, registered under a test-only namespace. ModificationsDB is
+  // a process-wide singleton, so every section uses its own names.
+  const ResidueModification* define(const std::string& id, char origin, const std::string& formula)
+  {
+    ResidueModification d;
+    d.setId(id);
+    d.setOrigin(origin);
+    d.setTermSpecificity(ResidueModification::ANYWHERE);
+    d.setFullId();
+    d.setDiffFormula(EmpiricalFormula(formula));
+    d.setDiffMonoMass(EmpiricalFormula(formula).getMonoWeight());
+    return ModificationsDB::getInstance()->registerDefinition(d);
+  }
+}
+
+START_TEST(ModificationDefinitionIO, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+START_SECTION([EXTRA] collect - only the DEFINED named modifications a run references)
+{
+  const ResidueModification* adduct = define("TestIO:Adduct", 'K', "C9H11N2O8P");
+  const ResidueModification* var_only = define("TestIO:VarOnly", 'S', "HPO3");
+  TEST_TRUE(adduct != nullptr)
+  TEST_TRUE(var_only != nullptr)
+
+  ProteinIdentification prot;
+  prot.setIdentifier("run1");
+  ProteinIdentification::SearchParameters sp;
+  sp.variable_modifications.push_back("Oxidation (M)");       // CV: must NOT be collected
+  sp.variable_modifications.push_back("TestIO:VarOnly (S)");  // defined, but on no hit: MUST be collected
+  prot.setSearchParameters(sp);
+
+  PeptideIdentification pep;
+  pep.setIdentifier("run1");
+  PeptideHit hit;
+  hit.setSequence(AASequence::fromString("PEPTK(TestIO:Adduct)M(Oxidation)IDE"));
+  pep.insertHit(hit);
+
+  // a second run that references nothing must not appear at all
+  ProteinIdentification other;
+  other.setIdentifier("run2");
+
+  std::vector<ProteinIdentification> prots;
+  prots.push_back(prot);
+  prots.push_back(other);
+  PeptideIdentificationList peps;
+  peps.push_back(pep);
+
+  auto defs = ModificationDefinitionIO::collect(prots, peps);
+  TEST_EQUAL(defs.size(), 1)
+  TEST_EQUAL(defs.count("run1"), 1)
+  TEST_EQUAL(defs.count("run2"), 0)
+
+  const std::set<const ResidueModification*>& run_defs = defs["run1"];
+  TEST_EQUAL(run_defs.size(), 2)
+  TEST_EQUAL(run_defs.count(adduct), 1)
+  TEST_EQUAL(run_defs.count(var_only), 1)
+  for (const ResidueModification* m : run_defs)
+  {
+    TEST_FALSE(m->getId() == "Oxidation")
+  }
+}
+END_SECTION
+
+START_SECTION([EXTRA] encode - deterministic bytes for the same definitions)
+{
+  const ResidueModification* a = define("TestIO:EncA", 'K', "C2H2O");
+  const ResidueModification* b = define("TestIO:EncB", 'K', "CH2");
+  std::set<const ResidueModification*> defs;
+  defs.insert(a);
+  defs.insert(b);
+
+  const std::string once = ModificationDefinitionIO::encode(defs);
+  const std::string twice = ModificationDefinitionIO::encode(defs);
+  TEST_EQUAL(once, twice)
+  TEST_TRUE(once.find("TestIO:EncA") != std::string::npos)
+  TEST_TRUE(once.find("TestIO:EncB") != std::string::npos)
+
+  std::vector<std::string> records = ResidueModification::splitDefinitionRecords(once);
+  TEST_EQUAL(records.size(), 2)
+  TEST_TRUE(records[0] < records[1]) // sorted
+  TEST_EQUAL(ModificationDefinitionIO::encode(std::set<const ResidueModification*>()), "")
+}
+END_SECTION
+
+START_SECTION([EXTRA] attach - unions with what is already stored and never duplicates)
+{
+  const ResidueModification* a = define("TestIO:AttA", 'K', "C2H2O");
+  const ResidueModification* b = define("TestIO:AttB", 'R', "C2H2O");
+  const std::string& key = Constants::UserParam::MODIFICATION_DEFINITIONS;
+
+  ProteinIdentification::SearchParameters sp;
+  ModificationDefinitionIO::attach(sp, std::set<const ResidueModification*>());
+  TEST_FALSE(sp.metaValueExists(key)) // nothing to say, nothing written
+
+  std::set<const ResidueModification*> only_a;
+  only_a.insert(a);
+  ModificationDefinitionIO::attach(sp, only_a);
+  TEST_TRUE(sp.metaValueExists(key))
+  const std::string v1 = sp.getMetaValue(key).toString();
+  TEST_EQUAL(ResidueModification::splitDefinitionRecords(v1).size(), 1)
+
+  // attaching the same thing again changes nothing
+  ModificationDefinitionIO::attach(sp, only_a);
+  TEST_EQUAL(sp.getMetaValue(key).toString(), v1)
+
+  // attaching something new keeps what was there
+  std::set<const ResidueModification*> only_b;
+  only_b.insert(b);
+  ModificationDefinitionIO::attach(sp, only_b);
+  const std::string v2 = sp.getMetaValue(key).toString();
+  TEST_EQUAL(ResidueModification::splitDefinitionRecords(v2).size(), 2)
+  TEST_TRUE(v2.find("TestIO:AttA") != std::string::npos)
+  TEST_TRUE(v2.find("TestIO:AttB") != std::string::npos)
+}
+END_SECTION
+
+START_SECTION([EXTRA] registerFrom - registers the good records and skips a bad one loudly)
+{
+  const ModificationsDB* db = ModificationsDB::getInstance();
+  // Build the records by hand so this section does not depend on define() having registered them.
+  ResidueModification d;
+  d.setId("TestIO:FromBlob");
+  d.setOrigin('K');
+  d.setTermSpecificity(ResidueModification::ANYWHERE);
+  d.setFullId();
+  d.setDiffFormula(EmpiricalFormula("C9H11N2O8P"));
+  d.setDiffMonoMass(EmpiricalFormula("C9H11N2O8P").getMonoWeight());
+  TEST_FALSE(db->hasDefinedModification("TestIO:FromBlob"))
+
+  const std::string blob = d.toDefinitionString() + ";this is not a record;" + d.toDefinitionString();
+  Size n = ModificationDefinitionIO::registerFrom(blob);
+  TEST_EQUAL(n, 2) // the duplicate is registered idempotently, the garbage is skipped
+  TEST_TRUE(db->hasDefinedModification("TestIO:FromBlob"))
+
+  // ... and a peptide naming it now resolves, with the right chemistry
+  AASequence seq = AASequence::fromString("AEADNLDDK(TestIO:FromBlob)K");
+  TEST_REAL_SIMILAR(seq.getMonoWeight(), 1423.5504442334)
+  TEST_EQUAL(seq.getFormula(Residue::Full, 0).toString(), "C54H86N15O28P1")
+
+  // the SearchParameters overload
+  ProteinIdentification::SearchParameters sp;
+  TEST_EQUAL(ModificationDefinitionIO::registerFrom(sp), 0)
+  sp.setMetaValue(Constants::UserParam::MODIFICATION_DEFINITIONS, d.toDefinitionString());
+  TEST_EQUAL(ModificationDefinitionIO::registerFrom(sp), 1)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST

--- a/src/tests/class_tests/openms/source/ModificationDefinitionIO_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationDefinitionIO_test.cpp
@@ -26,8 +26,7 @@ using namespace std;
 
 namespace
 {
-  // A defined modification with a formula, registered under a test-only namespace. ModificationsDB is
-  // a process-wide singleton, so every section uses its own names.
+  // ModificationsDB is a process-wide singleton, so every section uses its own names
   const ResidueModification* define(const std::string& id, char origin, const std::string& formula)
   {
     ResidueModification d;

--- a/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
@@ -11,7 +11,12 @@
 
 ///////////////////////////
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
+#include <OpenMS/CHEMISTRY/ResidueModification.h>
 #include <limits>
+#include <sstream>
 #include <algorithm>
 ///////////////////////////
 
@@ -369,6 +374,104 @@ START_SECTION([EXTRA] multithreaded example)
   TEST_EQUAL(test, nr_iterations*1.0)
 
  }
+END_SECTION
+
+START_SECTION([EXTRA] registerDefinition - same name is the same modification and re-registration is idempotent)
+{
+  const ModificationsDB* db = ModificationsDB::getInstance();
+  ResidueModification d;
+  d.setId("TestDef:Idem");
+  d.setOrigin('K');
+  d.setTermSpecificity(ResidueModification::ANYWHERE);
+  d.setFullId();
+  d.setDiffFormula(EmpiricalFormula("C2H2O"));
+  d.setDiffMonoMass(EmpiricalFormula("C2H2O").getMonoWeight());
+
+  const Size before = db->getNumberOfModifications();
+  const ResidueModification* first = db->registerDefinition(d);
+  TEST_TRUE(first != nullptr)
+  TEST_EQUAL(db->getNumberOfModifications(), before + 1)
+  if (first != nullptr)
+  {
+    TEST_EQUAL(first->getProvenance(), ResidueModification::DEFINED)
+  }
+
+  // Re-registration must be SILENT: addModification() logs "already exists" on its duplicate path,
+  // and registerDefinition's has() pre-check exists precisely so that re-reading a file does not
+  // emit that once per definition.
+  std::ostringstream captured;
+  OPENMS_LOG_WARN.insert(captured);
+  const ResidueModification* second = db->registerDefinition(d);
+  OPENMS_LOG_WARN.remove(captured);
+  TEST_TRUE(first == second)
+  TEST_EQUAL(db->getNumberOfModifications(), before + 1)
+  TEST_TRUE(captured.str().find("already exists") == std::string::npos)
+  TEST_TRUE(captured.str().find("disagrees") == std::string::npos)
+
+  TEST_TRUE(db->hasDefinedModification("TestDef:Idem"))
+  TEST_TRUE(db->hasDefinedModification("TestDef:Idem (K)"))
+  TEST_FALSE(db->hasDefinedModification("Oxidation"))
+  TEST_FALSE(db->hasDefinedModification("Oxidation (M)"))
+  TEST_FALSE(db->hasDefinedModification("TestDef:NeverRegistered"))
+
+  // the same FullId with different chemistry keeps the first definition
+  ResidueModification conflict(d);
+  conflict.setDiffFormula(EmpiricalFormula("C3H2O"));
+  conflict.setDiffMonoMass(EmpiricalFormula("C3H2O").getMonoWeight());
+  std::ostringstream conflict_log;
+  OPENMS_LOG_WARN.insert(conflict_log);
+  const ResidueModification* kept = db->registerDefinition(conflict);
+  OPENMS_LOG_WARN.remove(conflict_log);
+  TEST_TRUE(kept == first)
+  TEST_TRUE(conflict_log.str().find("disagrees") != std::string::npos) // ... but a real conflict is loud
+  if (kept != nullptr)
+  {
+    TEST_EQUAL(kept->getDiffFormula().toString(), EmpiricalFormula("C2H2O").toString())
+  }
+  TEST_EQUAL(db->getNumberOfModifications(), before + 1)
+
+  ResidueModification nameless;
+  TEST_EXCEPTION(Exception::MissingInformation, db->registerDefinition(nameless))
+}
+END_SECTION
+
+START_SECTION([EXTRA] registerDefinition - one name on two residues is two entries that resolve at their own site)
+{
+  const ModificationsDB* db = ModificationsDB::getInstance();
+  const double delta = EmpiricalFormula("C2H2O").getMonoWeight();
+  const Size before = db->getNumberOfModifications();
+  for (const char origin : {'K', 'Y'})
+  {
+    ResidueModification d;
+    d.setId("TestDef:TwoSites");
+    d.setOrigin(origin);
+    d.setTermSpecificity(ResidueModification::ANYWHERE);
+    d.setFullId();
+    d.setDiffFormula(EmpiricalFormula("C2H2O"));
+    d.setDiffMonoMass(delta);
+    TEST_TRUE(db->registerDefinition(d) != nullptr)
+  }
+  TEST_EQUAL(db->getNumberOfModifications(), before + 2)
+
+  const ResidueModification* on_k = db->getModification("TestDef:TwoSites", "K", ResidueModification::ANYWHERE);
+  const ResidueModification* on_y = db->getModification("TestDef:TwoSites", "Y", ResidueModification::ANYWHERE);
+  TEST_TRUE(on_k != nullptr)
+  TEST_TRUE(on_y != nullptr)
+  TEST_TRUE(on_k != on_y)
+  if (on_k != nullptr && on_y != nullptr)
+  {
+    TEST_EQUAL(on_k->getOrigin(), 'K')
+    TEST_EQUAL(on_y->getOrigin(), 'Y')
+    TEST_EQUAL(on_k->getFullId(), "TestDef:TwoSites (K)")
+    TEST_EQUAL(on_y->getFullId(), "TestDef:TwoSites (Y)")
+  }
+
+  // The sequence round trip that catches the origin-'X' trap: the residue letter must survive.
+  AASequence seq = AASequence::fromString("PEPTK(TestDef:TwoSites)IDY(TestDef:TwoSites)E");
+  TEST_EQUAL(seq.toString(), "PEPTK(TestDef:TwoSites)IDY(TestDef:TwoSites)E")
+  TEST_TRUE(AASequence::fromString(seq.toString()) == seq)
+  TEST_REAL_SIMILAR(seq.getMonoWeight(), AASequence::fromString("PEPTKIDYE").getMonoWeight() + 2.0 * delta)
+}
 END_SECTION
 
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
@@ -396,9 +396,7 @@ START_SECTION([EXTRA] registerDefinition - same name is the same modification an
     TEST_EQUAL(first->getProvenance(), ResidueModification::DEFINED)
   }
 
-  // Re-registration must be SILENT: addModification() logs "already exists" on its duplicate path,
-  // and registerDefinition's has() pre-check exists precisely so that re-reading a file does not
-  // emit that once per definition.
+  // re-registration must be silent (no "already exists" from addModification's duplicate path)
   std::ostringstream captured;
   OPENMS_LOG_WARN.insert(captured);
   const ResidueModification* second = db->registerDefinition(d);

--- a/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
@@ -428,6 +428,17 @@ START_SECTION([EXTRA] registerDefinition - same name is the same modification an
   }
   TEST_EQUAL(db->getNumberOfModifications(), before + 1)
 
+  // the same formula with a different mono mass is a conflict too: the mono mass is what a residue weighs
+  ResidueModification mass_conflict(d);
+  mass_conflict.setDiffMonoMass(d.getDiffMonoMass() + 0.001);
+  std::ostringstream mass_log;
+  OPENMS_LOG_WARN.insert(mass_log);
+  const ResidueModification* kept_mass = db->registerDefinition(mass_conflict);
+  OPENMS_LOG_WARN.remove(mass_log);
+  TEST_TRUE(kept_mass == first)
+  TEST_TRUE(mass_log.str().find("disagrees") != std::string::npos)
+  TEST_EQUAL(db->getNumberOfModifications(), before + 1)
+
   ResidueModification nameless;
   TEST_EXCEPTION(Exception::MissingInformation, db->registerDefinition(nameless))
 }

--- a/src/tests/class_tests/openms/source/ResidueModification_test.cpp
+++ b/src/tests/class_tests/openms/source/ResidueModification_test.cpp
@@ -729,6 +729,15 @@ START_SECTION([EXTRA] definition record - round trip preserves every carried fie
   TEST_TRUE(back.getDiffAverageMass() == m.getDiffAverageMass())
   TEST_EQUAL(back.getNeutralLossDiffFormulas().size(), 2)
   TEST_TRUE(back.hasNeutralLoss())
+  // the record carries loss formulas only; the loss masses are derived from them on read
+  TEST_EQUAL(back.getNeutralLossMonoMasses().size(), 2)
+  TEST_EQUAL(back.getNeutralLossAverageMasses().size(), 2)
+  if (back.getNeutralLossMonoMasses().size() == 2 && back.getNeutralLossAverageMasses().size() == 2)
+  {
+    TEST_REAL_SIMILAR(back.getNeutralLossMonoMasses()[0], EmpiricalFormula("H3PO4").getMonoWeight())
+    TEST_REAL_SIMILAR(back.getNeutralLossMonoMasses()[1], EmpiricalFormula("H2O").getMonoWeight())
+    TEST_REAL_SIMILAR(back.getNeutralLossAverageMasses()[1], EmpiricalFormula("H2O").getAverageWeight())
+  }
   TEST_EQUAL(back.getProvenance(), ResidueModification::DEFINED)
   TEST_EQUAL(back.toDefinitionString(), rec) // stable under re-serialisation
 

--- a/src/tests/class_tests/openms/source/ResidueModification_test.cpp
+++ b/src/tests/class_tests/openms/source/ResidueModification_test.cpp
@@ -16,6 +16,7 @@
 #include <OpenMS/CHEMISTRY/ResidueModification.h>
 #include <OpenMS/CHEMISTRY/Residue.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
+#include <OpenMS/CONCEPT/Exception.h>
 
 #include <unordered_set>
 #include <unordered_map>
@@ -696,6 +697,79 @@ START_SECTION([EXTRA] Provenance - deliberately excluded from equality ordering 
   TEST_EQUAL(a.getProvenance(), ResidueModification::CV)
   ResidueModification c(a);
   TEST_EQUAL(c.getProvenance(), ResidueModification::CV)
+}
+END_SECTION
+
+START_SECTION([EXTRA] definition record - round trip preserves every carried field)
+{
+  ResidueModification m;
+  m.setId("TestDef:RoundTrip");
+  m.setFullName("a|b;c\\d"); // every structural character, to exercise the escaping
+  m.setOrigin('K');
+  m.setTermSpecificity(ResidueModification::ANYWHERE);
+  m.setFullId();
+  m.setDiffFormula(EmpiricalFormula("C9H11N2O8P"));
+  m.setDiffMonoMass(306.025304840900048);
+  m.setDiffAverageMass(306.16);
+  std::vector<EmpiricalFormula> losses;
+  losses.emplace_back("H3PO4");
+  losses.emplace_back("H2O");
+  m.setNeutralLossDiffFormulas(losses);
+
+  const std::string rec = m.toDefinitionString();
+  ResidueModification back = ResidueModification::fromDefinitionString(rec);
+
+  TEST_EQUAL(back.getId(), m.getId())
+  TEST_EQUAL(back.getFullId(), m.getFullId())
+  TEST_EQUAL(back.getFullName(), m.getFullName())
+  TEST_EQUAL(back.getOrigin(), 'K')
+  TEST_EQUAL(back.getTermSpecificity(), ResidueModification::ANYWHERE)
+  TEST_EQUAL(back.getDiffFormula().toString(), m.getDiffFormula().toString())
+  TEST_TRUE(back.getDiffMonoMass() == m.getDiffMonoMass())       // bit-exact, not TEST_REAL_SIMILAR
+  TEST_TRUE(back.getDiffAverageMass() == m.getDiffAverageMass())
+  TEST_EQUAL(back.getNeutralLossDiffFormulas().size(), 2)
+  TEST_TRUE(back.hasNeutralLoss())
+  TEST_EQUAL(back.getProvenance(), ResidueModification::DEFINED)
+  TEST_EQUAL(back.toDefinitionString(), rec) // stable under re-serialisation
+
+  // records containing escaped ';' survive the record splitter intact
+  std::vector<std::string> recs = ResidueModification::splitDefinitionRecords(rec + ";" + rec);
+  TEST_EQUAL(recs.size(), 2)
+  TEST_EQUAL(recs[0], rec)
+  TEST_EQUAL(ResidueModification::splitDefinitionRecords("").size(), 0)
+
+  // a terminal modification keeps its specificity and site
+  ResidueModification t;
+  t.setId("TestDef:NTerm");
+  t.setTermSpecificity(ResidueModification::N_TERM);
+  t.setFullId();
+  t.setDiffMonoMass(42.010565);
+  ResidueModification tback = ResidueModification::fromDefinitionString(t.toDefinitionString());
+  TEST_EQUAL(tback.getTermSpecificity(), ResidueModification::N_TERM)
+  TEST_EQUAL(tback.getFullId(), "TestDef:NTerm (N-term)")
+  TEST_EQUAL(tback.getOrigin(), 'X')
+}
+END_SECTION
+
+START_SECTION([EXTRA] definition record - malformed input is rejected loudly)
+{
+  ResidueModification nameless;
+  TEST_EXCEPTION(Exception::MissingInformation, nameless.toDefinitionString())
+
+  // unsupported version, too few fields, empty Id, malformed number
+  TEST_EXCEPTION(Exception::ParseError, ResidueModification::fromDefinitionString("2|X|X (K)||K|none|O|15.99|15.99|"))
+  TEST_EXCEPTION(Exception::ParseError, ResidueModification::fromDefinitionString("1|X|X (K)||K"))
+  TEST_EXCEPTION(Exception::ParseError, ResidueModification::fromDefinitionString("1||X (K)||K|none|O|15.99|15.99|"))
+  TEST_EXCEPTION(Exception::ParseError, ResidueModification::fromDefinitionString("1|X|X (K)||K|none|O|abc|15.99|"))
+
+  // forward compatibility: an extra trailing field is ignored, not an error
+  ResidueModification ok = ResidueModification::fromDefinitionString("1|TestDef:Fwd|TestDef:Fwd (K)||K|none|O|15.994915|15.9994||future");
+  TEST_EQUAL(ok.getId(), "TestDef:Fwd")
+  TEST_EQUAL(ok.getDiffFormula().toString(), EmpiricalFormula("O").toString())
+
+  // a FullId omitted from the record is derived from Id and site
+  ResidueModification derived = ResidueModification::fromDefinitionString("1|TestDef:Der|||K|none|O|15.994915|15.9994|");
+  TEST_EQUAL(derived.getFullId(), "TestDef:Der (K)")
 }
 END_SECTION
 


### PR DESCRIPTION
Third step of #10003, on top of #10040 (the provenance mark, merged; it needs `getProvenance()`). No file format is touched yet — this is the record, its registration policy, and the collector; PR 4 wires it into idXML, featureXML, consensusXML and `.idparquet`.

## The record

```
1|Id|FullId|FullName|origin|term_spec|diff_formula|diff_mono_mass|diff_average_mass|neutral_loss_formulas
```

One record is one `ModificationsDB` entry — one (Id, origin, term specificity) triple — because that is how the database is keyed: `addModification` dedups on `FullId`, and `setFullId()` derives `FullId` from exactly those three. A name used on several residues is several records.

**Is a single name sufficient as the identity?** Yes, with two qualifications the record encodes and one boundary:

1. The use site supplies the rest — `K(NuXL:U-H2O)` gives the origin via the residue letter and the term spec via position, and `searchModificationsFast` filters the name's entries by both. But the **origin in the record must be the real residue**: `ResidueDB::getModifiedResidue`'s origin check is `OPENMS_PRECONDITION` (debug-only), so in release a record with origin `X` attaches silently and `toString()` writes `X(NuXL:U-H2O)`.
2. Name-as-identity is only safe under the namespacing convention (`NuXL:U-H2O`, not `U-H2O`), which a format cannot enforce — so the **chemistry fields are what make it safe**: same `FullId` + different chemistry is the only detectable collision.
3. Boundary: sufficient for the four formats in scope. Not for mzIdentML (`MS:1001460 unknown modification` for anything without a UniMod accession) or mzTab (`CHEMMOD:<mass>`) — the name never reaches those files regardless. Out of scope; stated so nobody expects this to cover them.

**Every field kept or dropped for a verified reason** (details in the commit message): `Name` is not carried — not a lookup key, nothing reads it; `FullId` is derivable but carried for an exact round trip; `diff_mono_mass` is carried even with a formula because `setDiffFormula()` does not derive it; **`neutral_loss_formulas` was added to the settled six-field list** because `Residue::setModification` copies losses onto the residue and the theoretical spectrum generator consumes them there — without it a defined modification generates a different spectrum after a round trip; the absolute masses are deliberately *not* carried because `Residue::setModification` takes `getMonoMass()` as a per-residue absolute weight.

## Registration policy

`ModificationsDB::registerDefinition`: same `FullId` = same modification, first wins. Re-reading a file in one process is idempotent **and silent** — a `has()` pre-check stops `addModification`'s duplicate warning firing once per definition per file. A genuine conflict (different formula, or masses > 1e-6 Da apart) keeps the first and logs at **WARN**, not debug — two tools using one name for two things is something the user should see. `hasDefinedModification()` is the question a reader asks before trusting a name in a file; `has()` is also true for every shipped vocabulary entry.

It deliberately takes no critical section of its own: `has()`, `searchModificationsFast()` and `addModification()` each take `critical(OpenMS_ModificationsDB)`, and same-name OpenMP critical regions are not reentrant.

## Why one `string`, not a `stringList`

The carrier is a single `SearchParameters` meta value, `modification_definitions`. idXML would tolerate a `stringList` (`writeUserParam_` escapes `,` → `\|`), but `.idparquet` would not: `DataValue::toString()` for a list is the plain vector streamer with **no escaping**, and `ArrowIOHelpers::readMetaValues` reads it back with an unconditional split on `,` plus trimming. There is no unescape step to make it safe. A `string` is verbatim on all four lanes, which is the only reason one encoder can serve them all. Precedent: `extra_features` is a comma-joined `string` for the same reason.

## Layering

`ModificationDefinitionIO` lives in FORMAT because CHEMISTRY cannot depend on METADATA; every writer call site and `OpenNuXL.cpp` already include FORMAT. `attach()` **unions** with what is already stored, so a filter tool that drops every hit of a modification does not silently drop its definition too. `encode()` sorts — a set of pointers has no stable order across processes.

## Testing

Round trip including escaping of every structural character, bit-exact doubles and neutral losses; every malformed-record rejection; forward compatibility with a trailing extra field; silent idempotent re-registration (log captured and asserted empty) versus a loud conflict; one name on two residues resolving at each site and surviving `AASequence::fromString(seq.toString())` — the assertion that catches the origin-`X` trap; and the collector picking up a defined modification from a hit and one from the search space while leaving Oxidation out.

Each of those behaviours was verified to **fail under a targeted mutation** (pre-check removed → duplicate warning appears; losses dropped from the record; provenance ignored by the collector → Oxidation collected; conflict check disabled → no warning), then restored and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Update:** rebased onto `develop` after #10040 (the copy of #10027) merged; a fix commit replaces the floating-point `std::from_chars` in the record reader with `StringUtils::toDouble`, because libc++ on the macOS lanes has no such overload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for defining and registering custom residue modifications.
  * Added serialization and parsing of modification definition records, including escaped values and validation.
  * Added utilities to collect, encode, attach, and restore custom modifications through search metadata.
  * Custom modifications are preserved across runs and can be resolved by supported names.

* **Bug Fixes**
  * Prevented duplicate registrations and conflicting chemistry from overwriting existing definitions.
  * Improved chemistry comparisons using formulas and mass tolerances.
  * Malformed metadata records are skipped safely during restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->