### PR TITLE
[FIX] UnimodXMLHandler: stop folding <Ignore> into the diff formula, and read a <NeutralLoss>'s own masses

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1313,6 +1313,14 @@ Fixes:
     assay library) were wrong for peptides carrying them, while the mass-based API stayed correct. Element
     collection is now scoped to <delta> and <NeutralLoss>, and a regression test asserts that diff formula
     and diff mono mass agree for every UniMod entry (fixes #10030)
+  - Fix: UnimodXMLHandler never read a <NeutralLoss>'s own mono_mass/avge_mass attributes -- it pushed the
+    <delta> masses instead, and since <specificity> (which encloses <NeutralLoss>) always precedes <delta>,
+    every neutral loss mono and average mass in ModificationsDB was 0 (871 modifications), while the
+    neutral loss formulas themselves were correct. Those mass vectors were also written to the
+    modification once per <specificity> rather than per site, so the last site's vector was copied over
+    all sites and could not even match the per-site formula vector in length. Both are now parsed and
+    stored per site, and a regression test asserts that neutral loss formulas, mono masses and average
+    masses line up for every UniMod entry (fixes #10030)
 
 Documentation:
   - Comprehensive documentation for the Targeted Quantitation algorithms (#8588)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1306,6 +1306,13 @@ Fixes:
     unpacked with preserved pre-2020 timestamps. The test now brackets the wall clock around a
     temporary file it writes and checks itself, which no longer depends on how the tree was unpacked
     while still catching the bug the original bounds guarded against (#10018)
+  - Fix: UnimodXMLHandler folded the <element> children of a modification's <Ignore> blocks into its diff
+    formula. ICAT-D (UNIMOD:13) and ICAT-D:2H(8) (UNIMOD:12) -- the only unimod.xml entries carrying such
+    blocks -- therefore loaded with a diff formula about 2250 Da heavier than their diff mass, so
+    AASequence::getFormula() and every isotope pattern derived from it (e.g. FeatureFinderIdentification's
+    assay library) were wrong for peptides carrying them, while the mass-based API stayed correct. Element
+    collection is now scoped to <delta> and <NeutralLoss>, and a regression test asserts that diff formula
+    and diff mono mass agree for every UniMod entry (fixes #10030)
 
 Documentation:
   - Comprehensive documentation for the Targeted Quantitation algorithms (#8588)

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/UnimodXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/UnimodXMLHandler.h
@@ -64,10 +64,17 @@ private:
 
       std::vector<EmpiricalFormula> neutral_loss_diff_formula_;
 
+      /// masses of the \<NeutralLoss\> currently open; the \<delta\> masses live in #mono_mass_ / #avge_mass_
+      double neutral_loss_mono_mass_{0.0};
+      double neutral_loss_avge_mass_{0.0};
+
       bool was_valid_peptide_modification_;
       std::vector<std::vector<EmpiricalFormula>> neutral_loss_diff_formulas_;
       std::vector<double> neutral_loss_mono_masses_;
       std::vector<double> neutral_loss_avg_masses_;
+      /// one entry per specificity, parallel to #neutral_loss_diff_formulas_
+      std::vector<std::vector<double>> neutral_loss_mono_masses_all_;
+      std::vector<std::vector<double>> neutral_loss_avg_masses_all_;
 
       ResidueModification* modification_;
 

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/UnimodXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/UnimodXMLHandler.h
@@ -51,6 +51,17 @@ private:
 
       EmpiricalFormula diff_formula_;
 
+      /**
+          @brief Whether \<element\> children currently contribute to #diff_formula_
+
+          Only \<delta\> (the composition of the modification itself) and \<NeutralLoss\> (the
+          composition of a neutral loss) describe the chemistry of the modification. \<Ignore\>
+          (reagent fragments a search must not consider), \<aa\> and \<brick\> carry
+          \<element\> children as well, and folding those into the formula would leave it
+          inconsistent with the recorded delta mass.
+      */
+      bool collect_elements_{false};
+
       std::vector<EmpiricalFormula> neutral_loss_diff_formula_;
 
       bool was_valid_peptide_modification_;

--- a/src/openms/source/FORMAT/HANDLERS/UnimodXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/UnimodXMLHandler.cpp
@@ -108,6 +108,8 @@ namespace OpenMS::Internal
       {
         // mono_mass="97.976896" avge_mass="97.9952" flag="false"
         //                               composition="H(3) O(4) P">
+        neutral_loss_mono_mass_ = attributeAsDouble_(attributes, "mono_mass");
+        neutral_loss_avge_mass_ = attributeAsDouble_(attributes, "avge_mass");
         collect_elements_ = true;
         return;
       }
@@ -171,6 +173,8 @@ namespace OpenMS::Internal
           new_mod->setOrigin(sites_[i]);
           new_mod->setTermSpecificity(term_specs_[i]);
           new_mod->setNeutralLossDiffFormulas(neutral_loss_diff_formulas_[i]);
+          new_mod->setNeutralLossMonoMasses(neutral_loss_mono_masses_all_[i]);
+          new_mod->setNeutralLossAverageMasses(neutral_loss_avg_masses_all_[i]);
           modifications_.push_back(new_mod);
         }
 
@@ -181,6 +185,8 @@ namespace OpenMS::Internal
         term_specs_.clear();
         sites_.clear();
         neutral_loss_diff_formulas_.clear();
+        neutral_loss_mono_masses_all_.clear();
+        neutral_loss_avg_masses_all_.clear();
 
         delete modification_;
         return;
@@ -191,8 +197,8 @@ namespace OpenMS::Internal
         if (was_valid_peptide_modification_) // as we exclude "Protein" modifications (see above)
         {
           neutral_loss_diff_formulas_.push_back(neutral_loss_diff_formula_);
-          modification_->setNeutralLossMonoMasses(neutral_loss_mono_masses_);
-          modification_->setNeutralLossAverageMasses(neutral_loss_avg_masses_);
+          neutral_loss_mono_masses_all_.push_back(neutral_loss_mono_masses_);
+          neutral_loss_avg_masses_all_.push_back(neutral_loss_avg_masses_);
           neutral_loss_diff_formula_.clear();
           neutral_loss_mono_masses_.clear();
           neutral_loss_avg_masses_.clear();
@@ -212,10 +218,8 @@ namespace OpenMS::Internal
         {
           // now diff_formula_ contains the neutral loss diff formula
           neutral_loss_diff_formula_.push_back(diff_formula_);
-          neutral_loss_mono_masses_.push_back(mono_mass_);
-          neutral_loss_avg_masses_.push_back(avge_mass_);
-          avge_mass_ = 0.0;
-          mono_mass_ = 0.0;
+          neutral_loss_mono_masses_.push_back(neutral_loss_mono_mass_);
+          neutral_loss_avg_masses_.push_back(neutral_loss_avge_mass_);
           diff_formula_ = EmpiricalFormula();
         }
       }

--- a/src/openms/source/FORMAT/HANDLERS/UnimodXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/UnimodXMLHandler.cpp
@@ -108,7 +108,8 @@ namespace OpenMS::Internal
       {
         // mono_mass="97.976896" avge_mass="97.9952" flag="false"
         //                               composition="H(3) O(4) P">
-
+        collect_elements_ = true;
+        return;
       }
 
       // delta mass definitions?
@@ -117,11 +118,14 @@ namespace OpenMS::Internal
         // avge_mass="-0.9848" mono_mass="-0.984016" composition="H N O(-1)" >
         avge_mass_ = StringUtils::toDouble(sm_.convert(attributes.valueByIndex(attributes.index(sm_.convert("avge_mass").c_str()))));
         mono_mass_ = StringUtils::toDouble(sm_.convert(attributes.valueByIndex(attributes.index(sm_.convert("mono_mass").c_str()))));
+        collect_elements_ = true;
         return;
       }
 
       // <umod:element symbol="H" number="1"/>
-      if (tag_ == "umod:element")
+      // Only elements below <delta> and <NeutralLoss> belong to the modification; those below
+      // <Ignore>, <aa> and <brick> describe something else and are skipped (see #collect_elements_).
+      if ((tag_ == "umod:element" || tag_ == "element") && collect_elements_)
       {
         std::string symbol = sm_.convert(attributes.valueByIndex(attributes.index(sm_.convert("symbol").c_str())));
         std::string num = sm_.convert(attributes.valueByIndex(attributes.index(sm_.convert("number").c_str())));
@@ -173,6 +177,7 @@ namespace OpenMS::Internal
         avge_mass_ = 0.0;
         mono_mass_ = 0.0;
         diff_formula_ = EmpiricalFormula();
+        collect_elements_ = false;
         term_specs_.clear();
         sites_.clear();
         neutral_loss_diff_formulas_.clear();
@@ -194,15 +199,25 @@ namespace OpenMS::Internal
         }
       }
 
-      if ( (tag_ == "umod:NeutralLoss" || tag_ == "NeutralLoss") && !diff_formula_.isEmpty() )
+      if (tag_ == "umod:delta" || tag_ == "delta")
       {
-        // now diff_formula_ contains the neutral loss diff formula
-        neutral_loss_diff_formula_.push_back(diff_formula_);
-        neutral_loss_mono_masses_.push_back(mono_mass_);
-        neutral_loss_avg_masses_.push_back(avge_mass_);
-        avge_mass_ = 0.0;
-        mono_mass_ = 0.0;
-        diff_formula_ = EmpiricalFormula();
+        collect_elements_ = false;
+        return;
+      }
+
+      if (tag_ == "umod:NeutralLoss" || tag_ == "NeutralLoss")
+      {
+        collect_elements_ = false;
+        if (!diff_formula_.isEmpty())
+        {
+          // now diff_formula_ contains the neutral loss diff formula
+          neutral_loss_diff_formula_.push_back(diff_formula_);
+          neutral_loss_mono_masses_.push_back(mono_mass_);
+          neutral_loss_avg_masses_.push_back(avge_mass_);
+          avge_mass_ = 0.0;
+          mono_mass_ = 0.0;
+          diff_formula_ = EmpiricalFormula();
+        }
       }
     }
 

--- a/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
@@ -232,6 +232,23 @@ START_SECTION((const ResidueModification& getModification(const std::string& mod
 }
 END_SECTION
 
+START_SECTION([EXTRA] diff formula of a UniMod entry matches its diff mono mass)
+{
+  // ICAT-D (UNIMOD:13) and ICAT-D:2H(8) (UNIMOD:12) are the only unimod.xml entries with <Ignore>
+  // blocks. Their <element> children used to be folded into the modification's own formula, leaving
+  // it ~2250 Da heavier than the delta mass that getDiffMonoMass() reports.
+  // See https://github.com/OpenMS/OpenMS/issues/10030
+  for (const std::string& acc : {std::string("UNIMOD:12"), std::string("UNIMOD:13")})
+  {
+    const ResidueModification* mod = ptr->getModification(acc);
+    TEST_REAL_SIMILAR(mod->getDiffFormula().getMonoWeight(), mod->getDiffMonoMass());
+  }
+
+  TEST_REAL_SIMILAR(ptr->getModification("UNIMOD:12")->getDiffMonoMass(), 450.275205);
+  TEST_REAL_SIMILAR(ptr->getModification("UNIMOD:13")->getDiffMonoMass(), 442.224991);
+}
+END_SECTION
+
 START_SECTION((Size findModificationIndex(const std::string& mod_name) const))
 {
   Size index = numeric_limits<Size>::max();

--- a/src/tests/class_tests/openms/source/UnimodXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/UnimodXMLFile_test.cpp
@@ -119,6 +119,62 @@ START_SECTION([EXTRA] diff formula and diff mono mass agree for every entry)
 }
 END_SECTION
 
+START_SECTION([EXTRA] neutral loss formulas and neutral loss masses agree for every entry)
+{
+  // A <NeutralLoss> carries its own mono_mass/avge_mass. Those attributes were never read - the
+  // <delta> masses were pushed instead, and since <specificity> (which encloses <NeutralLoss>)
+  // always precedes <delta>, every neutral loss mass in the DB was 0. The mass vectors were also
+  // written to the modification once per <specificity> rather than per site, so the last site's
+  // vector was copied over all of them and could not even match the per-site formula vector in
+  // length. See https://github.com/OpenMS/OpenMS/issues/10030
+  UnimodXMLFile file;
+  vector<ResidueModification*> modifications;
+  file.load("CHEMISTRY/unimod.xml", modifications);
+
+  const double mono_tolerance = 1e-3;  // as above: OpenMS vs. UniMod element masses
+  const double avg_tolerance = 0.05;   // average atomic weights differ more; worst observed is ~0.006 Da
+  Size with_neutral_loss = 0;
+  Size length_mismatches = 0;
+  Size mass_mismatches = 0;
+  for (const ResidueModification* mod : modifications)
+  {
+    if (!mod->hasNeutralLoss()) continue;
+    ++with_neutral_loss;
+
+    const vector<EmpiricalFormula>& formulas = mod->getNeutralLossDiffFormulas();
+    const vector<double> mono_masses = mod->getNeutralLossMonoMasses();
+    const vector<double> avg_masses = mod->getNeutralLossAverageMasses();
+    if (formulas.size() != mono_masses.size() || formulas.size() != avg_masses.size())
+    {
+      ++length_mismatches;
+      STATUS(mod->getId() << " (" << mod->getOrigin() << "): " << formulas.size() << " neutral loss formula(s) but "
+             << mono_masses.size() << " mono and " << avg_masses.size() << " average mass(es)");
+      continue;
+    }
+    for (Size i = 0; i < formulas.size(); ++i)
+    {
+      if (std::fabs(formulas[i].getMonoWeight() - mono_masses[i]) > mono_tolerance ||
+          std::fabs(formulas[i].getAverageWeight() - avg_masses[i]) > avg_tolerance)
+      {
+        ++mass_mismatches;
+        STATUS(mod->getId() << " (" << mod->getOrigin() << "): neutral loss " << formulas[i].toString()
+               << " weighs " << formulas[i].getMonoWeight() << " / " << formulas[i].getAverageWeight()
+               << " but its masses are " << mono_masses[i] << " / " << avg_masses[i]);
+      }
+    }
+  }
+  TEST_EQUAL(with_neutral_loss > 0, true)
+  TEST_EQUAL(length_mismatches, 0)
+  TEST_EQUAL(mass_mismatches, 0)
+
+  // cleanup
+  for (Size k = 0; k < modifications.size(); k++)
+  {
+    delete modifications[k];
+  }
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST

--- a/src/tests/class_tests/openms/source/UnimodXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/UnimodXMLFile_test.cpp
@@ -13,8 +13,10 @@
 
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/FORMAT/UnimodXMLFile.h>
+#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
 #include <OpenMS/CHEMISTRY/ResidueModification.h>
 
+#include <cmath>
 #include <vector>
 
 ///////////////////////////
@@ -62,6 +64,60 @@ START_SECTION(void load(const std::string& filename, vector<ResidueModification*
 END_SECTION
 
 delete ptr;
+
+START_SECTION([EXTRA] diff formula and diff mono mass agree for every entry)
+{
+  // The composition of a modification is given by the <element> children of its <delta> block.
+  // <Ignore> blocks (reagent fragments a search must not consider) carry <element> children as
+  // well; folding those into the formula made ICAT-D (UNIMOD:12) and ICAT-D:2H(8) (UNIMOD:13)
+  // roughly 2250 Da heavier than their delta mass. getDiffMonoMass() is read from the mono_mass
+  // attribute and stayed correct, so only formula-derived results - AASequence::getFormula() and
+  // every isotope pattern computed from it - were wrong, silently.
+  // See https://github.com/OpenMS/OpenMS/issues/10030
+  UnimodXMLFile file;
+  vector<ResidueModification*> modifications;
+  file.load("CHEMISTRY/unimod.xml", modifications);
+
+  // OpenMS' element masses differ marginally from those UniMod used for its mono_mass attribute;
+  // the largest deviation over all entries is ~3e-5 Da, so 1e-3 Da leaves ample headroom while
+  // still catching a stray element.
+  const double tolerance = 1e-3;
+  Size mismatches = 0;
+  for (const ResidueModification* mod : modifications)
+  {
+    const double from_formula = mod->getDiffFormula().getMonoWeight();
+    if (std::fabs(from_formula - mod->getDiffMonoMass()) > tolerance)
+    {
+      ++mismatches;
+      STATUS(mod->getUniModAccession() << " (" << mod->getId() << "): diff formula "
+             << mod->getDiffFormula().toString() << " weighs " << from_formula
+             << " but diff mono mass is " << mod->getDiffMonoMass());
+    }
+  }
+  TEST_EQUAL(mismatches, 0)
+
+  // the two entries the scoping bug hit, checked by name
+  for (const ResidueModification* mod : modifications)
+  {
+    if (mod->getId() == "ICAT-D")
+    {
+      TEST_EQUAL(mod->getDiffFormula() == EmpiricalFormula("C20H34N4O5S"), true)
+      TEST_REAL_SIMILAR(mod->getDiffMonoMass(), 442.224991)
+    }
+    else if (mod->getId() == "ICAT-D:2H(8)")
+    {
+      TEST_EQUAL(mod->getDiffFormula() == EmpiricalFormula("C20H26(2)H8N4O5S"), true)
+      TEST_REAL_SIMILAR(mod->getDiffMonoMass(), 450.275205)
+    }
+  }
+
+  // cleanup
+  for (Size k = 0; k < modifications.size(); k++)
+  {
+    delete modifications[k];
+  }
+}
+END_SECTION
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

Fixes #10030 — two defects of the same shape in `UnimodXMLHandler`: stored chemistry inconsistent with the stored mass. Both are silent, both are caught by the same new regression test.

### 1. `<element>` children of `<Ignore>` were folded into the modification's diff formula

The handler accumulated **every** `<element>` child into `diff_formula_` regardless of its parent. `ICAT-D` (`UNIMOD:13`) and `ICAT-D:2H(8)` (`UNIMOD:12`) are the only `unimod.xml` entries carrying `<Ignore>` blocks — the reagent fragments a search must *not* consider — and each block contributed its own elements:

| | diff mono mass | diff formula (before) | its weight |
|---|---|---|---|
| `UNIMOD:12` | 450.275205 | `(2)H40C118H166N24O26S9` | 2703.553229 |
| `UNIMOD:13` | 442.224991 | `C118H206N24O26S9` | 2663.302159 |

`getDiffMonoMass()` is read from the `mono_mass` attribute and stayed correct, so anything mass-based looked fine. But `AASequence::getFormula()` — and every isotope pattern computed from it, e.g. `FeatureFinderIdentification`'s assay library intensities — was wrong by ~2250 Da for any peptide carrying ICAT-D, with no warning.

Element collection is now gated on being inside `<delta>` (the composition of the modification) or `<NeutralLoss>` (the composition of a neutral loss). `<Ignore>`, and the `<aa>`/`<brick>` blocks that follow the modification list, no longer contribute. `</delta>` is now handled so the scope closes with its element, which also removes the parser's reliance on `<specificity>` preceding `<delta>`. The `element` tag is additionally accepted without the `umod:` prefix, matching how every other tag in this handler is tested (no effect on the shipped file).

A survey of `unimod.xml` confirms the scope: `<element>` children live under `delta` (6367), `NeutralLoss` (3592), `Ignore` (65), `aa` (90) and `brick` (88). **Only records 12 and 13 change**; all 1543 neutral-loss formula sets are byte-identical before and after.

### 2. Every neutral loss mono and average mass was 0

Found while fixing the above, [documented on the issue](https://github.com/OpenMS/OpenMS/issues/10030#issuecomment-5496838420), and fixed here since it is the same file and the same regression test guards it. Two bugs that compound:

- **`<NeutralLoss>`'s own `mono_mass`/`avge_mass` attributes were never read.** `onStartElement` had an empty body for that tag, and `</NeutralLoss>` pushed `mono_mass_`/`avge_mass_` — the members holding the **`<delta>`** masses. `<specificity>` (which encloses `<NeutralLoss>`) precedes `<delta>` in every one of the 1543 `<umod:mod>` blocks, so those members were still `0.0`. All **871** modifications with a neutral loss stored `0`, e.g. `Phospho (S)` → `H3O4P1` with a mono mass of `0` instead of `97.976896`.
- **The mass vectors were stored per modification, not per site.** `</specificity>` called `modification_->setNeutralLossMonoMasses(...)` on the template modification, so each specificity overwrote the previous one and the *last* site's vector was copied onto every site. `neutral_loss_diff_formulas_` is already collected per site, so the two could differ in length — `Deamidated (R)` carried one neutral loss formula and zero masses.

Both are now parsed from the `<NeutralLoss>` element and stored per site, so formula, mono mass and average mass at index `i` describe the same neutral loss.

**Blast radius:** nothing outside `ResidueModification`'s `operator==` / `operator<` / `std::hash` reads these masses — the library consumes only `getNeutralLossDiffFormulas()`, via `Residue::getLossFormulas()` — and only modifications that already carry neutral loss formulas are affected, so exact-match lookups (`ModificationsDB::searchModification`) are unchanged for every modification without one. No reference files change.

### Verification

Built against a full local build and confirmed end to end:

```
UNIMOD:12  450.275  (2)H8C20H26N4O5S1  450.275
UNIMOD:13  442.225  C20H34N4O5S1       442.225
PEPTC(ICAT-D)IDER  formula=C63H104N16O22S2  formula weight=1500.7  getMonoWeight()=1500.7
```

```
mods with neutral loss: 871 | formula/mass vector length mismatches: 0 | zero mono masses: 0
| |formula weight - NL mono mass| > 1e-3: 0 (worst 2.9e-05)
```

New regression tests, **both of which fail on the unpatched handler** with exactly the numbers above:

- `UnimodXMLFile_test` — sweeps every entry asserting `getDiffFormula().getMonoWeight() ≈ getDiffMonoMass()`, plus the two ICAT-D compositions; and asserts that the neutral loss formula, mono mass and average mass vectors have equal length and agree in mass. Tolerances are 1e-3 Da (mono) and 0.05 Da (average), against worst observed legitimate deviations of 2.9e-05 and 0.006 Da from OpenMS vs. UniMod element masses.
- `ModificationsDB_test` — the same diff-formula invariant through the `getModification("UNIMOD:12")` accession lookup the issue report used.

24 modification-related class tests pass locally, including `AASequence`, `ResidueDB`, `ResidueModification`, `EmpiricalFormula`, `ModifiedPeptideGenerator`, `TheoreticalSpectrumGenerator`, `TheoreticalSpectrumGeneratorXLMS`, `SimpleTSGXLMS`, `MRMIonSeries`, `MRMDecoy`, `ProFormaParser`, `PEFFFile`, `CrossLinksDB`.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.) — no API change; `ResidueModification`'s existing bindings already expose the affected getters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNYWBdeszJ2KrG25a5WHGi

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNYWBdeszJ2KrG25a5WHGi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected UniMod modification formulas so ignored elements no longer affect differential mass calculations.
  * Fixed neutral-loss mass handling to preserve accurate mono and average masses for each specificity site.

* **Tests**
  * Added regression coverage validating differential formulas and masses across UniMod entries.
  * Added checks ensuring neutral-loss formulas and mass values remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->