### PR TITLE
Fix small mass brackets snapping to a zero-diff PSI-MOD residue term (#10029)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1133,7 +1133,10 @@ OpenMS Library:
       (a) also tightens matching of coarsely written masses: "M[147.01]" (25 mDa off oxidized
       methionine, more than the 0.01 Da implied by two decimals) and other masses written with fewer
       decimals than their deviation from the database entry are now kept as exact unknown mass shifts
-      instead of being snapped to a named modification (#10029)
+      instead of being snapped to a named modification. (b) also affects the file readers that resolve
+      modifications by mass: a near-zero mass shift, e.g. the C-terminal "massdiff" of 0.0003 that
+      X!Tandem writes into pepXML, no longer picks up an unrelated zero-mass PSI-MOD term - such
+      peptides used to be annotated with a spurious "(MOD:00266)" (#10029)
   Performance:
     - ILPDCWrapper ~3.5x faster using std::unordered_map (#8618); unordered_map lookups in OpenSwath
       (#8651), PrecursorPurity, PeptideProteinResolution and PeptideIndexing (#8763, #8806)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1116,6 +1116,24 @@ OpenMS Library:
       consumer (peak picking, feature scoring, targeted extraction, OpenSwath/MRM analysis) sees slightly
       smoother, more accurate S/N-derived output; reference test data across ~60 TOPP tests was
       regenerated accordingly (#9781, #9967)
+    - Fix: a small signed mass bracket on a residue, e.g. "PEPT[-0.5]IDE" or "PEPT[+0.001]IDE", was
+      silently replaced by the zero-mass PSI-MOD term "MOD:00026 L-threonine residue" and the peptide
+      lost a water (18.0106 Da). Three causes, all fixed: (a) AASequence::parseModSquareBrackets_
+      under-counted the written decimals by one, so every mass bracket was matched ten times more
+      loosely than written ("[-0.5]" was matched with a tolerance of 1.0 Da, "[+0.001]" with 0.01 Da);
+      it now uses the precision the mass was written with. (b) ModificationsDB's mass searches
+      (getBestModificationByDiffMonoMass and the four searchModificationsByDiffMonoMass[Sorted]
+      overloads) returned modifications with a difference mass of 0 - PSI-MOD "residue" terms that
+      describe a residue rather than a change to it - as the best match for any small mass difference;
+      such entries are now only reported when a zero mass difference is what was searched for.
+      (c) Residue::setModification adopted the absolute mass and formula of a modification that
+      describes no difference at all; since PSI-MOD stores the residue as it occurs inside a peptide
+      chain, i.e. without the water of the free amino acid that Residue stores, this stripped a water
+      whenever such a term was applied - including via "(MOD:00026)" written into idXML. Note that
+      (a) also tightens matching of coarsely written masses: "M[147.01]" (25 mDa off oxidized
+      methionine, more than the 0.01 Da implied by two decimals) and other masses written with fewer
+      decimals than their deviation from the database entry are now kept as exact unknown mass shifts
+      instead of being snapped to a named modification (#10029)
   Performance:
     - ILPDCWrapper ~3.5x faster using std::unordered_map (#8618); unordered_map lookups in OpenSwath
       (#8651), PrecursorPurity, PeptideProteinResolution and PeptideIndexing (#8763, #8806)

--- a/doc/pyopenms/docs/source/user_guide/peptides_proteins.rst
+++ b/doc/pyopenms/docs/source/user_guide/peptides_proteins.rst
@@ -277,7 +277,7 @@ peptide "DFPIAMGER" with an oxidized methionine. There are multiple ways to spec
         print(oms.AASequence.fromString("DFPIAM[+16]GER"))
         print(oms.AASequence.fromString("DFPIAM[+15.99]GER"))
         print(oms.AASequence.fromString("DFPIAM[147]GER"))
-        print(oms.AASequence.fromString("DFPIAM[147.035405]GER"))
+        print(oms.AASequence.fromString("DFPIAM[147.0354]GER"))
 
 The above code outputs:
 
@@ -302,6 +302,11 @@ find the first modification matching to a mass difference of :math:`16 \pm 0.5`,
 latter will try to find the closest matching modification to the exact mass.
 The exact mass approach usually gives the intended results while the first
 approach may or may not. In all instances, it is better to use an exact description of the desired modification, such as UniMod, instead of mass differences.
+
+A mass tag is matched with the precision it is written with: ``[+15.99]`` accepts a
+modification within 0.01 Da of it, ``[+15.9949]`` one within 0.0001 Da. Writing more
+decimals than the modification databases store therefore asks for an (almost) exact
+match, and the mass is usually kept as an unknown modification instead.
 
 N- and C-terminal modifications are represented by brackets to the right of the dots
 terminating the sequence. For example, ``".(Dimethyl)DFPIAMGER."`` and

--- a/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
@@ -63,8 +63,13 @@ namespace OpenMS
       <tt>AASequence::fromString(".DFPIAM[+15.9949]GER.")</tt> -- while the
       former will try to find the @e first modification matching to a mass
       difference of 16 +/- 0.5, the latter will try to find the @e closest
-      matching modification to the exact mass. This usually gives the intended
-      results while the first approach may not.
+      matching modification within the precision the mass was written with,
+      i.e. one unit in the last decimal (here +/- 0.0001). This usually gives
+      the intended results while the first approach may not. If no
+      modification is that close, the mass is kept as it was written and the
+      residue carries an unknown modification with exactly that mass
+      difference (e.g. <tt>".DFPIAT[+0.5]GER."</tt> is a threonine shifted by
+      0.5 Da, not a threonine with some database modification).
 
       Arbitrary/unknown amino acids (usually due to an unknown modification)
       can be specified using tags preceded by X: "X[weight]". This indicates a
@@ -645,6 +650,15 @@ protected:
 
     /**
       @brief Parses modifications in square brackets (a mass)
+
+      A mass with a leading '+' or '-' is a mass difference, a mass without
+      sign is the absolute mass of the modified residue. The mass is looked up
+      in ModificationsDB with a tolerance derived from the number of decimals
+      it was written with (0.5 Da for an integer, 10^-n Da for n decimals).
+      If no modification lies within that tolerance, an unknown modification
+      carrying the exact mass is attached (see
+      ResidueModification::createUnknownFromMassString), so the sequence's mass
+      is always the one written.
 
       If dot notation is used it resolves cterm ambiguity based on the presence
       of the dot.

--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
@@ -185,6 +185,10 @@ public:
 
        If @p residue is set, only modifications with matching residue of origin are considered.
        If @p term_spec is set, only modifications with matching term specificity are considered.
+
+       @note Modifications without a mass difference (e.g. PSI-MOD terms that describe a residue
+       rather than a change to it, so that getDiffMonoMass() is 0) cannot explain a mass shift and
+       are only considered if @p mass is exactly 0.0.
     */
     void searchModificationsByDiffMonoMass(std::vector<std::string>& mods, double mass, double max_error, const std::string& residue = "", ResidueModification::TermSpecificity term_spec = ResidueModification::NUMBER_OF_TERM_SPECIFICITY) const;
     void searchModificationsByDiffMonoMass(std::vector<const ResidueModification*>& mods, double mass, double max_error, const std::string& residue = "", ResidueModification::TermSpecificity term_spec = ResidueModification::NUMBER_OF_TERM_SPECIFICITY) const;
@@ -195,6 +199,10 @@ public:
 
      If @p residue is set, only modifications with matching residue of origin are considered.
      If @p term_spec is set, only modifications with matching term specificity are considered.
+
+     @note Modifications without a mass difference (e.g. PSI-MOD terms that describe a residue
+     rather than a change to it, so that getDiffMonoMass() is 0) cannot explain a mass shift and
+     are only considered if @p mass is exactly 0.0.
     */
     void searchModificationsByDiffMonoMassSorted(std::vector<std::string>& mods, double mass, double max_error, const std::string& residue = "", ResidueModification::TermSpecificity term_spec = ResidueModification::NUMBER_OF_TERM_SPECIFICITY) const;
     void searchModificationsByDiffMonoMassSorted(std::vector<const ResidueModification*>& mods, double mass, double max_error, const std::string& residue = "", ResidueModification::TermSpecificity term_spec = ResidueModification::NUMBER_OF_TERM_SPECIFICITY) const;
@@ -212,7 +220,13 @@ public:
         will choose the _first_ match which defaults to the first matching
         UniMod entry.
 
-        @param[in] mass The monoisotopic mass of the residue including the mass of the modification
+        @note Modifications without a mass difference (e.g. PSI-MOD terms that
+        describe a residue rather than a change to it, so that
+        getDiffMonoMass() is 0) cannot explain a mass shift and are only
+        considered if @p mass is exactly 0.0. Without this, every small
+        @p mass would resolve to such a term.
+
+        @param[in] mass The monoisotopic mass difference (delta mass) to search for
         @param[in] max_error The maximal mass error in the modification search
         @param[in] residue The residue at which the modifications occurs
         @param[in] term_spec Only modifications with matching term specificity are considered.

--- a/src/openms/include/OpenMS/CHEMISTRY/Residue.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/Residue.h
@@ -331,7 +331,18 @@ public:
     /// sets the modification by name; the mod should be present in ModificationsDB
     void setModification(const std::string& name);
 
-    /// sets the modification by existing ResMod (make sure it exists in ModificationsDB)
+    /**
+       @brief sets the modification by existing ResMod (make sure it exists in ModificationsDB)
+
+       The residue's formula and masses are updated from the modification: if it has a diff
+       formula, that is added to the residue's formula (which also sets the masses); otherwise
+       the modification's absolute masses are adopted if set (or its mass difference is added)
+       and its absolute formula, if any, replaces the residue's. A modification that defines
+       neither a mass nor a formula difference (e.g. a PSI-MOD term that merely describes the
+       residue) leaves the residue's masses and formula untouched -- its absolute values follow
+       the conventions of the source database and are not comparable to a Residue's
+       free-amino-acid mass.
+    */
     void setModification(const ResidueModification* mod);
 
     /// sets the modification by looking for an exact match in the DB first, otherwise creating a

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -1076,7 +1076,11 @@ namespace OpenMS
     double tolerance = 0.5; // for integer mass values
     if (!integer_mass) // float mass values -> adapt tolerance to decimal precision
     {
-      size_t n_decimals = mod.size() - decimal_pos - 2;
+      // number of digits written after the decimal point (a leading '+'/'-' does not affect it)
+      size_t n_decimals = mod.size() - decimal_pos - 1;
+      // match with the precision the mass was written with, i.e. allow one unit in the last
+      // written digit. Note that this used to under-count the decimals by one, so e.g. "[-0.5]"
+      // was matched with a tolerance of 1.0 Da and could pick up an arbitrary modification.
       tolerance = std::pow(10.0, -int(n_decimals));
     }
     bool delta_mass = (mod[0] == '+') || (mod[0] == '-');

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -52,6 +52,23 @@ namespace OpenMS
     }
   }
 
+  namespace
+  {
+    /**
+      @brief Can @p mod explain a mass difference of @p mass?
+
+      Modifications without a mass difference cannot: PSI-MOD contains "residue" terms (e.g.
+      'MOD:00026 L-threonine residue') and similar entries that describe a residue rather than a
+      change to it, and they are loaded as ordinary modifications with a difference mass of 0.
+      Since the mass search minimizes |diff mass - mass|, such an entry would otherwise be
+      returned as the best match for any (small) mass difference within the search tolerance.
+    */
+    inline bool explainsMassDiff_(const ResidueModification* mod, double mass)
+    {
+      return (mod->getDiffMonoMass() != 0.0) || (mass == 0.0);
+    }
+  }
+
   bool ModificationsDB::is_instantiated_ = false;
 
   const ModificationsDB* ModificationsDB::getInstance()
@@ -345,6 +362,7 @@ namespace OpenMS
       for (auto const & m : mods_)
       {
         if ((fabs(m->getDiffMonoMass() - mass) <= max_error) &&
+            explainsMassDiff_(m, mass) &&
             residuesMatch_(res, m) &&
             ((term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY) ||
              (term_spec == m->getTermSpecificity())))
@@ -365,6 +383,7 @@ namespace OpenMS
       for (auto const & m : mods_)
       {
         if ((fabs(m->getDiffMonoMass() - mass) <= max_error) &&
+            explainsMassDiff_(m, mass) &&
             residuesMatch_(res, m) &&
             ((term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY) ||
              (term_spec == m->getTermSpecificity())))
@@ -389,6 +408,7 @@ namespace OpenMS
       {
         diff = fabs(m->getDiffMonoMass() - mass);
         if ((diff <= max_error) &&
+            explainsMassDiff_(m, mass) &&
             residuesMatch_(res, m) &&
             ((term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY) ||
              (term_spec == m->getTermSpecificity())))
@@ -417,6 +437,7 @@ namespace OpenMS
       {
         diff = fabs(m->getDiffMonoMass() - mass);
         if ((diff <= max_error) &&
+            explainsMassDiff_(m, mass) &&
             residuesMatch_(res, m) &&
             ((term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY) ||
              (term_spec == m->getTermSpecificity())))
@@ -450,6 +471,7 @@ namespace OpenMS
         // first matching UniMod entry)
         double mass_error = fabs(m->getDiffMonoMass() - mass);
         if ((mass_error < min_error) &&
+            explainsMassDiff_(m, mass) &&
             residuesMatch_(res, m) &&
             ((term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY) ||
              (term_spec == m->getTermSpecificity())))

--- a/src/openms/source/CHEMISTRY/Residue.cpp
+++ b/src/openms/source/CHEMISTRY/Residue.cpp
@@ -379,31 +379,44 @@ namespace OpenMS
   {
     modification_ = mod;
 
-    // update all the members
-    if (mod->getAverageMass() != 0)
-    {
-      average_weight_ = mod->getAverageMass();
-    }
-    if (mod->getMonoMass() != 0)
-    {
-      mono_weight_ = mod->getMonoMass();
-    }
-    // update mono_weight_ by DiffMonoMass, if MonoMass is not known, but DiffMonoMass is
-    // as in the case of XLMOD.obo modifications
-    if ( (mod->getMonoMass() == 0) && (mod->getDiffMonoMass() != 0) )
-    {
-      mono_weight_ += mod->getDiffMonoMass();
-    }
+    // A modification that describes neither a mass nor a formula difference does not change the
+    // residue. Its absolute mass and formula must not be adopted in that case: those follow the
+    // convention of the database the modification was read from, and PSI-MOD stores the residue
+    // as it occurs inside a peptide chain, i.e. without the water that Residue's (free amino
+    // acid) mass and formula include. Adopting them would silently strip a water, e.g. for the
+    // PSI-MOD "residue" terms such as 'MOD:00026 L-threonine residue'.
+    const bool changes_residue = (mod->getDiffMonoMass() != 0.0) ||
+                                 (mod->getDiffAverageMass() != 0.0) ||
+                                 !mod->getDiffFormula().isEmpty();
 
-    if (!mod->getDiffFormula().isEmpty())
+    // update all the members
+    if (changes_residue)
     {
-      setFormula(getFormula() + mod->getDiffFormula());
-    }
-    else if (!mod->getFormula().empty())
-    {
-      std::string formula = mod->getFormula();
-      StringUtils::removeWhitespaces(formula);
-      setFormula(EmpiricalFormula(formula));
+      if (mod->getAverageMass() != 0)
+      {
+        average_weight_ = mod->getAverageMass();
+      }
+      if (mod->getMonoMass() != 0)
+      {
+        mono_weight_ = mod->getMonoMass();
+      }
+      // update mono_weight_ by DiffMonoMass, if MonoMass is not known, but DiffMonoMass is
+      // as in the case of XLMOD.obo modifications
+      if ( (mod->getMonoMass() == 0) && (mod->getDiffMonoMass() != 0) )
+      {
+        mono_weight_ += mod->getDiffMonoMass();
+      }
+
+      if (!mod->getDiffFormula().isEmpty())
+      {
+        setFormula(getFormula() + mod->getDiffFormula());
+      }
+      else if (!mod->getFormula().empty())
+      {
+        std::string formula = mod->getFormula();
+        StringUtils::removeWhitespaces(formula);
+        setFormula(EmpiricalFormula(formula));
+      }
     }
 
     // neutral losses

--- a/src/pyOpenMS/tests/unittests/test_tutorial.py
+++ b/src/pyOpenMS/tests/unittests/test_tutorial.py
@@ -204,7 +204,7 @@ def testAASequenceTutorial():
     print(AASequence.fromString("DFPIAM[+16]GER"))
     print(AASequence.fromString("DFPIAM[+15.99]GER"))
     print(AASequence.fromString("DFPIAM[147]GER"))
-    print(AASequence.fromString("DFPIAM[147.035405]GER"))
+    print(AASequence.fromString("DFPIAM[147.0354]GER"))
 
     s = AASequence.fromString(".(Dimethyl)DFPIAMGER.")
     print(s, s.hasNTerminalModification())

--- a/src/tests/class_tests/openms/source/AASequence_test.cpp
+++ b/src/tests/class_tests/openms/source/AASequence_test.cpp
@@ -1254,9 +1254,40 @@ START_SECTION([EXTRA] Arbitrary tag in peptides using square brackets)
   AASequence test;
   TEST_EXCEPTION(Exception::ParseError, test = AASequence::fromString("PEPTX[+160.230654]IDE"));
 
-  AASequence seq11 = AASequence::fromString("PEPM[147.035405]TIDEK");
+  AASequence seq11 = AASequence::fromString("PEPM[147.0354]TIDEK");
   TEST_EQUAL(seq11.isModified(), true);
   TEST_STRING_EQUAL(seq11[3].getModificationName(), "Oxidation");
+}
+END_SECTION
+
+START_SECTION([EXTRA] Small mass tags are not replaced by a zero-mass modification)
+{
+  // Issue #10029: a small (signed) mass tag - a calibration offset, an isotope error or a
+  // placeholder written by an open search - used to be replaced by the PSI-MOD "residue" term
+  // 'MOD:00026 L-threonine residue' (mass difference 0), which additionally stripped a water
+  // from the peptide. Such a tag must be kept as an unknown modification of exactly that mass.
+  const double base = AASequence::fromString("PEPTIDE").getMonoWeight();
+  const std::vector<std::pair<std::string, double>> tags =
+    {{"PEPT[-0.5]IDE", -0.5},
+     {"PEPT[+0.001]IDE", 0.001},
+     {"PEPT[-0.001]IDE", -0.001},
+     {"PEPT[+0.000000001]IDE", 0.000000001},
+     {"PEPT[+0.00335]IDE", 0.00335}};
+  for (const auto& [seq_string, delta] : tags)
+  {
+    AASequence aa = AASequence::fromString(seq_string);
+    TEST_STRING_EQUAL(aa.toString(), seq_string)
+    TEST_EQUAL(aa[3].isModified(), true)
+    TEST_STRING_EQUAL(aa[3].getModificationName(), "") // user-defined, i.e. no database entry
+    TEST_REAL_SIMILAR(aa.getMonoWeight() - base, delta)
+  }
+
+  // The same term applied explicitly describes an (unmodified) threonine, so it must not change
+  // the mass of the peptide either
+  AASequence thr_term = AASequence::fromString("PEPT(MOD:00026)IDE");
+  TEST_EQUAL(thr_term[3].isModified(), true)
+  TEST_REAL_SIMILAR(thr_term.getMonoWeight(), base)
+  TEST_EQUAL(thr_term.getFormula() == AASequence::fromString("PEPTIDE").getFormula(), true)
 }
 END_SECTION
 
@@ -1266,11 +1297,20 @@ START_SECTION([EXTRA] Test integer vs float tags)
 
   // Test a few modifications with the "correct" accurate mass
   {
-  AASequence seq11 = AASequence::fromString("PEPM[147.035405]TIDEK"); // UniMod oxMet is 147.035405
+  AASequence seq11 = AASequence::fromString("PEPM[147.0354]TIDEK"); // UniMod oxMet is 147.035405
   TEST_EQUAL(seq11.isModified(), true);
   TEST_STRING_EQUAL(seq11[3].getModificationName(), "Oxidation");
   TEST_EQUAL(seq11[3].getModification()->getUniModRecordId(), 35)
   TEST_EQUAL(seq11[3].getModification()->getUniModAccession(), "UniMod:35")
+
+  // A mass is only matched with the precision it was written with. The absolute masses
+  // tabulated by UniMod are built from residue masses that are rounded to five decimals, so
+  // "147.035405" differs from OpenMS' Met + Oxidation by ~5e-6 Da - more than the 1e-6 Da
+  // implied by six decimals - and is therefore kept as an (exact) unknown mass:
+  AASequence seq11b = AASequence::fromString("PEPM[147.035405]TIDEK");
+  TEST_EQUAL(seq11b.isModified(), true);
+  TEST_STRING_EQUAL(seq11b[3].getModificationName(), "");
+  TEST_REAL_SIMILAR(seq11b.getMonoWeight(), seq11.getMonoWeight())
 
   AASequence seq12 = AASequence::fromString("PEPT[181.014]TIDEK");
   TEST_EQUAL(seq12.isModified(), true);
@@ -1293,10 +1333,16 @@ START_SECTION([EXTRA] Test integer vs float tags)
 
   // Test a few modifications with the accurate mass slightly off to match some other modification
   {
-  AASequence seq11 = AASequence::fromString("PEPM[147.01]TIDEK");
+  AASequence seq11 = AASequence::fromString("PEPM[147.03]TIDEK");
   TEST_EQUAL(seq11.isModified(), true);
   TEST_STRING_EQUAL(seq11[3].getModificationName(), "Oxidation")
   TEST_EQUAL(seq11[3].getModification()->getUniModRecordId(), 35)
+
+  // ... but only as far as the written precision allows: 147.01 is 25 mDa away from oxidized
+  // methionine, which is more than the 0.01 Da implied by two decimals
+  AASequence seq11b = AASequence::fromString("PEPM[147.01]TIDEK");
+  TEST_EQUAL(seq11b.isModified(), true);
+  TEST_STRING_EQUAL(seq11b[3].getModificationName(), "")
 
   AASequence seq12 = AASequence::fromString("PEPT[181.004]TIDEK");
   TEST_EQUAL(seq12.isModified(), true);
@@ -1308,7 +1354,7 @@ START_SECTION([EXTRA] Test integer vs float tags)
   TEST_STRING_EQUAL(seq13[3].getModificationName(), "Sulfo");
   TEST_EQUAL(seq13[3].getModification()->getUniModRecordId(), 40)
 
-  AASequence seq14 = AASequence::fromString("PEPTC[159.035405]IDE");
+  AASequence seq14 = AASequence::fromString("PEPTC[159.0354]IDE");
   TEST_EQUAL(seq14.isModified(), true);
   TEST_STRING_EQUAL(seq14[4].getModificationName(), "Delta:H(4)C(3)O(1)");
   TEST_EQUAL(seq14[4].getModification()->getUniModRecordId(), 206)
@@ -1323,7 +1369,7 @@ START_SECTION([EXTRA] Test integer vs float tags)
   TEST_EQUAL(seq11.isModified(), true);
   TEST_STRING_EQUAL(seq11[3].getModificationName(), "Oxidation");
 
-  AASequence seq12 = AASequence::fromString("PEPT[+79.96632]TIDEK");
+  AASequence seq12 = AASequence::fromString("PEPT[+79.96633]TIDEK");
   TEST_EQUAL(seq12.isModified(), true);
   TEST_STRING_EQUAL(seq12[3].getModificationName(), "Phospho");
 
@@ -1399,20 +1445,20 @@ START_SECTION([EXTRA] Peptide equivalence)
   TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString("DFPIAM[+16]GER"))
   TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString("DFPIAM[147]GER"))
   TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString("DFPIAM[+15.99]GER"))
-  TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString("DFPIAM[147.035405]GER"))
+  TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString("DFPIAM[147.0354]GER"))
   TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString("DFPIAM(Oxidation)GER"))
 
   // Test Oxidation
   TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString(".DFPIAM[+16]GER"))
   TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString(".DFPIAM[147]GER"))
   TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString(".DFPIAM[+15.99]GER"))
-  TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString(".DFPIAM[147.035405]GER"))
+  TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString(".DFPIAM[147.0354]GER"))
   TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString(".DFPIAM(Oxidation)GER"))
 
   TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString(".DFPIAM[+16]GER."))
   TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString(".DFPIAM[147]GER."))
   TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString(".DFPIAM[+15.99]GER."))
-  TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString(".DFPIAM[147.035405]GER."))
+  TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString(".DFPIAM[147.0354]GER."))
   TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString(".DFPIAM(Oxidation)GER."))
 
   // Test Phosphorylation

--- a/src/tests/class_tests/openms/source/AASequence_test.cpp
+++ b/src/tests/class_tests/openms/source/AASequence_test.cpp
@@ -1436,7 +1436,7 @@ START_SECTION([EXTRA] Peptide equivalence)
   // Test Carbamidomethyl
   TEST_EQUAL(AASequence::fromString("PEPTC(UniMod:4)IDE"), AASequence::fromString("PEPTC(Carbamidomethyl)IDE"))
   TEST_EQUAL(AASequence::fromString("PEPTC(UniMod:4)IDE"), AASequence::fromString("PEPTC(Iodoacetamide derivative)IDE"))
-  TEST_EQUAL(AASequence::fromString("PEPTC(UniMod:4)IDE"), AASequence::fromString("PEPTC[160.030654]IDE")) // 103.00919 + 57.02
+  TEST_EQUAL(AASequence::fromString("PEPTC(UniMod:4)IDE"), AASequence::fromString("PEPTC[160.0306]IDE")) // 103.00919 + 57.02
   TEST_EQUAL(AASequence::fromString("PEPTC(UniMod:4)IDE"), AASequence::fromString("PEPTC[+57.02]IDE"))
   TEST_EQUAL(AASequence::fromString("PEPTC(UniMod:4)IDE"), AASequence::fromString("PEPTC[160]IDE")) // 103.00919 + 57.02
   TEST_EQUAL(AASequence::fromString("PEPTC(UniMod:4)IDE"), AASequence::fromString("PEPTC[+57]IDE"))

--- a/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
@@ -209,6 +209,38 @@ START_SECTION((void searchModificationsByDiffMonoMass(std::vector<std::string>& 
   ptr->searchModificationsByDiffMonoMass(mods, 0.98, 1.0, "Q");
   TEST_EQUAL(mods.empty(), false)
   TEST_EQUAL(mods[0], "Deamidated (Q)")
+
+  // Modifications without a mass difference (PSI-MOD "residue" terms such as
+  // 'MOD:00026 L-threonine residue') cannot explain a mass shift and must not be reported
+  // for one, no matter how large the tolerance is (issue #10029).
+  std::vector<const ResidueModification*> mod_ptrs;
+  ptr->searchModificationsByDiffMonoMass(mod_ptrs, -0.5, 1.0, "T");
+  bool found_zero_diff = false;
+  for (const ResidueModification* m : mod_ptrs)
+  {
+    if (m->getDiffMonoMass() == 0.0) found_zero_diff = true;
+  }
+  TEST_EQUAL(found_zero_diff, false)
+  // ... they are still found when a zero mass difference is what was asked for
+  ptr->searchModificationsByDiffMonoMass(mods, 0.0, 0.001, "T");
+  TEST_EQUAL(find(mods.begin(), mods.end(), "L-threonine residue (T)") != mods.end(), true)
+}
+END_SECTION
+
+START_SECTION((const ResidueModification* getBestModificationByDiffMonoMass(double mass, double max_error, const std::string& residue, ResidueModification::TermSpecificity term_spec) const))
+{
+  TEST_EQUAL(ptr->getBestModificationByDiffMonoMass(15.994915, 0.001, "M", ResidueModification::ANYWHERE)->getFullId(), "Oxidation (M)")
+
+  // A modification with a mass difference of zero minimizes |diff mass - mass| for every small
+  // mass difference and used to be returned as the best match for it (issue #10029).
+  const ResidueModification* best = ptr->getBestModificationByDiffMonoMass(-0.5, 1.0, "T", ResidueModification::ANYWHERE);
+  TEST_EQUAL(best != nullptr && best->getDiffMonoMass() == 0.0, false)
+  TEST_EQUAL(ptr->getBestModificationByDiffMonoMass(0.001, 0.005, "T", ResidueModification::ANYWHERE) == nullptr, true)
+
+  // ... but a zero mass difference is still matched when explicitly searched for
+  best = ptr->getBestModificationByDiffMonoMass(0.0, 0.001, "T", ResidueModification::ANYWHERE);
+  TEST_EQUAL(best == nullptr, false)
+  TEST_REAL_SIMILAR(best->getDiffMonoMass(), 0.0)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/Residue_test.cpp
+++ b/src/tests/class_tests/openms/source/Residue_test.cpp
@@ -362,6 +362,25 @@ START_SECTION(void setModificationByDiffMonoMass(double diffMonoMass))
 }
 END_SECTION
 
+START_SECTION([EXTRA] setModification with a modification that has no mass difference)
+{
+  // Issue #10029: PSI-MOD stores the mass and formula of the residue as it occurs inside a
+  // peptide chain, i.e. without the water that Residue's (free amino acid) mass and formula
+  // include. Adopting those absolute values for a term that describes no difference at all -
+  // e.g. 'MOD:00026 L-threonine residue' - stripped a water from the residue.
+  Residue thr(*db->getResidue("Thr"));
+  const double mono_weight = thr.getMonoWeight();
+  const double average_weight = thr.getAverageWeight();
+  const EmpiricalFormula formula = thr.getFormula();
+
+  thr.setModification("MOD:00026");
+  TEST_EQUAL(thr.isModified(), true)
+  TEST_REAL_SIMILAR(thr.getMonoWeight(), mono_weight)
+  TEST_REAL_SIMILAR(thr.getAverageWeight(), average_weight)
+  TEST_EQUAL(thr.getFormula() == formula, true)
+}
+END_SECTION
+
 START_SECTION(std::string Residue::toString() const)
 {
   auto rr(*db->getResidue("Met"));

--- a/src/tests/topp/IDFileConverter_10_output.idXML
+++ b/src/tests/topp/IDFileConverter_10_output.idXML
@@ -30,7 +30,7 @@
 			<UserParam type="stringList" name="spectra_data" value="[c:/Inetpub/wwwroot/ISB/data/user-data/Lars/20141217_tMS2_tests/TPP/LN1/H_LN1.mzXML]"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="804.383175031900009" RT="383.87700000000001" spectrum_reference="scan=1671" >
-			<PeptideHit score="0.7911" sequence=".(Dimethyl:2H(4)13C(2))TGSESSQTGTSTTSSR.(MOD:00266)" charge="2" aa_before="R" aa_after="N" protein_refs="PH_0" >
+			<PeptideHit score="0.7911" sequence=".(Dimethyl:2H(4)13C(2))TGSESSQTGTSTTSSR" charge="2" aa_before="R" aa_after="N" protein_refs="PH_0" >
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="hyperscore" value="19.399999999999999"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
@@ -51,7 +51,7 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="863.492925031899972" RT="4120.789999999999964" spectrum_reference="scan=30513" >
-			<PeptideHit score="0.9938" sequence=".(Dimethyl:2H(4)13C(2))DLADELALVDVIEDK(Dimethyl:2H(4)13C(2)).(MOD:00266)" charge="2" aa_before="K" aa_after="L" protein_refs="PH_1" >
+			<PeptideHit score="0.9938" sequence=".(Dimethyl:2H(4)13C(2))DLADELALVDVIEDK(Dimethyl:2H(4)13C(2))" charge="2" aa_before="K" aa_after="L" protein_refs="PH_1" >
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="hyperscore" value="28.800000000000001"/>
 				<UserParam type="float" name="nextscore" value="8.0"/>
@@ -81,7 +81,7 @@
 			<UserParam type="stringList" name="spectra_data" value="[c:/Inetpub/wwwroot/ISB/data/user-data/Lars/20141217_tMS2_tests/TPP/LN1/L_LN1.mzXML]"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="587.947991698566625" RT="374.115999999999985" spectrum_reference="scan=1594" >
-			<PeptideHit score="1.0" sequence=".(Dimethyl)GDTPGHATPGHGGATSSAR.(MOD:00266)" charge="3" aa_before="R" aa_after="K" protein_refs="PH_2" >
+			<PeptideHit score="1.0" sequence=".(Dimethyl)GDTPGHATPGHGGATSSAR" charge="3" aa_before="R" aa_after="K" protein_refs="PH_2" >
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="hyperscore" value="34.200000000000003"/>
 				<UserParam type="float" name="nextscore" value="8.0"/>
@@ -102,7 +102,7 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="853.11645836523337" RT="4131.050000000000182" spectrum_reference="scan=30586" >
-			<PeptideHit score="1.0" sequence=".(Dimethyl)TLVLSNLSYSATEETLQEVFEK(Dimethyl).(MOD:00266)" charge="3" aa_before="K" aa_after="A" protein_refs="PH_3" >
+			<PeptideHit score="1.0" sequence=".(Dimethyl)TLVLSNLSYSATEETLQEVFEK(Dimethyl)" charge="3" aa_before="K" aa_after="A" protein_refs="PH_3" >
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="hyperscore" value="27.100000000000001"/>
 				<UserParam type="float" name="nextscore" value="8.0"/>


### PR DESCRIPTION
## Description

Fixes #10029. A small signed mass bracket on a residue was silently replaced by the PSI-MOD term `MOD:00026` ("L-threonine residue") and the peptide lost a water:

```
PEPT[-0.5]IDE          -> PEPT(MOD:00026)IDE  -18.010565
PEPT[+0.001]IDE        -> PEPT(MOD:00026)IDE  -18.010565
PEPT[+0.000000001]IDE  -> PEPT(MOD:00026)IDE  -18.010565
```

All three cooperating causes from the issue are addressed.

**1. Tolerance off-by-one — `AASequence::parseModSquareBrackets_`**

`n_decimals = mod.size() - decimal_pos - 2` under-counted the decimals by one, so every mass bracket was matched ten times more loosely than written (`"-0.5"` with a tolerance of 1.0 Da, `"+0.001"` with 0.01 Da). Now `- 1`, i.e. the mass is matched at the precision it was written with.

**2. Zero-diff terms as match targets — `ModificationsDB`**

PSI-MOD "residue" terms describe a residue rather than a change to it and load as ordinary modifications with `getDiffMonoMass() == 0.0`; 117 such entries are in the DB. Since the mass search minimises `|diff − mass|`, they were returned as the best match for *any* small mass difference. A new `explainsMassDiff_()` guard in `getBestModificationByDiffMonoMass` and all four `searchModificationsByDiffMonoMass[Sorted]` overloads skips them unless a zero mass difference is what was searched for.

**3. Applying one loses a water — `Residue::setModification`**

A modification that describes neither a mass nor a formula difference no longer has its absolute mass and formula adopted. Those follow the convention of the source database, and PSI-MOD stores the residue as it occurs inside a peptide chain, i.e. without the water that `Residue`'s free-amino-acid mass and formula include.

The concrete mechanism is worth recording: `MOD:00026`'s `DiffFormula` is `C 0 H 0 N 0 O 0`, which `EmpiricalFormula` parses to an **empty** formula (zero-count elements are dropped in `parseFormula_`). So `getDiffFormula().isEmpty()` was true and the code fell through to `setFormula(EmpiricalFormula("C4H7NO2"))` — PSI-MOD's peptide-internal formula, one H2O short. That is where the water went; the absolute-mass assignment above it is overwritten by `setFormula()` in the common case.

Causes 1 and 2 are both required: with only 2, `[-0.5]` at a tolerance of 1.0 snaps to a *different* PSI-MOD term at −1.007825.

### Also fixed: the same defect in the file readers

`TOPP_IDFileConverter_10` surfaced the identical bug reached through `PepXMLFile` rather than bracket parsing. The input declares `<terminal_modification terminus="c" massdiff="0.0003" mass="17.0031"/>` — the rounding artifact X!Tandem produces by writing the C-terminal OH as 17.0031 instead of 17.00274. That near-zero shift resolved to `MOD:00266` ("N-L-glutamyl-poly-L-glutamic acid"), whose diff mass is 0.0 and whose origin is E, so peptides ending in **R** and **K** were annotated with it. The term contributes no mass, so no peptide mass changes; the four affected sequences in `IDFileConverter_10_output.idXML` simply lose the meaningless `(MOD:00266)`. The reference was edited in place, not regenerated — the diff is exactly those four tokens.

### Behaviour change

A mass written with fewer decimals than its deviation from the database entry is now kept as an exact unknown mass shift instead of being snapped to a named modification. Common spellings are unaffected: `M[+15.99]`, `M[+15.9949]`, `M[147.0354]`, `C[+57.02]`, `C[160.030649]`, `T[181.014]` and all integer forms still resolve.

The exceptions are UniMod's *tabulated* absolute masses — `M[147.035405]`, `C[160.030654]`, `C[159.035405]` — which are built from residue masses rounded to five decimals and therefore sit ~5e-6 Da from OpenMS' element table, beyond the 1e-6 that six decimals imply. Five existing assertions and the pyOpenMS tutorial used those spellings and were changed to four-decimal ones, which still resolve. Scope of the exposure:

* The precision-derived tolerance is used in exactly one place, `parseModSquareBrackets_` — only for a mass in square brackets inside a sequence string. Every other mass lookup uses a fixed tolerance and is untouched (`PepXMLFile` 0.002, `ProtXMLFile` 0.001, `ProForma`/`PercolatorOutfile`/`XTandemXMLFile`/`XQuestResultXMLHandler` 0.01, `MzIdentMLHandler` cross-links 0.0001, `Residue::setModificationByDiffMonoMass` 0.002).
* Real pepXML carries these masses as the numeric attribute `<mod_aminoacid_mass mass="147.035405"/>`, resolved at 0.002 — it never reaches the bracket parser.
* Everything OpenMS itself writes in brackets round-trips exactly as before: `toBracketString()` → `M[147]` → `Oxidation`; `toBracketString(false)` → `C[160.030648985200003]` → unknown mass with `dMass=0`, unchanged; `toBracketString(false, true)` → `C[+57.021464000000002]` → `Carbamidomethyl`.

A tolerance floor (`max(10^-n, 1e-5)`) was tried to preserve the tabulated spellings and rejected on measurement: it fails 8 class tests where the shipped rule fails 1, and one failure is a real hazard — `residuesMatch_` lets residue `X` match any origin, so on an `X` mass tag the tolerance is all that separates an arbitrary mass from the whole database, and `DFPANGERX[113.0840643509]` became `DFPANGERK(HN3_mustard)`, silently changing the residue's identity.

### Tests

Regression tests added to `AASequence_test` (the issue's five cases plus explicit `PEPT(MOD:00026)IDE`), `ModificationsDB_test` (zero-diff terms excluded for a non-zero shift, still found for a zero one) and `Residue_test` (applying a no-difference term leaves mass, average mass and formula untouched).

Verified on a local Linux build: **2741/2741 tests pass** (711 class tests plus the TOPP suite). The 5 skipped tests are search-engine adapter tests needing third-party binaries.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrRnWDL5HwGm4mJu4KBAQS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signed mass-bracket parsing so modification matching follows the provided decimal precision.
  * Prevented zero-mass annotations from being assigned to nonzero or near-zero mass tags.
  * Preserved residue masses and formulas when applying modifications without mass or formula differences.
  * Improved cumulative modification handling to prevent mass loss and order-dependent results.

* **Documentation**
  * Updated modification examples and clarified precision-based mass matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->