### PR TITLE
[FEATURE] ProForma: write tool-defined modifications as chemistry plus INFO name, resolve the name first (#10003, part 4a)

### DIFF
--- a/src/openms/source/CHEMISTRY/ProForma.cpp
+++ b/src/openms/source/CHEMISTRY/ProForma.cpp
@@ -1673,6 +1673,7 @@ namespace
 
     std::unique_ptr<ResidueModification> new_mod(new ResidueModification);
     new_mod->setFullId(full_id); // FullId without Id keeps this an anonymous (user-defined) modification
+    new_mod->setProvenance(ResidueModification::MASS_ONLY); // reconstructible from its own tag
     new_mod->setFullName(ResidueModification::getDiffMonoMassWithBracket(diff_mono));
     new_mod->setTermSpecificity(ts);
     // setDiffFormula() alone leaves getDiffMonoMass() at 0.0
@@ -1808,14 +1809,56 @@ namespace
     return !std::holds_alternative<InfoTag>(tag) && !std::holds_alternative<PositionConstraint>(tag);
   }
 
+  bool sameChemistry_(const ResidueModification& a, const ResidueModification& b)
+  {
+    if (!a.getDiffFormula().isEmpty() && !b.getDiffFormula().isEmpty()) return a.getDiffFormula() == b.getDiffFormula();
+    return std::fabs(a.getDiffMonoMass() - b.getDiffMonoMass()) <= 1e-6;
+  }
+
   void resolveModification_(Modification& mod, char residue, ResidueModification::TermSpecificity term_spec)
   {
     if (mod.alternatives.empty()) return;
+
+    // an INFO tag naming a registered definition identifies the modification; the inline chemistry is
+    // the fallback. Gated on hasDefinedModification(), so free text naming a vocabulary entry has no effect.
+    const ResidueModification* by_name = nullptr;
+    for (const auto& [tag, label] : mod.alternatives)
+    {
+      const auto* info = std::get_if<InfoTag>(&tag);
+      if (info == nullptr || info->text.empty()) continue;
+      if (!ModificationsDB::getInstance()->hasDefinedModification(info->text)) continue;
+      NamedMod nm;
+      nm.name = info->text;
+      by_name = resolveModificationTag_(ModificationTag(nm), residue, term_spec);
+      if (by_name != nullptr) break;
+    }
+
     // the first chemistry-carrying alternative, so the tag order inside the bracket does not matter
+    const ResidueModification* by_tag = nullptr;
+    bool has_chemistry = false;
     for (const auto& [tag, label] : mod.alternatives)
     {
       if (!isChemistryTag_(tag)) continue;
-      mod.resolved_mod = resolveModificationTag_(tag, residue, term_spec);
+      has_chemistry = true;
+      by_tag = resolveModificationTag_(tag, residue, term_spec);
+      break;
+    }
+
+    if (by_name != nullptr)
+    {
+      if (by_tag != nullptr && !sameChemistry_(*by_name, *by_tag))
+      {
+        OPENMS_LOG_WARN << "ProForma: the definition of '" << by_name->getFullId() << "' ("
+                        << by_name->getDiffFormula().toString() << " / " << by_name->getDiffMonoMass()
+                        << " Da) disagrees with the inline chemistry (" << by_tag->getDiffFormula().toString()
+                        << " / " << by_tag->getDiffMonoMass() << " Da); using the definition." << std::endl;
+      }
+      mod.resolved_mod = by_name;
+      return;
+    }
+    if (has_chemistry)
+    {
+      mod.resolved_mod = by_tag;
       return;
     }
     // annotations only: report what alternatives[0] gives
@@ -2339,7 +2382,8 @@ namespace
 
     An anonymous modification (empty getId()) is written as a `Formula:` tag when it carries a formula
     and as a mass delta otherwise - never as a NamedMod with an empty name, which produced the
-    unparseable "[]".
+    unparseable "[]". A tool-defined modification is written the same way plus an `INFO:` tag carrying
+    its name, so the peptidoform is chemically complete on its own and the name still travels.
   */
   ProForma::Modification modificationToProForma_(const ResidueModification* mod)
   {
@@ -2357,6 +2401,26 @@ namespace
       ProForma::FormulaTag ft;
       ft.formula_string = mod->getDiffFormula().toString();
       pf_mod.alternatives.emplace_back(std::move(ft), std::nullopt);
+    }
+    else if (!mod->getId().empty() && mod->getProvenance() == ResidueModification::DEFINED)
+    { // tool-defined: the chemistry first (it resolves anywhere), the name as an annotation
+      if (!mod->getDiffFormula().isEmpty())
+      {
+        ProForma::FormulaTag ft;
+        ft.formula_string = mod->getDiffFormula().toString();
+        pf_mod.alternatives.emplace_back(std::move(ft), std::nullopt);
+      }
+      else
+      {
+        ProForma::MassDelta md;
+        md.source = ProForma::MassDelta::Source::NONE;
+        md.mass = mod->getDiffMonoMass();
+        md.original_text = massDeltaText_(md.mass);
+        pf_mod.alternatives.emplace_back(std::move(md), std::nullopt);
+      }
+      ProForma::InfoTag info;
+      info.text = mod->getId();
+      pf_mod.alternatives.emplace_back(std::move(info), std::nullopt);
     }
     else if (!mod->getId().empty())
     {

--- a/src/tests/class_tests/openms/source/ModificationDefinitionIO_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationDefinitionIO_test.cpp
@@ -16,6 +16,7 @@
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
+#include <OpenMS/CHEMISTRY/ProForma.h>
 #include <OpenMS/CHEMISTRY/ResidueModification.h>
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
@@ -188,6 +189,44 @@ START_SECTION([EXTRA] registerFrom - registers the good records and skips a bad 
   TEST_EQUAL(ModificationDefinitionIO::registerFrom(sp), 0)
   sp.setMetaValue(Constants::UserParam::MODIFICATION_DEFINITIONS, d.toDefinitionString());
   TEST_EQUAL(ModificationDefinitionIO::registerFrom(sp), 1)
+}
+END_SECTION
+
+START_SECTION([EXTRA] collect - an inline Formula tag is not a definition but an INFO-named one is)
+{
+  ProteinIdentification prot;
+  prot.setIdentifier("run4a");
+  std::vector<ProteinIdentification> prots;
+  prots.push_back(prot);
+
+  // anonymous: reconstructible from its own tag, nothing to carry
+  AASequence anon = ProForma::toAASequence(ProForma::parse("PEPM[Formula:O]TIDE"), ProForma::ConversionPolicy::BEST_EFFORT);
+  TEST_TRUE(anon[3].isModified())
+  TEST_FALSE(ModificationDefinitionIO::isDefinition(anon[3].getModification()))
+  PeptideIdentification pep_anon;
+  pep_anon.setIdentifier("run4a");
+  PeptideHit hit_anon;
+  hit_anon.setSequence(anon);
+  pep_anon.insertHit(hit_anon);
+  PeptideIdentificationList peps_anon;
+  peps_anon.push_back(pep_anon);
+  TEST_EQUAL(ModificationDefinitionIO::collect(prots, peps_anon).size(), 0)
+
+  // the parquet spelling of a defined modification resolves to the definition, which is collected
+  const ResidueModification* def = define("TestIO:ViaInfo", 'K', "C9H11N2O8P");
+  TEST_TRUE(def != nullptr)
+  AASequence named = ProForma::toAASequence(ProForma::parse("AEADNLDDK[Formula:C9H11N2O8P1|INFO:TestIO:ViaInfo]K"), ProForma::ConversionPolicy::FAIL_ON_LOSS);
+  TEST_EQUAL(named.toString(), "AEADNLDDK(TestIO:ViaInfo)K")
+  PeptideIdentification pep_named;
+  pep_named.setIdentifier("run4a");
+  PeptideHit hit_named;
+  hit_named.setSequence(named);
+  pep_named.insertHit(hit_named);
+  PeptideIdentificationList peps_named;
+  peps_named.push_back(pep_named);
+  auto defs = ModificationDefinitionIO::collect(prots, peps_named);
+  TEST_EQUAL(defs.size(), 1)
+  TEST_EQUAL(defs["run4a"].count(def), 1)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ProFormaParser_test.cpp
+++ b/src/tests/class_tests/openms/source/ProFormaParser_test.cpp
@@ -17,9 +17,11 @@
 #include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 #include <OpenMS/CHEMISTRY/ResidueModification.h>
+#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
 
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -82,6 +84,29 @@ vector<string> loadTestCases(const string& filename)
 }
 
 ///////////////////////////
+
+namespace
+{
+  // registers a tool-defined modification; ModificationsDB is process-wide, so every section uses its own name
+  const ResidueModification* defineMod4a(const std::string& id, char origin, const std::string& formula, double mass = 0.0)
+  {
+    ResidueModification d;
+    d.setId(id);
+    d.setOrigin(origin);
+    d.setTermSpecificity(ResidueModification::ANYWHERE);
+    d.setFullId();
+    if (!formula.empty())
+    {
+      d.setDiffFormula(EmpiricalFormula(formula));
+      d.setDiffMonoMass(EmpiricalFormula(formula).getMonoWeight());
+    }
+    else
+    {
+      d.setDiffMonoMass(mass);
+    }
+    return ModificationsDB::getInstance()->registerDefinition(d);
+  }
+}
 
 START_TEST(ProFormaParser, "$Id$")
 
@@ -2071,6 +2096,103 @@ START_SECTION([EXTRA] fromAASequence - a huge mass delta is written in full rath
   TEST_TRUE(written.find('e') == std::string::npos)
   Peptidoform back = ProForma::parse(written); // must parse
   TEST_TRUE(ProForma::getMonoWeight(back) > 1e63)
+}
+END_SECTION
+
+START_SECTION([EXTRA] fromAASequence - a tool-defined modification is written as its chemistry plus an INFO tag)
+{
+  TEST_TRUE(defineMod4a("Test4a:Adduct", 'K', "C9H11N2O8P") != nullptr)
+  AASequence seq = AASequence::fromString("AEADNLDDK(Test4a:Adduct)K");
+  TEST_EQUAL(ProForma::toString(ProForma::fromAASequence(seq), WriteMode::CANONICAL), "AEADNLDDK[Formula:C9H11N2O8P1|INFO:Test4a:Adduct]K")
+  TEST_EQUAL(ProForma::toString(ProForma::fromAASequence(seq), WriteMode::LOSSLESS), "AEADNLDDK[Formula:C9H11N2O8P1|INFO:Test4a:Adduct]K")
+
+  // without a formula the chemistry is the mass delta
+  TEST_TRUE(defineMod4a("Test4a:MassOnlyDef", 'S', "", 123.4567) != nullptr)
+  AASequence seq2 = AASequence::fromString("PEPS(Test4a:MassOnlyDef)IDE");
+  TEST_EQUAL(ProForma::toString(ProForma::fromAASequence(seq2), WriteMode::LOSSLESS), "PEPS[+123.4567|INFO:Test4a:MassOnlyDef]IDE")
+
+  // vocabulary entries are unaffected
+  TEST_EQUAL(ProForma::toString(ProForma::fromAASequence(AASequence::fromString("PEPM(Oxidation)TIDE")), WriteMode::CANONICAL), "PEPM[UNIMOD:35]TIDE")
+}
+END_SECTION
+
+START_SECTION([EXTRA] toAASequence - the INFO name restores the identity of a tool-defined modification)
+{
+  TEST_TRUE(defineMod4a("Test4a:Identity", 'K', "C9H11N2O8P") != nullptr)
+  AASequence seq = AASequence::fromString("AEADNLDDK(Test4a:Identity)K");
+  const std::string written = ProForma::toString(ProForma::fromAASequence(seq), WriteMode::CANONICAL);
+  Peptidoform pf = ProForma::parse(written);
+  TEST_TRUE(ProForma::getAASequenceConversionIssues(pf).empty())
+
+  AASequence back = ProForma::toAASequence(pf, ConversionPolicy::FAIL_ON_LOSS);
+  TEST_EQUAL(back.toString(), seq.toString()) // the name, not a mass bracket
+  TEST_TRUE(back[8].getModification() == seq[8].getModification())
+  TEST_EQUAL(back.getFormula().toString(), seq.getFormula().toString())
+  TEST_REAL_SIMILAR(back.getMonoWeight(), seq.getMonoWeight())
+
+  // tag order inside the bracket does not matter
+  AASequence back2 = ProForma::toAASequence(ProForma::parse("AEADNLDDK[INFO:Test4a:Identity|Formula:C9H11N2O8P1]K"), ConversionPolicy::FAIL_ON_LOSS);
+  TEST_EQUAL(back2.toString(), seq.toString())
+
+  // the mass-delta spelling of a formula-less definition resolves by name as well
+  TEST_TRUE(defineMod4a("Test4a:IdentityMass", 'S', "", 123.4567) != nullptr)
+  AASequence back3 = ProForma::toAASequence(ProForma::parse("PEPS[+123.4567|INFO:Test4a:IdentityMass]IDE"), ConversionPolicy::FAIL_ON_LOSS);
+  TEST_EQUAL(back3.toString(), "PEPS(Test4a:IdentityMass)IDE")
+}
+END_SECTION
+
+START_SECTION([EXTRA] toAASequence - the definition wins over disagreeing inline chemistry and says so)
+{
+  TEST_TRUE(defineMod4a("Test4a:Disagree", 'K', "C2H2O") != nullptr)
+  std::ostringstream captured;
+  OPENMS_LOG_WARN.insert(captured);
+  AASequence seq = ProForma::toAASequence(ProForma::parse("PEPK[Formula:O|INFO:Test4a:Disagree]TIDE"), ConversionPolicy::BEST_EFFORT);
+  OPENMS_LOG_WARN.remove(captured);
+
+  TEST_TRUE(seq[3].getModification() != nullptr)
+  if (seq[3].getModification() != nullptr)
+  {
+    TEST_EQUAL(seq[3].getModification()->getId(), "Test4a:Disagree")
+  }
+  TEST_REAL_SIMILAR(seq.getMonoWeight(), AASequence::fromString("PEPKTIDE").getMonoWeight() + EmpiricalFormula("C2H2O").getMonoWeight())
+  TEST_TRUE(captured.str().find("disagrees") != std::string::npos)
+
+  // agreeing chemistry is silent
+  std::ostringstream quiet;
+  OPENMS_LOG_WARN.insert(quiet);
+  ProForma::toAASequence(ProForma::parse("PEPK[Formula:C2H2O|INFO:Test4a:Disagree]TIDE"), ConversionPolicy::BEST_EFFORT);
+  OPENMS_LOG_WARN.remove(quiet);
+  TEST_TRUE(quiet.str().find("disagrees") == std::string::npos)
+}
+END_SECTION
+
+START_SECTION([EXTRA] toAASequence - free text naming a vocabulary entry does not override the chemistry)
+{
+  TEST_FALSE(ModificationsDB::getInstance()->hasDefinedModification("Oxidation"))
+  std::ostringstream captured;
+  OPENMS_LOG_WARN.insert(captured);
+  AASequence seq = ProForma::toAASequence(ProForma::parse("PEPM[Formula:C2H2O|INFO:Oxidation]TIDE"), ConversionPolicy::BEST_EFFORT);
+  OPENMS_LOG_WARN.remove(captured);
+  TEST_REAL_SIMILAR(seq.getMonoWeight(), AASequence::fromString("PEPMTIDE").getMonoWeight() + EmpiricalFormula("C2H2O").getMonoWeight())
+  TEST_TRUE(captured.str().find("disagrees") == std::string::npos)
+}
+END_SECTION
+
+START_SECTION([EXTRA] toAASequence - a Formula tag yields an anonymous modification)
+{
+  AASequence seq = ProForma::toAASequence(ProForma::parse("PEPM[Formula:O]TIDE"), ConversionPolicy::BEST_EFFORT);
+  TEST_TRUE(seq[3].getModification() != nullptr)
+  if (seq[3].getModification() != nullptr)
+  {
+    TEST_EQUAL(seq[3].getModification()->getProvenance(), ResidueModification::MASS_ONLY)
+    TEST_TRUE(seq[3].getModification()->getId().empty())
+  }
+  AASequence combined = ProForma::toAASequence(ProForma::parse("PEPM[Oxidation][Formula:O]TIDE"), ConversionPolicy::BEST_EFFORT);
+  TEST_TRUE(combined[3].getModification() != nullptr)
+  if (combined[3].getModification() != nullptr)
+  {
+    TEST_EQUAL(combined[3].getModification()->getProvenance(), ResidueModification::MASS_ONLY)
+  }
 }
 END_SECTION
 


### PR DESCRIPTION
Part 4a of #10003 (stacked on #10028; #10026 and #10040 are merged — read those first). ProForma only; the file readers/writers follow in 4b.

**What changes**

- `fromAASequence`: a tool-defined modification (`Provenance::DEFINED`, non-empty Id) is written as its chemistry plus its name — `[Formula:C9H11N2O8P1|INFO:NuXL:U-H2O]`, or `[+123.4567|INFO:name]` when it has no formula. Chemistry first, so a reader without the definition still gets the right mass and formula; the name travels as an annotation. Vocabulary entries are unchanged (`[UNIMOD:35]`, bare names for CV entries without a UniMod accession).
- `toAASequence`: an `INFO:` tag whose text is a **registered definition** (`ModificationsDB::hasDefinedModification`) identifies the modification; the inline chemistry is the fallback. If both resolve and their chemistry disagrees, a warning names both and the definition wins. The gate is `hasDefinedModification`, not `has()`: free text such as `[Formula:C2H2O|INFO:Oxidation]` does not acquire a UniMod identity.
- `resolveFormulaTag_`: a modification synthesised from an inline `Formula:` tag is stamped `MASS_ONLY`. On the merged tree it inherited the `DEFINED` default from #10040, and only `isDefinition()`'s empty-Id guard kept it out of the definitions block.

Result for the parquet lane: `psms.parquet` carries `AEADNLDDK[Formula:C9H11N2O8P1|INFO:NuXL:U-H2O]K`, which is chemically complete on its own, and a reader that has the definitions (4b) reconstructs `AEADNLDDK(NuXL:U-H2O)K` — identity restored, not just mass.

**Behaviour change to note:** the QPX `psm_id` (`PSM_COMPOSITE` hashes the peptidoform) changes for tool-defined modifications. Intended — the previous spelling was the unparseable `[NuXL:U-H2O]` / `[]`.

**Tests** (`ProFormaParser_test`, `ModificationDefinitionIO_test`): literal output for defined mods with and without formula; identity round trip `toAASequence(parse(toString(fromAASequence(seq)))).toString() == seq.toString()` in `FAIL_ON_LOSS` with no conversion issues, in either tag order; definition wins over disagreeing inline chemistry and the warning is captured, agreeing chemistry is silent; the vocabulary gate; `MASS_ONLY` for formula-synthesised and combined modifications; `collect()` returns nothing for an inline formula and the definition for the INFO-named spelling.

Failed-on-purpose: five mutations (`no_stamp`, `no_info`, `no_name_first`, `gate_has`, `no_warn`), each red on exactly the assertion written for it, restored build green — log in the first comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKPrmDHEE7cZCxGfTKTtFE



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved ProForma modification handling when named definitions and inline chemistry are both provided.
  * Tool-defined modifications now retain their names through ProForma serialization using chemistry details and `INFO` tags.
  * Anonymous formula- and mass-based modifications are represented more accurately.

* **Bug Fixes**
  * Added warnings when registered modification definitions conflict with inline chemistry.
  * Improved resolution of modifications regardless of tag order.

* **Tests**
  * Expanded coverage for ProForma parsing, serialization, definition collection, and conflicting modification data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->