### PR TITLE
[FEATURE] idXML, featureXML, consensusXML and the parquet bundles carry modification definitions (#10003, part 4b)

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/ModificationDefinitionIO.h
+++ b/src/openms/include/OpenMS/FORMAT/ModificationDefinitionIO.h
@@ -21,6 +21,8 @@
 
 namespace OpenMS
 {
+  class ConsensusMap;
+  class FeatureMap;
   class ResidueModification;
 
   /**
@@ -49,6 +51,12 @@ namespace OpenMS
       const std::vector<ProteinIdentification>& protein_ids,
       const PeptideIdentificationList& peptide_ids);
 
+    /// collect() over a FeatureMap: its runs, the identifications of every feature (subordinates included) and the unassigned ones
+    static std::map<std::string, std::set<const ResidueModification*>> collect(const FeatureMap& map);
+
+    /// collect() over a ConsensusMap: its runs, the identifications of every consensus feature and the unassigned ones
+    static std::map<std::string, std::set<const ResidueModification*>> collect(const ConsensusMap& map);
+
     /// Serialise @p defs into one ';'-joined string. Deterministic: records are sorted.
     static std::string encode(const std::set<const ResidueModification*>& defs);
 
@@ -56,6 +64,12 @@ namespace OpenMS
     /// what the meta value already holds. No-op when there is nothing to store.
     static void attach(ProteinIdentification::SearchParameters& sp,
                        const std::set<const ResidueModification*>& defs);
+
+    /// Per run identifier, the value attach() would store: @p defs unioned with what the run's
+    /// SearchParameters already carry. Runs with nothing to store are absent.
+    static std::map<std::string, std::string> encodeByRun(
+      const std::vector<ProteinIdentification>& protein_ids,
+      const std::map<std::string, std::set<const ResidueModification*>>& defs);
 
     /// Register every record in @p records into ModificationsDB; a malformed record is logged and
     /// skipped. @return the number of records registered

--- a/src/openms/include/OpenMS/FORMAT/ProteinIdentificationArrowIO.h
+++ b/src/openms/include/OpenMS/FORMAT/ProteinIdentificationArrowIO.h
@@ -112,6 +112,8 @@ public:
     @param[in] protein_identifications Vector of protein identifications
     @param[in] filename Output file path
     @param[in] config Parquet writing options
+    @param[in] definitions_by_run Per run identifier, the modification_definitions value to write
+               (replaces an inbound one); see ModificationDefinitionIO::encodeByRun
     @return true on success, false on error
   */
   static bool exportSearchParamsToParquet(

--- a/src/openms/include/OpenMS/FORMAT/ProteinIdentificationArrowIO.h
+++ b/src/openms/include/OpenMS/FORMAT/ProteinIdentificationArrowIO.h
@@ -98,10 +98,13 @@ public:
     Each ProteinIdentification's SearchParameters becomes one row.
 
     @param[in] protein_identifications Vector of protein identifications
+    @param[in] definitions_by_run Per run identifier, the modification_definitions value to write
+               (replaces an inbound one); see ModificationDefinitionIO::encodeByRun
     @return Shared pointer to Arrow Table, or nullptr on error
   */
   static std::shared_ptr<arrow::Table> exportSearchParamsToArrow(
-    const std::vector<ProteinIdentification>& protein_identifications);
+    const std::vector<ProteinIdentification>& protein_identifications,
+    const std::map<std::string, std::string>& definitions_by_run = {});
 
   /**
     @brief Export search parameters to Parquet file
@@ -114,7 +117,8 @@ public:
   static bool exportSearchParamsToParquet(
     const std::vector<ProteinIdentification>& protein_identifications,
     const std::string& filename,
-    const ParquetWriteConfig& config = ParquetWriteConfig{});
+    const ParquetWriteConfig& config = ParquetWriteConfig{},
+    const std::map<std::string, std::string>& definitions_by_run = {});
 
   // ==================== Import methods ====================
 

--- a/src/openms/source/FORMAT/ConsensusMapArrowIO.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowIO.cpp
@@ -16,6 +16,7 @@
 #include <OpenMS/FORMAT/ArrowIOHelpers.h>
 #include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
 #include <OpenMS/FORMAT/ProteinIdentificationArrowIO.h>
+#include <OpenMS/FORMAT/ModificationDefinitionIO.h>
 #include <OpenMS/FORMAT/QPXFile.h>
 #include <OpenMS/METADATA/DataProcessing.h>
 #include <OpenMS/CHEMISTRY/ProForma.h>
@@ -1170,7 +1171,8 @@ bool ConsensusMapArrowIO::exportToParquet(
     return false;
   }
   if (!ProteinIdentificationArrowIO::exportSearchParamsToParquet(
-          prot_ids, directory + "/search_params.parquet", config))
+          prot_ids, directory + "/search_params.parquet", config,
+          ModificationDefinitionIO::encodeByRun(prot_ids, ModificationDefinitionIO::collect(cmap))))
   {
     return false;
   }

--- a/src/openms/source/FORMAT/FeatureMapArrowIO.cpp
+++ b/src/openms/source/FORMAT/FeatureMapArrowIO.cpp
@@ -16,6 +16,7 @@
 #include <OpenMS/FORMAT/ArrowIOHelpers.h>
 #include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
 #include <OpenMS/FORMAT/ProteinIdentificationArrowIO.h>
+#include <OpenMS/FORMAT/ModificationDefinitionIO.h>
 #include <OpenMS/FORMAT/QPXFile.h>
 #include <OpenMS/METADATA/DataProcessing.h>
 #include <OpenMS/METADATA/PeptideEvidence.h>
@@ -1302,7 +1303,8 @@ bool FeatureMapArrowIO::exportToParquet(
     return false;
   }
   if (!ProteinIdentificationArrowIO::exportSearchParamsToParquet(
-          prot_ids, directory + "/search_params.parquet", config))
+          prot_ids, directory + "/search_params.parquet", config,
+          ModificationDefinitionIO::encodeByRun(prot_ids, ModificationDefinitionIO::collect(feature_map))))
   {
     return false;
   }

--- a/src/openms/source/FORMAT/HANDLERS/ConsensusXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ConsensusXMLHandler.cpp
@@ -13,6 +13,7 @@
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/UniqueIdGenerator.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
+#include <OpenMS/FORMAT/ModificationDefinitionIO.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/METADATA/DataProcessing.h>
 #include <OpenMS/SYSTEM/File.h>
@@ -91,6 +92,7 @@ namespace OpenMS::Internal
     }
     else if (tag == "SearchParameters")
     {
+      ModificationDefinitionIO::registerFrom(search_param_); // before any peptide sequence is parsed
       prot_id_.setSearchParameters(search_param_);
       search_param_ = ProteinIdentification::SearchParameters();
     }
@@ -657,6 +659,7 @@ namespace OpenMS::Internal
     // throws if protIDs are not unique, i.e. PeptideIDs will be randomly assigned (bad!)
     checkUniqueIdentifiers_(consensus_map.getProteinIdentifications());
 
+    const auto definitions = ModificationDefinitionIO::collect(consensus_map);
     for (UInt i = 0; i < consensus_map.getProteinIdentifications().size(); ++i)
     {
       setProgress(++progress_);
@@ -669,7 +672,11 @@ namespace OpenMS::Internal
       os << "search_engine_version=\"" << writeXMLEscape(current_prot_id.getSearchEngineVersion()) << "\">\n";
 
       //write search parameters
-      const ProteinIdentification::SearchParameters& search_param = current_prot_id.getSearchParameters();
+      ProteinIdentification::SearchParameters search_param = current_prot_id.getSearchParameters();
+      if (const auto d = definitions.find(current_prot_id.getIdentifier()); d != definitions.end())
+      {
+        ModificationDefinitionIO::attach(search_param, d->second);
+      }
       os << "\t\t<SearchParameters " << "db=\"" << search_param.db << "\" " << "db_version=\"" << search_param.db_version << "\" " << "taxonomy=\""
          << search_param.taxonomy << "\" ";
       if (search_param.mass_type == ProteinIdentification::PeakMassType::MONOISOTOPIC)

--- a/src/openms/source/FORMAT/HANDLERS/FeatureXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/FeatureXMLHandler.cpp
@@ -13,6 +13,7 @@
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
+#include <OpenMS/FORMAT/ModificationDefinitionIO.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/METADATA/DataProcessing.h>
 
@@ -107,6 +108,7 @@ namespace OpenMS::Internal
 
     // write identification runs
     Size prot_count = 0;
+    const auto definitions = ModificationDefinitionIO::collect(feature_map);
     for (Size i = 0; i < feature_map.getProteinIdentifications().size(); ++i)
     {
       const ProteinIdentification& current_prot_id = feature_map.getProteinIdentifications()[i];
@@ -118,7 +120,11 @@ namespace OpenMS::Internal
       os << "search_engine_version=\"" << writeXMLEscape(current_prot_id.getSearchEngineVersion()) << "\">\n";
 
       //write search parameters
-      const ProteinIdentification::SearchParameters& search_param = current_prot_id.getSearchParameters();
+      ProteinIdentification::SearchParameters search_param = current_prot_id.getSearchParameters();
+      if (const auto d = definitions.find(current_prot_id.getIdentifier()); d != definitions.end())
+      {
+        ModificationDefinitionIO::attach(search_param, d->second);
+      }
       os << "\t\t<SearchParameters "
          << "db=\"" << writeXMLEscape(search_param.db) << "\" "
          << "db_version=\"" << writeXMLEscape(search_param.db_version) << "\" "
@@ -792,6 +798,7 @@ namespace OpenMS::Internal
     }
     else if (tag == "SearchParameters")
     {
+      ModificationDefinitionIO::registerFrom(search_param_); // before any peptide sequence is parsed
       prot_id_.setSearchParameters(search_param_);
       search_param_ = ProteinIdentification::SearchParameters();
     }

--- a/src/openms/source/FORMAT/IdXMLFile.cpp
+++ b/src/openms/source/FORMAT/IdXMLFile.cpp
@@ -16,6 +16,7 @@
 #include <OpenMS/CHEMISTRY/EnzymaticDigestion.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/FORMAT/ModificationDefinitionIO.h>
 #include <OpenMS/METADATA/PeptideIdentificationList.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/SYSTEM/File.h>
@@ -111,14 +112,25 @@ namespace OpenMS
     }
     os << " xsi:noNamespaceSchemaLocation=\"https://www.openms.de/xml-schema/IdXML_1_5.xsd\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n";
 
-    // look up different search parameters
+    // look up different search parameters. SearchParameters::operator== ignores meta values, so runs
+    // collapse onto one block; the block carries the modification definitions of all of them.
+    const auto definitions = ModificationDefinitionIO::collect(protein_ids, peptide_ids);
     std::vector<ProteinIdentification::SearchParameters> params;
+    std::vector<std::set<const ResidueModification*>> params_defs;
     for (std::vector<ProteinIdentification>::const_iterator it = protein_ids.begin(); it != protein_ids.end(); ++it)
     {
-      if (find(params.begin(), params.end(), it->getSearchParameters()) == params.end())
+      const Size idx = static_cast<Size>(find(params.begin(), params.end(), it->getSearchParameters()) - params.begin());
+      if (idx == params.size())
       {
         params.push_back(it->getSearchParameters());
+        params_defs.emplace_back();
       }
+      const auto d = definitions.find(it->getIdentifier());
+      if (d != definitions.end()) params_defs[idx].insert(d->second.begin(), d->second.end());
+    }
+    for (Size i = 0; i != params.size(); ++i)
+    {
+      ModificationDefinitionIO::attach(params[i], params_defs[i]);
     }
 
     // write search parameters
@@ -174,7 +186,20 @@ namespace OpenMS
     //empty search parameters
     if (params.empty())
     {
-      os << "<SearchParameters charges=\"+0, +0\" id=\"ID_1\" db_version=\"0\" mass_type=\"monoisotopic\" peak_mass_tolerance=\"0.0\" precursor_peak_tolerance=\"0.0\" db=\"Unknown\"/>\n";
+      std::set<const ResidueModification*> all_defs;
+      for (const auto& d : definitions) all_defs.insert(d.second.begin(), d.second.end());
+      if (all_defs.empty())
+      {
+        os << "<SearchParameters charges=\"+0, +0\" id=\"ID_1\" db_version=\"0\" mass_type=\"monoisotopic\" peak_mass_tolerance=\"0.0\" precursor_peak_tolerance=\"0.0\" db=\"Unknown\"/>\n";
+      }
+      else
+      {
+        os << "<SearchParameters charges=\"+0, +0\" id=\"ID_1\" db_version=\"0\" mass_type=\"monoisotopic\" peak_mass_tolerance=\"0.0\" precursor_peak_tolerance=\"0.0\" db=\"Unknown\">\n";
+        ProteinIdentification::SearchParameters sp;
+        ModificationDefinitionIO::attach(sp, all_defs);
+        writeUserParam_("UserParam", os, sp, 4);
+        os << "\t</SearchParameters>\n";
+      }
     }
 
     // throws if protIDs are not unique, i.e. PeptideIDs will be randomly assigned (bad!)
@@ -835,6 +860,7 @@ namespace OpenMS
         }
       }
       last_meta_ = nullptr;
+      ModificationDefinitionIO::registerFrom(param_); // before any peptide sequence is parsed
       parameters_[id_] = param_;
     }
     else if (tag == "FixedModification")

--- a/src/openms/source/FORMAT/ModificationDefinitionIO.cpp
+++ b/src/openms/source/FORMAT/ModificationDefinitionIO.cpp
@@ -14,6 +14,8 @@
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/KERNEL/ConsensusMap.h>
+#include <OpenMS/KERNEL/FeatureMap.h>
 
 #include <algorithm>
 
@@ -25,54 +27,109 @@ namespace OpenMS
     return mod != nullptr && mod->getProvenance() == ResidueModification::DEFINED && !mod->getId().empty();
   }
 
-  std::map<std::string, std::set<const ResidueModification*>> ModificationDefinitionIO::collect(
-    const std::vector<ProteinIdentification>& protein_ids,
-    const PeptideIdentificationList& peptide_ids)
+  namespace
   {
-    std::map<std::string, std::set<const ResidueModification*>> out;
-    const ModificationsDB* db = ModificationsDB::getInstance();
+    using DefsByRun = std::map<std::string, std::set<const ResidueModification*>>;
 
-    // Definitions named by the search space, whether or not any hit carries them.
-    for (const ProteinIdentification& prot : protein_ids)
+    // definitions named by the search space, whether or not any hit carries them
+    void addSearchSpace_(DefsByRun& out, const std::vector<ProteinIdentification>& protein_ids)
     {
-      const ProteinIdentification::SearchParameters& sp = prot.getSearchParameters();
-      for (const std::vector<std::string>* names : {&sp.fixed_modifications, &sp.variable_modifications})
+      const ModificationsDB* db = ModificationsDB::getInstance();
+      for (const ProteinIdentification& prot : protein_ids)
       {
-        for (const std::string& name : *names)
+        const ProteinIdentification::SearchParameters& sp = prot.getSearchParameters();
+        for (const std::vector<std::string>* names : {&sp.fixed_modifications, &sp.variable_modifications})
         {
-          if (!db->has(name)) continue; // has() is silent; searchModifications logs on a miss
-          std::set<const ResidueModification*> matches; // a bare Id names every site it is defined on
-          db->searchModifications(matches, name);
-          for (const ResidueModification* mod : matches)
+          for (const std::string& name : *names)
           {
-            if (isDefinition(mod)) out[prot.getIdentifier()].insert(mod);
+            if (!db->has(name)) continue; // has() is silent; searchModifications logs on a miss
+            std::set<const ResidueModification*> matches; // a bare Id names every site it is defined on
+            db->searchModifications(matches, name);
+            for (const ResidueModification* mod : matches)
+            {
+              if (ModificationDefinitionIO::isDefinition(mod)) out[prot.getIdentifier()].insert(mod);
+            }
           }
         }
       }
     }
 
-    // Definitions actually sitting on peptidoforms.
-    for (const PeptideIdentification& pep : peptide_ids)
+    // definitions sitting on the peptidoforms of one identification
+    void addHits_(DefsByRun& out, const PeptideIdentification& pep)
     {
       const std::string& run = pep.getIdentifier();
       for (const PeptideHit& hit : pep.getHits())
       {
         const AASequence& seq = hit.getSequence();
-        if (seq.hasNTerminalModification() && isDefinition(seq.getNTerminalModification()))
+        if (seq.hasNTerminalModification() && ModificationDefinitionIO::isDefinition(seq.getNTerminalModification()))
         {
           out[run].insert(seq.getNTerminalModification());
         }
         for (Size i = 0; i < seq.size(); ++i)
         {
-          if (seq[i].isModified() && isDefinition(seq[i].getModification()))
+          if (seq[i].isModified() && ModificationDefinitionIO::isDefinition(seq[i].getModification()))
           {
             out[run].insert(seq[i].getModification());
           }
         }
-        if (seq.hasCTerminalModification() && isDefinition(seq.getCTerminalModification()))
+        if (seq.hasCTerminalModification() && ModificationDefinitionIO::isDefinition(seq.getCTerminalModification()))
         {
           out[run].insert(seq.getCTerminalModification());
         }
+      }
+    }
+
+    void addFeature_(DefsByRun& out, const Feature& feature)
+    {
+      for (const PeptideIdentification& pep : feature.getPeptideIdentifications()) addHits_(out, pep);
+      for (const Feature& sub : feature.getSubordinates()) addFeature_(out, sub);
+    }
+  } // namespace
+
+  std::map<std::string, std::set<const ResidueModification*>> ModificationDefinitionIO::collect(
+    const std::vector<ProteinIdentification>& protein_ids,
+    const PeptideIdentificationList& peptide_ids)
+  {
+    DefsByRun out;
+    addSearchSpace_(out, protein_ids);
+    for (const PeptideIdentification& pep : peptide_ids) addHits_(out, pep);
+    return out;
+  }
+
+  std::map<std::string, std::set<const ResidueModification*>> ModificationDefinitionIO::collect(const FeatureMap& map)
+  {
+    DefsByRun out;
+    addSearchSpace_(out, map.getProteinIdentifications());
+    for (const Feature& feature : map) addFeature_(out, feature);
+    for (const PeptideIdentification& pep : map.getUnassignedPeptideIdentifications()) addHits_(out, pep);
+    return out;
+  }
+
+  std::map<std::string, std::set<const ResidueModification*>> ModificationDefinitionIO::collect(const ConsensusMap& map)
+  {
+    DefsByRun out;
+    addSearchSpace_(out, map.getProteinIdentifications());
+    for (const ConsensusFeature& feature : map)
+    {
+      for (const PeptideIdentification& pep : feature.getPeptideIdentifications()) addHits_(out, pep);
+    }
+    for (const PeptideIdentification& pep : map.getUnassignedPeptideIdentifications()) addHits_(out, pep);
+    return out;
+  }
+
+  std::map<std::string, std::string> ModificationDefinitionIO::encodeByRun(
+    const std::vector<ProteinIdentification>& protein_ids,
+    const std::map<std::string, std::set<const ResidueModification*>>& defs)
+  {
+    std::map<std::string, std::string> out;
+    for (const ProteinIdentification& prot : protein_ids)
+    {
+      ProteinIdentification::SearchParameters sp = prot.getSearchParameters();
+      const auto it = defs.find(prot.getIdentifier());
+      attach(sp, it == defs.end() ? std::set<const ResidueModification*>() : it->second);
+      if (sp.metaValueExists(Constants::UserParam::MODIFICATION_DEFINITIONS))
+      {
+        out[prot.getIdentifier()] = sp.getMetaValue(Constants::UserParam::MODIFICATION_DEFINITIONS).toString();
       }
     }
     return out;

--- a/src/openms/source/FORMAT/PSMArrowIO.cpp
+++ b/src/openms/source/FORMAT/PSMArrowIO.cpp
@@ -13,6 +13,7 @@
 #include <OpenMS/FORMAT/ParquetFile.h>
 #include <OpenMS/FORMAT/QPXFile.h>
 #include <OpenMS/FORMAT/ProteinIdentificationArrowIO.h>
+#include <OpenMS/FORMAT/ModificationDefinitionIO.h>
 #include <OpenMS/SYSTEM/File.h>
 
 #include <arrow/api.h>
@@ -87,7 +88,8 @@ bool PSMArrowIO::exportToParquet(
     return false;
   }
   if (!ProteinIdentificationArrowIO::exportSearchParamsToParquet(
-        protein_identifications, dir + "/" + kSearchParams, config))
+        protein_identifications, dir + "/" + kSearchParams, config,
+        ModificationDefinitionIO::encodeByRun(protein_identifications, ModificationDefinitionIO::collect(protein_identifications, peptide_identifications))))
   {
     OPENMS_LOG_ERROR << "PSMArrowIO: failed to write " << kSearchParams << std::endl;
     return false;

--- a/src/openms/source/FORMAT/ProteinIdentificationArrowIO.cpp
+++ b/src/openms/source/FORMAT/ProteinIdentificationArrowIO.cpp
@@ -16,8 +16,10 @@
 #include <OpenMS/CHEMISTRY/EnzymaticDigestion.h>
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
+#include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/FORMAT/ArrowIOHelpers.h>
 #include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
+#include <OpenMS/FORMAT/ModificationDefinitionIO.h>
 
 #include <arrow/api.h>
 #include <arrow/builder.h>
@@ -800,7 +802,8 @@ bool ProteinIdentificationArrowIO::exportProteinGroupsToParquet(
 
 
 std::shared_ptr<arrow::Table> ProteinIdentificationArrowIO::exportSearchParamsToArrow(
-  const std::vector<ProteinIdentification>& protein_identifications)
+  const std::vector<ProteinIdentification>& protein_identifications,
+  const std::map<std::string, std::string>& definitions_by_run)
 {
   // -- Simple column builders --
   arrow::StringBuilder run_identifier_builder, search_engine_builder;
@@ -1111,7 +1114,20 @@ std::shared_ptr<arrow::Table> ProteinIdentificationArrowIO::exportSearchParamsTo
 
     // === sp_metavalues (not nullable) - from SearchParameters ===
     (void)sp_metavalues_builder.Append();
-    appendMetaValues_(sp, sp_mv_name_b, sp_mv_value_b, sp_mv_type_b, sp_mv_struct_b, no_exclusions);
+    const auto defs_it = definitions_by_run.find(prot_id.getIdentifier());
+    if (defs_it == definitions_by_run.end())
+    {
+      appendMetaValues_(sp, sp_mv_name_b, sp_mv_value_b, sp_mv_type_b, sp_mv_struct_b, no_exclusions);
+    }
+    else
+    { // the freshly collected modification definitions replace an inbound value
+      static const std::unordered_set<std::string> exclude_definitions{Constants::UserParam::MODIFICATION_DEFINITIONS};
+      appendMetaValues_(sp, sp_mv_name_b, sp_mv_value_b, sp_mv_type_b, sp_mv_struct_b, exclude_definitions);
+      (void)sp_mv_struct_b->Append();
+      (void)sp_mv_name_b->Append(Constants::UserParam::MODIFICATION_DEFINITIONS);
+      (void)sp_mv_value_b->Append(defs_it->second);
+      (void)sp_mv_type_b->Append("string");
+    }
 
   } // end prot_id loop
 
@@ -1218,9 +1234,10 @@ std::shared_ptr<arrow::Table> ProteinIdentificationArrowIO::exportSearchParamsTo
 bool ProteinIdentificationArrowIO::exportSearchParamsToParquet(
   const std::vector<ProteinIdentification>& protein_identifications,
   const std::string& filename,
-  const ParquetWriteConfig& config)
+  const ParquetWriteConfig& config,
+  const std::map<std::string, std::string>& definitions_by_run)
 {
-  auto table = exportSearchParamsToArrow(protein_identifications);
+  auto table = exportSearchParamsToArrow(protein_identifications, definitions_by_run);
   if (!table)
   {
     OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: Failed to create Arrow table for search params" << std::endl;
@@ -1405,6 +1422,7 @@ bool ProteinIdentificationArrowIO::importSearchParamsFromArrow(
 
     // SearchParameters metavalues (restore before setSearchParameters)
     ArrowIOHelpers::readMetaValues(col_sp_metavalues, row, sp);
+    ModificationDefinitionIO::registerFrom(sp); // before any peptidoform is parsed
 
     prot_id.setSearchParameters(sp);
 

--- a/src/pyOpenMS/bindings/bind_format.cpp
+++ b/src/pyOpenMS/bindings/bind_format.cpp
@@ -2728,7 +2728,8 @@ or chromatograms only (SRM/MRM) and forwards to the appropriate loader.
         .def_static("exportSearchParamsToParquet", &OpenMS::ProteinIdentificationArrowIO::exportSearchParamsToParquet,
             "protein_identifications"_a, "filename"_a,
             "config"_a = OpenMS::ParquetWriteConfig{},
-            "Export search parameters to Parquet file. Returns True on success")
+            "definitions_by_run"_a = std::map<std::string, std::string>{},
+            "Export search parameters to Parquet file; definitions_by_run maps a run identifier to its modification_definitions value. Returns True on success")
         // Import methods: std::vector<ProteinIdentification>& is an output param.
         // Since vectors go through nanobind's STL type caster (creates copies),
         // we must use lambdas that return the modified vector.

--- a/src/tests/class_tests/openms/CMakeLists.txt
+++ b/src/tests/class_tests/openms/CMakeLists.txt
@@ -180,6 +180,10 @@ target_link_libraries(ConsensusMapArrowIO_test
   ${OPENMS_ARROW_TARGET}
   ${OPENMS_PARQUET_TARGET}
 )
+target_link_libraries(PSMArrowIO_test
+  ${OPENMS_ARROW_TARGET}
+  ${OPENMS_PARQUET_TARGET}
+)
 target_link_libraries(XICParquetFile_test
   ${OPENMS_ARROW_TARGET}
   ${OPENMS_PARQUET_TARGET}

--- a/src/tests/class_tests/openms/source/ConsensusMapArrowIO_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapArrowIO_test.cpp
@@ -20,6 +20,15 @@
 #include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/KERNEL/ConsensusFeature.h>
 #include <OpenMS/KERNEL/FeatureHandle.h>
+#include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
+#include <OpenMS/CHEMISTRY/ModificationsDB.h>
+#include <OpenMS/CHEMISTRY/ResidueModification.h>
+#include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/DATASTRUCTURES/DateTime.h>
+
+#include <fstream>
+#include <sstream>
 #include <OpenMS/DATASTRUCTURES/DateTime.h>
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/METADATA/DataProcessing.h>
@@ -34,6 +43,60 @@
 
 using namespace OpenMS;
 using namespace std;
+
+namespace
+{
+  // registers a tool-defined modification; ModificationsDB is process-wide, so every section uses its own name
+  const ResidueModification* defineMod4b(const std::string& id, char origin, const std::string& formula)
+  {
+    ResidueModification d;
+    d.setId(id);
+    d.setOrigin(origin);
+    d.setTermSpecificity(ResidueModification::ANYWHERE);
+    d.setFullId();
+    d.setDiffFormula(EmpiricalFormula(formula));
+    d.setDiffMonoMass(EmpiricalFormula(formula).getMonoWeight());
+    return ModificationsDB::getInstance()->registerDefinition(d);
+  }
+
+  // a definition record for a name that is NOT registered in this process
+  std::string freshRecord4b(const std::string& id, char origin, const std::string& formula)
+  {
+    ResidueModification d;
+    d.setId(id);
+    d.setOrigin(origin);
+    d.setTermSpecificity(ResidueModification::ANYWHERE);
+    d.setFullId();
+    d.setDiffFormula(EmpiricalFormula(formula));
+    d.setDiffMonoMass(EmpiricalFormula(formula).getMonoWeight());
+    return d.toDefinitionString();
+  }
+
+  std::string slurp4b(const std::string& path)
+  {
+    std::ifstream in(path);
+    std::stringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+  }
+
+  bool fileContains4b(const std::string& path, const std::string& needle)
+  {
+    return slurp4b(path).find(needle) != std::string::npos;
+  }
+
+  // first occurrence only; returns false when @p from is absent
+  bool replaceInFile4b(const std::string& path, const std::string& from, const std::string& to)
+  {
+    std::string s = slurp4b(path);
+    const std::size_t pos = s.find(from);
+    if (pos == std::string::npos) return false;
+    s.replace(pos, from.size(), to);
+    std::ofstream out(path);
+    out << s;
+    return true;
+  }
+}
 
 START_TEST(ConsensusMapArrowIO, "$Id$")
 
@@ -1014,6 +1077,97 @@ START_SECTION(exportToParquet - duplicate ProteinIdentification identifiers thro
 
   TEST_EXCEPTION(Exception::InvalidValue,
                  ConsensusMapArrowIO::exportToParquet(cmap, tmp_dir))
+}
+END_SECTION
+
+START_SECTION([EXTRA] exportToParquet / importFromParquet - tool-defined modifications travel with their definitions)
+{
+  TEST_TRUE(defineMod4b("TestCMap:Assigned", 'K', "C2H2O") != nullptr)
+  TEST_TRUE(defineMod4b("TestCMap:Unassigned", 'R', "CH2") != nullptr)
+  ConsensusMap map;
+  map.ensureUniqueId();
+  map.getColumnHeaders()[0].filename = "file0.mzML";
+  map.getColumnHeaders()[0].size = 1;
+  ProteinIdentification prot;
+  prot.setIdentifier("run4b");
+  prot.setDateTime(DateTime::now());
+  map.getProteinIdentifications().push_back(prot);
+
+  ConsensusFeature f;
+  f.setRT(100.0);
+  f.setMZ(500.0);
+  f.setIntensity(1000.0);
+  f.ensureUniqueId();
+  f.insert(FeatureHandle(0, f));
+  PeptideIdentification pa;
+  pa.setIdentifier("run4b");
+  PeptideHit ha;
+  ha.setSequence(AASequence::fromString("PEPK(TestCMap:Assigned)IDE"));
+  pa.insertHit(ha);
+  f.getPeptideIdentifications().push_back(pa);
+  map.push_back(f);
+
+  PeptideIdentification pu;
+  pu.setIdentifier("run4b");
+  PeptideHit hu;
+  hu.setSequence(AASequence::fromString("PEPR(TestCMap:Unassigned)IDE"));
+  pu.insertHit(hu);
+  map.getUnassignedPeptideIdentifications().push_back(pu);
+
+  std::string dir;
+  NEW_TMP_FILE(dir) dir += ".cmd";
+  TEST_TRUE(ConsensusMapArrowIO::exportToParquet(map, dir))
+  ConsensusMap in;
+  TEST_TRUE(ConsensusMapArrowIO::importFromParquet(dir, in))
+  TEST_EQUAL(in.size(), 1)
+  TEST_EQUAL(in.getUnassignedPeptideIdentifications().size(), 1)
+  if (in.size() == 1 && !in[0].getPeptideIdentifications().empty() && !in[0].getPeptideIdentifications()[0].getHits().empty())
+  {
+    TEST_EQUAL(in[0].getPeptideIdentifications()[0].getHits()[0].getSequence().toString(), "PEPK(TestCMap:Assigned)IDE")
+  }
+  if (in.getUnassignedPeptideIdentifications().size() == 1 && !in.getUnassignedPeptideIdentifications()[0].getHits().empty())
+  {
+    TEST_EQUAL(in.getUnassignedPeptideIdentifications()[0].getHits()[0].getSequence().toString(), "PEPR(TestCMap:Unassigned)IDE")
+  }
+  if (in.getProteinIdentifications().size() == 1)
+  {
+    const auto& sp = in.getProteinIdentifications()[0].getSearchParameters();
+    TEST_TRUE(sp.metaValueExists(Constants::UserParam::MODIFICATION_DEFINITIONS))
+    if (sp.metaValueExists(Constants::UserParam::MODIFICATION_DEFINITIONS))
+    {
+      const std::string v = sp.getMetaValue(Constants::UserParam::MODIFICATION_DEFINITIONS).toString();
+      TEST_TRUE(v.find("TestCMap:Assigned") != std::string::npos)
+      TEST_TRUE(v.find("TestCMap:Unassigned") != std::string::npos)
+    }
+  }
+  File::removeDirRecursively(dir);
+}
+END_SECTION
+
+START_SECTION([EXTRA] importFromParquet - definitions are registered from search_params.parquet)
+{
+  const ModificationsDB* db = ModificationsDB::getInstance();
+  TEST_FALSE(db->hasDefinedModification("TestCMap:Fresh"))
+  ConsensusMap map;
+  map.ensureUniqueId();
+  map.getColumnHeaders()[0].filename = "file0.mzML";
+  map.getColumnHeaders()[0].size = 1;
+  ProteinIdentification prot;
+  prot.setIdentifier("run4b_fresh");
+  prot.setDateTime(DateTime::now());
+  ProteinIdentification::SearchParameters sp;
+  sp.setMetaValue(Constants::UserParam::MODIFICATION_DEFINITIONS, freshRecord4b("TestCMap:Fresh", 'K', "C2H2O"));
+  prot.setSearchParameters(sp);
+  map.getProteinIdentifications().push_back(prot);
+
+  std::string dir;
+  NEW_TMP_FILE(dir) dir += ".cmd";
+  TEST_TRUE(ConsensusMapArrowIO::exportToParquet(map, dir))
+  TEST_FALSE(db->hasDefinedModification("TestCMap:Fresh")) // exporting registers nothing
+  ConsensusMap in;
+  TEST_TRUE(ConsensusMapArrowIO::importFromParquet(dir, in))
+  TEST_TRUE(db->hasDefinedModification("TestCMap:Fresh"))
+  File::removeDirRecursively(dir);
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ConsensusXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusXMLFile_test.cpp
@@ -23,6 +23,15 @@
 #include <OpenMS/KERNEL/MSExperiment.h>
 
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
+#include <OpenMS/CHEMISTRY/ModificationsDB.h>
+#include <OpenMS/CHEMISTRY/ResidueModification.h>
+#include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/DATASTRUCTURES/DateTime.h>
+#include <fstream>
+#include <sstream>
+#include <OpenMS/KERNEL/FeatureHandle.h>
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 
 using namespace OpenMS;
@@ -33,6 +42,60 @@ DRange<1> makeRange(double a, double b)
 {
   DPosition<1> pa(a), pb(b);
   return DRange<1>(pa, pb);
+}
+
+namespace
+{
+  // registers a tool-defined modification; ModificationsDB is process-wide, so every section uses its own name
+  const ResidueModification* defineMod4b(const std::string& id, char origin, const std::string& formula)
+  {
+    ResidueModification d;
+    d.setId(id);
+    d.setOrigin(origin);
+    d.setTermSpecificity(ResidueModification::ANYWHERE);
+    d.setFullId();
+    d.setDiffFormula(EmpiricalFormula(formula));
+    d.setDiffMonoMass(EmpiricalFormula(formula).getMonoWeight());
+    return ModificationsDB::getInstance()->registerDefinition(d);
+  }
+
+  // a definition record for a name that is NOT registered in this process
+  std::string freshRecord4b(const std::string& id, char origin, const std::string& formula)
+  {
+    ResidueModification d;
+    d.setId(id);
+    d.setOrigin(origin);
+    d.setTermSpecificity(ResidueModification::ANYWHERE);
+    d.setFullId();
+    d.setDiffFormula(EmpiricalFormula(formula));
+    d.setDiffMonoMass(EmpiricalFormula(formula).getMonoWeight());
+    return d.toDefinitionString();
+  }
+
+  std::string slurp4b(const std::string& path)
+  {
+    std::ifstream in(path);
+    std::stringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+  }
+
+  bool fileContains4b(const std::string& path, const std::string& needle)
+  {
+    return slurp4b(path).find(needle) != std::string::npos;
+  }
+
+  // first occurrence only; returns false when @p from is absent
+  bool replaceInFile4b(const std::string& path, const std::string& from, const std::string& to)
+  {
+    std::string s = slurp4b(path);
+    const std::size_t pos = s.find(from);
+    if (pos == std::string::npos) return false;
+    s.replace(pos, from.size(), to);
+    std::ofstream out(path);
+    out << s;
+    return true;
+  }
 }
 
 START_TEST(ConsensusXMLFile, "$Id$")
@@ -519,6 +582,108 @@ START_SECTION([EXTRA] Protein groups without quantities are written unchanged)
   f.load(tmp_filename, loaded);
   TEST_EQUAL(loaded.getProteinIdentifications()[0].getIndistinguishableProteins().size(), 1)
   TEST_EQUAL(loaded.getProteinIdentifications()[0].getIndistinguishableProteins()[0].getFloatDataArrays().empty(), true)
+}
+END_SECTION
+
+START_SECTION([EXTRA] store/load - tool-defined modifications on assigned and unassigned identifications travel with their definitions)
+{
+  TEST_TRUE(defineMod4b("TestCXML:Assigned", 'K', "C2H2O") != nullptr)
+  TEST_TRUE(defineMod4b("TestCXML:Unassigned", 'R', "CH2") != nullptr)
+  ConsensusMap map;
+  map.ensureUniqueId();
+  map.getColumnHeaders()[0].filename = "file0.mzML";
+  map.getColumnHeaders()[0].size = 1;
+  ProteinIdentification prot;
+  prot.setIdentifier("run4b");
+  prot.setDateTime(DateTime::now());
+  map.getProteinIdentifications().push_back(prot);
+
+  ConsensusFeature f;
+  f.setRT(100.0);
+  f.setMZ(500.0);
+  f.setIntensity(1000.0);
+  f.ensureUniqueId();
+  f.insert(FeatureHandle(0, f));
+  PeptideIdentification pa;
+  pa.setIdentifier("run4b");
+  PeptideHit ha;
+  ha.setSequence(AASequence::fromString("PEPK(TestCXML:Assigned)IDE"));
+  pa.insertHit(ha);
+  f.getPeptideIdentifications().push_back(pa);
+  map.push_back(f);
+
+  PeptideIdentification pu;
+  pu.setIdentifier("run4b");
+  PeptideHit hu;
+  hu.setSequence(AASequence::fromString("PEPR(TestCXML:Unassigned)IDE"));
+  pu.insertHit(hu);
+  map.getUnassignedPeptideIdentifications().push_back(pu);
+
+  std::string tmp_filename;
+  NEW_TMP_FILE(tmp_filename)
+  ConsensusXMLFile().store(tmp_filename, map);
+  TEST_TRUE(fileContains4b(tmp_filename, "name=\"modification_definitions\""))
+  TEST_TRUE(fileContains4b(tmp_filename, "1|TestCXML:Assigned|TestCXML:Assigned (K)|"))
+  TEST_TRUE(fileContains4b(tmp_filename, "1|TestCXML:Unassigned|TestCXML:Unassigned (R)|"))
+
+  ConsensusMap in;
+  ConsensusXMLFile().load(tmp_filename, in);
+  TEST_EQUAL(in.size(), 1)
+  TEST_EQUAL(in.getUnassignedPeptideIdentifications().size(), 1)
+  if (in.size() == 1 && !in[0].getPeptideIdentifications().empty() && !in[0].getPeptideIdentifications()[0].getHits().empty())
+  {
+    TEST_EQUAL(in[0].getPeptideIdentifications()[0].getHits()[0].getSequence().toString(), "PEPK(TestCXML:Assigned)IDE")
+  }
+  if (in.getUnassignedPeptideIdentifications().size() == 1 && !in.getUnassignedPeptideIdentifications()[0].getHits().empty())
+  {
+    TEST_EQUAL(in.getUnassignedPeptideIdentifications()[0].getHits()[0].getSequence().toString(), "PEPR(TestCXML:Unassigned)IDE")
+  }
+}
+END_SECTION
+
+START_SECTION([EXTRA] load - definitions are registered before the sequences are parsed)
+{
+  const ModificationsDB* db = ModificationsDB::getInstance();
+  TEST_FALSE(db->hasDefinedModification("TestCXML:Fresh"))
+  ConsensusMap map;
+  map.ensureUniqueId();
+  map.getColumnHeaders()[0].filename = "file0.mzML";
+  map.getColumnHeaders()[0].size = 1;
+  ProteinIdentification prot;
+  prot.setIdentifier("run4b_fresh");
+  prot.setDateTime(DateTime::now());
+  ProteinIdentification::SearchParameters sp;
+  sp.setMetaValue(Constants::UserParam::MODIFICATION_DEFINITIONS, freshRecord4b("TestCXML:Fresh", 'K', "C2H2O"));
+  prot.setSearchParameters(sp);
+  map.getProteinIdentifications().push_back(prot);
+  ConsensusFeature f;
+  f.setRT(100.0);
+  f.setMZ(500.0);
+  f.setIntensity(1000.0);
+  f.ensureUniqueId();
+  f.insert(FeatureHandle(0, f));
+  PeptideIdentification pep;
+  pep.setIdentifier("run4b_fresh");
+  PeptideHit hit;
+  hit.setSequence(AASequence::fromString("PEPTKIDE"));
+  pep.insertHit(hit);
+  f.getPeptideIdentifications().push_back(pep);
+  map.push_back(f);
+
+  std::string tmp_filename;
+  NEW_TMP_FILE(tmp_filename)
+  ConsensusXMLFile().store(tmp_filename, map);
+  TEST_FALSE(db->hasDefinedModification("TestCXML:Fresh")) // storing registers nothing
+  // a hit using the not-yet-registered name, as a file from another process would carry it
+  TEST_TRUE(replaceInFile4b(tmp_filename, "sequence=\"PEPTKIDE\"", "sequence=\"PEPTK(TestCXML:Fresh)IDE\""))
+
+  ConsensusMap in;
+  ConsensusXMLFile().load(tmp_filename, in);
+  TEST_TRUE(db->hasDefinedModification("TestCXML:Fresh"))
+  if (in.size() == 1 && !in[0].getPeptideIdentifications().empty() && !in[0].getPeptideIdentifications()[0].getHits().empty())
+  {
+    TEST_EQUAL(in[0].getPeptideIdentifications()[0].getHits()[0].getSequence().toString(), "PEPTK(TestCXML:Fresh)IDE")
+  }
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/FeatureMapArrowIO_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureMapArrowIO_test.cpp
@@ -17,6 +17,13 @@
 
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
+#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
+#include <OpenMS/CHEMISTRY/ModificationsDB.h>
+#include <OpenMS/CHEMISTRY/ResidueModification.h>
+#include <OpenMS/CONCEPT/Constants.h>
+
+#include <fstream>
+#include <sstream>
 #include <OpenMS/DATASTRUCTURES/ConvexHull2D.h>
 #include <OpenMS/DATASTRUCTURES/DateTime.h>
 #include <OpenMS/FORMAT/FileTypes.h>
@@ -32,6 +39,60 @@
 
 using namespace OpenMS;
 using namespace std;
+
+namespace
+{
+  // registers a tool-defined modification; ModificationsDB is process-wide, so every section uses its own name
+  const ResidueModification* defineMod4b(const std::string& id, char origin, const std::string& formula)
+  {
+    ResidueModification d;
+    d.setId(id);
+    d.setOrigin(origin);
+    d.setTermSpecificity(ResidueModification::ANYWHERE);
+    d.setFullId();
+    d.setDiffFormula(EmpiricalFormula(formula));
+    d.setDiffMonoMass(EmpiricalFormula(formula).getMonoWeight());
+    return ModificationsDB::getInstance()->registerDefinition(d);
+  }
+
+  // a definition record for a name that is NOT registered in this process
+  std::string freshRecord4b(const std::string& id, char origin, const std::string& formula)
+  {
+    ResidueModification d;
+    d.setId(id);
+    d.setOrigin(origin);
+    d.setTermSpecificity(ResidueModification::ANYWHERE);
+    d.setFullId();
+    d.setDiffFormula(EmpiricalFormula(formula));
+    d.setDiffMonoMass(EmpiricalFormula(formula).getMonoWeight());
+    return d.toDefinitionString();
+  }
+
+  std::string slurp4b(const std::string& path)
+  {
+    std::ifstream in(path);
+    std::stringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+  }
+
+  bool fileContains4b(const std::string& path, const std::string& needle)
+  {
+    return slurp4b(path).find(needle) != std::string::npos;
+  }
+
+  // first occurrence only; returns false when @p from is absent
+  bool replaceInFile4b(const std::string& path, const std::string& from, const std::string& to)
+  {
+    std::string s = slurp4b(path);
+    const std::size_t pos = s.find(from);
+    if (pos == std::string::npos) return false;
+    s.replace(pos, from.size(), to);
+    std::ofstream out(path);
+    out << s;
+    return true;
+  }
+}
 
 START_TEST(FeatureMapArrowIO, "$Id$")
 
@@ -1747,5 +1808,91 @@ END_SECTION
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
+
+START_SECTION([EXTRA] exportToParquet / importFromParquet - tool-defined modifications travel with their definitions)
+{
+  TEST_TRUE(defineMod4b("TestFMap:Assigned", 'K', "C2H2O") != nullptr)
+  TEST_TRUE(defineMod4b("TestFMap:Unassigned", 'R', "CH2") != nullptr)
+  FeatureMap map;
+  map.ensureUniqueId();
+  ProteinIdentification prot;
+  prot.setIdentifier("run4b");
+  prot.setDateTime(DateTime::now());
+  map.getProteinIdentifications().push_back(prot);
+
+  Feature f;
+  f.setRT(100.0);
+  f.setMZ(500.0);
+  f.setIntensity(1000.0);
+  f.ensureUniqueId();
+  PeptideIdentification pa;
+  pa.setIdentifier("run4b");
+  PeptideHit ha;
+  ha.setSequence(AASequence::fromString("PEPK(TestFMap:Assigned)IDE"));
+  pa.insertHit(ha);
+  f.getPeptideIdentifications().push_back(pa);
+  map.push_back(f);
+
+  PeptideIdentification pu;
+  pu.setIdentifier("run4b");
+  PeptideHit hu;
+  hu.setSequence(AASequence::fromString("PEPR(TestFMap:Unassigned)IDE"));
+  pu.insertHit(hu);
+  map.getUnassignedPeptideIdentifications().push_back(pu);
+
+  std::string dir;
+  NEW_TMP_FILE(dir) dir += ".fmd";
+  TEST_TRUE(FeatureMapArrowIO::exportToParquet(map, dir))
+  FeatureMap in;
+  TEST_TRUE(FeatureMapArrowIO::importFromParquet(dir, in))
+  TEST_EQUAL(in.size(), 1)
+  TEST_EQUAL(in.getUnassignedPeptideIdentifications().size(), 1)
+  if (in.size() == 1 && !in[0].getPeptideIdentifications().empty() && !in[0].getPeptideIdentifications()[0].getHits().empty())
+  {
+    TEST_EQUAL(in[0].getPeptideIdentifications()[0].getHits()[0].getSequence().toString(), "PEPK(TestFMap:Assigned)IDE")
+  }
+  if (in.getUnassignedPeptideIdentifications().size() == 1 && !in.getUnassignedPeptideIdentifications()[0].getHits().empty())
+  {
+    TEST_EQUAL(in.getUnassignedPeptideIdentifications()[0].getHits()[0].getSequence().toString(), "PEPR(TestFMap:Unassigned)IDE")
+  }
+  if (in.getProteinIdentifications().size() == 1)
+  {
+    const auto& sp = in.getProteinIdentifications()[0].getSearchParameters();
+    TEST_TRUE(sp.metaValueExists(Constants::UserParam::MODIFICATION_DEFINITIONS))
+    if (sp.metaValueExists(Constants::UserParam::MODIFICATION_DEFINITIONS))
+    {
+      const std::string v = sp.getMetaValue(Constants::UserParam::MODIFICATION_DEFINITIONS).toString();
+      TEST_TRUE(v.find("TestFMap:Assigned") != std::string::npos)
+      TEST_TRUE(v.find("TestFMap:Unassigned") != std::string::npos)
+    }
+  }
+  File::removeDirRecursively(dir);
+}
+END_SECTION
+
+START_SECTION([EXTRA] importFromParquet - definitions are registered from search_params.parquet)
+{
+  const ModificationsDB* db = ModificationsDB::getInstance();
+  TEST_FALSE(db->hasDefinedModification("TestFMap:Fresh"))
+  FeatureMap map;
+  map.ensureUniqueId();
+  ProteinIdentification prot;
+  prot.setIdentifier("run4b_fresh");
+  prot.setDateTime(DateTime::now());
+  ProteinIdentification::SearchParameters sp;
+  sp.setMetaValue(Constants::UserParam::MODIFICATION_DEFINITIONS, freshRecord4b("TestFMap:Fresh", 'K', "C2H2O"));
+  prot.setSearchParameters(sp);
+  map.getProteinIdentifications().push_back(prot);
+
+  std::string dir;
+  NEW_TMP_FILE(dir) dir += ".fmd";
+  TEST_TRUE(FeatureMapArrowIO::exportToParquet(map, dir))
+  TEST_FALSE(db->hasDefinedModification("TestFMap:Fresh")) // exporting registers nothing
+  FeatureMap in;
+  TEST_TRUE(FeatureMapArrowIO::importFromParquet(dir, in))
+  TEST_TRUE(db->hasDefinedModification("TestFMap:Fresh"))
+  File::removeDirRecursively(dir);
+}
+END_SECTION
 
 END_TEST

--- a/src/tests/class_tests/openms/source/FeatureXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureXMLFile_test.cpp
@@ -17,10 +17,17 @@
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
+#include <OpenMS/CHEMISTRY/ModificationsDB.h>
+#include <OpenMS/CHEMISTRY/ResidueModification.h>
+#include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/DATASTRUCTURES/DateTime.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 
 #include <fstream>
+#include <sstream>
 
 using namespace OpenMS;
 using namespace std;
@@ -32,6 +39,60 @@ DRange<1> makeRange(double a, double b)
 }
 
 ///////////////////////////
+
+namespace
+{
+  // registers a tool-defined modification; ModificationsDB is process-wide, so every section uses its own name
+  const ResidueModification* defineMod4b(const std::string& id, char origin, const std::string& formula)
+  {
+    ResidueModification d;
+    d.setId(id);
+    d.setOrigin(origin);
+    d.setTermSpecificity(ResidueModification::ANYWHERE);
+    d.setFullId();
+    d.setDiffFormula(EmpiricalFormula(formula));
+    d.setDiffMonoMass(EmpiricalFormula(formula).getMonoWeight());
+    return ModificationsDB::getInstance()->registerDefinition(d);
+  }
+
+  // a definition record for a name that is NOT registered in this process
+  std::string freshRecord4b(const std::string& id, char origin, const std::string& formula)
+  {
+    ResidueModification d;
+    d.setId(id);
+    d.setOrigin(origin);
+    d.setTermSpecificity(ResidueModification::ANYWHERE);
+    d.setFullId();
+    d.setDiffFormula(EmpiricalFormula(formula));
+    d.setDiffMonoMass(EmpiricalFormula(formula).getMonoWeight());
+    return d.toDefinitionString();
+  }
+
+  std::string slurp4b(const std::string& path)
+  {
+    std::ifstream in(path);
+    std::stringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+  }
+
+  bool fileContains4b(const std::string& path, const std::string& needle)
+  {
+    return slurp4b(path).find(needle) != std::string::npos;
+  }
+
+  // first occurrence only; returns false when @p from is absent
+  bool replaceInFile4b(const std::string& path, const std::string& from, const std::string& to)
+  {
+    std::string s = slurp4b(path);
+    const std::size_t pos = s.find(from);
+    if (pos == std::string::npos) return false;
+    s.replace(pos, from.size(), to);
+    std::ofstream out(path);
+    out << s;
+    return true;
+  }
+}
 
 START_TEST(FeatureXMLFile, "$Id$")
 
@@ -442,6 +503,102 @@ START_SECTION([EXTRA])
 END_SECTION
 
 
+
+START_SECTION([EXTRA] store/load - tool-defined modifications on assigned and unassigned identifications travel with their definitions)
+{
+  TEST_TRUE(defineMod4b("TestFXML:Assigned", 'K', "C2H2O") != nullptr)
+  TEST_TRUE(defineMod4b("TestFXML:Unassigned", 'R', "CH2") != nullptr)
+  FeatureMap map;
+  map.ensureUniqueId();
+  ProteinIdentification prot;
+  prot.setIdentifier("run4b");
+  prot.setDateTime(DateTime::now());
+  map.getProteinIdentifications().push_back(prot);
+
+  Feature f;
+  f.setRT(100.0);
+  f.setMZ(500.0);
+  f.setIntensity(1000.0);
+  f.ensureUniqueId();
+  PeptideIdentification pa;
+  pa.setIdentifier("run4b");
+  PeptideHit ha;
+  ha.setSequence(AASequence::fromString("PEPK(TestFXML:Assigned)IDE"));
+  pa.insertHit(ha);
+  f.getPeptideIdentifications().push_back(pa);
+  map.push_back(f);
+
+  PeptideIdentification pu;
+  pu.setIdentifier("run4b");
+  PeptideHit hu;
+  hu.setSequence(AASequence::fromString("PEPR(TestFXML:Unassigned)IDE"));
+  pu.insertHit(hu);
+  map.getUnassignedPeptideIdentifications().push_back(pu);
+
+  std::string tmp_filename;
+  NEW_TMP_FILE(tmp_filename)
+  FeatureXMLFile().store(tmp_filename, map);
+  TEST_TRUE(fileContains4b(tmp_filename, "name=\"modification_definitions\""))
+  TEST_TRUE(fileContains4b(tmp_filename, "1|TestFXML:Assigned|TestFXML:Assigned (K)|"))
+  TEST_TRUE(fileContains4b(tmp_filename, "1|TestFXML:Unassigned|TestFXML:Unassigned (R)|"))
+
+  FeatureMap in;
+  FeatureXMLFile().load(tmp_filename, in);
+  TEST_EQUAL(in.size(), 1)
+  TEST_EQUAL(in.getUnassignedPeptideIdentifications().size(), 1)
+  if (in.size() == 1 && !in[0].getPeptideIdentifications().empty() && !in[0].getPeptideIdentifications()[0].getHits().empty())
+  {
+    TEST_EQUAL(in[0].getPeptideIdentifications()[0].getHits()[0].getSequence().toString(), "PEPK(TestFXML:Assigned)IDE")
+  }
+  if (in.getUnassignedPeptideIdentifications().size() == 1 && !in.getUnassignedPeptideIdentifications()[0].getHits().empty())
+  {
+    TEST_EQUAL(in.getUnassignedPeptideIdentifications()[0].getHits()[0].getSequence().toString(), "PEPR(TestFXML:Unassigned)IDE")
+  }
+}
+END_SECTION
+
+START_SECTION([EXTRA] load - definitions are registered before the sequences are parsed)
+{
+  const ModificationsDB* db = ModificationsDB::getInstance();
+  TEST_FALSE(db->hasDefinedModification("TestFXML:Fresh"))
+  FeatureMap map;
+  map.ensureUniqueId();
+  ProteinIdentification prot;
+  prot.setIdentifier("run4b_fresh");
+  prot.setDateTime(DateTime::now());
+  ProteinIdentification::SearchParameters sp;
+  sp.setMetaValue(Constants::UserParam::MODIFICATION_DEFINITIONS, freshRecord4b("TestFXML:Fresh", 'K', "C2H2O"));
+  prot.setSearchParameters(sp);
+  map.getProteinIdentifications().push_back(prot);
+  Feature f;
+  f.setRT(100.0);
+  f.setMZ(500.0);
+  f.setIntensity(1000.0);
+  f.ensureUniqueId();
+  PeptideIdentification pep;
+  pep.setIdentifier("run4b_fresh");
+  PeptideHit hit;
+  hit.setSequence(AASequence::fromString("PEPTKIDE"));
+  pep.insertHit(hit);
+  f.getPeptideIdentifications().push_back(pep);
+  map.push_back(f);
+
+  std::string tmp_filename;
+  NEW_TMP_FILE(tmp_filename)
+  FeatureXMLFile().store(tmp_filename, map);
+  TEST_FALSE(db->hasDefinedModification("TestFXML:Fresh")) // storing registers nothing
+  // a hit using the not-yet-registered name, as a file from another process would carry it
+  TEST_TRUE(replaceInFile4b(tmp_filename, "sequence=\"PEPTKIDE\"", "sequence=\"PEPTK(TestFXML:Fresh)IDE\""))
+
+  FeatureMap in;
+  FeatureXMLFile().load(tmp_filename, in);
+  TEST_TRUE(db->hasDefinedModification("TestFXML:Fresh"))
+  if (in.size() == 1 && !in[0].getPeptideIdentifications().empty() && !in[0].getPeptideIdentifications()[0].getHits().empty())
+  {
+    TEST_EQUAL(in[0].getPeptideIdentifications()[0].getHits()[0].getSequence().toString(), "PEPTK(TestFXML:Fresh)IDE")
+  }
+}
+END_SECTION
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/IdXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/IdXMLFile_test.cpp
@@ -15,8 +15,72 @@
 #include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/CONCEPT/FuzzyStringComparator.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
+#include <OpenMS/CHEMISTRY/ModificationsDB.h>
+#include <OpenMS/CHEMISTRY/ResidueModification.h>
+#include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/DATASTRUCTURES/DateTime.h>
+#include <fstream>
+#include <sstream>
 
 ///////////////////////////
+
+using namespace OpenMS;
+
+namespace
+{
+  // registers a tool-defined modification; ModificationsDB is process-wide, so every section uses its own name
+  const ResidueModification* defineMod4b(const std::string& id, char origin, const std::string& formula)
+  {
+    ResidueModification d;
+    d.setId(id);
+    d.setOrigin(origin);
+    d.setTermSpecificity(ResidueModification::ANYWHERE);
+    d.setFullId();
+    d.setDiffFormula(EmpiricalFormula(formula));
+    d.setDiffMonoMass(EmpiricalFormula(formula).getMonoWeight());
+    return ModificationsDB::getInstance()->registerDefinition(d);
+  }
+
+  // a definition record for a name that is NOT registered in this process
+  std::string freshRecord4b(const std::string& id, char origin, const std::string& formula)
+  {
+    ResidueModification d;
+    d.setId(id);
+    d.setOrigin(origin);
+    d.setTermSpecificity(ResidueModification::ANYWHERE);
+    d.setFullId();
+    d.setDiffFormula(EmpiricalFormula(formula));
+    d.setDiffMonoMass(EmpiricalFormula(formula).getMonoWeight());
+    return d.toDefinitionString();
+  }
+
+  std::string slurp4b(const std::string& path)
+  {
+    std::ifstream in(path);
+    std::stringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+  }
+
+  bool fileContains4b(const std::string& path, const std::string& needle)
+  {
+    return slurp4b(path).find(needle) != std::string::npos;
+  }
+
+  // first occurrence only; returns false when @p from is absent
+  bool replaceInFile4b(const std::string& path, const std::string& from, const std::string& to)
+  {
+    std::string s = slurp4b(path);
+    const std::size_t pos = s.find(from);
+    if (pos == std::string::npos) return false;
+    s.replace(pos, from.size(), to);
+    std::ofstream out(path);
+    out << s;
+    return true;
+  }
+}
 
 START_TEST(IdXMLFile, "$Id$")
 
@@ -320,6 +384,148 @@ START_SECTION([EXTRA] Compressed file writing - bzip2 round-trip)
   TEST_EQUAL(peptide_ids_bz2.size(), peptide_ids.size())
   TEST_EQUAL(protein_ids_bz2[0].getHits().size(), protein_ids[0].getHits().size())
   TEST_EQUAL(protein_ids_bz2[0].getHits()[0].getAccession(), protein_ids[0].getHits()[0].getAccession())
+END_SECTION
+
+START_SECTION([EXTRA] store/load - a tool-defined modification travels with its definition)
+{
+  TEST_TRUE(defineMod4b("TestIdXML:Adduct", 'K', "C9H11N2O8P") != nullptr)
+  ProteinIdentification prot;
+  prot.setIdentifier("run4b");
+  prot.setDateTime(DateTime::now());
+  PeptideIdentification pep;
+  pep.setIdentifier("run4b");
+  PeptideHit hit;
+  hit.setSequence(AASequence::fromString("AEADNLDDK(TestIdXML:Adduct)K"));
+  pep.insertHit(hit);
+  std::vector<ProteinIdentification> prots(1, prot);
+  PeptideIdentificationList peps;
+  peps.push_back(pep);
+
+  std::string filename;
+  NEW_TMP_FILE(filename)
+  IdXMLFile().store(filename, prots, peps);
+  TEST_TRUE(fileContains4b(filename, "name=\"modification_definitions\""))
+  TEST_TRUE(fileContains4b(filename, "1|TestIdXML:Adduct|TestIdXML:Adduct (K)|"))
+
+  std::vector<ProteinIdentification> prots_in;
+  PeptideIdentificationList peps_in;
+  IdXMLFile().load(filename, prots_in, peps_in);
+  TEST_EQUAL(prots_in.size(), 1)
+  TEST_EQUAL(peps_in.size(), 1)
+  if (prots_in.size() == 1 && peps_in.size() == 1 && !peps_in[0].getHits().empty())
+  {
+    TEST_TRUE(prots_in[0].getSearchParameters().metaValueExists(Constants::UserParam::MODIFICATION_DEFINITIONS))
+    const AASequence& back = peps_in[0].getHits()[0].getSequence();
+    TEST_EQUAL(back.toString(), "AEADNLDDK(TestIdXML:Adduct)K")
+    TEST_EQUAL(back.getFormula(Residue::Full, 0).toString(), "C54H86N15O28P1")
+  }
+}
+END_SECTION
+
+START_SECTION([EXTRA] store - runs with equal parameters share one block that carries both definition sets)
+{
+  TEST_TRUE(defineMod4b("TestIdXML:RunA", 'K', "C2H2O") != nullptr)
+  TEST_TRUE(defineMod4b("TestIdXML:RunB", 'R', "CH2") != nullptr)
+  std::vector<ProteinIdentification> prots(2);
+  prots[0].setIdentifier("runA");
+  prots[0].setDateTime(DateTime::now());
+  prots[1].setIdentifier("runB");
+  prots[1].setDateTime(DateTime::now());
+  PeptideIdentificationList peps(2);
+  peps[0].setIdentifier("runA");
+  peps[1].setIdentifier("runB");
+  PeptideHit ha, hb;
+  ha.setSequence(AASequence::fromString("PEPK(TestIdXML:RunA)IDE"));
+  hb.setSequence(AASequence::fromString("PEPR(TestIdXML:RunB)IDE"));
+  peps[0].insertHit(ha);
+  peps[1].insertHit(hb);
+
+  std::string filename;
+  NEW_TMP_FILE(filename)
+  IdXMLFile().store(filename, prots, peps);
+  const std::string text = slurp4b(filename);
+  Size blocks = 0;
+  for (std::size_t pos = text.find("<SearchParameters "); pos != std::string::npos; pos = text.find("<SearchParameters ", pos + 1)) ++blocks;
+  TEST_EQUAL(blocks, 1)
+  TEST_TRUE(text.find("1|TestIdXML:RunA|TestIdXML:RunA (K)|") != std::string::npos)
+  TEST_TRUE(text.find("1|TestIdXML:RunB|TestIdXML:RunB (R)|") != std::string::npos)
+
+  std::vector<ProteinIdentification> prots_in;
+  PeptideIdentificationList peps_in;
+  IdXMLFile().load(filename, prots_in, peps_in);
+  TEST_EQUAL(prots_in.size(), 2)
+  TEST_EQUAL(peps_in.size(), 2)
+  if (peps_in.size() == 2 && !peps_in[0].getHits().empty() && !peps_in[1].getHits().empty())
+  {
+    TEST_EQUAL(peps_in[0].getHits()[0].getSequence().toString(), "PEPK(TestIdXML:RunA)IDE")
+    TEST_EQUAL(peps_in[1].getHits()[0].getSequence().toString(), "PEPR(TestIdXML:RunB)IDE")
+  }
+}
+END_SECTION
+
+START_SECTION([EXTRA] store - a defined variable modification on no hit keeps its definition)
+{
+  TEST_TRUE(defineMod4b("TestIdXML:VarOnly", 'S', "HPO3") != nullptr)
+  ProteinIdentification prot;
+  prot.setIdentifier("run4b_var");
+  prot.setDateTime(DateTime::now());
+  ProteinIdentification::SearchParameters sp;
+  sp.variable_modifications.push_back("TestIdXML:VarOnly (S)");
+  prot.setSearchParameters(sp);
+  PeptideIdentification pep;
+  pep.setIdentifier("run4b_var");
+  PeptideHit hit;
+  hit.setSequence(AASequence::fromString("PEPTIDE"));
+  pep.insertHit(hit);
+  std::vector<ProteinIdentification> prots(1, prot);
+  PeptideIdentificationList peps;
+  peps.push_back(pep);
+
+  std::string filename;
+  NEW_TMP_FILE(filename)
+  IdXMLFile().store(filename, prots, peps);
+  TEST_TRUE(fileContains4b(filename, "1|TestIdXML:VarOnly|TestIdXML:VarOnly (S)|"))
+}
+END_SECTION
+
+START_SECTION([EXTRA] load - definitions are registered before the sequences are parsed)
+{
+  const ModificationsDB* db = ModificationsDB::getInstance();
+  TEST_FALSE(db->hasDefinedModification("TestIdXML:Fresh"))
+  ProteinIdentification prot;
+  prot.setIdentifier("run4b_fresh");
+  prot.setDateTime(DateTime::now());
+  ProteinIdentification::SearchParameters sp;
+  sp.setMetaValue(Constants::UserParam::MODIFICATION_DEFINITIONS, freshRecord4b("TestIdXML:Fresh", 'K', "C2H2O"));
+  prot.setSearchParameters(sp);
+  PeptideIdentification pep;
+  pep.setIdentifier("run4b_fresh");
+  PeptideHit hit;
+  hit.setSequence(AASequence::fromString("PEPTKIDE"));
+  pep.insertHit(hit);
+  std::vector<ProteinIdentification> prots(1, prot);
+  PeptideIdentificationList peps;
+  peps.push_back(pep);
+
+  std::string filename;
+  NEW_TMP_FILE(filename)
+  IdXMLFile().store(filename, prots, peps);
+  TEST_FALSE(db->hasDefinedModification("TestIdXML:Fresh")) // storing registers nothing
+  // a hit using the not-yet-registered name, as a file from another process would carry it
+  TEST_TRUE(replaceInFile4b(filename, "sequence=\"PEPTKIDE\"", "sequence=\"PEPTK(TestIdXML:Fresh)IDE\""))
+
+  std::vector<ProteinIdentification> prots_in;
+  PeptideIdentificationList peps_in;
+  IdXMLFile().load(filename, prots_in, peps_in);
+  TEST_TRUE(db->hasDefinedModification("TestIdXML:Fresh"))
+  TEST_EQUAL(peps_in.size(), 1)
+  if (peps_in.size() == 1 && !peps_in[0].getHits().empty())
+  {
+    const AASequence& back = peps_in[0].getHits()[0].getSequence();
+    TEST_EQUAL(back.toString(), "PEPTK(TestIdXML:Fresh)IDE")
+    TEST_REAL_SIMILAR(back.getMonoWeight(), AASequence::fromString("PEPTKIDE").getMonoWeight() + EmpiricalFormula("C2H2O").getMonoWeight())
+  }
+}
 END_SECTION
 
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/PSMArrowIO_test.cpp
+++ b/src/tests/class_tests/openms/source/PSMArrowIO_test.cpp
@@ -12,8 +12,19 @@
 #include <OpenMS/FORMAT/PSMArrowIO.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/METADATA/PeptideEvidence.h>
+#include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
+#include <OpenMS/CHEMISTRY/ModificationsDB.h>
+#include <OpenMS/CHEMISTRY/ResidueModification.h>
+#include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/DATASTRUCTURES/DateTime.h>
+
+#include <arrow/api.h>
+#include <arrow/io/api.h>
+#include <parquet/arrow/reader.h>
 
 #include <fstream>
+#include <sstream>
 
 using namespace OpenMS;
 using namespace std;
@@ -54,6 +65,109 @@ namespace
     hit.addPeptideEvidence(ev);
     pid.getHits().push_back(hit);
     pep_ids.push_back(pid);
+  }
+}
+
+namespace
+{
+  // registers a tool-defined modification; ModificationsDB is process-wide, so every section uses its own name
+  const ResidueModification* defineMod4b(const std::string& id, char origin, const std::string& formula)
+  {
+    ResidueModification d;
+    d.setId(id);
+    d.setOrigin(origin);
+    d.setTermSpecificity(ResidueModification::ANYWHERE);
+    d.setFullId();
+    d.setDiffFormula(EmpiricalFormula(formula));
+    d.setDiffMonoMass(EmpiricalFormula(formula).getMonoWeight());
+    return ModificationsDB::getInstance()->registerDefinition(d);
+  }
+
+  // a definition record for a name that is NOT registered in this process
+  std::string freshRecord4b(const std::string& id, char origin, const std::string& formula)
+  {
+    ResidueModification d;
+    d.setId(id);
+    d.setOrigin(origin);
+    d.setTermSpecificity(ResidueModification::ANYWHERE);
+    d.setFullId();
+    d.setDiffFormula(EmpiricalFormula(formula));
+    d.setDiffMonoMass(EmpiricalFormula(formula).getMonoWeight());
+    return d.toDefinitionString();
+  }
+
+  std::string slurp4b(const std::string& path)
+  {
+    std::ifstream in(path);
+    std::stringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+  }
+
+  bool fileContains4b(const std::string& path, const std::string& needle)
+  {
+    return slurp4b(path).find(needle) != std::string::npos;
+  }
+
+  // first occurrence only; returns false when @p from is absent
+  bool replaceInFile4b(const std::string& path, const std::string& from, const std::string& to)
+  {
+    std::string s = slurp4b(path);
+    const std::size_t pos = s.find(from);
+    if (pos == std::string::npos) return false;
+    s.replace(pos, from.size(), to);
+    std::ofstream out(path);
+    out << s;
+    return true;
+  }
+}
+
+namespace
+{
+  std::shared_ptr<arrow::Table> readTable4b(const std::string& path)
+  {
+    arrow::MemoryPool* pool = arrow::default_memory_pool();
+    auto o = arrow::io::ReadableFile::Open(path.c_str());
+    if (!o.ok()) { return nullptr; }
+    auto rr = parquet::arrow::OpenFile(o.ValueOrDie(), pool);
+    if (!rr.ok()) { return nullptr; }
+    auto rd = std::move(rr).ValueOrDie();
+    std::shared_ptr<arrow::Table> t;
+    if (!rd->ReadTable(&t).ok()) { return nullptr; }
+    auto c = t->CombineChunks(pool);
+    return c.ok() ? c.ValueOrDie() : nullptr;
+  }
+
+  // how many sp_metavalues entries of row 0 carry @p key
+  int countSpMetaKey4b(const std::string& search_params_path, const std::string& key)
+  {
+    auto table = readTable4b(search_params_path);
+    if (!table) return -1;
+    auto col = table->GetColumnByName("sp_metavalues");
+    if (!col || col->num_chunks() == 0 || table->num_rows() == 0) return -1;
+    auto list = std::static_pointer_cast<arrow::ListArray>(col->chunk(0));
+    auto structs = std::static_pointer_cast<arrow::StructArray>(list->values());
+    auto names = std::static_pointer_cast<arrow::StringArray>(structs->GetFieldByName("name"));
+    int n = 0;
+    for (int64_t i = list->value_offset(0); i < list->value_offset(1); ++i)
+    {
+      if (names->GetString(i) == key) ++n;
+    }
+    return n;
+  }
+
+  bool columnContains4b(const std::string& path, const std::string& column, const std::string& needle)
+  {
+    auto table = readTable4b(path);
+    if (!table) return false;
+    auto col = table->GetColumnByName(column);
+    if (!col || col->num_chunks() == 0) return false;
+    auto arr = std::static_pointer_cast<arrow::StringArray>(col->chunk(0));
+    for (int64_t i = 0; i < arr->length(); ++i)
+    {
+      if (!arr->IsNull(i) && arr->GetString(i).find(needle) != std::string::npos) return true;
+    }
+    return false;
   }
 }
 
@@ -303,6 +417,66 @@ START_SECTION(([EXTRA] exportToParquet rejects duplicate ProteinIdentification i
 
   // clean up if a regression let the export run instead of throwing
   if (File::exists(dir)) { File::removeDirRecursively(dir); }
+}
+END_SECTION
+
+START_SECTION([EXTRA] export/import - the peptidoform column carries the chemistry and the definition restores the name)
+{
+  TEST_TRUE(defineMod4b("TestPSM:Adduct", 'K', "C9H11N2O8P") != nullptr)
+  std::vector<ProteinIdentification> prots;
+  PeptideIdentificationList peps;
+  buildMinimalIds(prots, peps);
+  peps[0].getHits()[0].setSequence(AASequence::fromString("AEADNLDDK(TestPSM:Adduct)K"));
+
+  std::string dir;
+  NEW_TMP_FILE(dir)
+  TEST_TRUE(PSMArrowIO::exportToParquet(prots, peps, dir))
+  TEST_TRUE(columnContains4b(dir + "/psms.parquet", "peptidoform", "AEADNLDDK[Formula:C9H11N2O8P1|INFO:TestPSM:Adduct]K"))
+  TEST_EQUAL(countSpMetaKey4b(dir + "/search_params.parquet", Constants::UserParam::MODIFICATION_DEFINITIONS), 1)
+
+  std::vector<ProteinIdentification> prots_in;
+  PeptideIdentificationList peps_in;
+  TEST_TRUE(PSMArrowIO::importFromParquet(dir, prots_in, peps_in))
+  TEST_EQUAL(peps_in.size(), 1)
+  if (peps_in.size() == 1 && !peps_in[0].getHits().empty())
+  {
+    const AASequence& back = peps_in[0].getHits()[0].getSequence();
+    TEST_EQUAL(back.toString(), "AEADNLDDK(TestPSM:Adduct)K") // the name, not a mass bracket
+    TEST_EQUAL(back.getFormula(Residue::Full, 0).toString(), "C54H86N15O28P1")
+  }
+  if (prots_in.size() == 1)
+  {
+    TEST_TRUE(prots_in[0].getSearchParameters().metaValueExists(Constants::UserParam::MODIFICATION_DEFINITIONS))
+  }
+  File::removeDirRecursively(dir);
+
+  // an inbound value (e.g. from an idXML load) is replaced, not duplicated
+  std::string dir2;
+  NEW_TMP_FILE(dir2)
+  TEST_TRUE(PSMArrowIO::exportToParquet(prots_in, peps_in, dir2))
+  TEST_EQUAL(countSpMetaKey4b(dir2 + "/search_params.parquet", Constants::UserParam::MODIFICATION_DEFINITIONS), 1)
+  File::removeDirRecursively(dir2);
+}
+END_SECTION
+
+START_SECTION([EXTRA] import - definitions are registered from search_params.parquet)
+{
+  const ModificationsDB* db = ModificationsDB::getInstance();
+  TEST_FALSE(db->hasDefinedModification("TestPSM:Fresh"))
+  std::vector<ProteinIdentification> prots;
+  PeptideIdentificationList peps;
+  buildMinimalIds(prots, peps);
+  prots[0].getSearchParameters().setMetaValue(Constants::UserParam::MODIFICATION_DEFINITIONS, freshRecord4b("TestPSM:Fresh", 'K', "C2H2O"));
+
+  std::string dir;
+  NEW_TMP_FILE(dir)
+  TEST_TRUE(PSMArrowIO::exportToParquet(prots, peps, dir))
+  TEST_FALSE(db->hasDefinedModification("TestPSM:Fresh")) // exporting registers nothing
+  std::vector<ProteinIdentification> prots_in;
+  PeptideIdentificationList peps_in;
+  TEST_TRUE(PSMArrowIO::importFromParquet(dir, prots_in, peps_in))
+  TEST_TRUE(db->hasDefinedModification("TestPSM:Fresh"))
+  File::removeDirRecursively(dir);
 }
 END_SECTION
 

--- a/src/topp/ProSE.cpp
+++ b/src/topp/ProSE.cpp
@@ -17,6 +17,7 @@
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/PROCESSING/ID/IDFilter.h>
+#include <OpenMS/FORMAT/ModificationDefinitionIO.h>
 #include <OpenMS/FORMAT/QPXFile.h>
 #include <OpenMS/FORMAT/ProteinGroupArrowExport.h>
 #include <OpenMS/FORMAT/ProteinIdentificationArrowIO.h>
@@ -763,11 +764,13 @@ class ProSE :
 
           // Search params
           const std::string oms_sp_file = out_parquet_dir + "/" + basename + ".search_params.parquet";
-          auto sp_table = ProteinIdentificationArrowIO::exportSearchParamsToArrow(result.protein_ids);
+          const auto sp_definitions = ModificationDefinitionIO::encodeByRun(
+            result.protein_ids, ModificationDefinitionIO::collect(result.protein_ids, result.peptide_ids));
+          auto sp_table = ProteinIdentificationArrowIO::exportSearchParamsToArrow(result.protein_ids, sp_definitions);
           if (sp_table)
           {
             oms_sp_tables.push_back(sp_table);
-            if (!ProteinIdentificationArrowIO::exportSearchParamsToParquet(result.protein_ids, oms_sp_file))
+            if (!ProteinIdentificationArrowIO::exportSearchParamsToParquet(result.protein_ids, oms_sp_file, ParquetWriteConfig{}, sp_definitions))
             {
               OPENMS_LOG_ERROR << "Failed to write search params parquet for " << in_file << " -> " << oms_sp_file << endl;
               input_failed = true;


### PR DESCRIPTION
Part 4b of #10003 — stacked on #10036 (4a), which sits on #10028 → #10027 → #10026. Read those first; this PR is the six file lanes.

**What changes**

A file that names a tool-defined modification now carries its definition, and every reader registers the definitions before it parses a peptide sequence. Carrier: the `modification_definitions` meta value on `ProteinIdentification::SearchParameters` (one string, records from `ResidueModification::toDefinitionString`) — the structure all six formats already serialise, so no schema changes.

Writers
- **idXML**: `IdXMLFile::store` collapses `SearchParameters` blocks with an `operator==` that ignores meta values; the definitions of every run collapsed onto a block are unioned onto that block. The `params.empty()` fallback writes a real element when there is something to carry, and stays byte-identical otherwise.
- **featureXML / consensusXML**: one `<SearchParameters>` per run — a local copy gets the run's definitions attached before it is written. Assigned identifications (subordinate features included) and unassigned ones are both collected.
- **.idparquet / .featureparquet / .consensusparquet**: `exportSearchParamsToArrow/ToParquet` take a defaulted `definitions_by_run`; when present, it replaces an inbound `modification_definitions` entry in `sp_metavalues` (no duplicate), otherwise the row is written as before. The three callers pass `encodeByRun(collect(...))`.

Readers — one call each, before any sequence is parsed
- `IdXMLFile` at `</SearchParameters>`; `FeatureXMLHandler` / `ConsensusXMLHandler` at `</SearchParameters>` (before `setSearchParameters`); `ProteinIdentificationArrowIO::importSearchParamsFromArrow` after the meta values are read — which covers all three parquet bundles, as each orchestrator imports search parameters first.

New API on `ModificationDefinitionIO`: `collect(const FeatureMap&)`, `collect(const ConsensusMap&)`, `encodeByRun(...)`.

Two further direct callers of the changed export functions are covered: ProSE's per-file `search_params.parquet` goes through the same definitions path, and the pyOpenMS binding of `exportSearchParamsToParquet` gains the optional `definitions_by_run` argument.

Files without definitions are unaffected on both sides: `attach` with nothing to store is a no-op, `encodeByRun` yields no entry, `registerFrom` on a missing key returns 0.

**Compatibility, as settled on the issue:** a new file carrying `K(NuXL:U-H2O)` is a hard load failure in an OpenMS without this PR (unknown modification name), not a degraded read. PR 6 turns that into an asserted `WILL_FAIL` fixture.

**Tests** — per lane: (a) store → load of a tool-defined modification asserts the record is in the file and the *name* comes back (`AEADNLDDK(TestIdXML:Adduct)K`, formula `C54H86N15O28P1`), assigned and unassigned; (b) a reader-ordering proof that is failable in-process: a definition record for a name never registered in this process is placed on the inbound `SearchParameters`, the written file is edited to use that name in a hit, and `load` must register before parsing. idXML additionally: two runs with equal parameters share one block carrying both definition sets; a defined variable modification on no hit keeps its definition. Parquet additionally: the `peptidoform` column literally contains `AEADNLDDK[Formula:C9H11N2O8P1|INFO:TestPSM:Adduct]K`, and re-exporting an imported bundle leaves exactly one `modification_definitions` entry. All temp XML files pass `VALIDATE_TMP_FILES`.

Failed-on-purpose: ten mutations (each reader hook, each writer's `attach`, the idXML block union, parquet without definitions, parquet duplicating the inbound key) — log in the first comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKPrmDHEE7cZCxGfTKTtFE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserved custom modification definitions when storing and loading IdXML, FeatureXML, and ConsensusXML files.
  * Included per-run modification definitions in Arrow and Parquet exports, including ProSE and PSM workflows.
  * Registered imported modification definitions before parsing peptide sequences, allowing previously unknown modifications to resolve correctly.

* **Bug Fixes**
  * Prevented loss or duplication of modification metadata during format conversion and round trips.

* **Tests**
  * Added coverage for assigned and unassigned identifications, custom modifications, and import/export round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->