### PR TITLE
[TEST] #10003 PR 6: fresh-process proofs that modification definitions are registered on load

### DIFF
--- a/src/tests/class_tests/openms/source/NuXLReport_test.cpp
+++ b/src/tests/class_tests/openms/source/NuXLReport_test.cpp
@@ -8,8 +8,10 @@
 
 #include <OpenMS/CONCEPT/ClassTest.h>
 
+#include <OpenMS/ANALYSIS/NUXL/NuXLModificationsGenerator.h>
 #include <OpenMS/ANALYSIS/NUXL/NuXLReport.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
 #include <OpenMS/CONCEPT/Constants.h>
 
 using namespace OpenMS;
@@ -28,6 +30,15 @@ START_SECTION((static std::vector<NuXLReportRow> annotate(const PeakMap&, Peptid
 
   AASequence peptide_with_adduct = peptide;
   peptide_with_adduct.setModificationByDiffMonoMass(0, adduct_mass);
+
+  // The named definition on a clean residue, and folded into the oxidised one.
+  const EmpiricalFormula adduct_formula("C9H11N2O8P1");
+  AASequence peptide_with_definition = peptide;
+  peptide_with_definition.setModification(4, NuXLModificationsGenerator::registerPrecursorAdduct("U-H2O1", adduct_formula, peptide[4]));
+  TEST_STRING_EQUAL(peptide_with_definition.toString(), "M(Oxidation)PEPT(NuXL:U-H2O1)IDE")
+  AASequence peptide_with_combined_definition = peptide;
+  peptide_with_combined_definition.setModification(0, NuXLModificationsGenerator::registerPrecursorAdduct("U-H2O1", adduct_formula, peptide[0]));
+  TEST_STRING_EQUAL(peptide_with_combined_definition.toString(), "M(NuXL:U-H2O1~Oxidation)PEPTIDE")
 
   PeakMap spectra;
   PeptideIdentificationList peptide_ids;
@@ -64,9 +75,12 @@ START_SECTION((static std::vector<NuXLReportRow> annotate(const PeakMap&, Peptid
   add_psm(peptide_with_adduct, 0);
   // Unlocalized results intentionally retain the legacy representation.
   add_psm(peptide, -1);
+  // Named definitions must yield the same masses as the mass-delta form.
+  add_psm(peptide_with_definition, 4);
+  add_psm(peptide_with_combined_definition, 0);
 
   const vector<NuXLReportRow> rows = NuXLReport::annotate(spectra, peptide_ids, {}, 0.05);
-  TEST_EQUAL(rows.size(), 3)
+  TEST_EQUAL(rows.size(), 5)
 
   for (Size i = 0; i != rows.size(); ++i)
   {
@@ -84,6 +98,8 @@ START_SECTION((static std::vector<NuXLReportRow> annotate(const PeakMap&, Peptid
   TEST_STRING_EQUAL(rows[0].peptide, peptide.toString())
   TEST_STRING_EQUAL(rows[1].peptide, peptide_with_adduct.toString())
   TEST_STRING_EQUAL(rows[2].peptide, peptide.toString())
+  TEST_STRING_EQUAL(rows[3].peptide, peptide_with_definition.toString())
+  TEST_STRING_EQUAL(rows[4].peptide, peptide_with_combined_definition.toString())
 }
 END_SECTION
 

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -2674,6 +2674,95 @@ if (NOT MSVC) # currently some minor numeric differences on windows. needs fixin
   endif()
 endif(NOT MSVC)
 
+# OpenNuXL writes localized cross-links as named modifications (K(NuXL:U-H2O1)) whose definitions
+# travel in the SearchParameters. A class test cannot prove that a reader registers them: the
+# writer's own registration is still in the process-wide ModificationsDB. These tests read the
+# checked-in fixture in fresh processes. The input is the committed fixture rather than the
+# OpenNuXL run's output, so they need neither that run nor its platform guard.
+#
+# idXML fresh read: every sequence attribute survives, the definitions block is rewritten.
+add_test("TOPP_OpenNuXL_definitions_reread" ${TOPP_BIN_PATH}/IDFileConverter
+  -in ${DATA_DIR_TOPP}/OpenNuXL_1_output.idXML
+  -out ${TESTS_TEMP_DIR}/OpenNuXL_definitions_reread.tmp.idXML -out_type idXML)
+add_test("TOPP_OpenNuXL_definitions_reread_sequences" ${CMAKE_COMMAND}
+  -DINPUT_FILE=${TESTS_TEMP_DIR}/OpenNuXL_definitions_reread.tmp.idXML
+  -DREFERENCE_FILE=${DATA_DIR_TOPP}/OpenNuXL_1_output.idXML
+  -P ${DATA_DIR_TOPP}/compare_sequence_attributes.cmake)
+set_tests_properties("TOPP_OpenNuXL_definitions_reread_sequences" PROPERTIES DEPENDS "TOPP_OpenNuXL_definitions_reread")
+add_test("TOPP_OpenNuXL_definitions_reread_check" ${CMAKE_COMMAND}
+  -DINPUT_FILE=${TESTS_TEMP_DIR}/OpenNuXL_definitions_reread.tmp.idXML
+  -P ${DATA_DIR_TOPP}/OpenNuXL_adduct_in_sequence_test.cmake)
+set_tests_properties("TOPP_OpenNuXL_definitions_reread_check" PROPERTIES DEPENDS "TOPP_OpenNuXL_definitions_reread")
+#
+# Repeated read: a second pass is byte-identical, so nothing is re-registered or duplicated.
+add_test("TOPP_OpenNuXL_definitions_reread2" ${TOPP_BIN_PATH}/IDFileConverter
+  -in ${TESTS_TEMP_DIR}/OpenNuXL_definitions_reread.tmp.idXML
+  -out ${TESTS_TEMP_DIR}/OpenNuXL_definitions_reread2.tmp.idXML -out_type idXML)
+set_tests_properties("TOPP_OpenNuXL_definitions_reread2" PROPERTIES DEPENDS "TOPP_OpenNuXL_definitions_reread")
+add_test("TOPP_OpenNuXL_definitions_idempotent" ${DIFF} -whitelist "IdentificationRun date"
+  -in1 ${TESTS_TEMP_DIR}/OpenNuXL_definitions_reread.tmp.idXML -in2 ${TESTS_TEMP_DIR}/OpenNuXL_definitions_reread2.tmp.idXML)
+set_tests_properties("TOPP_OpenNuXL_definitions_idempotent" PROPERTIES DEPENDS "TOPP_OpenNuXL_definitions_reread2")
+#
+# The definitions block is load-bearing: the same file without it must fail to load, with the
+# unresolved-modification error, not degrade to a bare sequence. The stripped input is derived
+# at test time so the property is exactly "same file minus the block".
+add_test("TOPP_OpenNuXL_definitions_strip" ${CMAKE_COMMAND}
+  -DINPUT_FILE=${DATA_DIR_TOPP}/OpenNuXL_1_output.idXML
+  -DOUTPUT_FILE=${TESTS_TEMP_DIR}/OpenNuXL_definitions_missing.tmp.idXML
+  -DNAME=modification_definitions
+  -P ${DATA_DIR_TOPP}/remove_user_param.cmake)
+add_test(NAME "TOPP_OpenNuXL_definitions_missing" COMMAND ${CMAKE_COMMAND}
+  "-DCOMMAND=${TOPP_BIN_PATH}/IDFileConverter;-in;${TESTS_TEMP_DIR}/OpenNuXL_definitions_missing.tmp.idXML;-out;${TESTS_TEMP_DIR}/OpenNuXL_definitions_missing_out.tmp.idXML;-out_type;idXML"
+  -DEXPECTED_CODE=8
+  "-DEXPECTED_OUTPUT_REGEX=Cannot convert string to peptide modification"
+  -P ${DATA_DIR_TOPP}/check_exit_code.cmake)
+set_tests_properties("TOPP_OpenNuXL_definitions_missing" PROPERTIES DEPENDS "TOPP_OpenNuXL_definitions_strip")
+#
+# Parquet lane: idXML -> .idparquet -> idXML restores the names, and psms.parquet on its own
+# spells each cross-link with its chemistry ([Formula:...|INFO:name]).
+add_test("TOPP_OpenNuXL_definitions_idparquet_write" ${TOPP_BIN_PATH}/IDFileConverter
+  -in ${DATA_DIR_TOPP}/OpenNuXL_1_output.idXML
+  -out ${TESTS_TEMP_DIR}/OpenNuXL_definitions.tmp.idparquet -out_type idparquet)
+add_test("TOPP_OpenNuXL_definitions_idparquet_read" ${TOPP_BIN_PATH}/IDFileConverter
+  -in ${TESTS_TEMP_DIR}/OpenNuXL_definitions.tmp.idparquet
+  -out ${TESTS_TEMP_DIR}/OpenNuXL_definitions_fromparquet.tmp.idXML -out_type idXML)
+set_tests_properties("TOPP_OpenNuXL_definitions_idparquet_read" PROPERTIES DEPENDS "TOPP_OpenNuXL_definitions_idparquet_write")
+add_test("TOPP_OpenNuXL_definitions_idparquet_sequences" ${CMAKE_COMMAND}
+  -DINPUT_FILE=${TESTS_TEMP_DIR}/OpenNuXL_definitions_fromparquet.tmp.idXML
+  -DREFERENCE_FILE=${DATA_DIR_TOPP}/OpenNuXL_1_output.idXML
+  -P ${DATA_DIR_TOPP}/compare_sequence_attributes.cmake)
+set_tests_properties("TOPP_OpenNuXL_definitions_idparquet_sequences" PROPERTIES DEPENDS "TOPP_OpenNuXL_definitions_idparquet_read")
+add_test("TOPP_OpenNuXL_definitions_idparquet_check" ${CMAKE_COMMAND}
+  -DINPUT_FILE=${TESTS_TEMP_DIR}/OpenNuXL_definitions_fromparquet.tmp.idXML
+  -P ${DATA_DIR_TOPP}/OpenNuXL_adduct_in_sequence_test.cmake)
+set_tests_properties("TOPP_OpenNuXL_definitions_idparquet_check" PROPERTIES DEPENDS "TOPP_OpenNuXL_definitions_idparquet_read")
+add_test("TOPP_OpenNuXL_definitions_idparquet_dump" ${TOPP_BIN_PATH}/ParquetDiff
+  -in1 ${TESTS_TEMP_DIR}/OpenNuXL_definitions.tmp.idparquet/psms.parquet
+  -out_tsv ${TESTS_TEMP_DIR}/OpenNuXL_definitions_psms.tmp.tsv -pk peptidoform precursor_charge)
+set_tests_properties("TOPP_OpenNuXL_definitions_idparquet_dump" PROPERTIES DEPENDS "TOPP_OpenNuXL_definitions_idparquet_write")
+add_test("TOPP_OpenNuXL_definitions_idparquet_peptidoform" ${CMAKE_COMMAND}
+  -DINPUT_FILE=${TESTS_TEMP_DIR}/OpenNuXL_definitions_psms.tmp.tsv
+  "-DEXPECTED=AEADNLDDK[Formula:C9H11N2O8P1|INFO:NuXL:U-H2O1]K"
+  -P ${DATA_DIR_TOPP}/check_file_contains.cmake)
+set_tests_properties("TOPP_OpenNuXL_definitions_idparquet_peptidoform" PROPERTIES DEPENDS "TOPP_OpenNuXL_definitions_idparquet_dump")
+#
+# Old files: the mass-bracket spelling that predates the definitions loads unchanged and
+# acquires no definitions block (a mass-only modification has nothing to define).
+add_test("TOPP_OpenNuXL_legacy_mass_delta" ${TOPP_BIN_PATH}/IDFileConverter
+  -in ${DATA_DIR_TOPP}/OpenNuXL_1_output_legacy_mass_delta.idXML
+  -out ${TESTS_TEMP_DIR}/OpenNuXL_legacy_mass_delta.tmp.idXML -out_type idXML)
+add_test("TOPP_OpenNuXL_legacy_mass_delta_sequences" ${CMAKE_COMMAND}
+  -DINPUT_FILE=${TESTS_TEMP_DIR}/OpenNuXL_legacy_mass_delta.tmp.idXML
+  -DREFERENCE_FILE=${DATA_DIR_TOPP}/OpenNuXL_1_output_legacy_mass_delta.idXML
+  -P ${DATA_DIR_TOPP}/compare_sequence_attributes.cmake)
+set_tests_properties("TOPP_OpenNuXL_legacy_mass_delta_sequences" PROPERTIES DEPENDS "TOPP_OpenNuXL_legacy_mass_delta")
+add_test("TOPP_OpenNuXL_legacy_mass_delta_check" ${CMAKE_COMMAND}
+  -DINPUT_FILE=${TESTS_TEMP_DIR}/OpenNuXL_legacy_mass_delta.tmp.idXML
+  "-DEXPECTED=sequence=\"AEADNLDDK[+306.025304840900048]K\""
+  -DFORBIDDEN=modification_definitions
+  -P ${DATA_DIR_TOPP}/check_file_contains.cmake)
+set_tests_properties("TOPP_OpenNuXL_legacy_mass_delta_check" PROPERTIES DEPENDS "TOPP_OpenNuXL_legacy_mass_delta")
+
 #------------------------------------------------------------------------------
 # SeedListGenerator tests
 add_test("TOPP_SeedListGenerator_1" ${TOPP_BIN_PATH}/SeedListGenerator -test -in ${DATA_DIR_TOPP}/PepXMLFile_test.mzML -out_prefix tmp_path/SeedListGenerator_1_output_tmp)

--- a/src/tests/topp/check_exit_code.cmake
+++ b/src/tests/topp/check_exit_code.cmake
@@ -6,6 +6,8 @@
 # ILLEGAL_PARAMETERS rather than abort). Use this when the specific code is the assertion.
 #
 # Required: -DCOMMAND=<;-separated argv> -DEXPECTED_CODE=<int>
+# Optional: -DEXPECTED_OUTPUT_REGEX=<regex> -- stdout+stderr must also match, so a test can
+# insist on the specific failure it is about rather than on any error return.
 if(NOT DEFINED COMMAND)
   message(FATAL_ERROR "check_exit_code.cmake: -DCOMMAND=... is required")
 endif()
@@ -20,6 +22,11 @@ if(NOT actual_code STREQUAL EXPECTED_CODE)
   # this check most often exists to catch.
   message(FATAL_ERROR
     "Expected exit code ${EXPECTED_CODE}, got '${actual_code}'.\n"
+    "--- stdout ---\n${out}\n--- stderr ---\n${err}")
+endif()
+if(DEFINED EXPECTED_OUTPUT_REGEX AND NOT "${out}${err}" MATCHES "${EXPECTED_OUTPUT_REGEX}")
+  message(FATAL_ERROR
+    "Output does not match '${EXPECTED_OUTPUT_REGEX}'.\n"
     "--- stdout ---\n${out}\n--- stderr ---\n${err}")
 endif()
 message(STATUS "Exit code ${actual_code} as expected")

--- a/src/tests/topp/check_file_contains.cmake
+++ b/src/tests/topp/check_file_contains.cmake
@@ -1,0 +1,29 @@
+# Usage: cmake -DINPUT_FILE=<file> [-DEXPECTED=<literal;...>] [-DFORBIDDEN=<literal;...>] -P check_file_contains.cmake
+#
+# Requires every EXPECTED literal to occur in the file and every FORBIDDEN literal to be
+# absent. Literals rather than regexes, so bracket-heavy strings such as ProForma
+# peptidoforms need no escaping. A literal cannot contain ';' (the list separator).
+if (NOT DEFINED INPUT_FILE)
+  message(FATAL_ERROR "INPUT_FILE is required")
+endif()
+if (NOT DEFINED EXPECTED AND NOT DEFINED FORBIDDEN)
+  message(FATAL_ERROR "EXPECTED or FORBIDDEN is required")
+endif()
+
+file(READ "${INPUT_FILE}" contents)
+
+foreach(literal IN LISTS EXPECTED)
+  string(FIND "${contents}" "${literal}" position)
+  if (position EQUAL -1)
+    message(FATAL_ERROR "${INPUT_FILE} does not contain: ${literal}")
+  endif()
+endforeach()
+
+foreach(literal IN LISTS FORBIDDEN)
+  string(FIND "${contents}" "${literal}" position)
+  if (NOT position EQUAL -1)
+    message(FATAL_ERROR "${INPUT_FILE} must not contain: ${literal}")
+  endif()
+endforeach()
+
+message(STATUS "${INPUT_FILE} passed the content checks")

--- a/src/tests/topp/compare_sequence_attributes.cmake
+++ b/src/tests/topp/compare_sequence_attributes.cmake
@@ -1,0 +1,40 @@
+# Usage: cmake -DINPUT_FILE=<idXML> -DREFERENCE_FILE=<idXML> -P compare_sequence_attributes.cmake
+#
+# Requires both files to carry the same sequence="..." attributes in the same order. This is
+# the round-trip check for a peptidoform spelling: a reader that degrades a modification
+# (drops it, renames it, turns a named modification into a mass bracket) changes the
+# attribute even when every mass and score still compares clean. FuzzyDiff cannot do this
+# job: it compares lines positionally, and UserParam order is process-dependent.
+foreach(required INPUT_FILE REFERENCE_FILE)
+  if (NOT DEFINED ${required})
+    message(FATAL_ERROR "${required} is required")
+  endif()
+endforeach()
+
+file(READ "${INPUT_FILE}" input_contents)
+file(READ "${REFERENCE_FILE}" reference_contents)
+string(REGEX MATCHALL "sequence=\"[^\"]*\"" input_sequences "${input_contents}")
+string(REGEX MATCHALL "sequence=\"[^\"]*\"" reference_sequences "${reference_contents}")
+list(LENGTH input_sequences input_count)
+list(LENGTH reference_sequences reference_count)
+
+if (reference_count EQUAL 0)
+  message(FATAL_ERROR "${REFERENCE_FILE} carries no sequence attributes")
+endif()
+
+if (NOT input_count EQUAL reference_count)
+  message(FATAL_ERROR
+    "${INPUT_FILE} carries ${input_count} sequence attributes, ${REFERENCE_FILE} carries ${reference_count}")
+endif()
+
+math(EXPR last "${reference_count} - 1")
+foreach(i RANGE ${last})
+  list(GET input_sequences ${i} input_sequence)
+  list(GET reference_sequences ${i} reference_sequence)
+  if (NOT input_sequence STREQUAL reference_sequence)
+    message(FATAL_ERROR
+      "sequence attribute ${i} differs:\n  input:     ${input_sequence}\n  reference: ${reference_sequence}")
+  endif()
+endforeach()
+
+message(STATUS "${input_count} sequence attributes identical to the reference")

--- a/src/tests/topp/remove_user_param.cmake
+++ b/src/tests/topp/remove_user_param.cmake
@@ -1,0 +1,21 @@
+# Usage: cmake -DINPUT_FILE=<xml> -DOUTPUT_FILE=<xml> -DNAME=<UserParam name> -P remove_user_param.cmake
+#
+# Writes a copy of an OpenMS XML file with every single-line <UserParam ... name="NAME" .../>
+# element deleted. It derives a "same file minus one element" input at test time, so a
+# compatibility property can be asserted without a second copy of a large fixture.
+foreach(required INPUT_FILE OUTPUT_FILE NAME)
+  if (NOT DEFINED ${required})
+    message(FATAL_ERROR "${required} is required")
+  endif()
+endforeach()
+
+file(READ "${INPUT_FILE}" contents)
+string(REGEX MATCHALL "[^\n]*<UserParam [^\n]*name=\"${NAME}\"[^\n]*\n" removed "${contents}")
+list(LENGTH removed removed_count)
+if (removed_count EQUAL 0)
+  message(FATAL_ERROR "${INPUT_FILE} carries no UserParam named ${NAME}")
+endif()
+string(REGEX REPLACE "[^\n]*<UserParam [^\n]*name=\"${NAME}\"[^\n]*\n" "" contents "${contents}")
+file(WRITE "${OUTPUT_FILE}" "${contents}")
+
+message(STATUS "Removed ${removed_count} UserParam(s) named ${NAME}")


### PR DESCRIPTION
Part of #10003 (PR 6 of the series; stacked on #10038). Test-only.

## Why a fresh process

A class test cannot prove that a reader registers the modification definitions it finds in `SearchParameters`: after `store()`, the writer's own registration is still in the process-wide `ModificationsDB`, so any single-process round trip passes even if the reader does nothing. These tests read the committed `OpenNuXL_1_output.idXML` fixture through fresh `IDFileConverter` processes, chained with `DEPENDS`.

The input is the committed fixture rather than the `TOPP_OpenNuXL_1` run's output, so the tests need neither that run nor its `NOT MSVC` guard and run on every platform.

## What is asserted (16 ctests)

| lane | property |
|---|---|
| `definitions_reread` + `_sequences` + `_check` | idXML re-read keeps every `sequence="…"` attribute identical to the fixture (25/25) and rewrites the definitions block naming `NuXL:U-H2O1` / `C9H11N2O8P1` |
| `definitions_reread2` + `_idempotent` | a second read is **byte-identical** (`FuzzyDiff`, only the run date whitelisted): nothing re-registered, no duplicated records, no `" (K)"` drift |
| `definitions_strip` + `_missing` | the same file with the `modification_definitions` UserParam removed **fails to load** with exit 8 *and* `Cannot convert string to peptide modification` — the settled compatibility break, now an asserted property rather than a degraded read |
| `definitions_idparquet_write/read/_sequences/_check` | idXML → `.idparquet` → idXML restores the **names**, not just the masses |
| `definitions_idparquet_dump` + `_peptidoform` | `psms.parquet` on its own spells the cross-link `AEADNLDDK[Formula:C9H11N2O8P1\|INFO:NuXL:U-H2O1]K` — the "an extracted psms.parquet is still chemically meaningful alone" claim |
| `legacy_mass_delta` + `_sequences` + `_check` | the pre-#10038 mass-bracket fixture converts with sequences unchanged and acquires **no** definitions block |

`NuXLReport_test` gains a PSM carrying the named definition on a clean residue (`M(Oxidation)PEPT(NuXL:U-H2O1)IDE`) and one with the adduct folded into the oxidised residue (`M(NuXL:U-H2O1~Oxidation)PEPTIDE`); all five PSMs must report identical `peptide_weight`, `xl_weight`, `m_2H` and zero precursor error.

## Why not FuzzyDiff against the fixture

FuzzyDiff compares lines positionally, and UserParam order inside idXML is `MetaInfoRegistry` registration order, i.e. process-dependent (`target_decoy` / `scan_index` swap places between the June-2025 fixture and a fresh re-read). So the fixture cannot be diffed against its own re-read. Three small CMake scripts do the job instead:

- `compare_sequence_attributes.cmake` — every `sequence="…"` attribute, in order, must match.
- `check_file_contains.cmake` — literal `EXPECTED` / `FORBIDDEN` substrings (literals, so ProForma brackets need no escaping).
- `remove_user_param.cmake` — derives the "same file minus the block" input at test time, so the compatibility property is exactly that, without a second 100 kB copy of the fixture.
- `check_exit_code.cmake` gains an optional `EXPECTED_OUTPUT_REGEX`, so the failure lane insists on the specific error (a truncated XML also exits non-zero — with code 3 and a different message — and must not satisfy it).

Same-tool re-reads *are* byte-identical, so the idempotence lane uses `${DIFF}` as usual.

## Verification

- `ctest -R "OpenNuXL|NuXL|IdXMLFile|PSMArrowIO|ParquetDiff|IDFileConverter|FeatureXMLFile|ConsensusXMLFile|ArrowIO|ModificationDefinitionIO|ProFormaParser"` → 132/132.
- Every new check failed on purpose first — mutation log in the first comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKPrmDHEE7cZCxGfTKTtFE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for named precursor-adduct modifications, including combinations with oxidation and verification of peptide annotations and masses.
  - Added round-trip validation for localized cross-link modifications across identification file formats.
  - Added checks for sequence attributes, modification definitions, legacy mass-bracket formats, and expected conversion errors.
  - Added reusable validation checks for file contents, XML attributes, exit messages, and removal operations, improving confidence in conversion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->