### PR TITLE
Remove broken multi-fraction design parameter from FeatureLinker

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -761,6 +761,14 @@ TOPP tools:
         independently (#9247, #9250)
     FeatureFinderMultiplex, MultiplexResolver:
       - BREAKING: parameter `missed_cleavages` renamed to `max_nr_labelled_aas` (#8911)
+    FeatureLinkerUnlabeled, FeatureLinkerUnlabeledQT, FeatureLinkerUnlabeledKD, FeatureLinkerWNet:
+      - BREAKING: the -design parameter was removed. Multi-fraction grouping never worked: the loop over
+        fractions re-used the first k feature maps for every fraction and each group() call cleared the
+        output map, so a design with n fractions silently yielded the grouping of a single fraction and
+        dropped the remaining input maps without a warning. FeatureLinkerUnlabeled registered the
+        parameter but never read it. Link each fraction separately and combine the results with
+        FileMerger -append_method append_cols; fractionated label-free quantification is covered by
+        ProteomicsLFQ, which does its own per-fraction linking (#10043)
     IDConflictResolver:
       - Added a rank aggregation resolve method (--resolve_method rank_aggregation) for consensus
         replicate identifications (#8907)

--- a/share/OpenMS/examples/TOPPAS/QualityControl.toppas
+++ b/share/OpenMS/examples/TOPPAS/QualityControl.toppas
@@ -537,7 +537,6 @@
         <ITEMLIST name="in" type="input-file" description="input files separated by blanks" required="true" advanced="false" supported_formats="*.featureXML,*.consensusXML">
         </ITEMLIST>
         <ITEM name="out" value="" type="output-file" description="Output file" required="true" advanced="false" supported_formats="*.consensusXML" />
-        <ITEM name="design" value="" type="input-file" description="input file containing the experimental design" required="false" advanced="false" supported_formats="*.tsv" />
         <ITEM name="keep_subelements" value="false" type="bool" description="For consensusXML input only: If set, the sub-features of the inputs are transferred to the output." required="false" advanced="false" />
         <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />

--- a/src/tests/topp/FeatureLinkerUnlabeledKD_4_parameters.ini
+++ b/src/tests/topp/FeatureLinkerUnlabeledKD_4_parameters.ini
@@ -6,7 +6,6 @@
       <ITEMLIST name="in" type="input-file" description="input files separated by blanks" required="true" advanced="false" supported_formats="*.featureXML,*.consensusXML">
       </ITEMLIST>
       <ITEM name="out" value="" type="output-file" description="Output file" required="true" advanced="false" supported_formats="*.consensusXML" />
-      <ITEM name="design" value="" type="input-file" description="input file containing the experimental design" required="false" advanced="false" supported_formats="*.tsv" />
       <ITEM name="keep_subelements" value="false" type="string" description="For consensusXML input only: If set, the sub-features of the inputs are transferred to the output." required="false" advanced="false" restrictions="true,false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />

--- a/src/tests/topp/FeatureLinkerWNet_1_parameters.ini
+++ b/src/tests/topp/FeatureLinkerWNet_1_parameters.ini
@@ -6,7 +6,6 @@
       <ITEMLIST name="in" type="input-file" description="input files separated by blanks" required="true" advanced="false" supported_formats="*.featureXML,*.consensusXML">
       </ITEMLIST>
       <ITEM name="out" value="" type="output-file" description="Output file" required="true" advanced="false" supported_formats="*.consensusXML" />
-      <ITEM name="design" value="" type="input-file" description="input file containing the experimental design" required="false" advanced="false" supported_formats="*.tsv" />
       <ITEM name="keep_subelements" value="false" type="bool" description="For consensusXML input only: If set, the sub-features of the inputs are transferred to the output." required="false" advanced="false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />

--- a/src/tests/topp/INIUpdater_1_noupdate.toppas
+++ b/src/tests/topp/INIUpdater_1_noupdate.toppas
@@ -142,7 +142,6 @@
         <ITEMLIST name="in" type="input-file" description="input files separated by blanks" required="true" advanced="false" supported_formats="*.featureXML,*.consensusXML,*.featureparquet,*.consensusparquet">
         </ITEMLIST>
         <ITEM name="out" value="" type="output-file" description="Output file" required="true" advanced="false" supported_formats="*.consensusXML,*.consensusparquet" />
-        <ITEM name="design" value="" type="input-file" description="input file containing the experimental design" required="false" advanced="false" supported_formats="*.tsv" />
         <ITEM name="keep_subelements" value="false" type="bool" description="For consensusXML/consensusparquet input only: If set, the sub-features of the inputs are transferred to the output." required="false" advanced="false" />
         <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />

--- a/src/tests/topp/INIUpdater_3_old_out.toppas
+++ b/src/tests/topp/INIUpdater_3_old_out.toppas
@@ -140,7 +140,6 @@
         <ITEMLIST name="in" type="input-file" description="input files separated by blanks" required="true" advanced="false" supported_formats="*.featureXML,*.consensusXML,*.featureparquet,*.consensusparquet">
         </ITEMLIST>
         <ITEM name="out" value="" type="output-file" description="Output file" required="true" advanced="false" supported_formats="*.consensusXML,*.consensusparquet" />
-        <ITEM name="design" value="" type="input-file" description="input file containing the experimental design" required="false" advanced="false" supported_formats="*.tsv" />
         <ITEM name="keep_subelements" value="false" type="bool" description="For consensusXML/consensusparquet input only: If set, the sub-features of the inputs are transferred to the output." required="false" advanced="false" />
         <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />

--- a/src/topp/FeatureLinkerBase.cpp
+++ b/src/topp/FeatureLinkerBase.cpp
@@ -13,8 +13,6 @@
 #include <OpenMS/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithm.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/CONCEPT/ProgressLogger.h>
-#include <OpenMS/METADATA/ExperimentalDesign.h>
-#include <OpenMS/FORMAT/ExperimentalDesignFile.h>
 
 #include <OpenMS/KERNEL/ConversionHelper.h>
 
@@ -71,8 +69,6 @@ protected:
     setValidFormats_("in", ListUtils::create<std::string>("featureXML,consensusXML,featureparquet,consensusparquet"));
     registerOutputFile_("out", "<file>", "", "Output file", true);
     setValidFormats_("out", ListUtils::create<std::string>("consensusXML,consensusparquet"));
-    registerInputFile_("design", "<file>", "", "input file containing the experimental design", false);
-    setValidFormats_("design", ListUtils::create<std::string>("tsv"));
     addEmptyLine_();
     registerFlag_("keep_subelements", "For consensusXML/consensusparquet input only: If set, the sub-features of the inputs are transferred to the output.");
   }
@@ -122,55 +118,9 @@ protected:
     ConsensusMap out_map;
     StringList ms_run_locations;
 
-    std::string design_file;
-
-    // TODO: support design in labeled feature linker
-    if (!labeled)
-    {
-      design_file = getStringOption_("design");
-    }
-
-    if ((file_type == FileTypes::CONSENSUSXML || file_type == FileTypes::CONSENSUSPARQUET) && !design_file.empty())
-    {
-      writeLogError_("Error: Using fractionated design with consensusXML/consensusparquet as input is not supported!");
-      return ILLEGAL_PARAMETERS;
-    }
-  
     if (file_type == FileTypes::FEATUREXML || file_type == FileTypes::FEATUREPARQUET)
     {
       OPENMS_LOG_INFO << "Linking " << ins.size() << " feature maps." << endl;
-  
-      //-------------------------------------------------------------
-      // Extract (optional) fraction identifiers and associate with featureXMLs
-      //-------------------------------------------------------------
-
-      // determine map of fractions to MS files
-      map<unsigned, vector<std::string>> frac2files;
-
-      if (!design_file.empty())
-      {
-        // parse design file and determine fractions
-        ExperimentalDesign ed = ExperimentalDesignFile::load(design_file, false);
-
-        // determine if design defines more than one fraction
-        frac2files = ed.getFractionToMSFilesMapping();
-
-        writeDebug_("Grouping " + StringUtils::toStr(ed.getNumberOfFractions()) + " fractions.", 3);
-
-        // check if all fractions have the same number of MS runs associated
-        if (!ed.sameNrOfMSFilesPerFraction())
-        {
-          writeLogError_("Error: Number of runs must match for every fraction!");
-          return ILLEGAL_PARAMETERS;
-        }
-      }
-      else // no design file given
-      {
-        for (Size i = 0; i != ins.size(); ++i)
-        {
-          frac2files[1].emplace_back("file" + StringUtils::toStr(i)); // associate each run with fraction 1
-        }
-      }
 
       vector<FeatureMap > maps(ins.size());
       FileHandler f;
@@ -255,26 +205,8 @@ protected:
 
       ////////////////////////////////////////////////////
       // invoke feature grouping algorithm
-      
-      if (frac2files.size() == 1) // group one fraction
-      {
-        algorithm->group(maps, out_map);
-      }
-      else // group multiple fractions
-      {
-        writeDebug_("Stored in " + StringUtils::toStr(maps.size()) + " maps.", 3);
-        for (Size i = 1; i <= frac2files.size(); ++i)
-        {
-          vector<FeatureMap> fraction_maps;
-          // TODO FRACTIONS: here we assume that the order of featureXML is from fraction 1..n
-          // we should check if these are shuffled and error / warn          
-          for (size_t feature_map_index = 0; feature_map_index != frac2files[i].size(); ++feature_map_index)
-          {
-            fraction_maps.push_back(maps[feature_map_index]);
-          }
-          algorithm->group(fraction_maps, out_map);
-        }
-      }
+
+      algorithm->group(maps, out_map);
     }
     else
     {


### PR DESCRIPTION
## Description

This PR removes the non-functional `-design` parameter from FeatureLinkerUnlabeled and related tools (FeatureLinkerUnlabeledQT, FeatureLinkerUnlabeledKD, FeatureLinkerWNet).

### Why this change?

The multi-fraction grouping feature was fundamentally broken:
- The loop over fractions re-used the first k feature maps for every fraction
- Each `group()` call cleared the output map, so results from previous fractions were lost
- A design with n fractions silently yielded only the grouping of a single fraction and dropped remaining input maps without warning
- FeatureLinkerUnlabeled registered the parameter but never actually read it

### What was removed?

1. **Includes**: Removed unused `ExperimentalDesign.h` and `ExperimentalDesignFile.h` headers
2. **Parameter registration**: Removed the `-design` input file parameter
3. **Design file parsing logic**: Removed all code that parsed the experimental design file and attempted fraction-based grouping
4. **Fraction mapping**: Removed the `frac2files` map and associated logic that tried to group maps by fraction

### Recommended alternative

Users who need fractionated label-free quantification should:
- Link each fraction separately using FeatureLinkerUnlabeled
- Combine results with FileMerger using `-append_method append_cols`
- Or use ProteomicsLFQ, which handles per-fraction linking correctly

### Changes made

- `src/topp/FeatureLinkerBase.cpp`: Removed parameter registration, includes, and fraction grouping logic
- `CHANGELOG`: Added breaking change notice with migration guidance
- Test files: Updated parameter files and TOPPAS examples to remove the `-design` parameter

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (N/A - no API changes)

https://claude.ai/code/session_01LnmKjdyAx3BPiWqefVPW1r

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Removed the experimental-design (`-design`) option from unlabeled feature-linking tools.
  - Fraction-specific grouping is no longer supported through these tools. Process each fraction separately and combine the results using column appending.
  - Fractionated label-free quantification should use ProteomicsLFQ.

- **Workflow Updates**
  - Updated affected TOPPAS workflows and parameter files to remove the obsolete design-file input.

- **Documentation**
  - Added release notes describing the behavior change and migration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->