### PR TITLE
[FIX] Update preconditions for matrix dimensions in MRMScoring 

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMScoring.cpp
@@ -391,14 +391,14 @@ namespace OpenSwath
     // return $deltascore_mean + $deltascore_stdev
     double MRMScoring::calcXcorrCoelutionScore()
     {
-      OPENSWATH_PRECONDITION(xcorr_matrix_max_peak_.rows() > 1, "Expect cross-correlation matrix of at least 2x2");
+      OPENSWATH_PRECONDITION(xcorr_matrix_max_peak_.rows() > 0, "Expect cross-correlation matrix of at least 1x1");
       return meanStdevUpperTriangle(xcorr_matrix_max_peak_);
     }
 
     double MRMScoring::calcXcorrCoelutionWeightedScore(
             const std::vector<double>& normalized_library_intensity)
     {
-      OPENSWATH_PRECONDITION(xcorr_matrix_max_peak_.rows() > 1, "Expect cross-correlation matrix of at least 2x2");
+      OPENSWATH_PRECONDITION(xcorr_matrix_max_peak_.rows() > 0, "Expect cross-correlation matrix of at least 1x1");
       return weightedTriangularSum(xcorr_matrix_max_peak_, normalized_library_intensity);
     }
 
@@ -455,14 +455,14 @@ namespace OpenSwath
     ///
     double MRMScoring::calcXcorrShapeScore()
     {
-      OPENSWATH_PRECONDITION(xcorr_matrix_max_peak_sec_.rows() > 1, "Expect cross-correlation matrix of at least 2x2");
+      OPENSWATH_PRECONDITION(xcorr_matrix_max_peak_sec_.rows() > 0, "Expect cross-correlation matrix of at least 1x1");
       return meanUpperTriangle(xcorr_matrix_max_peak_sec_);
     }
 
     double MRMScoring::calcXcorrShapeWeightedScore(
             const std::vector<double>& normalized_library_intensity)
     {
-      OPENSWATH_PRECONDITION(xcorr_matrix_max_peak_sec_.rows() > 1, "Expect cross-correlation matrix of at least 2x2");
+      OPENSWATH_PRECONDITION(xcorr_matrix_max_peak_sec_.rows() > 0, "Expect cross-correlation matrix of at least 1x1");
       return weightedTriangularSum(xcorr_matrix_max_peak_sec_, normalized_library_intensity);
     }
 
@@ -776,7 +776,7 @@ namespace OpenSwath
     
     double MRMScoring::calcMIScore()
     {
-      OPENSWATH_PRECONDITION(mi_matrix_.rows() > 1, "Expect mutual information matrix of at least 2x2");
+      OPENSWATH_PRECONDITION(mi_matrix_.rows() > 0, "Expect mutual information matrix of at least 1x1");
       auto em = OpenMS::eigenView(mi_matrix_);
       double mi_scores = em.sum();
       //mi_matrix_ is a triangular matrix
@@ -787,7 +787,7 @@ namespace OpenSwath
     double MRMScoring::calcMIWeightedScore(
             const std::vector<double>& normalized_library_intensity)
     {
-      OPENSWATH_PRECONDITION(mi_matrix_.rows() > 1, "Expect mutual information matrix of at least 2x2");
+      OPENSWATH_PRECONDITION(mi_matrix_.rows() > 0, "Expect mutual information matrix of at least 1x1");
       return weightedTriangularSum(mi_matrix_, normalized_library_intensity);
     }
 

--- a/src/tests/class_tests/openms/source/MRMScoring_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMScoring_test.cpp
@@ -448,6 +448,26 @@ END_SECTION*/
         }
     END_SECTION
 
+    START_SECTION(test_single_transition_xcorr_scores)
+        {
+          MockMRMFeature * imrmfeature = new MockMRMFeature();
+          MRMScoring mrmscore;
+          std::vector<std::string> native_ids;
+          std::vector<double> weights {1.0};
+          fill_mock_objects(imrmfeature, native_ids);
+          native_ids.resize(1);
+          mrmscore.initializeXCorrMatrix(imrmfeature, native_ids);
+          delete imrmfeature;
+
+          TEST_EQUAL(mrmscore.getXCorrMatrix().rows(), 1)
+          TEST_EQUAL(mrmscore.getXCorrMatrix().cols(), 1)
+          TEST_REAL_SIMILAR(mrmscore.calcXcorrCoelutionScore(), 0.0)
+          TEST_REAL_SIMILAR(mrmscore.calcXcorrCoelutionWeightedScore(weights), 0.0)
+          TEST_REAL_SIMILAR(mrmscore.calcXcorrShapeScore(), 1.0)
+          TEST_REAL_SIMILAR(mrmscore.calcXcorrShapeWeightedScore(weights), 1.0)
+        }
+    END_SECTION
+
     START_SECTION(calcXcorrPrecursorContrastCoelutionScore)
         {
           MockMRMFeature * imrmfeature = new MockMRMFeature();
@@ -803,6 +823,25 @@ mean(m4)
           // xcorr_deltas = [1, 0.3969832, 1] * array([0.25, 2*0.5*0.5,0.25])
           // sum(xcorr_deltas)
           TEST_REAL_SIMILAR(mrmscore.calcMIWeightedScore(weights), 3.3231)
+        }
+    END_SECTION
+
+    START_SECTION(test_single_transition_mi_scores)
+        {
+          MockMRMFeature * imrmfeature = new MockMRMFeature();
+          MRMScoring mrmscore;
+          std::vector<std::string> native_ids;
+          std::vector<double> weights {1.0};
+          fill_mock_objects(imrmfeature, native_ids);
+          native_ids.resize(1);
+          mrmscore.initializeMIMatrix(imrmfeature, native_ids);
+          delete imrmfeature;
+
+          TEST_EQUAL(mrmscore.getMIMatrix().rows(), 1)
+          TEST_EQUAL(mrmscore.getMIMatrix().cols(), 1)
+          TEST_REAL_SIMILAR(mrmscore.getMIMatrix()(0, 0), 3.2776)
+          TEST_REAL_SIMILAR(mrmscore.calcMIScore(), 3.2776)
+          TEST_REAL_SIMILAR(mrmscore.calcMIWeightedScore(weights), 3.2776)
         }
     END_SECTION
 


### PR DESCRIPTION
## Description

Addresses [#10050](https://github.com/OpenMS/OpenMS/issues/10050)

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Single-transition data is now supported when calculating cross-correlation and mutual-information scores.
  * Scoring results for 1×1 transition matrices are produced correctly, including weighted and unweighted calculations.

* **Tests**
  * Added coverage for single-transition cross-correlation and mutual-information scoring scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->