### PR TITLE
[FIX,TEST] Avoid shared-directory race in TOPPExternalToolBase_test

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1566,6 +1566,8 @@ Build System:
     to latest, and doc/pyopenms/ruff.toml selects the pyOpenMS documentation's lint rules explicitly. Ruff
     0.16 widened its default lint selection from 59 to 413 rules, which turned the job red with no commit
     of ours in between (#9899, #9906)
+  - Tests: TOPPExternalToolBase_test uses `ls -ld .` instead of listing the shared test directory,
+    avoiding intermittent failures when parallel tests remove temporary files (#9973).
   - Tests: TOPP_OpenSwathWorkflow_17_cache wrote to the same output file names as TOPP_OpenSwathWorkflow_17,
     so the two tests could collide when a Windows nightly run scheduled them concurrently; the cache variant
     now uses its own file names (#9937)

--- a/src/tests/class_tests/openms/source/TOPPExternalToolBase_test.cpp
+++ b/src/tests/class_tests/openms/source/TOPPExternalToolBase_test.cpp
@@ -67,7 +67,8 @@ START_SECTION(([EXTRA] ExitCodes runExternalProcess_(const std::string& executab
   const std::vector<std::string> args_broken = {"/C", "doesnotexist"};
 #else
   const std::string exe = "ls";
-  const std::vector<std::string> args = {"-l"};
+  // Inspect the directory itself: parallel tests may delete entries while ls lists them.
+  const std::vector<std::string> args = {"-ld", "."};
   const std::vector<std::string> args_broken = {"-0"};
 #endif //
 


### PR DESCRIPTION
## Description

Change the successful command in `TOPPExternalToolBase_test` from `ls -l` to `ls -ld .`.

The test checks how `runExternalProcess_` maps process outcomes to exit codes. It does not need to list directory contents. Under parallel CTest execution, another test can delete temporary files while `ls -l` is inspecting them, causing an unrelated nonzero exit. `ls -ld .` inspects only the working directory itself and avoids this race.

The missing-executable and invalid-argument checks, all assertions, and the Windows branch remain unchanged. Includes a short changelog entry.

This addresses the [GCC CI failure on #9973](https://github.com/OpenMS/OpenMS/actions/runs/33864091293/job/100994860016). Related: #9948 and #9955, which fixed the same problem in `ExternalProcess_test`.

## Validation

- `git diff --check` and patch application checks passed.
- In a local 500-iteration probe with concurrent creation/deletion of 128 files, `ls -l` failed 86 times; `ls -ld .` passed all 500 executions.
- `ls -0` still returned exit code 2, preserving the intentional failure case.
- The OpenMS test binary and full suite were not run locally; CI validation is pending.

## Checklist

- [x] Author is listed in AUTHORS
- [x] CHANGELOG updated
- [x] Added a comment explaining the command choice
- [ ] New and existing unit tests pass locally with my changes (not run locally)
- [x] No Python binding changes needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test reliability by preventing intermittent failures during parallel test execution.
  - Updated directory checks to inspect the directory itself rather than its contents, avoiding errors when temporary files are removed concurrently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->