### PR TITLE
Update CHANGELOG: Percolator Normalizer double-instantiation and MRMScoring single-transition fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1614,6 +1614,18 @@ Build System:
     LLVM/clang 21+, which no longer provides them transitively (#9651, #9653)
   - Fix: removed default(none) from the SimpleSearchEngineAlgorithm OpenMP pragma, which broke builds on
     macOS/Xcode where _OPENMP is not defined (#9388)
+  - Fix: PercolatorAdapter's in-process rescoring backend aborted with "Multiple instantiations of
+    Normalizer" (assert(false) in Debug builds, on every run since #9218) because both the vendored
+    SetHandler::normalizeFeatures() and Percolator::train()/rescore() independently called the singleton
+    factory Normalizer::getNormalizer(), constructing it twice. train()/rescore() now pass a null
+    Normalizer* into normalizeFeatures() and let it perform the one factory call, as upstream Percolator's
+    own Caller.cpp does; Release builds were unaffected numerically, since NDEBUG disables the assert and
+    the redundant call just returned the existing instance (#10049, #10057)
+  - Fix: MRMScoring's cross-correlation and mutual-information scoring (calcXcorrCoelutionScore,
+    calcXcorrCoelutionWeightedScore, calcXcorrShapeScore, calcXcorrShapeWeightedScore, calcMIScore,
+    calcMIWeightedScore) required its score matrix to hold at least two transitions, so OpenSwath
+    compounds with only a single transition failed the precondition instead of being scored; the checks
+    now accept a 1x1 matrix (#10050, #10055)
   - Security patterns added to .gitignore (#8545); configure return value checking in CI packaging (#8515);
     Claude GitHub Actions workflows added for CI automation (#8675, #8676); removed leftover traces of the
     removed doc_internal target (#2256)


### PR DESCRIPTION
## Description

Two recently merged fixes landed without their own CHANGELOG entry:

- #10057 (fixes #10049) — `Percolator::train()`/`rescore()` called `Normalizer::getNormalizer()` themselves even though the vendored `SetHandler::normalizeFeatures()` already constructs the singleton via its out-parameter. Calling the factory twice tripped the vendored Normalizer's `assert(false)` ("Multiple instantiations of Normalizer") in Debug builds on every in-process Percolator run since #9218. `train()`/`rescore()` now pass a null `Normalizer*` into `normalizeFeatures()` and let it perform the single factory call, matching upstream Percolator's own `Caller.cpp`. Release builds were unaffected numerically (`NDEBUG` disables the assert, and the redundant call just returned the existing singleton).
- #10055 (fixes #10050) — `MRMScoring`'s cross-correlation and mutual-information scoring functions (`calcXcorrCoelutionScore`, `calcXcorrCoelutionWeightedScore`, `calcXcorrShapeScore`, `calcXcorrShapeWeightedScore`, `calcMIScore`, `calcMIWeightedScore`) required their score matrix to be at least 2x2, so OpenSwath compounds with only a single transition failed the precondition instead of being scored. The checks now accept a 1x1 matrix.

This PR only adds the corresponding CHANGELOG entries under the 3.6.0 (under development) "Fixes:" section; no code changes.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas (not applicable; CHANGELOG-only change)
- [ ] New and existing unit tests pass locally with my changes (not applicable; CHANGELOG-only change)
- [x] Updated or added python bindings for changed or new classes (no updates necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHEsujKnJFTTChdC6Q8qGu

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHEsujKnJFTTChdC6Q8qGu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an error that could interrupt in-process Percolator rescoring.
  * Enabled MRMScoring cross-correlation and mutual-information scores for compounds containing a single transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->