### PR TITLE
[FIX] Keep DefaultParamHandler-cached members in sync when copying (#532)

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h
@@ -133,7 +133,7 @@ namespace OpenMS
     bool add_metainfo_;
     bool add_isotopes_;
     bool add_internal_fragments_;
-    int isotope_model_;
+    int isotope_model_ = 0;
     bool add_precursor_peaks_;
     bool add_all_precursor_charges_ ;
     bool add_abundant_immonium_ions_;

--- a/src/openms/source/CHEMISTRY/NucleicAcidSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/NucleicAcidSpectrumGenerator.cpp
@@ -74,16 +74,10 @@ namespace OpenMS
   }
 
 
-  NucleicAcidSpectrumGenerator::NucleicAcidSpectrumGenerator(const NucleicAcidSpectrumGenerator& source) : DefaultParamHandler(source)
-  {
-  }
+  NucleicAcidSpectrumGenerator::NucleicAcidSpectrumGenerator(const NucleicAcidSpectrumGenerator& source) = default;
 
 
-  NucleicAcidSpectrumGenerator& NucleicAcidSpectrumGenerator::operator=(const NucleicAcidSpectrumGenerator& source)
-  {
-    DefaultParamHandler::operator=(source);
-    return *this;
-  }
+  NucleicAcidSpectrumGenerator& NucleicAcidSpectrumGenerator::operator=(const NucleicAcidSpectrumGenerator& source) = default;
 
 
   NucleicAcidSpectrumGenerator::~NucleicAcidSpectrumGenerator() = default;

--- a/src/openms/source/CHEMISTRY/SimpleTSGXLMS.cpp
+++ b/src/openms/source/CHEMISTRY/SimpleTSGXLMS.cpp
@@ -101,19 +101,9 @@ namespace OpenMS
     }
   }
 
-  SimpleTSGXLMS::SimpleTSGXLMS(const SimpleTSGXLMS & rhs) :
-    DefaultParamHandler(rhs)
-  {
-  }
+  SimpleTSGXLMS::SimpleTSGXLMS(const SimpleTSGXLMS& rhs) = default;
 
-  SimpleTSGXLMS & SimpleTSGXLMS::operator=(const SimpleTSGXLMS & rhs)
-  {
-    if (this != &rhs)
-    {
-      DefaultParamHandler::operator=(rhs);
-    }
-    return *this;
-  }
+  SimpleTSGXLMS& SimpleTSGXLMS::operator=(const SimpleTSGXLMS& rhs) = default;
 
   SimpleTSGXLMS::~SimpleTSGXLMS() = default;
 

--- a/src/openms/source/CHEMISTRY/SpectrumAnnotator.cpp
+++ b/src/openms/source/CHEMISTRY/SpectrumAnnotator.cpp
@@ -78,19 +78,9 @@ namespace OpenMS
     defaultsToParam_();
   }
 
-  SpectrumAnnotator::SpectrumAnnotator(const SpectrumAnnotator & rhs) :
-    DefaultParamHandler(rhs)
-  {
-  }
+  SpectrumAnnotator::SpectrumAnnotator(const SpectrumAnnotator& rhs) = default;
 
-  SpectrumAnnotator & SpectrumAnnotator::operator=(const SpectrumAnnotator & rhs)
-  {
-    if (this != &rhs)
-    {
-      DefaultParamHandler::operator=(rhs);
-    }
-    return *this;
-  }
+  SpectrumAnnotator& SpectrumAnnotator::operator=(const SpectrumAnnotator& rhs) = default;
 
   SpectrumAnnotator::~SpectrumAnnotator() = default;
 

--- a/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
@@ -112,17 +112,10 @@ namespace OpenMS
   }
 
 
-  TheoreticalSpectrumGenerator::TheoreticalSpectrumGenerator(const TheoreticalSpectrumGenerator& rhs) :
-    DefaultParamHandler(rhs)
-  {
-  }
+  TheoreticalSpectrumGenerator::TheoreticalSpectrumGenerator(const TheoreticalSpectrumGenerator& rhs) = default;
 
 
-  TheoreticalSpectrumGenerator& TheoreticalSpectrumGenerator::operator=(const TheoreticalSpectrumGenerator& rhs)
-  {
-    DefaultParamHandler::operator=(rhs);
-    return *this;
-  }
+  TheoreticalSpectrumGenerator& TheoreticalSpectrumGenerator::operator=(const TheoreticalSpectrumGenerator& rhs) = default;
 
   TheoreticalSpectrumGenerator::~TheoreticalSpectrumGenerator() = default;
 
@@ -1285,6 +1278,7 @@ namespace OpenMS
     add_internal_fragments_ = param_.getValue("add_internal_fragments").toBool();
     if (param_.getValue("isotope_model") == "coarse") isotope_model_ = 1;
     else if (param_.getValue("isotope_model") == "fine") isotope_model_ = 2;
+    else isotope_model_ = 0; // 'none': reset, otherwise a previous setting would linger
     sort_by_position_ = param_.getValue("sort_by_position").toBool();
     add_precursor_peaks_ = param_.getValue("add_precursor_peaks").toBool();
     add_all_precursor_charges_ = param_.getValue("add_all_precursor_charges").toBool();

--- a/src/openms/source/CHEMISTRY/TheoreticalSpectrumGeneratorXLMS.cpp
+++ b/src/openms/source/CHEMISTRY/TheoreticalSpectrumGeneratorXLMS.cpp
@@ -119,19 +119,9 @@ namespace OpenMS
     }
   }
 
-  TheoreticalSpectrumGeneratorXLMS::TheoreticalSpectrumGeneratorXLMS(const TheoreticalSpectrumGeneratorXLMS & rhs) :
-    DefaultParamHandler(rhs)
-  {
-  }
+  TheoreticalSpectrumGeneratorXLMS::TheoreticalSpectrumGeneratorXLMS(const TheoreticalSpectrumGeneratorXLMS& rhs) = default;
 
-  TheoreticalSpectrumGeneratorXLMS & TheoreticalSpectrumGeneratorXLMS::operator=(const TheoreticalSpectrumGeneratorXLMS & rhs)
-  {
-    if (this != &rhs)
-    {
-      DefaultParamHandler::operator=(rhs);
-    }
-    return *this;
-  }
+  TheoreticalSpectrumGeneratorXLMS& TheoreticalSpectrumGeneratorXLMS::operator=(const TheoreticalSpectrumGeneratorXLMS& rhs) = default;
 
   TheoreticalSpectrumGeneratorXLMS::~TheoreticalSpectrumGeneratorXLMS() = default;
 

--- a/src/openms/source/PROCESSING/SCALING/Normalizer.cpp
+++ b/src/openms/source/PROCESSING/SCALING/Normalizer.cpp
@@ -22,19 +22,9 @@ namespace OpenMS
 
   Normalizer::~Normalizer() = default;
 
-  Normalizer::Normalizer(const Normalizer & source) :
-    DefaultParamHandler(source)
-  {
-  }
+  Normalizer::Normalizer(const Normalizer& source) = default;
 
-  Normalizer & Normalizer::operator=(const Normalizer & source)
-  {
-    if (this != &source)
-    {
-      DefaultParamHandler::operator=(source);
-    }
-    return *this;
-  }
+  Normalizer& Normalizer::operator=(const Normalizer& source) = default;
 
   void Normalizer::filterPeakSpectrum(PeakSpectrum& spectrum) const
   {

--- a/src/tests/class_tests/openms/source/Normalizer_test.cpp
+++ b/src/tests/class_tests/openms/source/Normalizer_test.cpp
@@ -43,6 +43,30 @@ START_SECTION((Normalizer(const Normalizer& source)))
 	Normalizer copy(*e_ptr);
 	TEST_EQUAL(copy.getParameters(), e_ptr->getParameters())
 	TEST_EQUAL(copy.getName(), e_ptr->getName())
+
+	// a copy must behave like the source: an unset 'method_' throws InvalidValue
+	Normalizer configured;
+	Param cfg(configured.getParameters());
+	cfg.setValue("method", "to_TIC");
+	configured.setParameters(cfg);
+	Normalizer configured_copy(configured);
+
+	PeakSpectrum copy_test_spec;
+	Peak1D copy_test_peak;
+	copy_test_peak.setMZ(100.0);
+	copy_test_peak.setIntensity(1.0f);
+	copy_test_spec.push_back(copy_test_peak);
+	copy_test_peak.setMZ(200.0);
+	copy_test_peak.setIntensity(3.0f);
+	copy_test_spec.push_back(copy_test_peak);
+
+	configured_copy.filterSpectrum(copy_test_spec);
+	double copy_test_sum(0);
+	for (PeakSpectrum::ConstIterator it = copy_test_spec.begin(); it != copy_test_spec.end(); ++it)
+	{
+		copy_test_sum += it->getIntensity();
+	}
+	TEST_REAL_SIMILAR(copy_test_sum, 1.0)
 END_SECTION
 
 START_SECTION((Normalizer& operator = (const Normalizer& source)))
@@ -50,6 +74,31 @@ START_SECTION((Normalizer& operator = (const Normalizer& source)))
 	copy = *e_ptr;
 	TEST_EQUAL(copy.getParameters(), e_ptr->getParameters())
 	TEST_EQUAL(copy.getName(), e_ptr->getName())
+
+	// same check for assignment
+	Normalizer configured;
+	Param cfg(configured.getParameters());
+	cfg.setValue("method", "to_TIC");
+	configured.setParameters(cfg);
+	Normalizer assigned;
+	assigned = configured;
+
+	PeakSpectrum assign_test_spec;
+	Peak1D assign_test_peak;
+	assign_test_peak.setMZ(100.0);
+	assign_test_peak.setIntensity(1.0f);
+	assign_test_spec.push_back(assign_test_peak);
+	assign_test_peak.setMZ(200.0);
+	assign_test_peak.setIntensity(3.0f);
+	assign_test_spec.push_back(assign_test_peak);
+
+	assigned.filterSpectrum(assign_test_spec);
+	double assign_test_sum(0);
+	for (PeakSpectrum::ConstIterator it = assign_test_spec.begin(); it != assign_test_spec.end(); ++it)
+	{
+		assign_test_sum += it->getIntensity();
+	}
+	TEST_REAL_SIMILAR(assign_test_sum, 1.0)
 END_SECTION
 
 

--- a/src/tests/class_tests/openms/source/Normalizer_test.cpp
+++ b/src/tests/class_tests/openms/source/Normalizer_test.cpp
@@ -44,29 +44,21 @@ START_SECTION((Normalizer(const Normalizer& source)))
 	TEST_EQUAL(copy.getParameters(), e_ptr->getParameters())
 	TEST_EQUAL(copy.getName(), e_ptr->getName())
 
-	// a copy must behave like the source: an unset 'method_' throws InvalidValue
+	// getParameters() cannot see 'method_', which updateMembers_() caches, so also
+	// check that a copy of a configured Normalizer filters the same way
 	Normalizer configured;
-	Param cfg(configured.getParameters());
-	cfg.setValue("method", "to_TIC");
-	configured.setParameters(cfg);
+	Param p(configured.getParameters());
+	p.setValue("method", "to_TIC");
+	configured.setParameters(p);
 	Normalizer configured_copy(configured);
 
-	PeakSpectrum copy_test_spec;
-	Peak1D copy_test_peak;
-	copy_test_peak.setMZ(100.0);
-	copy_test_peak.setIntensity(1.0f);
-	copy_test_spec.push_back(copy_test_peak);
-	copy_test_peak.setMZ(200.0);
-	copy_test_peak.setIntensity(3.0f);
-	copy_test_spec.push_back(copy_test_peak);
-
-	configured_copy.filterSpectrum(copy_test_spec);
-	double copy_test_sum(0);
-	for (PeakSpectrum::ConstIterator it = copy_test_spec.begin(); it != copy_test_spec.end(); ++it)
-	{
-		copy_test_sum += it->getIntensity();
-	}
-	TEST_REAL_SIMILAR(copy_test_sum, 1.0)
+	PeakSpectrum unfiltered;
+	unfiltered.push_back(Peak1D(100.0, 1.0f));
+	unfiltered.push_back(Peak1D(200.0, 3.0f));
+	PeakSpectrum from_source(unfiltered), from_copy(unfiltered);
+	configured.filterSpectrum(from_source);
+	configured_copy.filterSpectrum(from_copy);
+	TEST_EQUAL(from_copy == from_source, true)
 END_SECTION
 
 START_SECTION((Normalizer& operator = (const Normalizer& source)))
@@ -75,30 +67,21 @@ START_SECTION((Normalizer& operator = (const Normalizer& source)))
 	TEST_EQUAL(copy.getParameters(), e_ptr->getParameters())
 	TEST_EQUAL(copy.getName(), e_ptr->getName())
 
-	// same check for assignment
+	// same for assignment
 	Normalizer configured;
-	Param cfg(configured.getParameters());
-	cfg.setValue("method", "to_TIC");
-	configured.setParameters(cfg);
+	Param p(configured.getParameters());
+	p.setValue("method", "to_TIC");
+	configured.setParameters(p);
 	Normalizer assigned;
 	assigned = configured;
 
-	PeakSpectrum assign_test_spec;
-	Peak1D assign_test_peak;
-	assign_test_peak.setMZ(100.0);
-	assign_test_peak.setIntensity(1.0f);
-	assign_test_spec.push_back(assign_test_peak);
-	assign_test_peak.setMZ(200.0);
-	assign_test_peak.setIntensity(3.0f);
-	assign_test_spec.push_back(assign_test_peak);
-
-	assigned.filterSpectrum(assign_test_spec);
-	double assign_test_sum(0);
-	for (PeakSpectrum::ConstIterator it = assign_test_spec.begin(); it != assign_test_spec.end(); ++it)
-	{
-		assign_test_sum += it->getIntensity();
-	}
-	TEST_REAL_SIMILAR(assign_test_sum, 1.0)
+	PeakSpectrum unfiltered;
+	unfiltered.push_back(Peak1D(100.0, 1.0f));
+	unfiltered.push_back(Peak1D(200.0, 3.0f));
+	PeakSpectrum from_source(unfiltered), from_assigned(unfiltered);
+	configured.filterSpectrum(from_source);
+	assigned.filterSpectrum(from_assigned);
+	TEST_EQUAL(from_assigned == from_source, true)
 END_SECTION
 
 

--- a/src/tests/class_tests/openms/source/NucleicAcidSpectrumGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/NucleicAcidSpectrumGenerator_test.cpp
@@ -59,7 +59,7 @@ START_SECTION(NucleicAcidSpectrumGenerator(const NucleicAcidSpectrumGenerator& s
   }
 END_SECTION
 
-START_SECTION(NucleicAcidSpectrumGenerator& operator=(const TheoreticalSpectrumGenerator& source))
+START_SECTION(NucleicAcidSpectrumGenerator& operator=(const NucleicAcidSpectrumGenerator& source))
   NucleicAcidSpectrumGenerator copy;
   copy = *ptr;
   TEST_EQUAL(copy.getParameters(), ptr->getParameters())

--- a/src/tests/class_tests/openms/source/NucleicAcidSpectrumGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/NucleicAcidSpectrumGenerator_test.cpp
@@ -37,12 +37,53 @@ END_SECTION
 START_SECTION(NucleicAcidSpectrumGenerator(const NucleicAcidSpectrumGenerator& source))
   NucleicAcidSpectrumGenerator copy(*ptr);
   TEST_EQUAL(copy.getParameters(), ptr->getParameters())
+
+  // a copy must behave like the source, not merely carry the same parameters
+  NucleicAcidSpectrumGenerator configured;
+  Param cfg(configured.getParameters());
+  cfg.setValue("add_a_ions", "true");
+  cfg.setValue("add_b_ions", "false");
+  configured.setParameters(cfg);
+
+  NucleicAcidSpectrumGenerator configured_copy(configured);
+  NASequence copy_test_oligo = NASequence::fromString("[m1A]UCCACAGp");
+  MSSpectrum spec_source, spec_copy;
+  configured.getSpectrum(spec_source, copy_test_oligo, -1, -1);
+  configured_copy.getSpectrum(spec_copy, copy_test_oligo, -1, -1);
+  TEST_EQUAL(spec_source.empty(), false)
+  TEST_EQUAL(spec_copy.size(), spec_source.size())
+  ABORT_IF(spec_copy.size() != spec_source.size())
+  for (Size i = 0; i != spec_source.size(); ++i)
+  {
+    TEST_REAL_SIMILAR(spec_copy[i].getMZ(), spec_source[i].getMZ())
+  }
 END_SECTION
 
 START_SECTION(NucleicAcidSpectrumGenerator& operator=(const TheoreticalSpectrumGenerator& source))
   NucleicAcidSpectrumGenerator copy;
   copy = *ptr;
   TEST_EQUAL(copy.getParameters(), ptr->getParameters())
+
+  // same check for assignment
+  NucleicAcidSpectrumGenerator configured;
+  Param cfg(configured.getParameters());
+  cfg.setValue("add_a_ions", "true");
+  cfg.setValue("add_b_ions", "false");
+  configured.setParameters(cfg);
+
+  NucleicAcidSpectrumGenerator assigned;
+  assigned = configured;
+  NASequence assign_test_oligo = NASequence::fromString("[m1A]UCCACAGp");
+  MSSpectrum spec_source, spec_assigned;
+  configured.getSpectrum(spec_source, assign_test_oligo, -1, -1);
+  assigned.getSpectrum(spec_assigned, assign_test_oligo, -1, -1);
+  TEST_EQUAL(spec_source.empty(), false)
+  TEST_EQUAL(spec_assigned.size(), spec_source.size())
+  ABORT_IF(spec_assigned.size() != spec_source.size())
+  for (Size i = 0; i != spec_source.size(); ++i)
+  {
+    TEST_REAL_SIMILAR(spec_assigned[i].getMZ(), spec_source[i].getMZ())
+  }
 END_SECTION
 
 START_SECTION(~NucleicAcidSpectrumGenerator())

--- a/src/tests/class_tests/openms/source/NucleicAcidSpectrumGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/NucleicAcidSpectrumGenerator_test.cpp
@@ -38,25 +38,20 @@ START_SECTION(NucleicAcidSpectrumGenerator(const NucleicAcidSpectrumGenerator& s
   NucleicAcidSpectrumGenerator copy(*ptr);
   TEST_EQUAL(copy.getParameters(), ptr->getParameters())
 
-  // a copy must behave like the source, not merely carry the same parameters
+  // getParameters() cannot see the members updateMembers_() caches, so also check
+  // that a copy of a configured generator produces the same spectrum
   NucleicAcidSpectrumGenerator configured;
-  Param cfg(configured.getParameters());
-  cfg.setValue("add_a_ions", "true");
-  cfg.setValue("add_b_ions", "false");
-  configured.setParameters(cfg);
-
+  Param p(configured.getParameters());
+  p.setValue("add_a_ions", "true");
+  p.setValue("a_intensity", 0.5);
+  configured.setParameters(p);
   NucleicAcidSpectrumGenerator configured_copy(configured);
-  NASequence copy_test_oligo = NASequence::fromString("[m1A]UCCACAGp");
-  MSSpectrum spec_source, spec_copy;
-  configured.getSpectrum(spec_source, copy_test_oligo, -1, -1);
-  configured_copy.getSpectrum(spec_copy, copy_test_oligo, -1, -1);
-  TEST_EQUAL(spec_source.empty(), false)
-  TEST_EQUAL(spec_copy.size(), spec_source.size())
-  ABORT_IF(spec_copy.size() != spec_source.size())
-  for (Size i = 0; i != spec_source.size(); ++i)
-  {
-    TEST_REAL_SIMILAR(spec_copy[i].getMZ(), spec_source[i].getMZ())
-  }
+
+  NASequence oligo = NASequence::fromString("[m1A]UCCACAGp");
+  MSSpectrum from_source, from_copy;
+  configured.getSpectrum(from_source, oligo, -1, -1);
+  configured_copy.getSpectrum(from_copy, oligo, -1, -1);
+  TEST_EQUAL(from_copy == from_source, true)
 END_SECTION
 
 START_SECTION(NucleicAcidSpectrumGenerator& operator=(const NucleicAcidSpectrumGenerator& source))
@@ -64,26 +59,20 @@ START_SECTION(NucleicAcidSpectrumGenerator& operator=(const NucleicAcidSpectrumG
   copy = *ptr;
   TEST_EQUAL(copy.getParameters(), ptr->getParameters())
 
-  // same check for assignment
+  // same for assignment
   NucleicAcidSpectrumGenerator configured;
-  Param cfg(configured.getParameters());
-  cfg.setValue("add_a_ions", "true");
-  cfg.setValue("add_b_ions", "false");
-  configured.setParameters(cfg);
-
+  Param p(configured.getParameters());
+  p.setValue("add_a_ions", "true");
+  p.setValue("a_intensity", 0.5);
+  configured.setParameters(p);
   NucleicAcidSpectrumGenerator assigned;
   assigned = configured;
-  NASequence assign_test_oligo = NASequence::fromString("[m1A]UCCACAGp");
-  MSSpectrum spec_source, spec_assigned;
-  configured.getSpectrum(spec_source, assign_test_oligo, -1, -1);
-  assigned.getSpectrum(spec_assigned, assign_test_oligo, -1, -1);
-  TEST_EQUAL(spec_source.empty(), false)
-  TEST_EQUAL(spec_assigned.size(), spec_source.size())
-  ABORT_IF(spec_assigned.size() != spec_source.size())
-  for (Size i = 0; i != spec_source.size(); ++i)
-  {
-    TEST_REAL_SIMILAR(spec_assigned[i].getMZ(), spec_source[i].getMZ())
-  }
+
+  NASequence oligo = NASequence::fromString("[m1A]UCCACAGp");
+  MSSpectrum from_source, from_assigned;
+  configured.getSpectrum(from_source, oligo, -1, -1);
+  assigned.getSpectrum(from_assigned, oligo, -1, -1);
+  TEST_EQUAL(from_assigned == from_source, true)
 END_SECTION
 
 START_SECTION(~NucleicAcidSpectrumGenerator())

--- a/src/tests/class_tests/openms/source/SimpleTSGXLMS_test.cpp
+++ b/src/tests/class_tests/openms/source/SimpleTSGXLMS_test.cpp
@@ -40,6 +40,26 @@ END_SECTION
 START_SECTION(SimpleTSGXLMS(const SimpleTSGXLMS& source))
   SimpleTSGXLMS copy(*ptr);
   TEST_EQUAL(copy.getParameters(), ptr->getParameters())
+
+  // a copy must behave like the source, not merely carry the same parameters
+  SimpleTSGXLMS configured;
+  Param cfg(configured.getParameters());
+  cfg.setValue("add_a_ions", "false");
+  cfg.setValue("add_b_ions", "false");
+  configured.setParameters(cfg);
+
+  SimpleTSGXLMS configured_copy(configured);
+  AASequence copy_test_peptide = AASequence::fromString("IFSQVGK");
+  std::vector< SimpleTSGXLMS::SimplePeak > spec_source, spec_copy;
+  configured.getLinearIonSpectrum(spec_source, copy_test_peptide, 3, 2);
+  configured_copy.getLinearIonSpectrum(spec_copy, copy_test_peptide, 3, 2);
+  TEST_EQUAL(spec_source.empty(), false)
+  TEST_EQUAL(spec_copy.size(), spec_source.size())
+  ABORT_IF(spec_copy.size() != spec_source.size())
+  for (Size i = 0; i != spec_source.size(); ++i)
+  {
+    TEST_REAL_SIMILAR(spec_copy[i].mz, spec_source[i].mz)
+  }
 END_SECTION
 
 START_SECTION(~SimpleTSGXLMS())
@@ -53,6 +73,26 @@ START_SECTION(SimpleTSGXLMS& operator = (const SimpleTSGXLMS& tsg))
   SimpleTSGXLMS copy;
   copy = *ptr;
   TEST_EQUAL(copy.getParameters(), ptr->getParameters())
+
+  // same check for assignment
+  SimpleTSGXLMS configured;
+  Param cfg(configured.getParameters());
+  cfg.setValue("add_a_ions", "false");
+  cfg.setValue("add_b_ions", "false");
+  configured.setParameters(cfg);
+
+  SimpleTSGXLMS assigned;
+  assigned = configured;
+  std::vector< SimpleTSGXLMS::SimplePeak > spec_source, spec_assigned;
+  configured.getLinearIonSpectrum(spec_source, peptide, 3, 2);
+  assigned.getLinearIonSpectrum(spec_assigned, peptide, 3, 2);
+  TEST_EQUAL(spec_source.empty(), false)
+  TEST_EQUAL(spec_assigned.size(), spec_source.size())
+  ABORT_IF(spec_assigned.size() != spec_source.size())
+  for (Size i = 0; i != spec_source.size(); ++i)
+  {
+    TEST_REAL_SIMILAR(spec_assigned[i].mz, spec_source[i].mz)
+  }
 END_SECTION
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/tests/class_tests/openms/source/SimpleTSGXLMS_test.cpp
+++ b/src/tests/class_tests/openms/source/SimpleTSGXLMS_test.cpp
@@ -41,24 +41,23 @@ START_SECTION(SimpleTSGXLMS(const SimpleTSGXLMS& source))
   SimpleTSGXLMS copy(*ptr);
   TEST_EQUAL(copy.getParameters(), ptr->getParameters())
 
-  // a copy must behave like the source, not merely carry the same parameters
+  // getParameters() cannot see the members updateMembers_() caches, so also check
+  // that a copy of a configured generator produces the same spectrum
   SimpleTSGXLMS configured;
-  Param cfg(configured.getParameters());
-  cfg.setValue("add_a_ions", "false");
-  cfg.setValue("add_b_ions", "false");
-  configured.setParameters(cfg);
-
+  Param p(configured.getParameters());
+  p.setValue("add_b_ions", "false");
+  configured.setParameters(p);
   SimpleTSGXLMS configured_copy(configured);
-  AASequence copy_test_peptide = AASequence::fromString("IFSQVGK");
-  std::vector< SimpleTSGXLMS::SimplePeak > spec_source, spec_copy;
-  configured.getLinearIonSpectrum(spec_source, copy_test_peptide, 3, 2);
-  configured_copy.getLinearIonSpectrum(spec_copy, copy_test_peptide, 3, 2);
-  TEST_EQUAL(spec_source.empty(), false)
-  TEST_EQUAL(spec_copy.size(), spec_source.size())
-  ABORT_IF(spec_copy.size() != spec_source.size())
-  for (Size i = 0; i != spec_source.size(); ++i)
+
+  AASequence seq = AASequence::fromString("IFSQVGK");
+  std::vector<SimpleTSGXLMS::SimplePeak> from_source, from_copy;
+  configured.getLinearIonSpectrum(from_source, seq, 3, 2);
+  configured_copy.getLinearIonSpectrum(from_copy, seq, 3, 2);
+  TEST_EQUAL(from_copy.size(), from_source.size())
+  ABORT_IF(from_copy.size() != from_source.size())
+  for (Size i = 0; i != from_source.size(); ++i)
   {
-    TEST_REAL_SIMILAR(spec_copy[i].mz, spec_source[i].mz)
+    TEST_REAL_SIMILAR(from_copy[i].mz, from_source[i].mz)
   }
 END_SECTION
 
@@ -74,24 +73,22 @@ START_SECTION(SimpleTSGXLMS& operator = (const SimpleTSGXLMS& tsg))
   copy = *ptr;
   TEST_EQUAL(copy.getParameters(), ptr->getParameters())
 
-  // same check for assignment
+  // same for assignment
   SimpleTSGXLMS configured;
-  Param cfg(configured.getParameters());
-  cfg.setValue("add_a_ions", "false");
-  cfg.setValue("add_b_ions", "false");
-  configured.setParameters(cfg);
-
+  Param p(configured.getParameters());
+  p.setValue("add_b_ions", "false");
+  configured.setParameters(p);
   SimpleTSGXLMS assigned;
   assigned = configured;
-  std::vector< SimpleTSGXLMS::SimplePeak > spec_source, spec_assigned;
-  configured.getLinearIonSpectrum(spec_source, peptide, 3, 2);
-  assigned.getLinearIonSpectrum(spec_assigned, peptide, 3, 2);
-  TEST_EQUAL(spec_source.empty(), false)
-  TEST_EQUAL(spec_assigned.size(), spec_source.size())
-  ABORT_IF(spec_assigned.size() != spec_source.size())
-  for (Size i = 0; i != spec_source.size(); ++i)
+
+  std::vector<SimpleTSGXLMS::SimplePeak> from_source, from_assigned;
+  configured.getLinearIonSpectrum(from_source, peptide, 3, 2);
+  assigned.getLinearIonSpectrum(from_assigned, peptide, 3, 2);
+  TEST_EQUAL(from_assigned.size(), from_source.size())
+  ABORT_IF(from_assigned.size() != from_source.size())
+  for (Size i = 0; i != from_source.size(); ++i)
   {
-    TEST_REAL_SIMILAR(spec_assigned[i].mz, spec_source[i].mz)
+    TEST_REAL_SIMILAR(from_assigned[i].mz, from_source[i].mz)
   }
 END_SECTION
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/SpectrumAnnotator_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumAnnotator_test.cpp
@@ -204,6 +204,67 @@ START_SECTION((void SpectrumAnnotator::addPeakAnnotationsToPeptideHit(PeptideHit
   TEST_EQUAL(unannotated_count, 2) // 2 unmatched peaks
 END_SECTION
 
+START_SECTION((SpectrumAnnotator(const SpectrumAnnotator& source)))
+{
+  // a copy must behave like the source, not merely carry the same parameters
+  SpectrumAnnotator configured;
+  Param cfg(configured.getParameters());
+  cfg.setValue("max_series", "false");
+  configured.setParameters(cfg);
+  SpectrumAnnotator configured_copy(configured);
+  TEST_EQUAL(configured_copy.getParameters(), configured.getParameters())
+
+  // fresh spectrum: the shared 'spec' fixture is modified by the sections above
+  PeakSpectrum copy_test_spec;
+  copy_test_spec.setMSLevel(2);
+  Peak1D copy_test_peak;
+  for (Size i = 0; i != pls; ++i)
+  {
+    copy_test_peak.setIntensity(1.1f);
+    copy_test_peak.setMZ(peaklist[i]);
+    copy_test_spec.push_back(copy_test_peak);
+  }
+
+  PeptideIdentification pi_copy;
+  pi_copy.setHits(std::vector<PeptideHit>(1, hit));
+  configured_copy.addIonMatchStatistics(pi_copy, copy_test_spec, tg, sa);
+  ABORT_IF(pi_copy.getHits().empty())
+  // 'max_series' is off, so the copy must not add the corresponding meta values
+  TEST_EQUAL(pi_copy.getHits()[0].metaValueExists("max_series_type"), false)
+  TEST_EQUAL(pi_copy.getHits()[0].metaValueExists("max_series_size"), false)
+}
+END_SECTION
+
+START_SECTION((SpectrumAnnotator& operator=(const SpectrumAnnotator& source)))
+{
+  // same check for assignment
+  SpectrumAnnotator configured;
+  Param cfg(configured.getParameters());
+  cfg.setValue("max_series", "false");
+  configured.setParameters(cfg);
+  SpectrumAnnotator assigned;
+  assigned = configured;
+  TEST_EQUAL(assigned.getParameters(), configured.getParameters())
+
+  PeakSpectrum assign_test_spec;
+  assign_test_spec.setMSLevel(2);
+  Peak1D assign_test_peak;
+  for (Size i = 0; i != pls; ++i)
+  {
+    assign_test_peak.setIntensity(1.1f);
+    assign_test_peak.setMZ(peaklist[i]);
+    assign_test_spec.push_back(assign_test_peak);
+  }
+
+  PeptideIdentification pi_assigned;
+  pi_assigned.setHits(std::vector<PeptideHit>(1, hit));
+  assigned.addIonMatchStatistics(pi_assigned, assign_test_spec, tg, sa);
+  ABORT_IF(pi_assigned.getHits().empty())
+  TEST_EQUAL(pi_assigned.getHits()[0].metaValueExists("max_series_type"), false)
+  TEST_EQUAL(pi_assigned.getHits()[0].metaValueExists("max_series_size"), false)
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST

--- a/src/tests/class_tests/openms/source/SpectrumAnnotator_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumAnnotator_test.cpp
@@ -206,62 +206,39 @@ END_SECTION
 
 START_SECTION((SpectrumAnnotator(const SpectrumAnnotator& source)))
 {
-  // a copy must behave like the source, not merely carry the same parameters
+  // getParameters() cannot see the members updateMembers_() caches, so check that a
+  // copy honours the source's configuration: 'max_series' off means no max_series_* .
   SpectrumAnnotator configured;
-  Param cfg(configured.getParameters());
-  cfg.setValue("max_series", "false");
-  configured.setParameters(cfg);
+  Param p(configured.getParameters());
+  p.setValue("max_series", "false");
+  configured.setParameters(p);
   SpectrumAnnotator configured_copy(configured);
-  TEST_EQUAL(configured_copy.getParameters(), configured.getParameters())
-
-  // fresh spectrum: the shared 'spec' fixture is modified by the sections above
-  PeakSpectrum copy_test_spec;
-  copy_test_spec.setMSLevel(2);
-  Peak1D copy_test_peak;
-  for (Size i = 0; i != pls; ++i)
-  {
-    copy_test_peak.setIntensity(1.1f);
-    copy_test_peak.setMZ(peaklist[i]);
-    copy_test_spec.push_back(copy_test_peak);
-  }
 
   PeptideIdentification pi_copy;
   pi_copy.setHits(std::vector<PeptideHit>(1, hit));
-  configured_copy.addIonMatchStatistics(pi_copy, copy_test_spec, tg, sa);
+  configured_copy.addIonMatchStatistics(pi_copy, spec, tg, sa);
   ABORT_IF(pi_copy.getHits().empty())
-  // 'max_series' is off, so the copy must not add the corresponding meta values
-  TEST_EQUAL(pi_copy.getHits()[0].metaValueExists("max_series_type"), false)
-  TEST_EQUAL(pi_copy.getHits()[0].metaValueExists("max_series_size"), false)
+  TEST_EQUAL(pi_copy.getHits()[0].metaValueExists("peak_number"), true)      // annotation ran
+  TEST_EQUAL(pi_copy.getHits()[0].metaValueExists("max_series_type"), false) // but max_series was off
 }
 END_SECTION
 
 START_SECTION((SpectrumAnnotator& operator=(const SpectrumAnnotator& source)))
 {
-  // same check for assignment
+  // same for assignment
   SpectrumAnnotator configured;
-  Param cfg(configured.getParameters());
-  cfg.setValue("max_series", "false");
-  configured.setParameters(cfg);
+  Param p(configured.getParameters());
+  p.setValue("max_series", "false");
+  configured.setParameters(p);
   SpectrumAnnotator assigned;
   assigned = configured;
-  TEST_EQUAL(assigned.getParameters(), configured.getParameters())
-
-  PeakSpectrum assign_test_spec;
-  assign_test_spec.setMSLevel(2);
-  Peak1D assign_test_peak;
-  for (Size i = 0; i != pls; ++i)
-  {
-    assign_test_peak.setIntensity(1.1f);
-    assign_test_peak.setMZ(peaklist[i]);
-    assign_test_spec.push_back(assign_test_peak);
-  }
 
   PeptideIdentification pi_assigned;
   pi_assigned.setHits(std::vector<PeptideHit>(1, hit));
-  assigned.addIonMatchStatistics(pi_assigned, assign_test_spec, tg, sa);
+  assigned.addIonMatchStatistics(pi_assigned, spec, tg, sa);
   ABORT_IF(pi_assigned.getHits().empty())
+  TEST_EQUAL(pi_assigned.getHits()[0].metaValueExists("peak_number"), true)
   TEST_EQUAL(pi_assigned.getHits()[0].metaValueExists("max_series_type"), false)
-  TEST_EQUAL(pi_assigned.getHits()[0].metaValueExists("max_series_size"), false)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/TheoreticalSpectrumGeneratorXLMS_test.cpp
+++ b/src/tests/class_tests/openms/source/TheoreticalSpectrumGeneratorXLMS_test.cpp
@@ -43,6 +43,26 @@ END_SECTION
 START_SECTION(TheoreticalSpectrumGeneratorXLMS(const TheoreticalSpectrumGeneratorXLMS& source))
   TheoreticalSpectrumGeneratorXLMS copy(*ptr);
   TEST_EQUAL(copy.getParameters(), ptr->getParameters())
+
+  // a copy must behave like the source, not merely carry the same parameters
+  TheoreticalSpectrumGeneratorXLMS configured;
+  Param cfg(configured.getParameters());
+  cfg.setValue("add_a_ions", "false");
+  cfg.setValue("add_b_ions", "false");
+  configured.setParameters(cfg);
+
+  TheoreticalSpectrumGeneratorXLMS configured_copy(configured);
+  AASequence copy_test_peptide = AASequence::fromString("IFSQVGK");
+  PeakSpectrum spec_source, spec_copy;
+  configured.getLinearIonSpectrum(spec_source, copy_test_peptide, 3, true, 2);
+  configured_copy.getLinearIonSpectrum(spec_copy, copy_test_peptide, 3, true, 2);
+  TEST_EQUAL(spec_source.empty(), false)
+  TEST_EQUAL(spec_copy.size(), spec_source.size())
+  ABORT_IF(spec_copy.size() != spec_source.size())
+  for (Size i = 0; i != spec_source.size(); ++i)
+  {
+    TEST_REAL_SIMILAR(spec_copy[i].getPosition()[0], spec_source[i].getPosition()[0])
+  }
 END_SECTION
 
 START_SECTION(~TheoreticalSpectrumGeneratorXLMS())
@@ -56,6 +76,26 @@ START_SECTION(TheoreticalSpectrumGeneratorXLMS& operator = (const TheoreticalSpe
   TheoreticalSpectrumGeneratorXLMS copy;
   copy = *ptr;
   TEST_EQUAL(copy.getParameters(), ptr->getParameters())
+
+  // same check for assignment
+  TheoreticalSpectrumGeneratorXLMS configured;
+  Param cfg(configured.getParameters());
+  cfg.setValue("add_a_ions", "false");
+  cfg.setValue("add_b_ions", "false");
+  configured.setParameters(cfg);
+
+  TheoreticalSpectrumGeneratorXLMS assigned;
+  assigned = configured;
+  PeakSpectrum spec_source, spec_assigned;
+  configured.getLinearIonSpectrum(spec_source, peptide, 3, true, 2);
+  assigned.getLinearIonSpectrum(spec_assigned, peptide, 3, true, 2);
+  TEST_EQUAL(spec_source.empty(), false)
+  TEST_EQUAL(spec_assigned.size(), spec_source.size())
+  ABORT_IF(spec_assigned.size() != spec_source.size())
+  for (Size i = 0; i != spec_source.size(); ++i)
+  {
+    TEST_REAL_SIMILAR(spec_assigned[i].getPosition()[0], spec_source[i].getPosition()[0])
+  }
 END_SECTION
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/tests/class_tests/openms/source/TheoreticalSpectrumGeneratorXLMS_test.cpp
+++ b/src/tests/class_tests/openms/source/TheoreticalSpectrumGeneratorXLMS_test.cpp
@@ -44,25 +44,20 @@ START_SECTION(TheoreticalSpectrumGeneratorXLMS(const TheoreticalSpectrumGenerato
   TheoreticalSpectrumGeneratorXLMS copy(*ptr);
   TEST_EQUAL(copy.getParameters(), ptr->getParameters())
 
-  // a copy must behave like the source, not merely carry the same parameters
+  // getParameters() cannot see the members updateMembers_() caches, so also check
+  // that a copy of a configured generator produces the same spectrum
   TheoreticalSpectrumGeneratorXLMS configured;
-  Param cfg(configured.getParameters());
-  cfg.setValue("add_a_ions", "false");
-  cfg.setValue("add_b_ions", "false");
-  configured.setParameters(cfg);
-
+  Param p(configured.getParameters());
+  p.setValue("add_b_ions", "false");
+  p.setValue("a_intensity", 0.5);
+  configured.setParameters(p);
   TheoreticalSpectrumGeneratorXLMS configured_copy(configured);
-  AASequence copy_test_peptide = AASequence::fromString("IFSQVGK");
-  PeakSpectrum spec_source, spec_copy;
-  configured.getLinearIonSpectrum(spec_source, copy_test_peptide, 3, true, 2);
-  configured_copy.getLinearIonSpectrum(spec_copy, copy_test_peptide, 3, true, 2);
-  TEST_EQUAL(spec_source.empty(), false)
-  TEST_EQUAL(spec_copy.size(), spec_source.size())
-  ABORT_IF(spec_copy.size() != spec_source.size())
-  for (Size i = 0; i != spec_source.size(); ++i)
-  {
-    TEST_REAL_SIMILAR(spec_copy[i].getPosition()[0], spec_source[i].getPosition()[0])
-  }
+
+  AASequence seq = AASequence::fromString("IFSQVGK");
+  PeakSpectrum from_source, from_copy;
+  configured.getLinearIonSpectrum(from_source, seq, 3, true, 2);
+  configured_copy.getLinearIonSpectrum(from_copy, seq, 3, true, 2);
+  TEST_EQUAL(from_copy == from_source, true)
 END_SECTION
 
 START_SECTION(~TheoreticalSpectrumGeneratorXLMS())
@@ -77,25 +72,19 @@ START_SECTION(TheoreticalSpectrumGeneratorXLMS& operator = (const TheoreticalSpe
   copy = *ptr;
   TEST_EQUAL(copy.getParameters(), ptr->getParameters())
 
-  // same check for assignment
+  // same for assignment
   TheoreticalSpectrumGeneratorXLMS configured;
-  Param cfg(configured.getParameters());
-  cfg.setValue("add_a_ions", "false");
-  cfg.setValue("add_b_ions", "false");
-  configured.setParameters(cfg);
-
+  Param p(configured.getParameters());
+  p.setValue("add_b_ions", "false");
+  p.setValue("a_intensity", 0.5);
+  configured.setParameters(p);
   TheoreticalSpectrumGeneratorXLMS assigned;
   assigned = configured;
-  PeakSpectrum spec_source, spec_assigned;
-  configured.getLinearIonSpectrum(spec_source, peptide, 3, true, 2);
-  assigned.getLinearIonSpectrum(spec_assigned, peptide, 3, true, 2);
-  TEST_EQUAL(spec_source.empty(), false)
-  TEST_EQUAL(spec_assigned.size(), spec_source.size())
-  ABORT_IF(spec_assigned.size() != spec_source.size())
-  for (Size i = 0; i != spec_source.size(); ++i)
-  {
-    TEST_REAL_SIMILAR(spec_assigned[i].getPosition()[0], spec_source[i].getPosition()[0])
-  }
+
+  PeakSpectrum from_source, from_assigned;
+  configured.getLinearIonSpectrum(from_source, peptide, 3, true, 2);
+  assigned.getLinearIonSpectrum(from_assigned, peptide, 3, true, 2);
+  TEST_EQUAL(from_assigned == from_source, true)
 END_SECTION
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
@@ -45,6 +45,27 @@ START_SECTION(TheoreticalSpectrumGenerator(const TheoreticalSpectrumGenerator& s
   ptr = new TheoreticalSpectrumGenerator();
   TheoreticalSpectrumGenerator copy(*ptr);
   TEST_EQUAL(copy.getParameters(), ptr->getParameters())
+
+  // a copy must behave like the source, not merely carry the same parameters
+  TheoreticalSpectrumGenerator configured;
+  Param cfg(configured.getParameters());
+  cfg.setValue("add_b_ions", "false");
+  cfg.setValue("add_y_ions", "false");
+  cfg.setValue("add_a_ions", "true");
+  configured.setParameters(cfg);
+
+  TheoreticalSpectrumGenerator configured_copy(configured);
+  AASequence copy_test_peptide = AASequence::fromString("IFSQVGK");
+  PeakSpectrum spec_source, spec_copy;
+  configured.getSpectrum(spec_source, copy_test_peptide, 1, 1);
+  configured_copy.getSpectrum(spec_copy, copy_test_peptide, 1, 1);
+  TEST_EQUAL(spec_source.empty(), false)
+  TEST_EQUAL(spec_copy.size(), spec_source.size())
+  ABORT_IF(spec_copy.size() != spec_source.size())
+  for (Size i = 0; i != spec_source.size(); ++i)
+  {
+    TEST_REAL_SIMILAR(spec_copy[i].getMZ(), spec_source[i].getMZ())
+  }
 END_SECTION
 
 START_SECTION(~TheoreticalSpectrumGenerator())
@@ -58,6 +79,27 @@ START_SECTION(TheoreticalSpectrumGenerator& operator = (const TheoreticalSpectru
   TheoreticalSpectrumGenerator copy;
   copy = *ptr;
   TEST_EQUAL(copy.getParameters(), ptr->getParameters())
+
+  // same check for assignment
+  TheoreticalSpectrumGenerator configured;
+  Param cfg(configured.getParameters());
+  cfg.setValue("add_b_ions", "false");
+  cfg.setValue("add_y_ions", "false");
+  cfg.setValue("add_a_ions", "true");
+  configured.setParameters(cfg);
+
+  TheoreticalSpectrumGenerator assigned;
+  assigned = configured;
+  PeakSpectrum spec_source, spec_assigned;
+  configured.getSpectrum(spec_source, peptide, 1, 1);
+  assigned.getSpectrum(spec_assigned, peptide, 1, 1);
+  TEST_EQUAL(spec_source.empty(), false)
+  TEST_EQUAL(spec_assigned.size(), spec_source.size())
+  ABORT_IF(spec_assigned.size() != spec_source.size())
+  for (Size i = 0; i != spec_source.size(); ++i)
+  {
+    TEST_REAL_SIMILAR(spec_assigned[i].getMZ(), spec_source[i].getMZ())
+  }
 END_SECTION
 
 START_SECTION(void getSpectrum(PeakSpectrum& spec, const AASequence& peptide, Int min_charge = 1, Int max_charge = 1))

--- a/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
@@ -46,26 +46,20 @@ START_SECTION(TheoreticalSpectrumGenerator(const TheoreticalSpectrumGenerator& s
   TheoreticalSpectrumGenerator copy(*ptr);
   TEST_EQUAL(copy.getParameters(), ptr->getParameters())
 
-  // a copy must behave like the source, not merely carry the same parameters
+  // getParameters() cannot see the members updateMembers_() caches, so also check
+  // that a copy of a configured generator produces the same spectrum
   TheoreticalSpectrumGenerator configured;
-  Param cfg(configured.getParameters());
-  cfg.setValue("add_b_ions", "false");
-  cfg.setValue("add_y_ions", "false");
-  cfg.setValue("add_a_ions", "true");
-  configured.setParameters(cfg);
-
+  Param p(configured.getParameters());
+  p.setValue("add_a_ions", "true");
+  p.setValue("a_intensity", 0.5);
+  configured.setParameters(p);
   TheoreticalSpectrumGenerator configured_copy(configured);
-  AASequence copy_test_peptide = AASequence::fromString("IFSQVGK");
-  PeakSpectrum spec_source, spec_copy;
-  configured.getSpectrum(spec_source, copy_test_peptide, 1, 1);
-  configured_copy.getSpectrum(spec_copy, copy_test_peptide, 1, 1);
-  TEST_EQUAL(spec_source.empty(), false)
-  TEST_EQUAL(spec_copy.size(), spec_source.size())
-  ABORT_IF(spec_copy.size() != spec_source.size())
-  for (Size i = 0; i != spec_source.size(); ++i)
-  {
-    TEST_REAL_SIMILAR(spec_copy[i].getMZ(), spec_source[i].getMZ())
-  }
+
+  AASequence seq = AASequence::fromString("IFSQVGK");
+  PeakSpectrum from_source, from_copy;
+  configured.getSpectrum(from_source, seq, 1, 1);
+  configured_copy.getSpectrum(from_copy, seq, 1, 1);
+  TEST_EQUAL(from_copy == from_source, true)
 END_SECTION
 
 START_SECTION(~TheoreticalSpectrumGenerator())
@@ -80,26 +74,19 @@ START_SECTION(TheoreticalSpectrumGenerator& operator = (const TheoreticalSpectru
   copy = *ptr;
   TEST_EQUAL(copy.getParameters(), ptr->getParameters())
 
-  // same check for assignment
+  // same for assignment
   TheoreticalSpectrumGenerator configured;
-  Param cfg(configured.getParameters());
-  cfg.setValue("add_b_ions", "false");
-  cfg.setValue("add_y_ions", "false");
-  cfg.setValue("add_a_ions", "true");
-  configured.setParameters(cfg);
-
+  Param p(configured.getParameters());
+  p.setValue("add_a_ions", "true");
+  p.setValue("a_intensity", 0.5);
+  configured.setParameters(p);
   TheoreticalSpectrumGenerator assigned;
   assigned = configured;
-  PeakSpectrum spec_source, spec_assigned;
-  configured.getSpectrum(spec_source, peptide, 1, 1);
-  assigned.getSpectrum(spec_assigned, peptide, 1, 1);
-  TEST_EQUAL(spec_source.empty(), false)
-  TEST_EQUAL(spec_assigned.size(), spec_source.size())
-  ABORT_IF(spec_assigned.size() != spec_source.size())
-  for (Size i = 0; i != spec_source.size(); ++i)
-  {
-    TEST_REAL_SIMILAR(spec_assigned[i].getMZ(), spec_source[i].getMZ())
-  }
+
+  PeakSpectrum from_source, from_assigned;
+  configured.getSpectrum(from_source, peptide, 1, 1);
+  assigned.getSpectrum(from_assigned, peptide, 1, 1);
+  TEST_EQUAL(from_assigned == from_source, true)
 END_SECTION
 
 START_SECTION(void getSpectrum(PeakSpectrum& spec, const AASequence& peptide, Int min_charge = 1, Int max_charge = 1))


### PR DESCRIPTION
Six DefaultParamHandler subclasses declared a copy constructor and an
assignment operator that only forwarded to DefaultParamHandler. That copies
param_, but not the member variables their updateMembers_() caches from it -
DefaultParamHandler.h only documents "call updateMembers_() at the end of the
derived classes' copy constructor and assignment operator", nothing enforces it.

Since none of the members have in-class initializers, a copied object read
indeterminate values:

  - TheoreticalSpectrumGenerator      (30 cached members)
  - TheoreticalSpectrumGeneratorXLMS  (25)
  - NucleicAcidSpectrumGenerator      (23)
  - SimpleTSGXLMS                     (13)
  - SpectrumAnnotator                  (8)
  - Normalizer                         (1: copying threw InvalidValue,
                                        because method_ was left empty)

The two XLMS generators additionally left loss_db_ empty, so a copy threw
std::out_of_range from loss_db_.at() whenever losses were requested.

All six copy operations are now = default: the compiler-generated versions copy
param_ and the cached members together, which is exactly the state
updateMembers_() would have produced (none of the six do anything but assign
scalars from param_). All six also expose their copy constructor to Python via
nanobind (nb::init<const T&>(), __copy__, __deepcopy__), so copy.deepcopy() on a
configured object was affected as well.

Also reset TheoreticalSpectrumGenerator::isotope_model_ for isotope_model 'none'
and give it an in-class initializer; updateMembers_() previously only assigned it
for 'coarse' and 'fine', leaving it unset on the default code path.

The existing copy tests only compared getParameters(), which the base class
copies in any case and which therefore could not detect any of this. They now
configure an object, copy it and compare what the copy actually produces.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016pYQmepYoKPtSBVDZggDEG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed copying and assignment for spectrum generators, spectrum annotators, and normalizers so configuration and cached settings remain synchronized.
  - Ensured disabled isotope settings reset correctly, preventing stale values from affecting generated spectra.
  - Improved isotope configuration initialization for more predictable behavior.

- **Tests**
  - Added regression coverage confirming copied and assigned components produce results matching their originals across supported spectrum-processing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->