### PR TITLE
[FIX] Guard against ambiguous precursor correction mappings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1227,6 +1227,8 @@ OpenMS Library:
     - Iterator patterns, container checks and memory allocation optimized in hot paths (#8656)
 
 Fixes:
+  - Fix: MS1 peak-based PrecursorCorrection now rejects ambiguous RT mappings and spectra with multiple
+    precursors before applying any corrections, preventing updates to the wrong precursor.
   - Fix: Biosaur2Algorithm::run() left the stored MS data empty on FAIMS input -- the per-CV split moves
     the spectra out of ms_data_ and nothing put them back, so getMSData() handed the caller a cleared
     experiment. ProteomicsLFQ with -Seeding:algorithm biosaur2 passed exactly that on to

--- a/src/openms/include/OpenMS/PROCESSING/CALIBRATION/PrecursorCorrection.h
+++ b/src/openms/include/OpenMS/PROCESSING/CALIBRATION/PrecursorCorrection.h
@@ -79,6 +79,10 @@ class OPENMS_DLLAPI PrecursorCorrection
      For each MS2 spectrum the corresponding MS1 spectrum is determined by using the rt information of the precursor.
      In the MS1, the peak closest to the uncorrected precursor m/z is selected and used as corrected precursor m/z.
 
+     @throws Exception::IllegalArgument if spectra are not sorted by RT, a spectrum has multiple precursors,
+     or the RT lookup cannot identify the original spectrum unambiguously. Validation precedes any changes
+     to @p exp or the output vectors.
+
      @param[in] exp: MSExperiment.
      @param[in] mz_tolerance: double tolerance used for precursor correction in mass range.
      @param[in] ppm: bool enables usage of ppm.
@@ -99,6 +103,10 @@ class OPENMS_DLLAPI PrecursorCorrection
 
      For each MS2 spectrum the corresponding MS1 spectrum is determined by using the rt information of the precursor.
      In the MS1, the peak with the highest intensity in a given mass range to the uncorrected precursor m/z is selected and used as corrected precursor m/z.
+
+     @throws Exception::IllegalArgument if spectra are not sorted by RT, a spectrum has multiple precursors,
+     or the RT lookup cannot identify the original spectrum unambiguously. Validation precedes any changes
+     to @p exp or the output vectors.
 
      @param[in] exp: MSExperiment.
      @param[in] mz_tolerance: double tolerance used for precursor correction in mass range.

--- a/src/openms/source/PROCESSING/CALIBRATION/PrecursorCorrection.cpp
+++ b/src/openms/source/PROCESSING/CALIBRATION/PrecursorCorrection.cpp
@@ -12,6 +12,7 @@
 
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/METADATA/Precursor.h>
+#include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 
 #include <algorithm>
@@ -26,6 +27,37 @@ using namespace OpenMS;
 
 namespace
 {
+  void validatePrecursorMapping(const MSExperiment& exp)
+  {
+    if (!exp.isSorted(false))
+    {
+      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "MS1 peak-based precursor correction requires spectra sorted by retention time.");
+    }
+
+    // Validate all mappings before changing any precursors or output vectors.
+    // PASEF MS2 spectra can share a frame RT even with combined IM arrays;
+    // feature correction with keep_original can also produce duplicate RTs.
+    for (Size scan = 0; scan < exp.size(); ++scan)
+    {
+      const auto& precursors = exp[scan].getPrecursors();
+      if (precursors.empty()) { continue; }
+      if (precursors.size() != 1)
+      {
+        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+          "MS1 peak-based precursor correction requires exactly one precursor per spectrum; spectrum index "
+          + std::to_string(scan) + " has multiple precursors.");
+      }
+      if (exp.RTBegin(exp[scan].getRT() - 1e-8) != exp.begin() + scan)
+      {
+        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+          "Ambiguous precursor mapping at spectrum index " + std::to_string(scan)
+          + ": the RT lookup (with a 1e-8 s offset) does not identify the original spectrum. "
+            "Shared or nearly identical spectrum RTs are not supported by MS1 peak-based precursor correction.");
+      }
+    }
+  }
+
   /**
     @brief The region in which a feature accepts a precursor.
 
@@ -114,6 +146,7 @@ namespace OpenMS
                                                             vector<double> & mzs,
                                                             vector<double> & rts)
     {
+      validatePrecursorMapping(exp);
       set<Size> corrected_precursors;
       // load experiment and extract precursors
       vector<Precursor> precursors;  // precursor
@@ -190,6 +223,7 @@ namespace OpenMS
                                                                     vector<double> & mzs,
                                                                     vector<double> & rts)
     {
+      validatePrecursorMapping(exp);
       set<Size> corrected_precursors;
       // load experiment and extract precursors
       vector<Precursor> precursors;  // precursor

--- a/src/tests/class_tests/openms/source/PrecursorCorrection_test.cpp
+++ b/src/tests/class_tests/openms/source/PrecursorCorrection_test.cpp
@@ -15,6 +15,7 @@
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/KERNEL/Feature.h>
+#include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/FuzzyStringComparator.h>
 #include <OpenMS/DATASTRUCTURES/ConvexHull2D.h>
 #include <OpenMS/DATASTRUCTURES/DBoundingBox.h>
@@ -298,6 +299,83 @@ std::cout << dmz_2[2] << std::endl;
 TEST_REAL_SIMILAR(dmz_2[0], 0.0001);
 TEST_REAL_SIMILAR(dmz_2[1], -0.0003);
 TEST_REAL_SIMILAR(dmz_2[2], -0.0004);
+}
+END_SECTION
+
+START_SECTION((MS1 peak correction rejects ambiguous precursor mappings before modifying outputs))
+{
+  MSExperiment input;
+  MSSpectrum ms1;
+  ms1.setMSLevel(1);
+  ms1.setRT(9.0);
+  const vector<double> corrected_mzs{500.001, 600.001, 700.002};
+  for (double mz : corrected_mzs)
+  {
+    Peak1D peak;
+    peak.setMZ(mz);
+    peak.setIntensity(1000.0f);
+    ms1.push_back(peak);
+  }
+  MSSpectrum::FloatDataArray mobility;
+  mobility.setName("Ion Mobility");
+  mobility.assign({0.8f, 1.0f, 1.2f});
+  ms1.getFloatDataArrays().push_back(mobility);
+  input.addSpectrum(ms1);
+  for (Size i = 0; i < corrected_mzs.size(); ++i)
+  {
+    MSSpectrum ms2;
+    ms2.setMSLevel(2);
+    ms2.setRT(10.0 + i);
+    ms2.setNativeID("scan=" + to_string(i + 2));
+    Precursor precursor;
+    precursor.setMZ(500.0 + 100.0 * i);
+    precursor.setCharge(2);
+    ms2.setPrecursors({precursor});
+    input.addSpectrum(ms2);
+  }
+
+  // Leave the first MS2 correctable, so a late check would cause partial mutation.
+  vector<MSExperiment> invalid_inputs(6, input);
+  invalid_inputs[0][3].setRT(11.0); // Different precursors from the same PASEF frame.
+  invalid_inputs[1][3].setRT(11.0);
+  invalid_inputs[1][3].getPrecursors()[0].setMZ(600.0); // Equal m/z does not imply identity.
+  invalid_inputs[2][3].setRT(11.0 + 0.5e-8); // Collision within the RT lookup offset.
+  invalid_inputs[3][2].setMSLevel(1);
+  invalid_inputs[3][2].setPrecursors({});
+  invalid_inputs[3][2].setRT(12.0); // RT lookup resolves the MS2 to an MS1 spectrum.
+  invalid_inputs[4][3].getPrecursors().push_back(input[2].getPrecursors()[0]);
+  swap(invalid_inputs[5][2], invalid_inputs[5][3]); // Unsorted retention times.
+
+  for (auto correct : {&PrecursorCorrection::correctToNearestMS1Peak,
+                       &PrecursorCorrection::correctToHighestIntensityMS1Peak})
+  {
+    for (auto invalid : invalid_inputs)
+    {
+      const MSExperiment before = invalid;
+      vector<double> dmz{1.0}, mz{2.0}, rt{3.0};
+      const auto dmz_before = dmz, mz_before = mz, rt_before = rt;
+      TEST_EXCEPTION(Exception::IllegalArgument, correct(invalid, 10.0, true, dmz, mz, rt));
+      TEST_TRUE(invalid == before);
+      TEST_TRUE(dmz == dmz_before);
+      TEST_TRUE(mz == mz_before);
+      TEST_TRUE(rt == rt_before);
+    }
+
+    // Concatenated mobility arrays are accepted when precursor mapping is unambiguous.
+    MSExperiment valid = input;
+    vector<double> dmz, mz, rt;
+    const auto corrected = correct(valid, 10.0, true, dmz, mz, rt);
+    const set<Size> expected_indices{1, 2, 3};
+    TEST_TRUE(corrected == expected_indices);
+    TEST_EQUAL(dmz.size(), 3);
+    TEST_EQUAL(mz.size(), 3);
+    TEST_EQUAL(rt.size(), 3);
+    TEST_TRUE(valid[0] == input[0]);
+    for (Size i = 0; i < corrected_mzs.size(); ++i)
+    {
+      TEST_REAL_SIMILAR(valid[i + 1].getPrecursors()[0].getMZ(), corrected_mzs[i]);
+    }
+  }
 }
 END_SECTION
 

--- a/src/topp/HighResPrecursorMassCorrector.cpp
+++ b/src/topp/HighResPrecursorMassCorrector.cpp
@@ -54,6 +54,10 @@ Three methods are available: 'nearest_peak', 'highest_intensity_peak' and 'featu
   - highest_intensity_peak: Use highest intensity centroided MS1 peak in a given mass range for precursor mass correction.
   - feature: Use features for precursor mass correction, which allows for charge correction.
 
+The MS1 peak methods reject ambiguous precursor mappings before applying corrections. These can occur
+when PASEF MS2 spectra share a frame RT (including combined ion mobility arrays), or after copying
+spectra with 'feature:keep_original'. Spectra with multiple precursors are also rejected by these methods.
+
 The method hightest_intensity_peak searches in a specific m/z-window of the precursor information for the peak with the highest intensity.
 Suggestioned value 1/maximal expected charge. E.g maximal expected charge 5, m/z-window = +/- 0.2 Da
 


### PR DESCRIPTION
Both MS1 peak correction methods recover the target spectrum through `RTBegin(rt - 1e-8)`. When this resolves to an earlier spectrum, a correction can overwrite the wrong precursor. Shared RTs occur with PASEF spectra from the same frame, including combined IM arrays, and with spectra copied by `feature:keep_original`.

Add a shared preflight check to both library methods. It rejects incorrect RT mappings, unsorted spectra and spectra with multiple precursors before changing the experiment or appending to the reporting vectors. Valid inputs with IM arrays remain accepted. The source and tool documentation briefly explain when shared RTs occur.

Regression tests cover both methods: duplicate RTs with different or equal precursor m/z, nearly identical RTs, MS1/MS2 RT ties, multiple precursors, unsorted input and a valid IM-array control. Rejected inputs must leave the entire experiment and prepopulated output vectors unchanged.

The first CI run compiled successfully and passed `PrecursorCorrection_test` on all five platforms, but failed 71 ProteomicsLFQ-related tests on each platform. The six BSA fraction fixtures store all MS1 spectra before all MS2 spectra, so they are not sorted by RT. ProteomicsLFQ only sorted peaks by m/z before calling precursor correction. It now sorts spectra by RT before centroiding and correction. The library still rejects unsorted or ambiguous mappings; the existing TOPP tests cover the caller regression. The branch also includes current `develop`, with the changelog conflict resolved.

Validation: `git diff --check` passed. Local runtime checks with pyOpenMS `3.6.0.dev20260907` reproduced the unsorted output of the old preprocessing on all six BSA fixtures. With RT sorting, all precursor mappings passed the preflight conditions and both correction methods completed. The checks verified that sorting preserved each spectrum's contents and native ID, and correction preserved MS1 spectra. These runtime checks use the installed library and an equivalent check of the new guard conditions; the full C++ class and TOPP suites for this commit remain CI gates because there is no configured local OpenMS build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - MS1 peak-based precursor correction now rejects ambiguous retention-time mappings, unsorted spectra, and spectra with missing or multiple precursors before applying corrections.
  - Prevents corrections from being applied to the wrong precursor and preserves input data when validation fails.
  - ProteomicsLFQ now sorts spectra by retention time before precursor correction, including data grouped by MS level.

- **Documentation**
  - Clarified the conditions that cause nearest-peak and highest-intensity-peak correction methods to reject an input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->