### PR TITLE
[FEATURE,PYOPENMS,CI] Ship working Thermo RAW support in pyOpenMS wheels

### DIFF
--- a/.github/workflows/pyopenms-wheels-cibuildwheel.yml
+++ b/.github/workflows/pyopenms-wheels-cibuildwheel.yml
@@ -147,17 +147,14 @@ jobs:
             bash -c '
               # The native thermo bridge compiles against the nethost headers/library
               # from the .NET host pack (the managed assemblies come pre-built, see
-              # tools/ci/fetch_thermo_assets.sh). Use the Microsoft dotnet-install.sh
-              # rather than the distro dotnet-sdk-8.0 RPM: AlmaLinux names its host
-              # pack Microsoft.NETCore.App.Host.rhel.9-x64, which FindDotNetHost.cmake
-              # in the bridge (linux-x64 RID) does not find. libicu is the
-              # only dependency the SDK needs. /usr/share/dotnet is a default
-              # search location for both FindDotNetHost and the nethost runtime.
+              # tools/ci/fetch_thermo_assets.sh). The pinned, SHA-512 verified SDK
+              # tarball is used instead of the distro dotnet-sdk-8.0 RPM, whose host
+              # pack is named with the rhel.9-x64 RID that the bridge does not search
+              # (see tools/ci/install_dotnet_sdk_linux.sh). libicu is the only
+              # dependency the SDK needs.
               yum install -y cmake ninja-build libcurl-devel libicu
-              curl -sSL --retry 5 --retry-all-errors https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
-              bash /tmp/dotnet-install.sh --channel 8.0 --install-dir /usr/share/dotnet
+              bash tools/ci/install_dotnet_sdk_linux.sh /usr/share/dotnet
               export DOTNET_ROOT=/usr/share/dotnet
-              ls "$DOTNET_ROOT"/packs/Microsoft.NETCore.App.Host.linux-x64/
               mkdir build && cd build
               cmake .. \
                 -G Ninja \

--- a/.github/workflows/pyopenms-wheels-cibuildwheel.yml
+++ b/.github/workflows/pyopenms-wheels-cibuildwheel.yml
@@ -145,13 +145,19 @@ jobs:
             -w /project \
             ghcr.io/openms/contrib_manylinux_2_34:latest-amd64 \
             bash -c '
-              # dotnet-sdk-8.0 provides the nethost headers/library the native thermo
-              # bridge compiles against (the managed assemblies come pre-built, see
-              # tools/ci/fetch_thermo_assets.sh). The RPM installs .NET under
-              # /usr/lib64/dotnet, which FindDotNetHost only finds via DOTNET_ROOT.
-              yum install -y cmake ninja-build libcurl-devel dotnet-sdk-8.0
-              export DOTNET_ROOT="$(dirname "$(readlink -f "$(command -v dotnet)")")"
-              echo "DOTNET_ROOT=$DOTNET_ROOT"
+              # The native thermo bridge compiles against the nethost headers/library
+              # from the .NET host pack (the managed assemblies come pre-built, see
+              # tools/ci/fetch_thermo_assets.sh). Use the Microsoft dotnet-install.sh
+              # rather than the distro dotnet-sdk-8.0 RPM: AlmaLinux names its host
+              # pack Microsoft.NETCore.App.Host.rhel.9-x64, which FindDotNetHost.cmake
+              # in the bridge (linux-x64 RID) does not find. libicu is the
+              # only dependency the SDK needs. /usr/share/dotnet is a default
+              # search location for both FindDotNetHost and the nethost runtime.
+              yum install -y cmake ninja-build libcurl-devel libicu
+              curl -sSL --retry 5 --retry-all-errors https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+              bash /tmp/dotnet-install.sh --channel 8.0 --install-dir /usr/share/dotnet
+              export DOTNET_ROOT=/usr/share/dotnet
+              ls "$DOTNET_ROOT"/packs/Microsoft.NETCore.App.Host.linux-x64/
               mkdir build && cd build
               cmake .. \
                 -G Ninja \

--- a/.github/workflows/pyopenms-wheels-cibuildwheel.yml
+++ b/.github/workflows/pyopenms-wheels-cibuildwheel.yml
@@ -4,6 +4,15 @@
 # using cibuildwheel. It requires OpenMS to be built first on each platform.
 #
 # Trigger: Release tags, nightly branch, develop PRs, or manual dispatch
+#
+# Thermo RAW support: the Linux x86_64, macOS arm64 and Windows wheels are built with
+# WITH_THERMO_RAW=ON. The managed half of openms-thermo-bridge (ThermoWrapperManaged.dll
+# and the Thermo CommonCore assemblies) is taken from the bridge's pre-built release zip
+# via tools/ci/fetch_thermo_assets.sh (retried, SHA-256 pinned, cached between runs), so
+# no NuGet restore and no Thermo package download happens in CI. Compiling the native
+# bridge still needs the nethost headers from a .NET SDK. The finished wheels are
+# smoke-tested by loading a real RAW file. Linux aarch64 stays off: Thermo ships no
+# native RawFileReader dependencies for it.
 
 name: pyopenms-wheels-cibuildwheel
 
@@ -115,6 +124,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Cache Thermo bridge assets
+        uses: actions/cache@v4
+        with:
+          path: |
+            thermo-managed
+            thermo-testdata
+          key: thermo-assets-linux-x64-${{ hashFiles('tools/ci/fetch_thermo_assets.sh') }}
+
+      # Idempotent: reuses cached files after verifying their SHA-256, downloads
+      # (with retries) only what is missing.
+      - name: Fetch Thermo bridge assets (prebuilt managed assemblies + RAW test file)
+        run: bash tools/ci/fetch_thermo_assets.sh linux-x64 "$GITHUB_WORKSPACE"
+
       - name: Build and install OpenMS in container
         run: |
           # Build and install OpenMS so libraries are stripped and paths are clean
@@ -123,7 +145,13 @@ jobs:
             -w /project \
             ghcr.io/openms/contrib_manylinux_2_34:latest-amd64 \
             bash -c '
-              yum install -y cmake ninja-build libcurl-devel
+              # dotnet-sdk-8.0 provides the nethost headers/library the native thermo
+              # bridge compiles against (the managed assemblies come pre-built, see
+              # tools/ci/fetch_thermo_assets.sh). The RPM installs .NET under
+              # /usr/lib64/dotnet, which FindDotNetHost only finds via DOTNET_ROOT.
+              yum install -y cmake ninja-build libcurl-devel dotnet-sdk-8.0
+              export DOTNET_ROOT="$(dirname "$(readlink -f "$(command -v dotnet)")")"
+              echo "DOTNET_ROOT=$DOTNET_ROOT"
               mkdir build && cd build
               cmake .. \
                 -G Ninja \
@@ -136,7 +164,8 @@ jobs:
                 -DWITH_GUI=OFF \
                 -DBUILD_TOPP_TOOLS=OFF \
                 -DINSTALL_OPENMS_EXAMPLES=OFF \
-                -DWITH_THERMO_RAW=OFF \
+                -DWITH_THERMO_RAW=ON \
+                -DOPENMS_THERMO_BRIDGE_PREBUILT_MANAGED_DIR=/project/thermo-managed \
                 -DENABLE_TUTORIALS=OFF \
                 -DENABLE_DOCS=OFF
               ninja OpenMS OpenSwathAlgo
@@ -164,12 +193,16 @@ jobs:
         env:
           CIBW_BUILD: ${{ needs.setup.outputs.cibw-build-linux-x64 }}
           CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/openms/contrib_manylinux_2_34:latest-amd64
-          CIBW_BEFORE_ALL: yum install -y libcurl-devel
-          # Use install directory with stripped libraries
+          # dotnet-runtime-8.0: the wheel test suite loads a Thermo RAW file
+          CIBW_BEFORE_ALL: yum install -y libcurl-devel dotnet-runtime-8.0
+          # Use install directory with stripped libraries.
+          # PYOPENMS_THERMO_RAW_TEST_FILE enables the Thermo RAW tests in the wheel test suite.
           CIBW_ENVIRONMENT: >-
             OpenMS_ROOT=/project/install
             CMAKE_PREFIX_PATH=/contrib-build:/project/install
             CMAKE_BUILD_PARALLEL_LEVEL=2
+            DOTNET_ROOT=/usr/lib64/dotnet
+            PYOPENMS_THERMO_RAW_TEST_FILE=/project/thermo-testdata/Angiotensin_AllScans.raw
           CIBW_BUILD_VERBOSITY: 1
 
       - uses: actions/upload-artifact@v4
@@ -231,6 +264,8 @@ jobs:
               cmake --install . --component share
               cmake --install . --component cmake
             '
+          # WITH_THERMO_RAW stays OFF here: Thermo's RawFileReader has no native
+          # dependencies for Linux aarch64 (https://github.com/thermofisherlsms/RawFileReader/issues/21).
 
       - name: Set pyOpenMS version
         run: |
@@ -294,13 +329,26 @@ jobs:
             xerces-c \
             zstd
 
-      # macOS runners do not ship a .NET SDK. OpenMSThermoBridge targets net8.0
-      # and FindDotNetHost.cmake needs the nethost SDK pack for osx-arm64; the
-      # action installs the SDK and exports DOTNET_ROOT.
+      # OpenMSThermoBridge needs the nethost headers/library from the .NET host
+      # pack for osx-arm64 to compile the native bridge (the managed assemblies
+      # come pre-built, see below); the action installs the SDK and exports
+      # DOTNET_ROOT, which is also what the wheel test suite uses to find the
+      # runtime.
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
+
+      - name: Cache Thermo bridge assets
+        uses: actions/cache@v4
+        with:
+          path: |
+            thermo-managed
+            thermo-testdata
+          key: thermo-assets-osx-arm64-${{ hashFiles('tools/ci/fetch_thermo_assets.sh') }}
+
+      - name: Fetch Thermo bridge assets (prebuilt managed assemblies + RAW test file)
+        run: bash tools/ci/fetch_thermo_assets.sh osx-arm64 "$GITHUB_WORKSPACE"
 
       - name: Build and install OpenMS
         run: |
@@ -322,6 +370,8 @@ jobs:
             -DWITH_GUI=OFF \
             -DBUILD_TOPP_TOOLS=OFF \
             -DINSTALL_OPENMS_EXAMPLES=OFF \
+            -DWITH_THERMO_RAW=ON \
+            -DOPENMS_THERMO_BRIDGE_PREBUILT_MANAGED_DIR=${{ github.workspace }}/thermo-managed \
             -DENABLE_TUTORIALS=OFF \
             -DENABLE_DOCS=OFF \
             -DMT_ENABLE_OPENMP=ON
@@ -351,11 +401,14 @@ jobs:
           CIBW_ARCHS_MACOS: "arm64"
           # Use old mechanism: copy libraries and use @loader_path
           # NO_DEPENDENCIES=OFF enables legacy library copying for macOS (with our fix_dependencies script)
+          # DOTNET_ROOT and PYOPENMS_THERMO_RAW_TEST_FILE enable the Thermo RAW tests in the wheel test suite.
           CIBW_ENVIRONMENT: >-
             OpenMS_ROOT="${{ github.workspace }}/install"
             CMAKE_PREFIX_PATH="/opt/homebrew:/opt/homebrew/opt/libomp:${{ github.workspace }}/install"
             MACOSX_DEPLOYMENT_TARGET=15.0
             CMAKE_BUILD_PARALLEL_LEVEL=2
+            DOTNET_ROOT="$DOTNET_ROOT"
+            PYOPENMS_THERMO_RAW_TEST_FILE="${{ github.workspace }}/thermo-testdata/Angiotensin_AllScans.raw"
           CIBW_BUILD_VERBOSITY: 1
           #CIBW_TEST_SKIP: "*"
 
@@ -397,6 +450,20 @@ jobs:
         with:
           arch: x64
 
+      - name: Cache Thermo bridge assets
+        uses: actions/cache@v4
+        with:
+          path: |
+            thermo-managed
+            thermo-testdata
+          key: thermo-assets-win-x64-${{ hashFiles('tools/ci/fetch_thermo_assets.sh') }}
+
+      # The Windows runner image ships .NET SDKs under C:\Program Files\dotnet, which
+      # FindDotNetHost.cmake searches by default for the nethost host pack.
+      - name: Fetch Thermo bridge assets (prebuilt managed assemblies + RAW test file)
+        shell: bash
+        run: bash tools/ci/fetch_thermo_assets.sh win-x64 "$GITHUB_WORKSPACE"
+
       - name: Build libcurl from source
         shell: bash
         run: |
@@ -432,7 +499,8 @@ jobs:
             -DWITH_GUI=OFF \
             -DBUILD_TOPP_TOOLS=OFF \
             -DINSTALL_OPENMS_EXAMPLES=OFF \
-            -DWITH_THERMO_RAW=OFF \
+            -DWITH_THERMO_RAW=ON \
+            -DOPENMS_THERMO_BRIDGE_PREBUILT_MANAGED_DIR="$GITHUB_WORKSPACE/thermo-managed" \
             -DENABLE_TUTORIALS=OFF \
             -DENABLE_DOCS=OFF
           cmake --build . --target OpenMS OpenSwathAlgo
@@ -459,9 +527,11 @@ jobs:
           OPENMS_ROOT_CMAKE=$(echo "${{ github.workspace }}/install" | sed 's|\\|/|g')
           CONTRIB_CMAKE=$(echo "${{ github.workspace }}/contrib" | sed 's|\\|/|g')
           QT_CMAKE=$(echo "${{ env.QT_ROOT_DIR }}" | sed 's|\\|/|g')
+          THERMO_RAW_TEST_FILE=$(echo "${{ github.workspace }}/thermo-testdata/Angiotensin_AllScans.raw" | sed 's|\\|/|g')
           echo "OPENMS_ROOT_CMAKE=${OPENMS_ROOT_CMAKE}" >> $GITHUB_ENV
           echo "CONTRIB_CMAKE=${CONTRIB_CMAKE}" >> $GITHUB_ENV
           echo "QT_CMAKE=${QT_CMAKE}" >> $GITHUB_ENV
+          echo "THERMO_RAW_TEST_FILE=${THERMO_RAW_TEST_FILE}" >> $GITHUB_ENV
 
       - name: Build wheels with cibuildwheel
         uses: pypa/cibuildwheel@v3.3
@@ -470,10 +540,14 @@ jobs:
           output-dir: wheelhouse
         env:
           CIBW_BUILD: ${{ needs.setup.outputs.cibw-build-windows-x64 }}
+          # PYOPENMS_THERMO_RAW_TEST_FILE enables the Thermo RAW tests in the wheel test suite
+          # (the runner image provides the .NET runtime).
           CIBW_ENVIRONMENT: >-
             OpenMS_ROOT="${{ env.OPENMS_ROOT_CMAKE }}"
             CMAKE_PREFIX_PATH="${{ env.QT_CMAKE }}/lib/cmake;${{ env.QT_CMAKE }};${{ env.CONTRIB_CMAKE }};${{ env.OPENMS_ROOT_CMAKE }}"
             CMAKE_BUILD_PARALLEL_LEVEL=2
+            PYOPENMS_THERMO_RAW_TEST_FILE="${{ env.THERMO_RAW_TEST_FILE }}"
+          # install/bin and install/lib also hold openms_thermo_bridge.dll and nethost.dll
           CIBW_REPAIR_WHEEL_COMMAND: "delvewheel repair --add-path ${{ env.OPENMS_ROOT_CMAKE }}/bin;${{ env.OPENMS_ROOT_CMAKE }}/lib;${{ env.QT_CMAKE }}/bin;${{ env.CONTRIB_CMAKE }}/lib -w {dest_dir} {wheel}"
           CIBW_BUILD_VERBOSITY: 1
 
@@ -494,17 +568,30 @@ jobs:
         python-version: ${{ fromJson(needs.setup.outputs.python-versions) }}
         os: [ubuntu-latest, ubuntu-22.04-arm, macos-15, windows-latest]
         include:
-          # Map os to artifact names
+          # Map os to artifact names and to the openms-thermo-bridge platform tag
+          # (empty = no Thermo RAW support in that wheel)
           - os: ubuntu-latest
             artifact: wheels-linux-x64
+            thermo-platform: linux-x64
           - os: ubuntu-22.04-arm
             artifact: wheels-linux-arm64
+            thermo-platform: ''
           - os: macos-15
             artifact: wheels-macos-arm64
+            thermo-platform: osx-arm64
           - os: windows-latest
             artifact: wheels-windows-x64
+            thermo-platform: win-x64
 
     steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            tools/ci/fetch_thermo_assets.sh
+            cmake/cmake_findExternalLibs.cmake
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.artifact }}
@@ -523,6 +610,47 @@ jobs:
           pip install wheelhouse/*cp${PYVER}*.whl
           python -c "import pyopenms; print('pyopenms version:', pyopenms.__version__)"
           python -c "import pyopenms; print(pyopenms.EmpiricalFormula('C6H12O6').getMonoWeight())"
+
+      # Thermo RAW smoke test on a fresh runner: only the .NET runtime may be
+      # present, everything else (bridge library, managed assemblies) must come
+      # from the wheel itself.
+      - name: Install .NET runtime for the Thermo RAW smoke test
+        if: matrix.thermo-platform != ''
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Cache Thermo RAW test file
+        if: matrix.thermo-platform != ''
+        uses: actions/cache@v4
+        with:
+          path: |
+            thermo-managed
+            thermo-testdata
+          key: thermo-assets-${{ matrix.thermo-platform }}-${{ hashFiles('tools/ci/fetch_thermo_assets.sh') }}
+
+      - name: Fetch Thermo RAW test file
+        if: matrix.thermo-platform != ''
+        shell: bash
+        run: bash tools/ci/fetch_thermo_assets.sh ${{ matrix.thermo-platform }} "$GITHUB_WORKSPACE"
+
+      - name: Smoke-test Thermo RAW reading
+        if: matrix.thermo-platform != ''
+        shell: bash
+        env:
+          PYOPENMS_THERMO_RAW_TEST_FILE: ${{ github.workspace }}/thermo-testdata/Angiotensin_AllScans.raw
+        run: |
+          python - <<'EOF'
+          import os, pyopenms
+          share = os.environ["OPENMS_DATA_PATH"]
+          managed = os.path.join(share, "openms_thermo_bridge", "managed")
+          assert os.path.isfile(os.path.join(managed, "ThermoWrapperManaged.dll")), managed
+          exp = pyopenms.MSExperiment()
+          pyopenms.FileHandler().loadExperiment(os.environ["PYOPENMS_THERMO_RAW_TEST_FILE"], exp)
+          n = exp.getNrSpectra()
+          print("Thermo RAW spectra loaded:", n)
+          assert n > 1000, n
+          EOF
 
   #----------------------------------------------------------------------------
   # Publish wheels

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -245,6 +245,14 @@ PyOpenMS:
     (#8674), 6 docutils ERROR-level warnings resolved (#9629), and corrected/added MSChromatogram and
     Mobilogram docstrings (#9812)
   - Build system modernized with py-build-cmake and cibuildwheel for PEP 517/518/621 compliance (#8530)
+  - Native Thermo .raw reading (FileHandler().loadExperiment("run.raw", exp)) now works from the
+    Linux x86_64, macOS arm64 and Windows wheels: libOpenMS is built with WITH_THERMO_RAW=ON and the
+    wheel carries both the openms_thermo_bridge library and its managed assemblies
+    (pyopenms/share/OpenMS/openms_thermo_bridge/managed). A .NET 8 or newer runtime must be installed
+    on the machine (set DOTNET_ROOT for non-standard locations). Previously Linux and Windows wheels
+    were built without the reader and the macOS wheel shipped the bridge without its managed half.
+    Linux aarch64 wheels stay without Thermo support (no vendor libraries for that platform). New
+    test_ThermoRawFile.py exercises a real RAW file when PYOPENMS_THERMO_RAW_TEST_FILE is set
 
 TOPP tools:
   Changes:
@@ -888,6 +896,11 @@ OpenMS Library:
       intensity, lowest/highest observed m/z, scan filter string, scan window, ion injection time,
       polarity, and instrument source/analyzer/detector info -- so output matches msconvert/ProteoWizard
       (#9389, #9623)
+    - ThermoRawFile: the managed bridge assemblies (ThermoWrapperManaged.dll, runtimeconfig, Thermo
+      CommonCore) are now also installed into share/OpenMS/openms_thermo_bridge/managed and looked up
+      there, after the new OPENMS_THERMO_MANAGED_DIR environment variable and before the bridge's own
+      next-to-the-library default, so relocated layouts such as Python wheels find them. On Windows
+      nethost.dll, which openms_thermo_bridge.dll imports, is installed next to the OpenMS libraries
     - IMAGING module for imaging mass spectrometry: IonImage (dense WxHxD intensity grid with per-pixel
       validity mask and m/z extraction window), MSImagingGeometry (pixel list with (x,y,z) -> spectrum
       index lookup and pixel-size metadata) and MSImagingExperiment (pixel-based spectrum access and
@@ -1453,6 +1466,12 @@ Documentation:
     VCPKG_MANIFEST_FEATURES alongside the corresponding WITH_* CMake flags (#9928)
 
 Build System:
+  - pyOpenMS wheel workflow: Thermo RAW support is built into the Linux x86_64, macOS arm64 and Windows
+    wheels. The managed half of openms-thermo-bridge comes from the bridge's pre-built release zip via
+    tools/ci/fetch_thermo_assets.sh (curl with retries, pinned SHA-256, cached with actions/cache,
+    bridge tag cross-checked against the FetchContent pin), passed to CMake as
+    OPENMS_THERMO_BRIDGE_PREBUILT_MANAGED_DIR, so no NuGet restore or Thermo package download runs in
+    CI. The wheel test suite and a smoke test on fresh runners load PNNL's Angiotensin_AllScans.raw
   - Removed the developer script tools/checker.php. Covered by .clang-format now.
   - Removed the ENABLE_STYLE_TESTING option along with the local cpplint, cppcheck integration and the "potential_for_loop_copies" check.
   - Removed further obsolete local-only developer tooling not run by any CI or build target: tools/pychecker_ignore.yaml (orphaned after the checker.php removal) and the tools/spellcheck Perl spell checker (#9945).

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -669,6 +669,28 @@ if (WITH_THERMO_RAW)
     install_library(openms_thermo_bridge)
     openms_register_export_target(openms_thermo_bridge)
 
+    if(WIN32)
+      # On Windows the bridge links the nethost *import* library, so
+      # openms_thermo_bridge.dll needs nethost.dll at run time. The .NET host pack
+      # that provides it is not on PATH, so install a copy next to the OpenMS
+      # libraries; installers and wheel repair tools (delvewheel) pick it up from
+      # there. FindDotNetHost.cmake ran inside the bridge's directory scope, so its
+      # result variables are not visible here: run it again in this scope.
+      list(APPEND CMAKE_MODULE_PATH "${OpenMSThermoBridge_SOURCE_DIR}/cmake")
+      find_package(DotNetHost QUIET)
+      list(POP_BACK CMAKE_MODULE_PATH)
+      if(DotNetHost_RUNTIME_LIBRARY)
+        install(FILES "${DotNetHost_RUNTIME_LIBRARY}"
+                DESTINATION ${INSTALL_LIB_DIR}
+                COMPONENT library)
+        message(STATUS "openms-thermo-bridge: installing ${DotNetHost_RUNTIME_LIBRARY} alongside libOpenMS")
+      else()
+        message(WARNING
+          "openms-thermo-bridge: nethost.dll was not located; openms_thermo_bridge.dll "
+          "will only load if nethost.dll is found on PATH at run time.")
+      endif()
+    endif()
+
     message(STATUS "openms-thermo-bridge: built from source (${OpenMSThermoBridge_SOURCE_DIR})")
 
     # Download and install the Thermo Fisher RawFileReader license.
@@ -705,6 +727,31 @@ if (WITH_THERMO_RAW)
                 COMPONENT share)
       endif()
     endif()
+  endif()
+
+  # Ship the managed half of the bridge (ThermoWrapperManaged.dll, its
+  # runtimeconfig.json and the Thermo CommonCore assemblies) inside the
+  # shared-data directory as well. The bridge installs them to
+  # <libdir>/openms_thermo_bridge/managed and locates them relative to its own
+  # shared library; that link breaks in relocated layouts such as Python wheels,
+  # where wheel repair tools rename and move the library. ThermoRawFile looks in
+  # <share>/openms_thermo_bridge/managed first, so every consumer that carries
+  # share/OpenMS (pyOpenMS wheels included) gets a working reader. The files are
+  # platform-independent IL assemblies (~1.6 MB), so they belong to 'share'.
+  # OpenMSThermoBridge_MANAGED_DIR is set by the bridge for both the
+  # FetchContent build (internal cache variable) and a system installation
+  # (OpenMSThermoBridgeHelpers.cmake). The directory is populated at build time
+  # when the bridge publishes the assemblies itself, which is fine for install().
+  if(OpenMSThermoBridge_MANAGED_DIR)
+    install(DIRECTORY "${OpenMSThermoBridge_MANAGED_DIR}/"
+            DESTINATION "${INSTALL_SHARE_DIR}/openms_thermo_bridge/managed"
+            COMPONENT share
+            PATTERN "*.pdb" EXCLUDE
+            PATTERN "*.zip" EXCLUDE)
+  else()
+    message(WARNING
+      "openms-thermo-bridge: OpenMSThermoBridge_MANAGED_DIR is not set; the managed "
+      "bridge assemblies will not be installed into ${INSTALL_SHARE_DIR}.")
   endif()
 endif()
 #------------------------------------------------------------------------------

--- a/doc/doxygen/install/common-cmake-parameters.doxygen
+++ b/doc/doxygen/install/common-cmake-parameters.doxygen
@@ -165,6 +165,15 @@ The most important CMake variables are:
     runtime), set the <code>DOTNET_ROOT</code> environment variable to that directory &mdash; the folder
     that contains the <code>dotnet</code> host and the <code>shared/</code> sub-directory
     (e.g. <code>export DOTNET_ROOT=/usr/share/dotnet</code>) &mdash; so the runtime can be found.
+    The managed half of the bridge (<code>ThermoWrapperManaged.dll</code>, its
+    <code>runtimeconfig.json</code> and the Thermo CommonCore assemblies) is installed both next to the
+    bridge library and into <code>share/OpenMS/openms_thermo_bridge/managed</code>; OpenMS looks in the
+    <code>OPENMS_THERMO_MANAGED_DIR</code> environment variable first, then in the share directory, then
+    next to the bridge library. To build without a NuGet/GitHub round trip for those assemblies, pass the
+    bridge's own <code>-DOPENMS_THERMO_BRIDGE_PREBUILT_MANAGED_DIR=/path/to/extracted-zip</code> (the zip is
+    published with every openms-thermo-bridge release) or
+    <code>-DOPENMS_THERMO_BRIDGE_DOWNLOAD_PREBUILT_MANAGED=ON</code>; the native bridge then only needs the
+    nethost headers from a .NET SDK / host pack.
     Disabled automatically on Linux/aarch64 targets.
     (Default: On on supported platforms)</td>
   </tr>

--- a/src/openms/include/OpenMS/FORMAT/ThermoRawFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ThermoRawFile.h
@@ -28,7 +28,8 @@ namespace OpenMS
     openms-thermo-bridge managed runtime files (ThermoWrapperManaged.dll, its
     runtimeconfig.json and the Thermo CommonCore assemblies). These are looked
     up in this order:
-      1. the directory named by the OPENMS_THERMO_MANAGED_DIR environment variable,
+      1. the directory named by the OPENMS_THERMO_MANAGED_DIR environment variable
+         (skipped with a warning if it does not hold the files),
       2. <OpenMS share dir>/openms_thermo_bridge/managed (installed by OpenMS,
          also shipped inside pyOpenMS wheels),
       3. the bridge's own default, i.e. a 'managed' directory next to the

--- a/src/openms/include/OpenMS/FORMAT/ThermoRawFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ThermoRawFile.h
@@ -24,9 +24,16 @@ namespace OpenMS
     RawFileReader through the .NET host runtime. Reads spectra (MS1 and MSn)
     including retention times, precursor information, and instrument metadata.
 
-    Requires the openms-thermo-bridge managed runtime files
-    (ThermoWrapperManaged.dll and its dependencies) to be installed alongside
-    the OpenMS binaries.
+    Requires a .NET 8 (or newer) runtime on the machine and the
+    openms-thermo-bridge managed runtime files (ThermoWrapperManaged.dll, its
+    runtimeconfig.json and the Thermo CommonCore assemblies). These are looked
+    up in this order:
+      1. the directory named by the OPENMS_THERMO_MANAGED_DIR environment variable,
+      2. <OpenMS share dir>/openms_thermo_bridge/managed (installed by OpenMS,
+         also shipped inside pyOpenMS wheels),
+      3. the bridge's own default, i.e. a 'managed' directory next to the
+         openms_thermo_bridge shared library.
+    Set DOTNET_ROOT if the .NET runtime is installed in a non-standard location.
 
     @ingroup FileIO
   */

--- a/src/openms/source/FORMAT/ThermoRawFile.cpp
+++ b/src/openms/source/FORMAT/ThermoRawFile.cpp
@@ -89,7 +89,9 @@ namespace OpenMS
       tree, but not for relocated layouts such as Python wheels, where wheel repair tools
       rename and move the bridge library. OpenMS therefore checks, in order:
 
-        1. the OPENMS_THERMO_MANAGED_DIR environment variable (used verbatim when set),
+        1. the OPENMS_THERMO_MANAGED_DIR environment variable, if it holds the managed files
+           (a stale or mistyped override is reported and skipped rather than breaking a
+           correctly bundled installation),
         2. <OpenMS share dir>/openms_thermo_bridge/managed, i.e. the copy that OpenMS installs
            into its shared-data directory (pyOpenMS ships share/OpenMS inside the wheel),
         3. nothing, so the bridge falls back to its own lookup.
@@ -99,12 +101,13 @@ namespace OpenMS
       if (const char* env = std::getenv("OPENMS_THERMO_MANAGED_DIR"); env != nullptr && env[0] != '\0')
       {
         std::filesystem::path dir(env);
-        if (!isManagedDirectory(dir))
+        if (isManagedDirectory(dir))
         {
-          OPENMS_LOG_WARN << "ThermoRawFile: OPENMS_THERMO_MANAGED_DIR='" << env
-                          << "' does not contain ThermoWrapperManaged.dll and its runtimeconfig.json\n";
+          return dir;
         }
-        return dir;
+        OPENMS_LOG_WARN << "ThermoRawFile: OPENMS_THERMO_MANAGED_DIR='" << env
+                        << "' does not contain ThermoWrapperManaged.dll and its runtimeconfig.json; "
+                        << "ignoring it and looking in the OpenMS share directory instead\n";
       }
 
       std::filesystem::path share_dir(File::getOpenMSDataPath());

--- a/src/openms/source/FORMAT/ThermoRawFile.cpp
+++ b/src/openms/source/FORMAT/ThermoRawFile.cpp
@@ -30,8 +30,10 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdlib>
 #include <filesystem>
 #include <limits>
+#include <optional>
 #include <set>
 #include <string>
 
@@ -69,6 +71,49 @@ namespace OpenMS
       {
         return false;
       }
+    }
+
+    /// True if @p dir holds the two files the bridge needs to start the .NET runtime.
+    bool isManagedDirectory(const std::filesystem::path& dir)
+    {
+      std::error_code ec;
+      return std::filesystem::is_regular_file(dir / "ThermoWrapperManaged.dll", ec)
+          && std::filesystem::is_regular_file(dir / "ThermoWrapperManaged.runtimeconfig.json", ec);
+    }
+
+    /**
+      @brief Locate the managed half of the thermo bridge (ThermoWrapperManaged.dll + runtimeconfig).
+
+      The bridge's own default looks next to its shared library (<lib dir>/managed or
+      <lib dir>/openms_thermo_bridge/managed). That works for a plain OpenMS build or install
+      tree, but not for relocated layouts such as Python wheels, where wheel repair tools
+      rename and move the bridge library. OpenMS therefore checks, in order:
+
+        1. the OPENMS_THERMO_MANAGED_DIR environment variable (used verbatim when set),
+        2. <OpenMS share dir>/openms_thermo_bridge/managed, i.e. the copy that OpenMS installs
+           into its shared-data directory (pyOpenMS ships share/OpenMS inside the wheel),
+        3. nothing, so the bridge falls back to its own lookup.
+    */
+    std::optional<std::filesystem::path> resolveManagedDirectory()
+    {
+      if (const char* env = std::getenv("OPENMS_THERMO_MANAGED_DIR"); env != nullptr && env[0] != '\0')
+      {
+        std::filesystem::path dir(env);
+        if (!isManagedDirectory(dir))
+        {
+          OPENMS_LOG_WARN << "ThermoRawFile: OPENMS_THERMO_MANAGED_DIR='" << env
+                          << "' does not contain ThermoWrapperManaged.dll and its runtimeconfig.json\n";
+        }
+        return dir;
+      }
+
+      std::filesystem::path share_dir(File::getOpenMSDataPath());
+      std::filesystem::path candidate = share_dir / "openms_thermo_bridge" / "managed";
+      if (isManagedDirectory(candidate))
+      {
+        return candidate;
+      }
+      return std::nullopt;
     }
 
     /// Find the value of the first trailer-extra label that contains @p needle (case-insensitive).
@@ -176,7 +221,10 @@ namespace OpenMS
 
     try
     {
-      openms::thermo_bridge::RawFile raw(raw_path);
+      const std::optional<std::filesystem::path> managed_dir = resolveManagedDirectory();
+      openms::thermo_bridge::RawFile raw = managed_dir
+        ? openms::thermo_bridge::RawFile(raw_path, *managed_dir)
+        : openms::thermo_bridge::RawFile(raw_path);
 
       // --- Source file metadata ---
       SourceFile src;

--- a/src/pyOpenMS/pyopenms/__init__.py
+++ b/src/pyOpenMS/pyopenms/__init__.py
@@ -69,6 +69,21 @@ else:
             )
         del _possible_paths, _path, Path
 
+# Point the Thermo RAW reader at the managed bridge assemblies bundled with this
+# package (share/OpenMS/openms_thermo_bridge/managed). libOpenMS resolves its data
+# directory from compiled-in paths before it consults OPENMS_DATA_PATH, so on a
+# machine that still has the build or source tree the reader would look in the
+# wrong share/ folder. OPENMS_THERMO_MANAGED_DIR is the documented explicit
+# override and takes precedence over that resolution. A value the user already
+# set is respected, and nothing is set when the wheel carries no bridge.
+if not os.environ.get("OPENMS_THERMO_MANAGED_DIR"):
+    for _share in (os.environ.get("OPENMS_DATA_PATH", ""), default_openms_data_path):
+        _managed = os.path.join(_share, "openms_thermo_bridge", "managed") if _share else ""
+        if _managed and os.path.isfile(os.path.join(_managed, "ThermoWrapperManaged.dll")):
+            os.environ["OPENMS_THERMO_MANAGED_DIR"] = _managed
+            break
+    del _share, _managed
+
 
 # Patch pyarrow to handle filesystem registration conflicts with OpenMS Arrow C++.
 # Both pyarrow and C++ Arrow try to register

--- a/src/pyOpenMS/pyopenms/__init__.py
+++ b/src/pyOpenMS/pyopenms/__init__.py
@@ -77,12 +77,19 @@ else:
 # override and takes precedence over that resolution. A value the user already
 # set is respected, and nothing is set when the wheel carries no bridge.
 if not os.environ.get("OPENMS_THERMO_MANAGED_DIR"):
+    # A directory only qualifies when the complete runtime is present, so a stale or
+    # partial share/ named by OPENMS_DATA_PATH cannot shadow the bundled copy.
+    _managed_runtime_files = (
+        "ThermoWrapperManaged.dll",
+        "ThermoWrapperManaged.runtimeconfig.json",
+        "ThermoFisher.CommonCore.RawFileReader.dll",
+    )
     for _share in (os.environ.get("OPENMS_DATA_PATH", ""), default_openms_data_path):
         _managed = os.path.join(_share, "openms_thermo_bridge", "managed") if _share else ""
-        if _managed and os.path.isfile(os.path.join(_managed, "ThermoWrapperManaged.dll")):
+        if _managed and all(os.path.isfile(os.path.join(_managed, _f)) for _f in _managed_runtime_files):
             os.environ["OPENMS_THERMO_MANAGED_DIR"] = _managed
             break
-    del _share, _managed
+    del _share, _managed, _managed_runtime_files
 
 
 # Patch pyarrow to handle filesystem registration conflicts with OpenMS Arrow C++.

--- a/src/pyOpenMS/tests/unittests/test_ThermoRawFile.py
+++ b/src/pyOpenMS/tests/unittests/test_ThermoRawFile.py
@@ -47,6 +47,9 @@ def test_managed_bridge_is_bundled_with_share():
                  "ThermoWrapperManaged.runtimeconfig.json",
                  "ThermoFisher.CommonCore.RawFileReader.dll"):
         assert os.path.isfile(os.path.join(managed, name)), name
+    # pyopenms/__init__.py hands this directory to the reader explicitly, so the
+    # lookup does not depend on which share/ folder libOpenMS resolves on its own.
+    assert os.path.samefile(os.environ.get("OPENMS_THERMO_MANAGED_DIR", ""), managed)
 
 
 @needs_raw_file

--- a/src/pyOpenMS/tests/unittests/test_ThermoRawFile.py
+++ b/src/pyOpenMS/tests/unittests/test_ThermoRawFile.py
@@ -25,8 +25,8 @@ needs_raw_file = pytest.mark.skipif(
 
 
 def test_raw_extension_is_recognized():
-    # Independent of WITH_THERMO_RAW: .raw is always typed as RAW so that
-    # tools can hand it to an external converter.
+    """.raw is typed as RAW regardless of WITH_THERMO_RAW, so tools can hand it
+    to an external converter even without the in-process reader."""
     assert pyopenms.FileHandler.getTypeByFileName("run.raw") == pyopenms.FileTypes.RAW
     assert pyopenms.FileHandler.getTypeByFileName("run.RAW") == pyopenms.FileTypes.RAW
 
@@ -51,6 +51,8 @@ def test_managed_bridge_is_bundled_with_share():
 
 @needs_raw_file
 def test_load_experiment_from_raw():
+    """FileHandler dispatches .raw to ThermoRawFile: spectra, RTs, precursors
+    and instrument metadata are populated from Angiotensin_AllScans.raw."""
     assert os.path.isfile(RAW_FILE), RAW_FILE
 
     exp = pyopenms.MSExperiment()
@@ -85,6 +87,7 @@ def test_load_experiment_from_raw():
 
 @needs_raw_file
 def test_load_experiment_from_raw_roundtrips_through_mzml(tmp_path):
+    """An experiment read from RAW survives a store/load round trip through mzML."""
     exp = pyopenms.MSExperiment()
     pyopenms.FileHandler().loadExperiment(RAW_FILE, exp)
 

--- a/src/pyOpenMS/tests/unittests/test_ThermoRawFile.py
+++ b/src/pyOpenMS/tests/unittests/test_ThermoRawFile.py
@@ -1,0 +1,98 @@
+"""Tests for native Thermo RAW reading through FileHandler.
+
+Reading a .raw file needs three things at run time: OpenMS built with
+``WITH_THERMO_RAW=ON``, the openms-thermo-bridge managed assemblies (shipped
+in ``pyopenms/share/OpenMS/openms_thermo_bridge/managed``), and a .NET 8 or
+newer runtime on the machine. The real-data tests therefore only run when
+``PYOPENMS_THERMO_RAW_TEST_FILE`` names a Thermo .raw file; the wheel CI sets
+it to PNNL's Angiotensin_AllScans.raw and provides the runtime.
+
+When the variable is set the tests must pass. A wheel that was built without
+Thermo support, or that lacks the managed assemblies, is exactly what they are
+meant to catch, so there is no feature-detection fallback here.
+"""
+import os
+
+import pytest
+import pyopenms
+
+RAW_FILE = os.environ.get("PYOPENMS_THERMO_RAW_TEST_FILE", "")
+
+needs_raw_file = pytest.mark.skipif(
+    not RAW_FILE,
+    reason="PYOPENMS_THERMO_RAW_TEST_FILE not set",
+)
+
+
+def test_raw_extension_is_recognized():
+    # Independent of WITH_THERMO_RAW: .raw is always typed as RAW so that
+    # tools can hand it to an external converter.
+    assert pyopenms.FileHandler.getTypeByFileName("run.raw") == pyopenms.FileTypes.RAW
+    assert pyopenms.FileHandler.getTypeByFileName("run.RAW") == pyopenms.FileTypes.RAW
+
+
+def test_managed_bridge_is_bundled_with_share():
+    """The managed assemblies travel with share/OpenMS; if the share folder is
+    present, the bridge files must be too, otherwise every .raw load fails at
+    run time with 'Managed bridge runtime files are missing'."""
+    share = os.environ.get("OPENMS_DATA_PATH", "")
+    if not share or not os.path.isdir(share):
+        pytest.skip("no OpenMS share directory available")
+    managed = os.path.join(share, "openms_thermo_bridge", "managed")
+    if not os.path.isdir(managed):
+        if RAW_FILE:
+            pytest.fail("PYOPENMS_THERMO_RAW_TEST_FILE is set but %s is missing" % managed)
+        pytest.skip("no bundled Thermo bridge (WITH_THERMO_RAW=OFF or in-tree build)")
+    for name in ("ThermoWrapperManaged.dll",
+                 "ThermoWrapperManaged.runtimeconfig.json",
+                 "ThermoFisher.CommonCore.RawFileReader.dll"):
+        assert os.path.isfile(os.path.join(managed, name)), name
+
+
+@needs_raw_file
+def test_load_experiment_from_raw():
+    assert os.path.isfile(RAW_FILE), RAW_FILE
+
+    exp = pyopenms.MSExperiment()
+    pyopenms.FileHandler().loadExperiment(RAW_FILE, exp)
+
+    # Angiotensin_AllScans.raw: 87 MS1 scans plus hundreds of MS2 scans.
+    assert exp.getNrSpectra() > 1000
+    assert len(exp.getSourceFiles()) == 1
+    assert exp.getSourceFiles()[0].getNameOfFile() == os.path.basename(RAW_FILE)
+
+    levels = [s.getMSLevel() for s in exp]
+    assert levels.count(1) > 0
+    assert sum(1 for level in levels if level >= 2) > 0
+
+    rts = [s.getRT() for s in exp]
+    assert rts == sorted(rts)
+
+    ms1 = next(s for s in exp if s.getMSLevel() == 1)
+    mz, intensity = ms1.get_peaks()
+    assert len(mz) > 0
+    assert len(mz) == len(intensity)
+
+    ms2_with_precursor = [s for s in exp if s.getMSLevel() >= 2 and len(s.getPrecursors()) > 0]
+    assert ms2_with_precursor
+    assert ms2_with_precursor[0].getPrecursors()[0].getMZ() > 0.0
+
+    # Instrument metadata is filled from the RAW header (Orbitrap, ESI).
+    instrument = exp.getInstrument()
+    assert len(instrument.getMassAnalyzers()) > 0
+    assert len(instrument.getIonSources()) > 0
+
+
+@needs_raw_file
+def test_load_experiment_from_raw_roundtrips_through_mzml(tmp_path):
+    exp = pyopenms.MSExperiment()
+    pyopenms.FileHandler().loadExperiment(RAW_FILE, exp)
+
+    out = str(tmp_path / "roundtrip.mzML")
+    pyopenms.MzMLFile().store(out, exp)
+
+    reloaded = pyopenms.MSExperiment()
+    pyopenms.MzMLFile().load(out, reloaded)
+    assert reloaded.getNrSpectra() == exp.getNrSpectra()
+    assert reloaded[0].getMSLevel() == exp[0].getMSLevel()
+    assert reloaded[0].getRT() == pytest.approx(exp[0].getRT())

--- a/tools/ci/fetch_thermo_assets.sh
+++ b/tools/ci/fetch_thermo_assets.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Fetch the assets the pyOpenMS wheel builds need for native Thermo RAW support,
+# without going through NuGet or the .NET SDK's package restore:
+#
+#   1. the pre-built managed half of openms-thermo-bridge (ThermoWrapperManaged.dll,
+#      its runtimeconfig.json and the Thermo CommonCore assemblies), published as a
+#      zip on the bridge's GitHub release. Passing the extracted directory to CMake
+#      as OPENMS_THERMO_BRIDGE_PREBUILT_MANAGED_DIR skips the bridge's own
+#      'dotnet publish' step, and with it the five Thermo .nupkg downloads from
+#      raw.githubusercontent.com and the nuget.org restore of their dependencies.
+#      Compiling the native bridge still needs the nethost headers from a .NET
+#      SDK / host pack.
+#   2. PNNL's Angiotensin_AllScans.raw from archive.openms.de, used to smoke-test
+#      the finished wheel.
+#
+# Every download is retried and verified against a pinned SHA-256, and the bridge
+# tag is checked against the FetchContent pin in cmake/cmake_findExternalLibs.cmake
+# so the two cannot drift apart silently.
+#
+# Usage: tools/ci/fetch_thermo_assets.sh <linux-x64|osx-arm64|win-x64> [dest-dir]
+#   dest-dir defaults to the current directory; creates <dest-dir>/thermo-managed
+#   and <dest-dir>/thermo-testdata. Existing, verified files are reused, so the
+#   two directories can be put into a CI cache.
+
+set -euo pipefail
+
+BRIDGE_TAG="v0.2.3"
+declare -A MANAGED_SHA256=(
+  [linux-x64]="c3388188f350280e1532d69e460c2cd76f5c69f4b4e6e4616a1a21e4347f5e4f"
+  [osx-arm64]="0253e156630db5bca4cdd4d401cfec5bfc532349b73b48ed2a60a004e3ff4f80"
+  [win-x64]="ac737effe6e5c4b379bf9fe242ac7c969f7b61616741bfb7241f3fdc9c620581"
+)
+RAW_URL="https://archive.openms.de/openms/testfiles/Angiotensin_AllScans.raw"
+RAW_SHA256="3a0236f719e7c91e3c958f57f4e66ae422803ec3e6a997b9af4d2af395332b9f"
+
+platform="${1:-}"
+dest="${2:-.}"
+if [[ -z "${MANAGED_SHA256[$platform]+x}" ]]; then
+  echo "usage: $0 <linux-x64|osx-arm64|win-x64> [dest-dir]" >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+
+# Guard against the pin in this script and the FetchContent pin diverging.
+if ! grep -A6 'OpenMSThermoBridge$' "${repo_root}/cmake/cmake_findExternalLibs.cmake" \
+     | grep -qE "GIT_TAG[[:space:]]+${BRIDGE_TAG}([[:space:]]|$)"; then
+  echo "error: BRIDGE_TAG=${BRIDGE_TAG} in $0 does not match the GIT_TAG pinned for" >&2
+  echo "       OpenMSThermoBridge in cmake/cmake_findExternalLibs.cmake" >&2
+  exit 1
+fi
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+# download <url> <file> <sha256>: reuse a verified existing file, otherwise fetch
+# with retries and fail loudly on a hash mismatch (never fall back silently).
+download() {
+  local url="$1" file="$2" expected="$3"
+  if [[ -f "$file" ]] && [[ "$(sha256_of "$file")" == "$expected" ]]; then
+    echo "reusing verified $file"
+    return 0
+  fi
+  echo "downloading $url"
+  rm -f "$file"
+  curl --fail --location --silent --show-error \
+       --retry 8 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 \
+       --output "$file" "$url"
+  local actual
+  actual="$(sha256_of "$file")"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "error: SHA-256 mismatch for $file" >&2
+    echo "       expected $expected" >&2
+    echo "       actual   $actual" >&2
+    rm -f "$file"
+    exit 1
+  fi
+}
+
+mkdir -p "${dest}/thermo-managed" "${dest}/thermo-testdata"
+
+# The managed directory is handed to CMake verbatim and installed as-is, so keep the
+# zip out of it. A fully extracted directory (e.g. restored from a CI cache) is reused.
+required_managed=(ThermoWrapperManaged.dll ThermoWrapperManaged.runtimeconfig.json ThermoFisher.CommonCore.RawFileReader.dll)
+managed_complete=true
+for required in "${required_managed[@]}"; do
+  [[ -f "${dest}/thermo-managed/${required}" ]] || managed_complete=false
+done
+if [[ "$managed_complete" == true ]]; then
+  echo "reusing extracted managed bridge in ${dest}/thermo-managed"
+else
+  zip_name="openms-thermo-bridge-managed-${platform}-${BRIDGE_TAG}.zip"
+  zip_path="$(mktemp -d)/${zip_name}"
+  download "https://github.com/jpfeuffer/openms-thermo-bridge/releases/download/${BRIDGE_TAG}/${zip_name}" \
+           "$zip_path" "${MANAGED_SHA256[$platform]}"
+  # cmake -E tar is available on every runner and understands zip on all platforms.
+  (cd "${dest}/thermo-managed" && cmake -E tar xf "$zip_path")
+  rm -rf "$(dirname "$zip_path")"
+  for required in "${required_managed[@]}"; do
+    if [[ ! -f "${dest}/thermo-managed/${required}" ]]; then
+      echo "error: ${required} missing after extracting ${zip_name}" >&2
+      exit 1
+    fi
+  done
+fi
+
+download "$RAW_URL" "${dest}/thermo-testdata/Angiotensin_AllScans.raw" "$RAW_SHA256"
+
+echo "Thermo assets ready:"
+echo "  managed bridge: ${dest}/thermo-managed"
+echo "  RAW test file:  ${dest}/thermo-testdata/Angiotensin_AllScans.raw"

--- a/tools/ci/fetch_thermo_assets.sh
+++ b/tools/ci/fetch_thermo_assets.sh
@@ -33,20 +33,22 @@
 set -euo pipefail
 
 BRIDGE_TAG="v0.2.3"
-declare -A MANAGED_SHA256=(
-  [linux-x64]="c3388188f350280e1532d69e460c2cd76f5c69f4b4e6e4616a1a21e4347f5e4f"
-  [osx-arm64]="0253e156630db5bca4cdd4d401cfec5bfc532349b73b48ed2a60a004e3ff4f80"
-  [win-x64]="ac737effe6e5c4b379bf9fe242ac7c969f7b61616741bfb7241f3fdc9c620581"
-)
 RAW_URL="https://archive.openms.de/openms/testfiles/Angiotensin_AllScans.raw"
 RAW_SHA256="3a0236f719e7c91e3c958f57f4e66ae422803ec3e6a997b9af4d2af395332b9f"
 
 platform="${1:-}"
 dest="${2:-.}"
-if [[ -z "${MANAGED_SHA256[$platform]+x}" ]]; then
-  echo "usage: $0 <linux-x64|osx-arm64|win-x64> [dest-dir]" >&2
-  exit 2
-fi
+# Plain case instead of an associative array: the stock macOS Bash is 3.2, which
+# has no 'declare -A', and the test-wheels job runs this script with that Bash.
+case "$platform" in
+  linux-x64) managed_sha256="c3388188f350280e1532d69e460c2cd76f5c69f4b4e6e4616a1a21e4347f5e4f" ;;
+  osx-arm64) managed_sha256="0253e156630db5bca4cdd4d401cfec5bfc532349b73b48ed2a60a004e3ff4f80" ;;
+  win-x64)   managed_sha256="ac737effe6e5c4b379bf9fe242ac7c969f7b61616741bfb7241f3fdc9c620581" ;;
+  *)
+    echo "usage: $0 <linux-x64|osx-arm64|win-x64> [dest-dir]" >&2
+    exit 2
+    ;;
+esac
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/../.." && pwd)"
@@ -109,7 +111,7 @@ else
   zip_name="openms-thermo-bridge-managed-${platform}-${BRIDGE_TAG}.zip"
   zip_path="$(mktemp -d)/${zip_name}"
   download "https://github.com/jpfeuffer/openms-thermo-bridge/releases/download/${BRIDGE_TAG}/${zip_name}" \
-           "$zip_path" "${MANAGED_SHA256[$platform]}"
+           "$zip_path" "${managed_sha256}"
   # cmake -E tar is available on every runner and understands zip on all platforms.
   (cd "${dest}/thermo-managed" && cmake -E tar xf "$zip_path")
   rm -rf "$(dirname "$zip_path")"

--- a/tools/ci/fetch_thermo_assets.sh
+++ b/tools/ci/fetch_thermo_assets.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+# Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# --------------------------------------------------------------------------
+# $Maintainer: Timo Sachsenberg $
+# $Authors: Timo Sachsenberg $
+# --------------------------------------------------------------------------
+#
 # Fetch the assets the pyOpenMS wheel builds need for native Thermo RAW support,
 # without going through NuGet or the .NET SDK's package restore:
 #
@@ -51,11 +59,14 @@ if ! grep -A6 'OpenMSThermoBridge$' "${repo_root}/cmake/cmake_findExternalLibs.c
   exit 1
 fi
 
+# Hash via stdin: given a file *name*, GNU coreutils escapes backslashes in it and
+# prefixes the whole line with '\' (seen with Git Bash on Windows, where
+# $GITHUB_WORKSPACE is D:\a\...), which would corrupt the extracted digest.
 sha256_of() {
   if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$1" | cut -d' ' -f1
+    sha256sum < "$1" | cut -d' ' -f1
   else
-    shasum -a 256 "$1" | cut -d' ' -f1
+    shasum -a 256 < "$1" | cut -d' ' -f1
   fi
 }
 

--- a/tools/ci/install_dotnet_sdk_linux.sh
+++ b/tools/ci/install_dotnet_sdk_linux.sh
@@ -32,7 +32,20 @@ DOTNET_SDK_SHA512="6503fd9f464d5e3a4f43a881d2b74afc6a2c46ceda74d027f1565b7239f4b
 
 install_dir="${1:-/usr/share/dotnet}"
 
-if [[ -f "${install_dir}/sdk/${DOTNET_SDK_VERSION}/dotnet.dll" ]]; then
+# Reuse an existing installation only if it carries both the pinned SDK and the
+# linux-x64 host pack we are here for. A distro-packaged SDK at the same version
+# may exist without that pack (its host pack uses a distro RID), in which case
+# the pinned archive is extracted on top.
+find_host_pack() {
+  # glob loop rather than ls|head: an unmatched glob must not trip 'set -e -o pipefail'
+  local d
+  for d in "${install_dir}"/packs/Microsoft.NETCore.App.Host.linux-x64/*/runtimes/linux-x64/native; do
+    if [[ -d "$d" ]]; then printf '%s' "$d"; return 0; fi
+  done
+  return 0
+}
+existing_host_pack="$(find_host_pack)"
+if [[ -f "${install_dir}/sdk/${DOTNET_SDK_VERSION}/dotnet.dll" && -n "${existing_host_pack}" && -f "${existing_host_pack}/nethost.h" ]]; then
   echo "reusing .NET SDK ${DOTNET_SDK_VERSION} in ${install_dir}"
 else
   tmp="$(mktemp -d)"
@@ -52,7 +65,7 @@ else
   tar -xzf "${tmp}/dotnet-sdk.tar.gz" -C "${install_dir}"
 fi
 
-host_pack="$(ls -d "${install_dir}"/packs/Microsoft.NETCore.App.Host.linux-x64/*/runtimes/linux-x64/native 2>/dev/null | head -1)"
+host_pack="$(find_host_pack)"
 if [[ -z "${host_pack}" || ! -f "${host_pack}/nethost.h" ]]; then
   echo "error: nethost host pack not found under ${install_dir}/packs" >&2
   exit 1

--- a/tools/ci/install_dotnet_sdk_linux.sh
+++ b/tools/ci/install_dotnet_sdk_linux.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# --------------------------------------------------------------------------
+# $Maintainer: Timo Sachsenberg $
+# $Authors: Timo Sachsenberg $
+# --------------------------------------------------------------------------
+#
+# Install a pinned .NET SDK (linux-x64) from Microsoft's release archive into a
+# directory, verifying the tarball against the SHA-512 Microsoft publishes in
+# https://builds.dotnet.microsoft.com/dotnet/release-metadata/8.0/releases.json.
+#
+# The pyOpenMS wheel build needs this for exactly one thing: the nethost headers
+# and static library in packs/Microsoft.NETCore.App.Host.linux-x64, which the
+# native openms-thermo-bridge compiles against. It is used instead of
+#   * the distro dotnet-sdk RPM: AlmaLinux names its host pack
+#     Microsoft.NETCore.App.Host.rhel.9-x64, which the bridge's
+#     FindDotNetHost.cmake (linux-x64 RID) does not find;
+#   * dotnet-install.sh: a mutable script fetched from a redirecting endpoint
+#     and executed unverified.
+#
+# Usage: tools/ci/install_dotnet_sdk_linux.sh [install-dir]   (default /usr/share/dotnet)
+#   /usr/share/dotnet is a default search location for both FindDotNetHost.cmake
+#   and the nethost runtime resolver, so DOTNET_ROOT is optional there.
+
+set -euo pipefail
+
+DOTNET_SDK_VERSION="8.0.424"
+DOTNET_SDK_URL="https://builds.dotnet.microsoft.com/dotnet/Sdk/${DOTNET_SDK_VERSION}/dotnet-sdk-${DOTNET_SDK_VERSION}-linux-x64.tar.gz"
+DOTNET_SDK_SHA512="6503fd9f464d5e3a4f43a881d2b74afc6a2c46ceda74d027f1565b7239f4b3ec884857c03c0dcd49eb52f384d5ae1fa5aaf135f0a6aabc5518103aceed643c74"
+
+install_dir="${1:-/usr/share/dotnet}"
+
+if [[ -f "${install_dir}/sdk/${DOTNET_SDK_VERSION}/dotnet.dll" ]]; then
+  echo "reusing .NET SDK ${DOTNET_SDK_VERSION} in ${install_dir}"
+else
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  echo "downloading ${DOTNET_SDK_URL}"
+  curl --fail --location --proto '=https' --proto-redir '=https' --silent --show-error \
+       --retry 8 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 900 \
+       --output "${tmp}/dotnet-sdk.tar.gz" "${DOTNET_SDK_URL}"
+  actual="$(sha512sum < "${tmp}/dotnet-sdk.tar.gz" | cut -d' ' -f1)"
+  if [[ "${actual}" != "${DOTNET_SDK_SHA512}" ]]; then
+    echo "error: SHA-512 mismatch for dotnet-sdk-${DOTNET_SDK_VERSION}-linux-x64.tar.gz" >&2
+    echo "       expected ${DOTNET_SDK_SHA512}" >&2
+    echo "       actual   ${actual}" >&2
+    exit 1
+  fi
+  mkdir -p "${install_dir}"
+  tar -xzf "${tmp}/dotnet-sdk.tar.gz" -C "${install_dir}"
+fi
+
+host_pack="$(ls -d "${install_dir}"/packs/Microsoft.NETCore.App.Host.linux-x64/*/runtimes/linux-x64/native 2>/dev/null | head -1)"
+if [[ -z "${host_pack}" || ! -f "${host_pack}/nethost.h" ]]; then
+  echo "error: nethost host pack not found under ${install_dir}/packs" >&2
+  exit 1
+fi
+echo ".NET SDK ${DOTNET_SDK_VERSION} ready in ${install_dir}; nethost pack: ${host_pack}"


### PR DESCRIPTION
Until now no pyopenms wheel could read a Thermo .raw file. The Linux and
Windows wheel jobs passed -DWITH_THERMO_RAW=OFF, and the macOS job built the
reader but the wheel only carried the native bridge library: the managed
half (ThermoWrapperManaged.dll, its runtimeconfig and the Thermo CommonCore
assemblies) stayed behind in install/lib because no wheel repair tool copies
non-native files. The bridge locates those files relative to its own shared
library, and auditwheel/delvewheel/delocate rename and move that library, so
the lookup can never succeed inside a wheel.

Library
- ThermoRawFile resolves the managed directory itself before handing it to
  the bridge: OPENMS_THERMO_MANAGED_DIR (env, skipped with a warning if it
  does not hold the files) first, then <share/OpenMS>/openms_thermo_bridge/managed,
  then the bridge default.
- CMake installs the managed assemblies into
  share/OpenMS/openms_thermo_bridge/managed (component share, .pdb excluded)
  in addition to the bridge's own lib/ copy. pyOpenMS already bundles
  share/OpenMS, so the wheel picks them up with no pyOpenMS build change.
- pyopenms/__init__.py sets OPENMS_THERMO_MANAGED_DIR to the bundled directory
  (unless the user set it, or the wheel carries no bridge). libOpenMS probes
  compiled-in paths before OPENMS_DATA_PATH, so on a machine that still has the
  build or source tree it would otherwise resolve a share/ without the files;
  the Windows CI runner hit exactly that.
- On Windows the bridge imports nethost.dll (the host pack ships an import
  library, not a static one); install it next to the OpenMS libraries so
  installers and delvewheel find it.

Wheel workflow
- Linux x86_64 and Windows now build with WITH_THERMO_RAW=ON; Linux aarch64
  stays OFF (Thermo ships no native libraries for it).
- The managed assemblies come from the bridge's pre-built release zip via
  tools/ci/fetch_thermo_assets.sh: curl with retries, pinned SHA-256 per
  platform, bridge tag cross-checked against the FetchContent pin, cached
  with actions/cache. Passed as OPENMS_THERMO_BRIDGE_PREBUILT_MANAGED_DIR,
  this skips 'dotnet publish' and with it the NuGet restore and the five
  Thermo .nupkg downloads, leaving only the nethost headers from a .NET SDK
  as a build requirement. On Linux that SDK is the pinned 8.0.424 tarball
  from Microsoft, SHA-512 verified by tools/ci/install_dotnet_sdk_linux.sh
  (the distro RPM names its host pack with the rhel.9-x64 RID, which the
  bridge does not search); Windows uses the runner image's SDK and macOS
  setup-dotnet.
- The wheel test suite runs a real RAW load (PNNL Angiotensin_AllScans.raw,
  fetched by the same script) on all three platforms, and test-wheels
  smoke-tests the finished wheel on a fresh runner with only a .NET runtime.

Tests: new test_ThermoRawFile.py checks .raw typing, that the managed
assemblies travel with share/OpenMS and are handed to the reader, and loads a
RAW file when PYOPENMS_THERMO_RAW_TEST_FILE is set.

Validation: built in the contrib_manylinux_2_34 image the workflow uses.
ThermoRawFile_test passes with the default lookup, a valid override and a
bogus override (warning, then fallback); a cibuildwheel cp312 wheel loads
1775 spectra from Angiotensin_AllScans.raw, also with the install tree's
managed directory hidden (which reproduced the Windows failure on the
previous revision). CI on the final head is green on all four wheel builds
and all 20 test-wheels jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NR4rm9vMRQqjLqNXn7AQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - PyOpenMS wheels for Linux x86_64, macOS arm64, and Windows now support reading Thermo RAW files.
  - Thermo RAW data can be loaded and converted through standard OpenMS workflows.
  - Managed Thermo bridge files are bundled and located automatically during RAW processing.

- **Documentation**
  - Added guidance on the required .NET 8+ runtime and managed bridge files.
  - Documented configuration options for locating the bridge and non-standard .NET installations.
  - Linux aarch64 wheels remain without Thermo RAW support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->