### PR TITLE
[FIX,CI] bioconda_deploy: repeat --packages per package for bioconda-utils lint

### DIFF
--- a/.github/workflows/bioconda_deploy.yaml
+++ b/.github/workflows/bioconda_deploy.yaml
@@ -121,7 +121,12 @@ jobs:
       - name: Lint and build OpenMS Bioconda packages
         run: |
           cd bioconda-recipes
-          bioconda-utils lint --packages pyopenms openms-meta
+          # bioconda-utils' --packages option must be repeated per package: it is a
+          # Typer list option (one value per flag), not a single flag taking several
+          # space-separated values. Passing "--packages pyopenms openms-meta" makes
+          # "openms-meta" the positional recipe_folder argument instead of a second
+          # package, which then fails with "path 'openms-meta' does not exist".
+          bioconda-utils lint --packages pyopenms --packages openms-meta
           bioconda-utils build --docker --pkg-dir $GITHUB_WORKSPACE/output --packages openms-meta
           python -m conda_index $GITHUB_WORKSPACE/output
 


### PR DESCRIPTION
## Summary
- Today's nightly "Deploy to Bioconda" run failed in the "Lint and build OpenMS Bioconda packages" step (run [34004204162](https://github.com/OpenMS/OpenMS/actions/runs/34004204162/job/101408347718)), while `Build and Test`, `Release`, `pyopenms-wheels-cibuildwheel` and `Deploy container images` all succeeded on the same nightly commit.
- Root cause: `bioconda-utils` recently migrated its CLI to Typer, where `--packages` is a list option that must be given **once per value**, not a single flag followed by several space-separated values. `bioconda-utils lint --packages pyopenms openms-meta` now parses `openms-meta` as the positional `recipe_folder` argument instead of a second package name, and fails with `path 'openms-meta' does not exist`.
- Fix: pass `--packages` twice — `--packages pyopenms --packages openms-meta` — matching the new CLI's expected usage.
- This workflow intentionally does not pin `bioconda-utils` (see the comments already in the file) so that it surfaces exactly this kind of upstream CLI/pinning breakage; the fix updates our invocation rather than pinning an older version.

## Test plan
- [ ] Nightly `Deploy to Bioconda` workflow succeeds on `nightly` after this change lands (the `lint` step in particular).
- [ ] `bioconda-utils build --docker --pkg-dir ... --packages openms-meta` and `--packages pyopenms` (already single-package, unaffected by this bug) continue to build correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KEYkAXfaKXLtUdQDeT9tN9

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEYkAXfaKXLtUdQDeT9tN9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Bioconda package linting so both `pyopenms` and `openms-meta` are processed correctly during builds.
  - Added clarification to the package validation workflow to prevent path-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->