### PR TITLE
[API,IO,FIX] Preserve Thermo metadata through mzML conversion

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,11 @@ PR - Pull Request (on GitHub), i.e. integration of a new feature or bugfix
 ------------------------------------------------------------------------------------------
 
 General:
+  - Thermo RAW imports preserve sample/method/trailer metadata, SHA-1 provenance, per-scan instrument
+    configurations, MSn/SPS precursor hierarchy and supplemental activation. New reader options expose
+    centroid charges, independently sampled noise arrays and auxiliary detector/PDA data for mzML export.
+    mzML round trips retain independent noise grids, detector array types/units, precursor intensity units,
+    precise timestamps and UTF-8/whitespace in metadata. Requires openms-thermo-bridge 0.3.0.
   - Fix: corrected inconsistent elemental formulas in several NuXL presets, including RNA/DNA UV,
     DEB, NM, and FA fragment adducts (#10031)
   - Qt is no longer needed outside the GUI: the core library and all non-GUI TOPP tools build without

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,8 @@ PR - Pull Request (on GitHub), i.e. integration of a new feature or bugfix
 ------------------------------------------------------------------------------------------
 
 General:
+  - Fix: XML metadata decoding now preserves UTF-8, including Latin-1 characters that previously
+    entered the ASCII fast path. mzML sample comments and attribute whitespace survive round trips.
   - Thermo RAW imports preserve sample/method/trailer metadata, SHA-1 provenance, per-scan instrument
     configurations, MSn/SPS precursor hierarchy and supplemental activation. New reader options expose
     centroid charges, independently sampled noise arrays and auxiliary detector/PDA data for mzML export.

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -606,7 +606,7 @@ endif()
 #------------------------------------------------------------------------------
 # openms-thermo-bridge (Thermo RAW file reading)
 if (WITH_THERMO_RAW)
-  find_package(OpenMSThermoBridge QUIET)
+  find_package(OpenMSThermoBridge 0.3 QUIET)
 
   if(OpenMSThermoBridge_FOUND)
     message(STATUS "openms-thermo-bridge: using system installation")
@@ -617,9 +617,9 @@ if (WITH_THERMO_RAW)
 
     FetchContent_Declare(
       OpenMSThermoBridge
-      GIT_REPOSITORY https://github.com/jpfeuffer/openms-thermo-bridge.git
+      GIT_REPOSITORY https://github.com/OpenMS/openms-thermo-bridge.git
       # Pin to a specific reviewed upstream revision to keep builds reproducible.
-      GIT_TAG        v0.2.3
+      GIT_TAG        4c0edddf5a49879e0470b0ca08cfe9955ceba3c9
     )
 
     # Configure the thermo bridge build options

--- a/doc/thermo_raw_mzml.md
+++ b/doc/thermo_raw_mzml.md
@@ -1,0 +1,73 @@
+# Thermo RAW to mzML with metadata preservation
+
+`ThermoRawFile` requires openms-thermo-bridge 0.3.0 (native and managed components
+from the same revision). It loads source SHA-1, the complete creation timestamp,
+sample fields, user sample fields, embedded method texts and the full scan trailer.
+Vendor values without a confirmed standardized unit are kept under `Thermo ...`
+metadata keys; they are not assigned guessed units.
+
+```cpp
+OpenMS::ThermoRawFile reader;
+OpenMS::ThermoRawFile::Options options;
+options.centroid = true;       // matches TRFP's default peak picking
+options.charge_data = true;    // TRFP --chargeData
+options.noise_data = true;     // TRFP --noiseData
+options.all_detectors = true;  // TRFP --allDetectors
+reader.setOptions(options);
+OpenMS::MSExperiment experiment;
+reader.load("input.raw", experiment);
+OpenMS::MzMLFile().store("output.mzML", experiment);
+```
+
+The same options are exposed in pyOpenMS as `ThermoRawFileOptions` and through
+`ThermoRawFile.getOptions()` / `setOptions()`. The default preserves the acquired
+profile/centroid representation; compare with TRFP's no-peak-picking mode or
+set `centroid = true` on both conversion paths. Optional charge/noise/detector
+exports are disabled by default. Trailer preservation, methods and SHA-1 are on;
+each can be disabled separately to control output size or hashing cost.
+
+| Metadata | OpenMS representation |
+| --- | --- |
+| Default instrument | `MSExperiment.getInstrument()` |
+| Other analyzer/source configurations | `getInstrumentConfigurations()`, referenced by acquisition `instrument_configuration_ref` |
+| Isolation target versus monoisotopic selection | `Precursor.getMZ()` is the selected ion; `isolation window target m/z` metadata preserves the target |
+| MSn hierarchy and SPS | Ordered precursor list with each precursor's `spectrum_ref`; ancestor descriptors retain their own references |
+| Supplemental activation | Separate supplemental CID/HCD and collision energy metadata; main activation remains distinct |
+| Full trailer | Acquisition `Thermo trailer extra`, JSON label/value pairs |
+| Embedded methods | Experiment `Thermo instrument methods`, JSON string array |
+| Native peak charges | Integer data array named `charge array` |
+| Sampled noise | Double-list metadata named `sampled noise m/z array`, `sampled noise intensity array`, `sampled noise baseline array`; written as independent 64-bit mzML binary arrays |
+| PDA spectra | Wavelength coordinates in the peak position slot, absorption scan mode and `mzml coordinate array = wavelength` / `mzml intensity array = absorption` |
+| Detector signals | Chromatograms with original labels/units; pressure/flow/absorption CV array types retained |
+
+Sampled noise is deliberately separate from peak annotations. Its point count
+and mass grid can differ from the spectrum; sorting or restricting spectrum
+peaks does not reorder, truncate or reduce precision in these arrays.
+
+The target is comparable mzML content, not identical XML bytes: OpenMS writes
+retention times in seconds, has its own software/data-processing records and
+compression/index layout, and its peak intensity container is float32. Extra
+vendor metadata is preserved beyond what TRFP writes to mzML. Match centroiding
+and optional export flags before comparing the files. Independently sampled
+noise values and m/z coordinates retain double precision.
+
+Regression coverage includes the standalone `ThermoRawFileMetadata_test` for
+precursor reconstruction, `MzMLFile_test` for synthetic metadata round trips,
+`ExperimentalSettings_test` for configuration ownership, and `ThermoRawFile_test`
+for RAW-to-mzML integration when `ENABLE_THERMO_RAW_TESTS=ON`. Python API tests
+are in `test_ThermoRawFile.py`.
+
+## Building the paired branches locally
+
+The bridge source revision is pinned in `cmake_findExternalLibs.cmake` and the
+vcpkg overlay. The paired bridge is published in
+https://github.com/OpenMS/openms-thermo-bridge/pull/11. To use a local checkout,
+use CMake's standard
+`-DFETCHCONTENT_SOURCE_DIR_OPENMSTHERMOBRIDGE=/absolute/path/to/openms-thermo-bridge`
+override to use the paired checkout. A matching prebuilt managed directory can
+be supplied with `OPENMS_THERMO_BRIDGE_PREBUILT_MANAGED_DIR`; otherwise a .NET 8
+SDK is required. Older 0.2.x system/vcpkg installations are rejected by the
+minimum-version check. The vcpkg overlay builds the matching managed component
+from source and requires a .NET 8 SDK on the build host; it does not depend on an
+unreleased 0.3.0 binary asset. The overlay fetches the pinned GitHub source
+archive with a verified SHA-512 checksum.

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
@@ -29,7 +29,6 @@
 //MISSING:
 // - more than one selected ion per precursor (warning if more than one)
 // - scanWindowList for each acquisition separately (currently for the whole spectrum only)
-// - instrumentConfigurationRef attribute for scan (why should the instrument change between scans? - warning if used)
 // - scanSettingsRef attribute for instrumentConfiguration tag (currently no information there because of missing mapping file entry - warning if used)
 
 // xs:id/xs:idref prefix list
@@ -340,6 +339,10 @@ protected:
       /// Helper method that writes a software
       void writeSoftware_(std::ostream& os, const std::string& id, const Software& software, const Internal::MzMLValidator& validator);
 
+      /// Write one instrument configuration, including its components.
+      void writeInstrument_(std::ostream& os, const std::string& id, const Instrument& instrument,
+                            const std::string& software_id, const Internal::MzMLValidator& validator);
+
       /// Helper method that writes a source file
       void writeSourceFile_(std::ostream& os, const std::string& id, const SourceFile& software, const Internal::MzMLValidator& validator);
 
@@ -404,6 +407,7 @@ protected:
       std::map<std::string, Software> software_;
       /// The data processing list: id => Instrument
       std::map<std::string, Instrument> instruments_;
+      std::string default_instrument_configuration_ref_;
       /// CV terms-path-combinations that have been checked in validateCV_()
       mutable std::map<std::pair<std::string, std::string>, bool> cached_terms_;
       /// The data processing list: id => Instrument

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ThermoRawFileMetadata.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ThermoRawFileMetadata.h
@@ -56,12 +56,12 @@ public:
 
   nlohmann::json precursors(const nlohmann::json& scan)
   {
-    const int scan_number = scan.at("scan_number");
-    const int level = scan.at("ms_level");
+    const int scan_number = scan.at("scan_number").get<int>();
+    const int level = scan.at("ms_level").get<int>();
     const auto& reactions = scan.at("reactions");
     State state;
     state.level = level;
-    state.native_id = scan.at("native_id");
+    state.native_id = scan.at("native_id").get<std::string>();
     if (level == 1)
     {
       filters_[""] = scan_number;
@@ -69,7 +69,7 @@ public:
       return state.precursors;
     }
     std::smatch match;
-    const std::string filter = scan.at("filter");
+    const std::string filter = scan.at("filter").get<std::string>();
     std::string key;
     static const std::regex filter_pattern(R"(ms\d+ (.+?) \[)");
     if (std::regex_search(filter, match, filter_pattern)) { key = match[1]; }
@@ -152,7 +152,7 @@ private:
 
   static bool supplemental_(const nlohmann::json& first, const nlohmann::json& second)
   {
-    const std::string a = first.at("activation"), b = second.at("activation");
+    const std::string a = first.at("activation").get<std::string>(), b = second.at("activation").get<std::string>();
     return first.at("precursor_mass").is_number() && second.at("precursor_mass").is_number()
            && std::abs(first.at("precursor_mass").get<double>() - second.at("precursor_mass").get<double>()) < 0.0001
            && (a == "ElectronTransferDissociation" || a == "ElectronCaptureDissociation")
@@ -198,7 +198,7 @@ private:
     static const std::regex modern_pattern(R"(SPS Masses(?:\s+Continued)?:)");
     for (const auto& entry : scan.at("trailer"))
     {
-      const std::string label = entry.at("label");
+      const std::string label = entry.at("label").get<std::string>();
       if ((! modern && std::regex_match(label, legacy_pattern)) || (modern && std::regex_match(label, modern_pattern)))
       {
         std::istringstream values(entry.at("value").get<std::string>());

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ThermoRawFileMetadata.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ThermoRawFileMetadata.h
@@ -1,0 +1,215 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+#pragma once
+
+#include <cmath>
+#include <locale>
+#include <map>
+#include <nlohmann/json.hpp>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace OpenMS::Internal
+{
+/** @brief Resolve the precursor hierarchy from bridge metadata without fetching
+   peaks. Keeps isolation targets distinct from selected ions, and retains SPS
+   selections and supplemental reactions. The filter fallback follows
+   ThermoRawFileParser. */
+class ThermoRawFileMetadata
+{
+public:
+  static std::string trailer(const nlohmann::json& scan, const std::string& label)
+  {
+    for (const auto& entry : scan.at("trailer"))
+    {
+      if (entry.at("label") == label && entry.at("value").is_string()) { return entry.at("value").get<std::string>(); }
+    }
+    return "";
+  }
+
+  static nlohmann::json number(const std::string& value)
+  {
+    std::istringstream stream(value);
+    stream.imbue(std::locale::classic());
+    double result;
+    if (! (stream >> result) || ! std::isfinite(result)) { return nullptr; }
+    stream >> std::ws;
+    return stream.eof() ? nlohmann::json(result) : nlohmann::json(nullptr);
+  }
+
+  static double selectedIon(double target, const nlohmann::json& mono, double width)
+  {
+    if (! mono.is_number() || mono.get<double>() <= 1e-8) { return target; }
+    double mz = mono.get<double>();
+    if (std::abs(mz - target) <= 0.0001) { return target; }
+    double half = width / 2;
+    if (half <= 2.0) { return mz >= target - 3.0 && mz <= target + 2.5 ? mz : target; }
+    return mz >= target - half && mz <= target + half ? mz : target;
+  }
+
+  nlohmann::json precursors(const nlohmann::json& scan)
+  {
+    const int scan_number = scan.at("scan_number");
+    const int level = scan.at("ms_level");
+    const auto& reactions = scan.at("reactions");
+    State state;
+    state.level = level;
+    state.native_id = scan.at("native_id");
+    if (level == 1)
+    {
+      filters_[""] = scan_number;
+      scans_[scan_number] = state;
+      return state.precursors;
+    }
+    std::smatch match;
+    const std::string filter = scan.at("filter");
+    std::string key;
+    static const std::regex filter_pattern(R"(ms\d+ (.+?) \[)");
+    if (std::regex_search(filter, match, filter_pattern)) { key = match[1]; }
+    int fallback = parentFromFilter_(key);
+    auto master = number(trailer(scan, "Master Scan Number:"));
+    int parent
+      = master.is_number() && master.get<double>() > 0 && master.get<double>() < scan_number ? static_cast<int>(master.get<double>()) : fallback;
+    auto parent_it = scans_.find(parent);
+    std::size_t index = parent_it == scans_.end() ? lastReaction_(reactions) : parent_it->second.reactions;
+    // Tribrid decision-tree scans may refer to a scan of the same MS order.
+    if (index >= reactions.size() && parent_it != scans_.end() && parent_it->second.level == level)
+    {
+      parent = fallback;
+      parent_it = scans_.find(parent);
+      index = parent_it == scans_.end() ? lastReaction_(reactions) : parent_it->second.reactions;
+    }
+    if (index < reactions.size())
+    {
+      const auto& reaction = reactions[index];
+      auto width = number(trailer(scan, "MS" + std::to_string(level) + " Isolation Width:"));
+      if (width.is_null()) { width = reaction.at("isolation_width"); }
+      if (width.is_number() && width.get<double>() < 0) { width = nullptr; }
+      const double target = reaction.at("precursor_mass").get<double>();
+      const double w = width.is_number() ? width.get<double>() : 0.0;
+      const double offset = reaction.at("isolation_offset").is_number() ? reaction.at("isolation_offset").get<double>() : 0.0;
+      auto charge = number(trailer(scan, "Charge State:"));
+      if (charge.is_number() && charge.get<double>() <= 0) { charge = nullptr; }
+      nlohmann::json precursor = {{"target_mz", target},
+                                  {"selected_mz", selectedIon(target, number(trailer(scan, "Monoisotopic M/Z:")), w)},
+                                  {"charge", charge},
+                                  {"width", width},
+                                  {"lower_offset", w / 2 - offset},
+                                  {"upper_offset", w / 2 + offset},
+                                  {"parent_scan", parent_it == scans_.end() ? 0 : parent},
+                                  {"estimate_intensity", true},
+                                  {"spectrum_ref", parent_it == scans_.end() ? "" : parent_it->second.native_id},
+                                  {"activation", reaction},
+                                  {"supplemental", nullptr}};
+      ++index;
+      // The parent's consumed reactions already account for earlier MS levels.
+      // Like TRFP, retain the remaining reaction as supplemental activation even
+      // when the vendor's activation flag or type is unexpected.
+      if (index < reactions.size()) { precursor["supplemental"] = reactions[index++]; }
+      state.precursors.push_back(precursor);
+      auto masses = spsMasses_(scan);
+      // First SPS selection is represented by the primary reaction.
+      for (std::size_t i = 1; i < masses.size(); ++i)
+      {
+        auto sps = precursor;
+        sps["target_mz"] = masses[i];
+        sps["selected_mz"] = masses[i];
+        sps["charge"] = nullptr;
+        sps["estimate_intensity"] = false;
+        state.precursors.push_back(std::move(sps));
+      }
+      if (parent_it != scans_.end())
+      {
+        for (const auto& ancestor : parent_it->second.precursors)
+        {
+          state.precursors.push_back(ancestor);
+        }
+      }
+      state.reactions = index;
+    }
+    if (! key.empty()) { filters_[key] = scan_number; }
+    scans_[scan_number] = state;
+    return state.precursors;
+  }
+
+private:
+  struct State
+  {
+    int level = 1;
+    std::size_t reactions = 0;
+    std::string native_id;
+    nlohmann::json precursors = nlohmann::json::array();
+  };
+  std::map<int, State> scans_;
+  std::map<std::string, int> filters_;
+
+  static bool supplemental_(const nlohmann::json& first, const nlohmann::json& second)
+  {
+    const std::string a = first.at("activation"), b = second.at("activation");
+    return first.at("precursor_mass").is_number() && second.at("precursor_mass").is_number()
+           && std::abs(first.at("precursor_mass").get<double>() - second.at("precursor_mass").get<double>()) < 0.0001
+           && (a == "ElectronTransferDissociation" || a == "ElectronCaptureDissociation")
+           && (b == "HigherEnergyCollisionalDissociation" || b == "CollisionInducedDissociation");
+  }
+  static std::size_t lastReaction_(const nlohmann::json& reactions)
+  {
+    if (reactions.empty()) { return 0; }
+    std::size_t index = reactions.size() - 1;
+    if (index > 0 && supplemental_(reactions[index - 1], reactions[index])) { --index; }
+    return index;
+  }
+  int parentFromFilter_(const std::string& key) const
+  {
+    std::istringstream stream(key);
+    std::vector<std::string> parts;
+    for (std::string part; stream >> part;)
+    {
+      parts.push_back(part);
+    }
+    if (! parts.empty())
+    {
+      const auto mass = parts.back().substr(0, parts.back().find('@'));
+      while (! parts.empty() && parts.back().substr(0, parts.back().find('@')) == mass)
+      {
+        parts.pop_back();
+      }
+    }
+    std::string parent_key;
+    for (const auto& part : parts)
+    {
+      if (! parent_key.empty()) { parent_key += ' '; }
+      parent_key += part;
+    }
+    auto it = filters_.find(parent_key);
+    return it == filters_.end() ? 0 : it->second;
+  }
+  static std::vector<double> spsMasses_(const nlohmann::json& scan)
+  {
+    std::vector<double> result;
+    const bool modern = ! trailer(scan, "SPS Masses:").empty();
+    static const std::regex legacy_pattern(R"(SPS Mass\s+\d+:)");
+    static const std::regex modern_pattern(R"(SPS Masses(?:\s+Continued)?:)");
+    for (const auto& entry : scan.at("trailer"))
+    {
+      const std::string label = entry.at("label");
+      if ((! modern && std::regex_match(label, legacy_pattern)) || (modern && std::regex_match(label, modern_pattern)))
+      {
+        std::istringstream values(entry.at("value").get<std::string>());
+        for (std::string value; std::getline(values, value, ',');)
+        {
+          auto mass = number(value);
+          if (mass.is_number() && mass.get<double>() > 0) { result.push_back(mass.get<double>()); }
+        }
+      }
+    }
+    return result;
+  }
+};
+} // namespace OpenMS::Internal

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/sources.cmake
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/sources.cmake
@@ -53,6 +53,7 @@ set(OpenMS_sources_h ${OpenMS_sources_h} ${sources_h})
 ### PRIVATE link dependency.
 set(private_headers_list_h
 SAX2HandlerAdapter.h
+ThermoRawFileMetadata.h
 MzIdentMLDOMHandler.h
 )
 set(private_sources_h)

--- a/src/openms/include/OpenMS/FORMAT/ThermoRawFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ThermoRawFile.h
@@ -33,6 +33,22 @@ namespace OpenMS
   class OPENMS_DLLAPI ThermoRawFile : public ProgressLogger
   {
   public:
+    /// Optional data exported by ThermoRawFileParser, plus lossless vendor metadata.
+    struct Options
+    {
+      bool centroid = false; ///< Preserve acquired representation by default; true matches TRFP peak picking.
+      bool charge_data = false; ///< Instrument-assigned centroid peak charge array.
+      bool noise_data = false; ///< Noise/baseline arrays and their independent mass coordinates.
+      bool all_detectors = false; ///< UV/PDA/Analog/MSAnalog traces and PDA spectra.
+      bool preserve_trailers = true; ///< Retain all original scan trailer label/value pairs.
+      bool instrument_methods = true; ///< Retain embedded method text once per run.
+      bool checksum = true; ///< Compute source SHA-1 for mzML provenance.
+    };
+
+    /// Returns current loading options.
+    const Options& getOptions() const { return options_; }
+    /// Set loading options.
+    void setOptions(const Options& options) { options_ = options; }
     /**
       @brief Load a Thermo RAW file into an MSExperiment.
 
@@ -47,6 +63,9 @@ namespace OpenMS
       @throws Exception::ParseError if the file cannot be read by the thermo bridge
     */
     void load(const std::string& path, MSExperiment& exp);
+
+  private:
+    Options options_;
   };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/METADATA/ExperimentalSettings.h
+++ b/src/openms/include/OpenMS/METADATA/ExperimentalSettings.h
@@ -18,6 +18,7 @@
 #include <OpenMS/DATASTRUCTURES/DateTime.h>
 
 #include <vector>
+#include <map>
 
 namespace OpenMS
 {
@@ -83,6 +84,15 @@ public:
     /// sets the MS instrument description
     void setInstrument(const Instrument & instrument);
 
+    /// Additional instrument configurations, keyed by mzML ID. Scan acquisitions reference
+    /// these IDs using the "instrument_configuration_ref" meta value. getInstrument()
+    /// continues to describe the default instrument (normally serialized as ic_0).
+    const std::map<std::string, Instrument>& getInstrumentConfigurations() const;
+    /// Mutable instrument configurations.
+    std::map<std::string, Instrument>& getInstrumentConfigurations();
+    /// Replace instrument configurations.
+    void setInstrumentConfigurations(const std::map<std::string, Instrument>& configurations);
+
     /// returns a const reference to the description of the HPLC run
     const HPLC & getHPLC() const;
     /// returns a mutable reference to the description of the HPLC run
@@ -110,6 +120,7 @@ protected:
     std::vector<SourceFile> source_files_;
     std::vector<ContactPerson> contacts_;
     Instrument instrument_;
+    std::map<std::string, Instrument> instrument_configurations_;
     HPLC hplc_;
     DateTime datetime_;
     std::string comment_;

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -24,6 +24,18 @@
 
 namespace OpenMS::Internal
 {
+    namespace
+    {
+      std::string writeXMLAttribute_(const std::string& value)
+      {
+        std::string result = XMLHandler::writeXMLEscape(value);
+        StringUtils::substitute(result, "\r", "&#13;");
+        StringUtils::substitute(result, "\n", "&#10;");
+        StringUtils::substitute(result, "\t", "&#9;");
+        return result;
+      }
+    }
+
 
     thread_local ProgressLogger pg_outer; ///< an extra logger for nested logging
 
@@ -278,12 +290,30 @@ namespace OpenMS::Internal
       // decode all base64 arrays
       MzMLHandlerHelper::decodeBase64Arrays(input_data, options_.getSkipXMLChecks());
 
+      for (auto it = input_data.begin(); it != input_data.end();)
+      {
+        const std::string name = it->meta.getName();
+        if (name == "sampled noise m/z array" || name == "sampled noise intensity array" || name == "sampled noise baseline array")
+        {
+          std::vector<double> values = it->precision == MzMLHandlerHelper::BinaryData::PRE_64 ? it->floats_64 :
+            std::vector<double>(it->floats_32.begin(), it->floats_32.end());
+          spectrum.setMetaValue(name, values);
+          it = input_data.erase(it);
+        }
+        else ++it;
+      }
+
       //look up the precision and the index of the intensity and m/z array
       bool mz_precision_64 = true;
       bool int_precision_64 = true;
       SignedSize mz_index = -1;
       SignedSize int_index = -1;
       MzMLHandlerHelper::computeDataProperties_(input_data, mz_precision_64, mz_index, "m/z array");
+      if (mz_index == -1)
+      {
+        MzMLHandlerHelper::computeDataProperties_(input_data, mz_precision_64, mz_index, "wavelength array");
+        if (mz_index != -1) spectrum.setMetaValue("mzml coordinate array", "wavelength");
+      }
       MzMLHandlerHelper::computeDataProperties_(input_data, int_precision_64, int_index, "intensity array");
 
       //Abort if no m/z or intensity array is present
@@ -361,13 +391,13 @@ namespace OpenMS::Internal
         for (Size i = 0; i < input_data.size(); i++)
         {
           if (static_cast<SignedSize>(i) == int_index || static_cast<SignedSize>(i) == mz_index) continue; // Skip m/z and intensity arrays
-          
+
           MetaArrayInfo info;
           info.input_index = i;
           info.data_type = input_data[i].data_type;
           info.precision = input_data[i].precision;
-            
-          if (input_data[i].data_type == MzMLHandlerHelper::BinaryData::DT_FLOAT) 
+
+          if (input_data[i].data_type == MzMLHandlerHelper::BinaryData::DT_FLOAT)
           {
             info.spectrum_index = meta_float_idx++;
             //create new array
@@ -376,7 +406,7 @@ namespace OpenMS::Internal
             spectrum.getFloatDataArrays().back().reserve(input_data[i].size);
             //copy meta info into MetaInfoDescription
             spectrum.getFloatDataArrays().back().MetaInfoDescription::operator=(input_data[i].meta);
-          } 
+          }
           else if (input_data[i].data_type == MzMLHandlerHelper::BinaryData::DT_INT)
           {
             info.spectrum_index = meta_int_idx++;
@@ -386,7 +416,7 @@ namespace OpenMS::Internal
             spectrum.getIntegerDataArrays().back().reserve(input_data[i].size);
             //copy meta info into MetaInfoDescription
             spectrum.getIntegerDataArrays().back().MetaInfoDescription::operator=(input_data[i].meta);
-          } 
+          }
           else if (input_data[i].data_type == MzMLHandlerHelper::BinaryData::DT_STRING)
           {
             info.spectrum_index = meta_string_idx++;
@@ -492,10 +522,10 @@ namespace OpenMS::Internal
       for (Size n = 0; n < default_arr_length; n++) {
         double mz = mz_precision_64 ? input_data[mz_index].floats_64[n] : input_data[mz_index].floats_32[n];
         double intensity = int_precision_64 ? input_data[int_index].floats_64[n] : input_data[int_index].floats_32[n];
-        
+
         if ((!has_mz_range || peak_file_options.getMZRange().encloses(DPosition<1>(mz))) &&
             (!has_intensity_range || peak_file_options.getIntensityRange().encloses(DPosition<1>(intensity)))) {
-          
+
           tmp.setIntensity(intensity);
           tmp.setMZ(mz);
           spectrum.push_back(tmp);
@@ -534,6 +564,17 @@ namespace OpenMS::Internal
 
       //decode all base64 arrays
       MzMLHandlerHelper::decodeBase64Arrays(input_data, options_.getSkipXMLChecks());
+
+      for (auto& array : input_data)
+      {
+        const std::map<std::string, std::string> types = {{"pressure array", "pressure"}, {"flow rate array", "flow"}, {"detector signal", "nonstandard"}};
+        const auto it = types.find(array.meta.getName());
+        if (it != types.end())
+        {
+          inp_chromatogram.setMetaValue("mzml intensity array", it->second);
+          array.meta.setName("intensity array");
+        }
+      }
 
       //look up the precision and the index of the intensity and m/z array
       bool int_precision_64 = true;
@@ -754,8 +795,8 @@ namespace OpenMS::Internal
       constexpr XMLCh s_external_spectrum_id[] = { 'e','x','t','e','r','n','a','l','S','p','e','c','t','r','u','m','I','D' , 0};
       // constexpr XMLCh s_default_source_file_ref[] = { 'd','e','f','a','u','l','t','S','o','u','r','c','e','F','i','l','e','R','e','f' , 0};
       constexpr XMLCh s_scan_settings_ref[] = { 's','c','a','n','S','e','t','t','i','n','g','s','R','e','f' , 0};
-      
-      
+
+
       open_tags_.push_back(sm_.convert(qname));
       const std::string& tag = open_tags_.back();
 
@@ -824,7 +865,7 @@ namespace OpenMS::Internal
           skip_chromatogram_ = true; // skip the remaining chrom, until endElement(chromatogram)
           ++chromatogram_count_;
         }
-    
+
         chromatogram_ = ChromatogramType();
         default_array_length_ = attributeAsInt_(attributes, s_default_array_length);
         std::string source_file_ref;
@@ -877,10 +918,10 @@ namespace OpenMS::Internal
         {
           return;
         }
-    
+
         // default data processing
         default_processing_ = attributeAsString_(attributes, s_default_data_processing_ref);
-    
+
         //Abort if we need meta data only
         if (options_.getMetadataOnly())
         {
@@ -1037,11 +1078,12 @@ namespace OpenMS::Internal
 
         //spectrumRef - not really needed
 
-        //instrumentConfigurationRef - not really needed: why should a scan have a different instrument?
+        // Preserve the instrument used for this scan (hybrid instruments may switch analyzers).
         std::string instrument_configuration_ref;
-        if (optionalAttributeAsString_(instrument_configuration_ref, attributes, s_instrument_configuration_ref))
+        if (optionalAttributeAsString_(instrument_configuration_ref, attributes, s_instrument_configuration_ref) &&
+            instrument_configuration_ref != default_instrument_configuration_ref_)
         {
-          warning(LOAD, "Unhandled attribute 'instrumentConfigurationRef' in 'scan' tag.");
+          tmp.setMetaValue("instrument_configuration_ref", instrument_configuration_ref);
         }
 
         spec_.getAcquisitionInfo().push_back(std::move(tmp));
@@ -1118,11 +1160,15 @@ namespace OpenMS::Internal
         //instrument
         std::string instrument_ref = attributeAsString_(attributes, s_default_instrument_configuration_ref);
         exp_->setInstrument(instruments_[instrument_ref]);
+        exp_->setInstrumentConfigurations(instruments_);
+        exp_->getInstrumentConfigurations().erase(instrument_ref);
+        default_instrument_configuration_ref_ = instrument_ref;
         //start time
         std::string start_time;
         if (optionalAttributeAsString_(start_time, attributes, s_start_time_stamp))
         {
           exp_->setDateTime(asDateTime_(start_time));
+          if (start_time.size() > 19) exp_->setMetaValue("mzml_start_time_stamp", start_time);
         }
         /*
         //defaultSourceFileRef
@@ -1130,8 +1176,8 @@ namespace OpenMS::Internal
         if (optionalAttributeAsString_(default_source_file_ref, attributes, s_default_source_file_ref))
         {
           exp_->getSourceFiles().push_back(source_files_[default_source_file_ref]);
-        } 
-        */       
+        }
+        */
       }
       else if (tag == "software")
       {
@@ -1385,7 +1431,7 @@ namespace OpenMS::Internal
         logger_.endProgress();
       }
       else if (equal_(qname, s_sourceFileList ))
-      {        
+      {
         for (auto const& ref_sourcefile : source_files_)
         {
           auto& sfs = exp_->getSourceFiles();
@@ -1423,7 +1469,7 @@ namespace OpenMS::Internal
     {
       // the actual value stored in the CVParam
       DataValue termValue = XMLHandler::cvParamToValue(cv_, parent_tag, accession, name, value, unit_accession);
-      
+
       if (termValue == DataValue::EMPTY) return; // conversion failed (warning message was emitted in cvParamToValue())
 
       //------------------------- run ----------------------------
@@ -1446,6 +1492,8 @@ namespace OpenMS::Internal
         if (cv_.isChildOf(accession, "MS:1000513")) // other array names as string
         {
           bin_data_.back().meta.setName(cv_.getTerm(accession).name);
+          if (accession == "MS:1000515" && unit_accession == "UO:0000269")
+            bin_data_.back().meta.setMetaValue("mzml intensity array", "absorption");
         }
 
         if (!MzMLHandlerHelper::handleBinaryDataArrayCVParam(bin_data_, accession, value, name, unit_accession))
@@ -1554,7 +1602,7 @@ namespace OpenMS::Internal
         }
         else if (accession == "MS:1000497") // deprecated: zoom scan is now a scan attribute
         {
-          OPENMS_LOG_DEBUG << "MS:1000497 - zoom scan is now a scan attribute. Reading it for backwards compatibility reasons as spectrum attribute." 
+          OPENMS_LOG_DEBUG << "MS:1000497 - zoom scan is now a scan attribute. Reading it for backwards compatibility reasons as spectrum attribute."
                            << " You can make this warning go away by converting this file using FileConverter to a newer version of the PSI ontology."
                            << " Or by using a recent converter that supports the newest PSI ontology."
                            << std::endl;
@@ -1569,6 +1617,10 @@ namespace OpenMS::Internal
         {
           //No member => meta data
           spec_.setMetaValue("base peak m/z", termValue);
+        }
+        else if (accession == "MS:1000618" || accession == "MS:1000619") // observed wavelength limits
+        {
+          spec_.setMetaValue(cv_.getTerm(accession).name, termValue);
         }
         else if (accession == "MS:1000505") //base peak intensity
         {
@@ -1633,6 +1685,7 @@ namespace OpenMS::Internal
       //------------------------- scanWindow ----------------------------
       else if (parent_tag == "scanWindow")
       {
+        if (!unit_accession.empty() && unit_accession != "MS:1000040") spec_.getInstrumentSettings().getScanWindows().back().setMetaValue("unit_accession", unit_accession);
         if (accession == "MS:1000501") //scan window lower limit
         {
           spec_.getInstrumentSettings().getScanWindows().back().begin = StringUtils::toDouble(value);
@@ -1702,14 +1755,10 @@ namespace OpenMS::Internal
         }
         else if (accession == "MS:1000042") //peak intensity
         {
-          if (in_spectrum_list_)
-          {
-            spec_.getPrecursors().back().setIntensity(StringUtils::toDouble(value));
-          }
-          else
-          {
-            chromatogram_.getPrecursor().setIntensity(StringUtils::toDouble(value));
-          }
+          Precursor& precursor = in_spectrum_list_ ? spec_.getPrecursors().back() : chromatogram_.getPrecursor();
+          precursor.setIntensity(StringUtils::toDouble(value));
+          if (precursor.getIntensity() == 0) precursor.setMetaValue("peak intensity", 0.0);
+          if (!unit_accession.empty() && unit_accession != "MS:1000132") precursor.setMetaValue("peak intensity unit accession", unit_accession);
         }
         else if (accession == "MS:1000633") //possible charge state
         {
@@ -1856,7 +1905,7 @@ namespace OpenMS::Internal
           else if (accession == "MS:1002472") //trap-type collision-induced dissociation
           {
             spec_.getPrecursors().back().getActivationMethods().insert(Precursor::ActivationMethod::TRAP);
-          }          
+          }
           else if (accession == "MS:1002481") //high-energy collision-induced dissociation
           {
             spec_.getPrecursors().back().getActivationMethods().insert(Precursor::ActivationMethod::HCID);
@@ -1873,13 +1922,15 @@ namespace OpenMS::Internal
           {
             spec_.getPrecursors().back().getActivationMethods().insert(Precursor::ActivationMethod::ETD);
           }
-          else if (accession == "MS:1003182"  //electron transfer and collision-induced dissociation
-            || accession == "MS:1002679")  // workaround: supplemental collision-induced dissociation (see https://github.com/compomics/ThermoRawFileParser/issues/182)
+          else if (accession == "MS:1002679" || accession == "MS:1002678" || accession == "MS:1002680")
+          {
+            spec_.getPrecursors().back().setMetaValue(cv_.getTerm(accession).name, termValue);
+          }
+          else if (accession == "MS:1003182") //electron transfer and collision-induced dissociation
           {
             spec_.getPrecursors().back().getActivationMethods().insert(Precursor::ActivationMethod::ETciD);
           }
-          else if (accession == "MS:1002631" //electron transfer and higher-energy collision dissociation
-            || accession == "MS:1002678") // workaround: supplemental beam-type collision-induced dissociation (see https://github.com/compomics/ThermoRawFileParser/issues/182)
+          else if (accession == "MS:1002631") //electron transfer and higher-energy collision dissociation
           {
             spec_.getPrecursors().back().getActivationMethods().insert(Precursor::ActivationMethod::EThcD);
           }
@@ -1894,7 +1945,11 @@ namespace OpenMS::Internal
           else if (accession == "MS:1002000") //LIFT
           {
             spec_.getPrecursors().back().getActivationMethods().insert(Precursor::ActivationMethod::LIFT);
-          }          
+          }
+          else if (cv_.isChildOf(accession, "MS:1000044"))
+          {
+            spec_.getPrecursors().back().setMetaValue(cv_.getTerm(accession).name, termValue);
+          }
           else
             warning(LOAD,std::string("Unhandled cvParam '") + accession + "' in tag '" + parent_tag + "'.");
         }
@@ -1979,7 +2034,7 @@ namespace OpenMS::Internal
           {
             chromatogram_.getPrecursor().getActivationMethods().insert(Precursor::ActivationMethod::TRAP);
           }
-          else if (accession == "MS:1002481") //high-energy collision-induced dissociation          
+          else if (accession == "MS:1002481") //high-energy collision-induced dissociation
           {
             chromatogram_.getPrecursor().getActivationMethods().insert(Precursor::ActivationMethod::HCID);
           }
@@ -2014,7 +2069,7 @@ namespace OpenMS::Internal
           else if (accession == "MS:1002000") //LIFT
           {
             chromatogram_.getPrecursor().getActivationMethods().insert(Precursor::ActivationMethod::LIFT);
-          }          
+          }
           else
           {
             warning(LOAD,std::string("Unhandled cvParam '") + accession + "' in tag '" + parent_tag + "'.");
@@ -2051,6 +2106,7 @@ namespace OpenMS::Internal
               if (in_spectrum_list_)
               {
                 spec_.getPrecursors().back().setIsolationWindowLowerOffset(offset_value);
+                if (offset_value == 0) spec_.getPrecursors().back().setMetaValue("isolation window lower offset", offset_value);
               }
               else
               {
@@ -2066,6 +2122,7 @@ namespace OpenMS::Internal
               if (in_spectrum_list_)
               {
                 spec_.getPrecursors().back().setIsolationWindowUpperOffset(offset_value);
+                if (offset_value == 0) spec_.getPrecursors().back().setMetaValue("isolation window upper offset", offset_value);
               }
               else
               {
@@ -2878,6 +2935,10 @@ namespace OpenMS::Internal
           //No member => meta data
           instruments_[current_id_].getIonSources().back().setMetaValue("matrix application type", " precoated plate");
         }
+        else if (cv_.isChildOf(accession, "MS:1000008"))
+        {
+          instruments_[current_id_].getIonSources().back().setMetaValue("ionization accession", accession);
+        }
         else
           warning(LOAD,std::string("Unhandled cvParam '") + accession + "' in tag '" + parent_tag + "'.");
       }
@@ -2935,6 +2996,10 @@ namespace OpenMS::Internal
         else if (accession == "MS:1000291") //linear ion trap
         {
           instruments_[current_id_].getMassAnalyzers().back().setType(MassAnalyzer::AnalyzerType::LIT);
+        }
+        else if (cv_.isChildOf(accession, "MS:1000443"))
+        {
+          instruments_[current_id_].getMassAnalyzers().back().setMetaValue("mass analyzer accession", accession);
         }
         else if (accession == "MS:1000443") //mass analyzer type (base term)
         {
@@ -3256,6 +3321,10 @@ namespace OpenMS::Internal
         {
           chromatogram_.setChromatogramType(ChromatogramSettings::ChromatogramType::EMISSION_CHROMATOGRAM);
         }
+        else if (accession == "MS:1003019" || accession == "MS:1003020" || accession == "MS:1000626")
+        {
+          chromatogram_.setMetaValue("chromatogram type accession", accession);
+        }
         else if (accession == "MS:1000809")
         {
           chromatogram_.setName(value);
@@ -3457,7 +3526,7 @@ namespace OpenMS::Internal
       std::string cvTerm = "<cvParam cvRef=\"" + StringUtils::prefix(c.id, ':') + "\" accession=\"" + c.id + "\" name=\"" + c.name;
       if (!metaValue.isEmpty())
       {
-        cvTerm += "\" value=\"" + writeXMLEscape(metaValue.toString());
+        cvTerm += "\" value=\"" + writeXMLAttribute_(metaValue.toString());
         if (metaValue.hasUnit())
         {
           //  unitAccession="UO:0000021" unitName="gram" unitCvRef="UO"
@@ -3532,7 +3601,7 @@ namespace OpenMS::Internal
           // if we could not write it as CVTerm we will store it at least as userParam
           if (!writtenAsCVTerm)
           {
-            std::string userParam = "<userParam name=\"" + *key + "\" type=\"";
+            std::string userParam = "<userParam name=\"" + writeXMLAttribute_(*key) + "\" type=\"";
 
             const DataValue& d = meta.getMetaValue(*key);
             //determine type
@@ -3549,7 +3618,7 @@ namespace OpenMS::Internal
               userParam += "xsd:string";
             }
 
-            userParam += "\" value=\"" + writeXMLEscape(d.toString());
+            userParam += "\" value=\"" + writeXMLAttribute_(d.toString());
 
             if (d.hasUnit())
             {
@@ -3633,11 +3702,11 @@ namespace OpenMS::Internal
       }
       else if (!so_term.id.empty())
       {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"" << so_term.id << "\" name=\"" << writeXMLEscape(so_term.name) << "\" />\n";
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"" << so_term.id << "\" name=\"" << writeXMLAttribute_(so_term.name) << "\" />\n";
       }
       else
       {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000799\" name=\"custom unreleased software tool\" value=\"" << writeXMLEscape(software.getName()) << "\" />\n";
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000799\" name=\"custom unreleased software tool\" value=\"" << writeXMLAttribute_(software.getName()) << "\" />\n";
       }
       writeUserParam_(os, software, 3, "/mzML/Software/cvParam/@accession", validator);
       os << "\t\t</software>\n";
@@ -3645,7 +3714,7 @@ namespace OpenMS::Internal
 
     void MzMLHandler::writeSourceFile_(std::ostream& os, const std::string& id, const SourceFile& source_file, const Internal::MzMLValidator& validator)
     {
-      os << "\t\t\t<sourceFile id=\"" << id << "\" name=\"" << writeXMLEscape(source_file.getNameOfFile()) << "\" location=\"" << writeXMLEscape(source_file.getPathToFile()) << "\">\n";
+      os << "\t\t\t<sourceFile id=\"" << id << "\" name=\"" << writeXMLAttribute_(source_file.getNameOfFile()) << "\" location=\"" << writeXMLAttribute_(source_file.getPathToFile()) << "\">\n";
       //checksum
       if (source_file.getChecksumType() == SourceFile::ChecksumType::SHA1)
       {
@@ -3809,611 +3878,14 @@ namespace OpenMS::Internal
       os << "\t\t</dataProcessing>\n";
     }
 
-    void MzMLHandler::writePrecursor_(std::ostream& os, const Precursor& precursor, const Internal::MzMLValidator& validator)
+    void MzMLHandler::writeInstrument_(std::ostream& os, const std::string& id, const Instrument& in,
+                                      const std::string& software_id, const Internal::MzMLValidator& validator)
     {
-      // optional attributes
-      std::string external_spectrum_id =
-          precursor.metaValueExists("external_spectrum_id") ?
-          " externalSpectrumID=\"" + precursor.getMetaValue("external_spectrum_id").toString() + "\"" :
-          "";
-      std::string spectrum_ref =
-          precursor.metaValueExists("spectrum_ref") ?
-          " spectrumRef=\"" + precursor.getMetaValue("spectrum_ref").toString() + "\"":
-          "";
-
-      os << "\t\t\t\t\t<precursor" + external_spectrum_id + spectrum_ref + ">\n";
-      //--------------------------------------------------------------------------------------------
-      //isolation window (optional)
-      //--------------------------------------------------------------------------------------------
-
-      // precursor m/z may come from "selected ion":
-      double mz = precursor.getMetaValue("isolation window target m/z",
-                                         precursor.getMZ());
-      // Note that TPP parsers break when the isolation window is written out
-      // in mzML files and the precursorMZ gets set to zero.
-      if (mz > 0.0 && !options_.getForceTPPCompatability())
-      {
-        os << "\t\t\t\t\t\t<isolationWindow>\n";
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000827\" name=\"isolation window target m/z\" value=\"" << mz << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
-        if (precursor.getIsolationWindowLowerOffset() > 0.0)
-        {
-          os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000828\" name=\"isolation window lower offset\" value=\"" << precursor.getIsolationWindowLowerOffset() << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
-        }
-        if (precursor.getIsolationWindowUpperOffset() > 0.0)
-        {
-          os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000829\" name=\"isolation window upper offset\" value=\"" << precursor.getIsolationWindowUpperOffset() << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
-        }
-        os << "\t\t\t\t\t\t</isolationWindow>\n";
-      }
-      //userParam: no extra object for it => no user parameters
-
-      //--------------------------------------------------------------------------------------------
-      //selected ion list (optional)
-      //--------------------------------------------------------------------------------------------
-      //
-
-      if (options_.getForceTPPCompatability() ||
-          precursor.getCharge() != 0 ||
-          precursor.getIntensity() > 0.0 ||
-          precursor.getDriftTime() >= 0.0 ||
-          precursor.getDriftTimeUnit() == DriftTimeUnit::FAIMS_COMPENSATION_VOLTAGE ||
-          !precursor.getPossibleChargeStates().empty() ||
-          precursor.getMZ() > 0.0)
-      {
-        // precursor m/z may come from "isolation window":
-        mz = precursor.getMetaValue("selected ion m/z",
-                                    precursor.getMZ());
-        os << "\t\t\t\t\t\t<selectedIonList count=\"1\">\n";
-        os << "\t\t\t\t\t\t\t<selectedIon>\n";
-        os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000744\" name=\"selected ion m/z\" value=\"" << mz << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
-        if (options_.getForceTPPCompatability() || precursor.getCharge() != 0)
-        {
-          os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000041\" name=\"charge state\" value=\"" << precursor.getCharge() << "\" />\n";
-        }
-        if ( precursor.getIntensity() > 0.0)
-        {
-          os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000042\" name=\"peak intensity\" value=\"" << precursor.getIntensity() << "\" unitAccession=\"MS:1000132\" unitName=\"percent of base peak\" unitCvRef=\"MS\" />\n";
-        }
-        for (Size j = 0; j < precursor.getPossibleChargeStates().size(); ++j)
-        {
-          os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000633\" name=\"possible charge state\" value=\"" << precursor.getPossibleChargeStates()[j] << "\" />\n";
-        }
-
-        if (precursor.getDriftTime() != IMTypes::DRIFTTIME_NOT_SET)
-        {
-          switch (precursor.getDriftTimeUnit())
-          {
-            default:
-              // assume milliseconds, but warn
-              warning(STORE,std::string("Precursor drift time unit not set, assume milliseconds"));
-              [[fallthrough]];
-            case DriftTimeUnit::MILLISECOND:
-              os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002476\" name=\"ion mobility drift time\" value=\"" << precursor.getDriftTime()
-                  << "\" unitAccession=\"UO:0000028\" unitName=\"millisecond\" unitCvRef=\"UO\" />\n";
-              break;
-            case DriftTimeUnit::VSSC:
-              os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002815\" name=\"inverse reduced ion mobility\" value=\"" << precursor.getDriftTime()
-                  << "\" unitAccession=\"MS:1002814\" unitName=\"volt-second per square centimeter\" unitCvRef=\"MS\" />\n";
-              break;
-            case DriftTimeUnit::CCS:
-              os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002954\" name=\"collisional cross sectional area\" value=\"" << precursor.getDriftTime()
-                  << "\" unitAccession=\"UO:0000324\" unitName=\"square angstrom\" unitCvRef=\"UO\" />\n";
-              break;
-          }
-        }
-        //userParam: no extra object for it => no user parameters
-        os << "\t\t\t\t\t\t\t</selectedIon>\n";
-        os << "\t\t\t\t\t\t</selectedIonList>\n";
-      }
-
-      //--------------------------------------------------------------------------------------------
-      //activation (mandatory)
-      //--------------------------------------------------------------------------------------------
-      os << "\t\t\t\t\t\t<activation>\n";
-#ifdef __clang__
-      #pragma clang diagnostic push
-      #pragma clang diagnostic ignored "-Wfloat-equal"
-#endif
-      if (precursor.getActivationEnergy() != 0)
-#ifdef __clang__
-      #pragma clang diagnostic pop
-#endif
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000509\" name=\"activation energy\" value=\"" << precursor.getActivationEnergy() << "\" unitAccession=\"UO:0000266\" unitName=\"electronvolt\" unitCvRef=\"UO\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::CID) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000133\" name=\"collision-induced dissociation\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::PD) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000134\" name=\"plasma desorption\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::PSD) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000135\" name=\"post-source decay\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::SID) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000136\" name=\"surface-induced dissociation\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::BIRD) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000242\" name=\"blackbody infrared radiative dissociation\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::ECD) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000250\" name=\"electron capture dissociation\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::IMD) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000262\" name=\"infrared multiphoton dissociation\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::SORI) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000282\" name=\"sustained off-resonance irradiation\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::HCID) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002481\" name=\"high-energy collision-induced dissociation\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::HCD) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000422\" name=\"beam-type collision-induced dissociation\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::TRAP) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002472\" name=\"trap-type collision-induced dissociation\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::LCID) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000433\" name=\"low-energy collision-induced dissociation\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::PHD) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000435\" name=\"photodissociation\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::ETD) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000598\" name=\"electron transfer dissociation\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::ETciD) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1003182\" name=\"electron transfer and collision-induced dissociation\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::EThcD) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002631\" name=\"electron transfer and higher-energy collision dissociation\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::PQD) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000599\" name=\"pulsed q dissociation\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::INSOURCE) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1001880\" name=\"in-source collision-induced dissociation\" />\n";
-      }
-      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::LIFT) != 0)
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002000\" name=\"LIFT\" />\n";
-      }      
-      if (precursor.getActivationMethods().empty())
-      {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000044\" name=\"dissociation method\" />\n";
-      }
-      // as "precursor" has no own user param its userParam is stored here;
-      // don't write out parameters that are used internally to distinguish
-      // between precursor m/z values from different sources:
-      writeUserParam_(os, precursor, 7, "/mzML/run/spectrumList/spectrum/precursorList/precursor/activation/cvParam/@accession", validator, {"isolation window target m/z", "selected ion m/z", "external_spectrum_id", "spectrum_ref"});
-      os << "\t\t\t\t\t\t</activation>\n";
-      os << "\t\t\t\t\t</precursor>\n";
-
-    }
-
-    void MzMLHandler::writeProduct_(std::ostream& os, const Product& product, const Internal::MzMLValidator& validator)
-    {
-      os << "\t\t\t\t\t<product>\n";
-      os << "\t\t\t\t\t\t<isolationWindow>\n";
-      os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000827\" name=\"isolation window target m/z\" value=\"" << product.getMZ() << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
-      if ( product.getIsolationWindowLowerOffset() > 0.0)
-      {
-          os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000828\" name=\"isolation window lower offset\" value=\"" << product.getIsolationWindowLowerOffset() << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
-      }
-      if ( product.getIsolationWindowUpperOffset() > 0.0)
-      {
-          os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000829\" name=\"isolation window upper offset\" value=\"" << product.getIsolationWindowUpperOffset() << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
-      }
-      writeUserParam_(os, product, 7, "/mzML/run/spectrumList/spectrum/productList/product/isolationWindow/cvParam/@accession", validator);
-      os << "\t\t\t\t\t\t</isolationWindow>\n";
-      os << "\t\t\t\t\t</product>\n";
-    }
-
-    void MzMLHandler::writeTo(std::ostream& os)
-    {
-      const MapType& exp = *(cexp_);
-      logger_.startProgress(0, exp.size() + exp.getChromatograms().size(), "storing mzML file");
-      int progress = 0;
-      UInt stored_spectra = 0;
-      UInt stored_chromatograms = 0;
-      Internal::MzMLValidator validator(mapping_, cv_);
-
-      std::vector<std::vector< ConstDataProcessingPtr > > dps;
-      //--------------------------------------------------------------------------------------------
-      //header
-      //--------------------------------------------------------------------------------------------
-      writeHeader_(os, exp, dps, validator);
-
-      //--------------------------------------------------------------------------------------------
-      // spectra
-      //--------------------------------------------------------------------------------------------
-      if (!exp.empty())
-      {
-        // INFO : do not try to be smart and skip empty spectra or
-        // chromatograms. There can be very good reasons for this (e.g. if the
-        // meta information needs to be stored here but the actual data is
-        // stored somewhere else).
-        os << "\t\t<spectrumList count=\"" << exp.size() << "\" defaultDataProcessingRef=\"dp_sp_0\">\n";
-
-        // check native ids
-        bool renew_native_ids = false;
-        for (Size s_idx = 0; s_idx < exp.size(); ++s_idx)
-        {
-          if (!StringUtils::has(exp[s_idx].getNativeID(), '='))
-          {
-            renew_native_ids = true;
-            break;
-          }
-        }
-
-        // issue warning if something is wrong
-        if (renew_native_ids)
-        {
-          warning(STORE,std::string("Invalid native IDs detected. Using spectrum identifier nativeID format (spectrum=xsd:nonNegativeInteger) for all spectra."));
-        }
-
-        // write actual data
-        for (Size s_idx = 0; s_idx < exp.size(); ++s_idx)
-        {
-          logger_.setProgress(progress++);
-          const SpectrumType& spec = exp[s_idx];
-          writeSpectrum_(os, spec, s_idx, validator, renew_native_ids, dps);
-          ++stored_spectra;
-        }
-        os << "\t\t</spectrumList>\n";
-      }
-
-      //--------------------------------------------------------------------------------------------
-      // chromatograms
-      //--------------------------------------------------------------------------------------------
-      if (!exp.getChromatograms().empty())
-      {
-        // INFO : do not try to be smart and skip empty spectra or
-        // chromatograms. There can be very good reasons for this (e.g. if the
-        // meta information needs to be stored here but the actual data is
-        // stored somewhere else).
-        os << "\t\t<chromatogramList count=\"" << exp.getChromatograms().size() << "\" defaultDataProcessingRef=\"dp_sp_0\">\n";
-        for (Size c_idx = 0; c_idx != exp.getChromatograms().size(); ++c_idx)
-        {
-          logger_.setProgress(progress++);
-          const ChromatogramType& chromatogram = exp.getChromatograms()[c_idx];
-          writeChromatogram_(os, chromatogram, c_idx, validator);
-          ++stored_chromatograms;
-        }
-        os << "\t\t</chromatogramList>" << "\n";
-      }
-
-      MzMLHandlerHelper::writeFooter_(os, options_, spectra_offsets_, chromatograms_offsets_);
-
-      OPENMS_LOG_DEBUG << stored_spectra << " spectra and " << stored_chromatograms << " chromatograms stored.\n";
-
-      logger_.endProgress(os.tellp());
-    }
-
-    void MzMLHandler::writeHeader_(std::ostream& os,
-                                   const MapType& exp,
-                                   std::vector<std::vector< ConstDataProcessingPtr > >& dps,
-                                   const Internal::MzMLValidator& validator)
-    {
-      os << "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n";
-
-      if (options_.getWriteIndex())
-      {
-        os << "<indexedmzML xmlns=\"http://psi.hupo.org/ms/mzml\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0_idx.xsd\">\n";
-      }
-      os << R"(<mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" accession=")" << writeXMLEscape(exp.getIdentifier()) << "\" version=\"" << version_ << "\">\n";
-      //--------------------------------------------------------------------------------------------
-      // CV list
-      //--------------------------------------------------------------------------------------------
-      os << "\t<cvList count=\"5\">\n"
-         << "\t\t<cv id=\"MS\" fullName=\"Proteomics Standards Initiative Mass Spectrometry Ontology\" URI=\"http://psidev.cvs.sourceforge.net/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo\"/>\n"
-         << "\t\t<cv id=\"UO\" fullName=\"Unit Ontology\" URI=\"http://obo.cvs.sourceforge.net/obo/obo/ontology/phenotype/unit.obo\"/>\n"
-         << "\t\t<cv id=\"BTO\" fullName=\"BrendaTissue545\" version=\"unknown\" URI=\"http://www.brenda-enzymes.info/ontology/tissue/tree/update/update_files/BrendaTissueOBO\"/>\n"
-         << "\t\t<cv id=\"GO\" fullName=\"Gene Ontology - Slim Versions\" version=\"unknown\" URI=\"http://www.geneontology.org/GO_slims/goslim_goa.obo\"/>\n"
-         << "\t\t<cv id=\"PATO\" fullName=\"Quality ontology\" version=\"unknown\" URI=\"http://obo.cvs.sourceforge.net/*checkout*/obo/obo/ontology/phenotype/quality.obo\"/>\n"
-         << "\t</cvList>\n";
-      //--------------------------------------------------------------------------------------------
-      // file content
-      //--------------------------------------------------------------------------------------------
-      os << "\t<fileDescription>\n";
-      os << "\t\t<fileContent>\n";
-      std::map<InstrumentSettings::ScanMode, UInt> file_content;
-      for (Size i = 0; i < exp.size(); ++i)
-      {
-        ++file_content[exp[i].getInstrumentSettings().getScanMode()];
-      }
-      if (file_content.contains(InstrumentSettings::ScanMode::MASSSPECTRUM))
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000294\" name=\"mass spectrum\" />\n";
-      }
-      if (file_content.contains(InstrumentSettings::ScanMode::MS1SPECTRUM))
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000579\" name=\"MS1 spectrum\" />\n";
-      }
-      if (file_content.contains(InstrumentSettings::ScanMode::MSNSPECTRUM))
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000580\" name=\"MSn spectrum\" />\n";
-      }
-      if (file_content.contains(InstrumentSettings::ScanMode::SIM))
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000582\" name=\"SIM spectrum\" />\n";
-      }
-      if (file_content.contains(InstrumentSettings::ScanMode::SRM))
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000583\" name=\"SRM spectrum\" />\n";
-      }
-      if (file_content.contains(InstrumentSettings::ScanMode::CRM))
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000581\" name=\"CRM spectrum\" />\n";
-      }
-      if (file_content.contains(InstrumentSettings::ScanMode::PRECURSOR))
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000341\" name=\"precursor ion spectrum\" />\n";
-      }
-      if (file_content.contains(InstrumentSettings::ScanMode::CNG))
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000325\" name=\"constant neutral gain spectrum\" />\n";
-      }
-      if (file_content.contains(InstrumentSettings::ScanMode::CNL))
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000326\" name=\"constant neutral loss spectrum\" />\n";
-      }
-      if (file_content.contains(InstrumentSettings::ScanMode::EMR))
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000804\" name=\"electromagnetic radiation spectrum\" />\n";
-      }
-      if (file_content.contains(InstrumentSettings::ScanMode::EMISSION))
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000805\" name=\"emission spectrum\" />\n";
-      }
-      if (file_content.contains(InstrumentSettings::ScanMode::ABSORPTION))
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000806\" name=\"absorption spectrum\" />\n";
-      }
-      if (file_content.contains(InstrumentSettings::ScanMode::EMC))
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000789\" name=\"enhanced multiply charged spectrum\" />\n";
-      }
-      if (file_content.contains(InstrumentSettings::ScanMode::TDF))
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000790\" name=\"time-delayed fragmentation spectrum\" />\n";
-      }
-      if (file_content.contains(InstrumentSettings::ScanMode::UNKNOWN) || file_content.empty())
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000294\" name=\"mass spectrum\" />\n";
-      }
-      // writeUserParam_(os, exp, 3, "/mzML/fileDescription/fileContent/cvParam/@accession", validator);
-      os << "\t\t</fileContent>\n";
-
-      //--------------------------------------------------------------------------------------------
-      // source file list
-      //--------------------------------------------------------------------------------------------
-      //find out how many spectra source files need to be written
-      UInt sf_sp_count = 0;
-      for (Size i = 0; i < exp.size(); ++i)
-      {
-        if (exp[i].getSourceFile() != SourceFile())
-        {
-          ++sf_sp_count;
-        }
-      }
-      if (!exp.getSourceFiles().empty() || sf_sp_count > 0)
-      {
-        os << "\t\t<sourceFileList count=\"" << exp.getSourceFiles().size() + sf_sp_count << "\">\n";
-
-        //write source file of run
-        for (Size i = 0; i < exp.getSourceFiles().size(); ++i)
-        {
-          writeSourceFile_(os,"sf_ru_" + StringUtils::toStr(i), exp.getSourceFiles()[i], validator);
-        }
-
-        // write source files of spectra
-        if (sf_sp_count > 0)
-        {
-          const SourceFile sf_default;
-          for (Size i = 0; i < exp.size(); ++i)
-          {
-            if (exp[i].getSourceFile() != sf_default)
-            {
-              writeSourceFile_(os,std::string("sf_sp_") + i, exp[i].getSourceFile(), validator);
-            }
-          }
-        }
-
-        os << "\t\t</sourceFileList>\n";
-      }
-
-      //--------------------------------------------------------------------------------------------
-      // contacts
-      //--------------------------------------------------------------------------------------------
-      for (Size i = 0; i < exp.getContacts().size(); ++i)
-      {
-        const ContactPerson& cp = exp.getContacts()[i];
-        os << "\t\t<contact>\n";
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000586\" name=\"contact name\" value=\"" << writeXMLEscape(cp.getLastName()) << ", " << writeXMLEscape(cp.getFirstName()) << "\" />\n";
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000590\" name=\"contact affiliation\" value=\"" << writeXMLEscape(cp.getInstitution()) << "\" />\n";
-
-        if (!cp.getAddress().empty())
-        {
-          os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000587\" name=\"contact address\" value=\"" << writeXMLEscape(cp.getAddress()) << "\" />\n";
-        }
-        if (!cp.getURL().empty())
-        {
-          os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000588\" name=\"contact URL\" value=\"" << writeXMLEscape(cp.getURL()) << "\" />\n";
-        }
-        if (!cp.getEmail().empty())
-        {
-          os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000589\" name=\"contact email\" value=\"" << writeXMLEscape(cp.getEmail()) << "\" />\n";
-        }
-        if (!cp.getContactInfo().empty())
-        {
-          os << "\t\t\t<userParam name=\"contact_info\" type=\"xsd:string\" value=\"" << writeXMLEscape(cp.getContactInfo()) << "\" />\n";
-        }
-        writeUserParam_(os, cp, 3, "/mzML/fileDescription/contact/cvParam/@accession", validator);
-        os << "\t\t</contact>\n";
-      }
-      os << "\t</fileDescription>\n";
-
-      //--------------------------------------------------------------------------------------------
-      // sample
-      //--------------------------------------------------------------------------------------------
-      const Sample& sa = exp.getSample();
-      os << "\t<sampleList count=\"1\">\n";
-      os << "\t\t<sample id=\"sa_0\" name=\"" << writeXMLEscape(sa.getName()) << "\">\n";
-      if (!sa.getNumber().empty())
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000001\" name=\"sample number\" value=\"" << writeXMLEscape(sa.getNumber()) << "\" />\n";
-      }
-      os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000004\" name=\"sample mass\" value=\"" << sa.getMass() << "\" unitAccession=\"UO:0000021\" unitName=\"gram\" unitCvRef=\"UO\" />\n";
-      os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000005\" name=\"sample volume\" value=\"" << sa.getVolume() << "\" unitAccession=\"UO:0000098\" unitName=\"milliliter\" unitCvRef=\"UO\" />\n";
-      os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000006\" name=\"sample concentration\" value=\"" << sa.getConcentration() << "\" unitAccession=\"UO:0000175\" unitName=\"gram per liter\" unitCvRef=\"UO\" />\n";
-      if (sa.getState() == Sample::SampleState::EMULSION)
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000047\" name=\"emulsion\" />\n";
-      }
-      else if (sa.getState() == Sample::SampleState::GAS)
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000048\" name=\"gas\" />\n";
-      }
-      else if (sa.getState() == Sample::SampleState::LIQUID)
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000049\" name=\"liquid\" />\n";
-      }
-      else if (sa.getState() == Sample::SampleState::SOLID)
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000050\" name=\"solid\" />\n";
-      }
-      else if (sa.getState() == Sample::SampleState::SOLUTION)
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000051\" name=\"solution\" />\n";
-      }
-      else if (sa.getState() == Sample::SampleState::SUSPENSION)
-      {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000052\" name=\"suspension\" />\n";
-      }
-      if (!sa.getComment().empty())
-      {
-        os << "\t\t\t<userParam name=\"comment\" type=\"xsd:string\" value=\"" << writeXMLEscape(sa.getComment()) << "\" />\n";
-      }
-      writeUserParam_(os, sa, 3, "/mzML/sampleList/sample/cvParam/@accession", validator);
-      os << "\t\t</sample>\n";
-      os << "\t</sampleList>\n";
-
-      //--------------------------------------------------------------------------------------------
-      // Software
-      //--------------------------------------------------------------------------------------------
-
-      // instrument software and fallback software is always written (see below)
-      Size num_software(2);
-
-      // Create a list of all different data processings: check if the
-      // DataProcessing of the current spectra/chromatogram is already present
-      // and if not, append it to the dps vector
-      for (Size s = 0; s < exp.size(); ++s)
-      {
-        bool already_present = false;
-        for (Size j = 0; j < dps.size(); j++)
-        {
-          already_present = OpenMS::Helpers::cmpPtrContainer(
-              exp[s].getDataProcessing(), dps[j]);
-          if (already_present) break;
-        }
-        if (!already_present)
-        {
-          dps.push_back(exp[s].getDataProcessing());
-          num_software += exp[s].getDataProcessing().size();
-        }
-      }
-      for (Size s = 0; s < exp.getChromatograms().size(); ++s)
-      {
-        bool already_present = false;
-        for (Size j = 0; j < dps.size(); j++)
-        {
-          already_present = OpenMS::Helpers::cmpPtrContainer(
-              exp.getChromatograms()[s].getDataProcessing(), dps[j]);
-          if (already_present) break;
-        }
-        if (!already_present)
-        {
-          dps.push_back(exp.getChromatograms()[s].getDataProcessing());
-          num_software += exp.getChromatograms()[s].getDataProcessing().size();
-        }
-      }
-
-      // count binary data array software
-      Size num_bi_software(0);
-
-      for (Size s = 0; s < exp.size(); ++s)
-      {
-        for (Size m = 0; m < exp[s].getFloatDataArrays().size(); ++m)
-        {
-          for (Size i = 0; i < exp[s].getFloatDataArrays()[m].getDataProcessing().size(); ++i)
-          {
-            ++num_bi_software;
-          }
-        }
-      }
-
-      os << "\t<softwareList count=\"" << num_software + num_bi_software << "\">\n";
-
-      // write instrument software
-      writeSoftware_(os, "so_in_0", exp.getInstrument().getSoftware(), validator);
-
-      // write fallback software
-      writeSoftware_(os, "so_default", Software(), validator);
-
-      // write the software of the dps
-      for (Size s1 = 0; s1 != dps.size(); ++s1)
-      {
-        for (Size s2 = 0; s2 != dps[s1].size(); ++s2)
-        {
-          writeSoftware_(os,std::string("so_dp_sp_") + s1 + "_pm_" + s2, dps[s1][s2]->getSoftware(), validator);
-        }
-      }
-
-      //write data processing (for each binary data array)
-      for (Size s = 0; s < exp.size(); ++s)
-      {
-        for (Size m = 0; m < exp[s].getFloatDataArrays().size(); ++m)
-        {
-          for (Size i = 0; i < exp[s].getFloatDataArrays()[m].getDataProcessing().size(); ++i)
-          {
-            writeSoftware_(os,std::string("so_dp_sp_") + s + "_bi_" + m + "_pm_" + i,
-                exp[s].getFloatDataArrays()[m].getDataProcessing()[i]->getSoftware(), validator);
-          }
-        }
-      }
-      os << "\t</softwareList>\n";
-
-      //--------------------------------------------------------------------------------------------
-      // instrument configuration (enclosing ion source, mass analyzer and detector)
-      //--------------------------------------------------------------------------------------------
-      const Instrument& in = exp.getInstrument();
-      os << "\t<instrumentConfigurationList count=\"1\">\n";
-      os << "\t\t<instrumentConfiguration id=\"ic_0\">\n";
-      ControlledVocabulary::CVTerm in_term = getChildWithName_("MS:1000031", in.getName());
+      os << "\t\t<instrumentConfiguration id=\"" << writeXMLAttribute_(id) << "\">\n";
+      ControlledVocabulary::CVTerm in_term = getChildWithName_("MS:1000031", (in.getName().empty() ? in.getModel() : in.getName()));
       if (!in_term.id.empty())
       {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"" << in_term.id << "\" name=\"" << writeXMLEscape(in_term.name) << "\" />\n";
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"" << in_term.id << "\" name=\"" << writeXMLAttribute_(in_term.name) << "\" />\n";
       }
       else
       {
@@ -4422,7 +3894,7 @@ namespace OpenMS::Internal
 
       if (!in.getCustomizations().empty())
       {
-        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000032\" name=\"customization\" value=\"" << writeXMLEscape(in.getCustomizations()) << "\" />\n";
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000032\" name=\"customization\" value=\"" << writeXMLAttribute_(in.getCustomizations()) << "\" />\n";
       }
 
       //ion optics
@@ -4561,7 +4033,11 @@ namespace OpenMS::Internal
             os << "\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000485\" name=\"nanospray inlet\" />\n";
           }
 
-          if (so.getIonizationMethod() == IonSource::IonizationMethod::APCI)
+          if (so.metaValueExists("ionization accession"))
+          {
+            os << "\t\t\t\t\t" << cv_.getTerm(so.getMetaValue("ionization accession").toString()).toXMLString("MS") << "\n";
+          }
+          else if (so.getIonizationMethod() == IonSource::IonizationMethod::APCI)
           {
             os << "\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000070\" name=\"atmospheric pressure chemical ionization\" />\n";
           }
@@ -4742,7 +4218,7 @@ namespace OpenMS::Internal
             os << "\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000008\" name=\"ionization type\" />\n";
           }
 
-          writeUserParam_(os, so, 5, "/mzML/instrumentConfigurationList/instrumentConfiguration/componentList/source/cvParam/@accession", validator);
+          writeUserParam_(os, so, 5, "/mzML/instrumentConfigurationList/instrumentConfiguration/componentList/source/cvParam/@accession", validator, {"ionization accession"});
           os << "\t\t\t\t</source>\n";
         }
         //FORCED
@@ -4777,7 +4253,11 @@ namespace OpenMS::Internal
             os << "\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000105\" name=\"reflectron off\" />\n";
           }
 
-          if (ma.getType() == MassAnalyzer::AnalyzerType::FOURIERTRANSFORM)
+          if (ma.metaValueExists("mass analyzer accession"))
+          {
+            os << "\t\t\t\t\t" << cv_.getTerm(ma.getMetaValue("mass analyzer accession").toString()).toXMLString("MS") << "\n";
+          }
+          else if (ma.getType() == MassAnalyzer::AnalyzerType::FOURIERTRANSFORM)
           {
             os << "\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000079\" name=\"fourier transform ion cyclotron resonance mass spectrometer\" />\n";
           }
@@ -4834,7 +4314,7 @@ namespace OpenMS::Internal
             os << "\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000443\" name=\"mass analyzer type\" />\n";
           }
 
-          writeUserParam_(os, ma, 5, "/mzML/instrumentConfigurationList/instrumentConfiguration/componentList/analyzer/cvParam/@accession", validator);
+          writeUserParam_(os, ma, 5, "/mzML/instrumentConfigurationList/instrumentConfiguration/componentList/analyzer/cvParam/@accession", validator, {"mass analyzer accession"});
           os << "\t\t\t\t</analyzer>\n";
         }
         //FORCED
@@ -4971,8 +4451,626 @@ namespace OpenMS::Internal
         }
         os << "\t\t\t</componentList>\n";
       }
-      os << "\t\t\t<softwareRef ref=\"so_in_0\" />\n";
+      os << "\t\t\t<softwareRef ref=\"" << writeXMLAttribute_(software_id) << "\" />\n";
       os << "\t\t</instrumentConfiguration>\n";
+
+    }
+
+    void MzMLHandler::writePrecursor_(std::ostream& os, const Precursor& precursor, const Internal::MzMLValidator& validator)
+    {
+      // optional attributes
+      std::string external_spectrum_id =
+          precursor.metaValueExists("external_spectrum_id") ?
+          " externalSpectrumID=\"" + writeXMLAttribute_(precursor.getMetaValue("external_spectrum_id").toString()) + "\"" :
+          "";
+      std::string spectrum_ref =
+          precursor.metaValueExists("spectrum_ref") ?
+          " spectrumRef=\"" + writeXMLAttribute_(precursor.getMetaValue("spectrum_ref").toString()) + "\"":
+          "";
+
+      os << "\t\t\t\t\t<precursor" + external_spectrum_id + spectrum_ref + ">\n";
+      //--------------------------------------------------------------------------------------------
+      //isolation window (optional)
+      //--------------------------------------------------------------------------------------------
+
+      // precursor m/z may come from "selected ion":
+      double mz = precursor.getMetaValue("isolation window target m/z",
+                                         precursor.getMZ());
+      // Note that TPP parsers break when the isolation window is written out
+      // in mzML files and the precursorMZ gets set to zero.
+      if (mz > 0.0 && !options_.getForceTPPCompatability())
+      {
+        os << "\t\t\t\t\t\t<isolationWindow>\n";
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000827\" name=\"isolation window target m/z\" value=\"" << mz << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
+        if (precursor.getIsolationWindowLowerOffset() > 0.0 || precursor.metaValueExists("isolation window lower offset"))
+        {
+          os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000828\" name=\"isolation window lower offset\" value=\"" << (precursor.getIsolationWindowLowerOffset() != 0.0 ? precursor.getIsolationWindowLowerOffset() : double(precursor.getMetaValue("isolation window lower offset", 0.0))) << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
+        }
+        if (precursor.getIsolationWindowUpperOffset() > 0.0 || precursor.metaValueExists("isolation window upper offset"))
+        {
+          os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000829\" name=\"isolation window upper offset\" value=\"" << (precursor.getIsolationWindowUpperOffset() != 0.0 ? precursor.getIsolationWindowUpperOffset() : double(precursor.getMetaValue("isolation window upper offset", 0.0))) << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
+        }
+        os << "\t\t\t\t\t\t</isolationWindow>\n";
+      }
+      //userParam: no extra object for it => no user parameters
+
+      //--------------------------------------------------------------------------------------------
+      //selected ion list (optional)
+      //--------------------------------------------------------------------------------------------
+      //
+
+      if (options_.getForceTPPCompatability() ||
+          precursor.getCharge() != 0 ||
+          precursor.getIntensity() > 0.0 ||
+          precursor.getDriftTime() >= 0.0 ||
+          precursor.getDriftTimeUnit() == DriftTimeUnit::FAIMS_COMPENSATION_VOLTAGE ||
+          !precursor.getPossibleChargeStates().empty() ||
+          precursor.getMZ() > 0.0)
+      {
+        // precursor m/z may come from "isolation window":
+        mz = precursor.getMetaValue("selected ion m/z",
+                                    precursor.getMZ());
+        os << "\t\t\t\t\t\t<selectedIonList count=\"1\">\n";
+        os << "\t\t\t\t\t\t\t<selectedIon>\n";
+        os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000744\" name=\"selected ion m/z\" value=\"" << mz << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
+        if (options_.getForceTPPCompatability() || precursor.getCharge() != 0)
+        {
+          os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000041\" name=\"charge state\" value=\"" << precursor.getCharge() << "\" />\n";
+        }
+        if (precursor.getIntensity() > 0.0 || precursor.metaValueExists("peak intensity"))
+        {
+          const auto& unit = cv_.getTerm(precursor.getMetaValue("peak intensity unit accession", "MS:1000132").toString());
+          os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000042\" name=\"peak intensity\" value=\"" << precursor.getIntensity()
+             << "\" unitAccession=\"" << unit.id << "\" unitName=\"" << unit.name << "\" unitCvRef=\"" << unit.id.substr(0, unit.id.find(':')) << "\" />\n";
+        }
+        for (Size j = 0; j < precursor.getPossibleChargeStates().size(); ++j)
+        {
+          os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000633\" name=\"possible charge state\" value=\"" << precursor.getPossibleChargeStates()[j] << "\" />\n";
+        }
+
+        if (precursor.getDriftTime() != IMTypes::DRIFTTIME_NOT_SET)
+        {
+          switch (precursor.getDriftTimeUnit())
+          {
+            default:
+              // assume milliseconds, but warn
+              warning(STORE,std::string("Precursor drift time unit not set, assume milliseconds"));
+              [[fallthrough]];
+            case DriftTimeUnit::MILLISECOND:
+              os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002476\" name=\"ion mobility drift time\" value=\"" << precursor.getDriftTime()
+                  << "\" unitAccession=\"UO:0000028\" unitName=\"millisecond\" unitCvRef=\"UO\" />\n";
+              break;
+            case DriftTimeUnit::VSSC:
+              os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002815\" name=\"inverse reduced ion mobility\" value=\"" << precursor.getDriftTime()
+                  << "\" unitAccession=\"MS:1002814\" unitName=\"volt-second per square centimeter\" unitCvRef=\"MS\" />\n";
+              break;
+            case DriftTimeUnit::CCS:
+              os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002954\" name=\"collisional cross sectional area\" value=\"" << precursor.getDriftTime()
+                  << "\" unitAccession=\"UO:0000324\" unitName=\"square angstrom\" unitCvRef=\"UO\" />\n";
+              break;
+          }
+        }
+        //userParam: no extra object for it => no user parameters
+        os << "\t\t\t\t\t\t\t</selectedIon>\n";
+        os << "\t\t\t\t\t\t</selectedIonList>\n";
+      }
+
+      //--------------------------------------------------------------------------------------------
+      //activation (mandatory)
+      //--------------------------------------------------------------------------------------------
+      os << "\t\t\t\t\t\t<activation>\n";
+#ifdef __clang__
+      #pragma clang diagnostic push
+      #pragma clang diagnostic ignored "-Wfloat-equal"
+#endif
+      if (precursor.getActivationEnergy() != 0)
+#ifdef __clang__
+      #pragma clang diagnostic pop
+#endif
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000509\" name=\"activation energy\" value=\"" << precursor.getActivationEnergy() << "\" unitAccession=\"UO:0000266\" unitName=\"electronvolt\" unitCvRef=\"UO\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::CID) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000133\" name=\"collision-induced dissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::PD) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000134\" name=\"plasma desorption\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::PSD) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000135\" name=\"post-source decay\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::SID) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000136\" name=\"surface-induced dissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::BIRD) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000242\" name=\"blackbody infrared radiative dissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::ECD) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000250\" name=\"electron capture dissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::IMD) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000262\" name=\"infrared multiphoton dissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::SORI) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000282\" name=\"sustained off-resonance irradiation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::HCID) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002481\" name=\"high-energy collision-induced dissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::HCD) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000422\" name=\"beam-type collision-induced dissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::TRAP) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002472\" name=\"trap-type collision-induced dissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::LCID) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000433\" name=\"low-energy collision-induced dissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::PHD) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000435\" name=\"photodissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::ETD) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000598\" name=\"electron transfer dissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::ETciD) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1003182\" name=\"electron transfer and collision-induced dissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::EThcD) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002631\" name=\"electron transfer and higher-energy collision dissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::PQD) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000599\" name=\"pulsed q dissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::INSOURCE) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1001880\" name=\"in-source collision-induced dissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::ActivationMethod::LIFT) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002000\" name=\"LIFT\" />\n";
+      }
+      if (precursor.getActivationMethods().empty())
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000044\" name=\"dissociation method\" />\n";
+      }
+      // as "precursor" has no own user param its userParam is stored here;
+      // don't write out parameters that are used internally to distinguish
+      // between precursor m/z values from different sources:
+      writeUserParam_(os, precursor, 7, "/mzML/run/spectrumList/spectrum/precursorList/precursor/activation/cvParam/@accession", validator, {"isolation window target m/z", "selected ion m/z", "external_spectrum_id", "spectrum_ref", "peak intensity unit accession", "peak intensity", "isolation window lower offset", "isolation window upper offset"});
+      os << "\t\t\t\t\t\t</activation>\n";
+      os << "\t\t\t\t\t</precursor>\n";
+
+    }
+
+    void MzMLHandler::writeProduct_(std::ostream& os, const Product& product, const Internal::MzMLValidator& validator)
+    {
+      os << "\t\t\t\t\t<product>\n";
+      os << "\t\t\t\t\t\t<isolationWindow>\n";
+      os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000827\" name=\"isolation window target m/z\" value=\"" << product.getMZ() << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
+      if ( product.getIsolationWindowLowerOffset() > 0.0)
+      {
+          os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000828\" name=\"isolation window lower offset\" value=\"" << product.getIsolationWindowLowerOffset() << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
+      }
+      if ( product.getIsolationWindowUpperOffset() > 0.0)
+      {
+          os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000829\" name=\"isolation window upper offset\" value=\"" << product.getIsolationWindowUpperOffset() << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
+      }
+      writeUserParam_(os, product, 7, "/mzML/run/spectrumList/spectrum/productList/product/isolationWindow/cvParam/@accession", validator);
+      os << "\t\t\t\t\t\t</isolationWindow>\n";
+      os << "\t\t\t\t\t</product>\n";
+    }
+
+    void MzMLHandler::writeTo(std::ostream& os)
+    {
+      const MapType& exp = *(cexp_);
+      logger_.startProgress(0, exp.size() + exp.getChromatograms().size(), "storing mzML file");
+      int progress = 0;
+      UInt stored_spectra = 0;
+      UInt stored_chromatograms = 0;
+      Internal::MzMLValidator validator(mapping_, cv_);
+
+      std::vector<std::vector< ConstDataProcessingPtr > > dps;
+      //--------------------------------------------------------------------------------------------
+      //header
+      //--------------------------------------------------------------------------------------------
+      writeHeader_(os, exp, dps, validator);
+
+      //--------------------------------------------------------------------------------------------
+      // spectra
+      //--------------------------------------------------------------------------------------------
+      if (!exp.empty())
+      {
+        // INFO : do not try to be smart and skip empty spectra or
+        // chromatograms. There can be very good reasons for this (e.g. if the
+        // meta information needs to be stored here but the actual data is
+        // stored somewhere else).
+        os << "\t\t<spectrumList count=\"" << exp.size() << "\" defaultDataProcessingRef=\"dp_sp_0\">\n";
+
+        // check native ids
+        bool renew_native_ids = false;
+        for (Size s_idx = 0; s_idx < exp.size(); ++s_idx)
+        {
+          if (!StringUtils::has(exp[s_idx].getNativeID(), '='))
+          {
+            renew_native_ids = true;
+            break;
+          }
+        }
+
+        // issue warning if something is wrong
+        if (renew_native_ids)
+        {
+          warning(STORE,std::string("Invalid native IDs detected. Using spectrum identifier nativeID format (spectrum=xsd:nonNegativeInteger) for all spectra."));
+        }
+
+        // write actual data
+        for (Size s_idx = 0; s_idx < exp.size(); ++s_idx)
+        {
+          logger_.setProgress(progress++);
+          const SpectrumType& spec = exp[s_idx];
+          writeSpectrum_(os, spec, s_idx, validator, renew_native_ids, dps);
+          ++stored_spectra;
+        }
+        os << "\t\t</spectrumList>\n";
+      }
+
+      //--------------------------------------------------------------------------------------------
+      // chromatograms
+      //--------------------------------------------------------------------------------------------
+      if (!exp.getChromatograms().empty())
+      {
+        // INFO : do not try to be smart and skip empty spectra or
+        // chromatograms. There can be very good reasons for this (e.g. if the
+        // meta information needs to be stored here but the actual data is
+        // stored somewhere else).
+        os << "\t\t<chromatogramList count=\"" << exp.getChromatograms().size() << "\" defaultDataProcessingRef=\"dp_sp_0\">\n";
+        for (Size c_idx = 0; c_idx != exp.getChromatograms().size(); ++c_idx)
+        {
+          logger_.setProgress(progress++);
+          const ChromatogramType& chromatogram = exp.getChromatograms()[c_idx];
+          writeChromatogram_(os, chromatogram, c_idx, validator);
+          ++stored_chromatograms;
+        }
+        os << "\t\t</chromatogramList>" << "\n";
+      }
+
+      MzMLHandlerHelper::writeFooter_(os, options_, spectra_offsets_, chromatograms_offsets_);
+
+      OPENMS_LOG_DEBUG << stored_spectra << " spectra and " << stored_chromatograms << " chromatograms stored.\n";
+
+      logger_.endProgress(os.tellp());
+    }
+
+    void MzMLHandler::writeHeader_(std::ostream& os,
+                                   const MapType& exp,
+                                   std::vector<std::vector< ConstDataProcessingPtr > >& dps,
+                                   const Internal::MzMLValidator& validator)
+    {
+      os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+
+      if (options_.getWriteIndex())
+      {
+        os << "<indexedmzML xmlns=\"http://psi.hupo.org/ms/mzml\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0_idx.xsd\">\n";
+      }
+      os << R"(<mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" accession=")" << writeXMLAttribute_(exp.getIdentifier()) << "\" version=\"" << version_ << "\">\n";
+      //--------------------------------------------------------------------------------------------
+      // CV list
+      //--------------------------------------------------------------------------------------------
+      os << "\t<cvList count=\"5\">\n"
+         << "\t\t<cv id=\"MS\" fullName=\"Proteomics Standards Initiative Mass Spectrometry Ontology\" URI=\"http://psidev.cvs.sourceforge.net/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo\"/>\n"
+         << "\t\t<cv id=\"UO\" fullName=\"Unit Ontology\" URI=\"http://obo.cvs.sourceforge.net/obo/obo/ontology/phenotype/unit.obo\"/>\n"
+         << "\t\t<cv id=\"BTO\" fullName=\"BrendaTissue545\" version=\"unknown\" URI=\"http://www.brenda-enzymes.info/ontology/tissue/tree/update/update_files/BrendaTissueOBO\"/>\n"
+         << "\t\t<cv id=\"GO\" fullName=\"Gene Ontology - Slim Versions\" version=\"unknown\" URI=\"http://www.geneontology.org/GO_slims/goslim_goa.obo\"/>\n"
+         << "\t\t<cv id=\"PATO\" fullName=\"Quality ontology\" version=\"unknown\" URI=\"http://obo.cvs.sourceforge.net/*checkout*/obo/obo/ontology/phenotype/quality.obo\"/>\n"
+         << "\t</cvList>\n";
+      //--------------------------------------------------------------------------------------------
+      // file content
+      //--------------------------------------------------------------------------------------------
+      os << "\t<fileDescription>\n";
+      os << "\t\t<fileContent>\n";
+      std::map<InstrumentSettings::ScanMode, UInt> file_content;
+      for (Size i = 0; i < exp.size(); ++i)
+      {
+        ++file_content[exp[i].getInstrumentSettings().getScanMode()];
+      }
+      if (file_content.contains(InstrumentSettings::ScanMode::MASSSPECTRUM))
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000294\" name=\"mass spectrum\" />\n";
+      }
+      if (file_content.contains(InstrumentSettings::ScanMode::MS1SPECTRUM))
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000579\" name=\"MS1 spectrum\" />\n";
+      }
+      if (file_content.contains(InstrumentSettings::ScanMode::MSNSPECTRUM))
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000580\" name=\"MSn spectrum\" />\n";
+      }
+      if (file_content.contains(InstrumentSettings::ScanMode::SIM))
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000582\" name=\"SIM spectrum\" />\n";
+      }
+      if (file_content.contains(InstrumentSettings::ScanMode::SRM))
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000583\" name=\"SRM spectrum\" />\n";
+      }
+      if (file_content.contains(InstrumentSettings::ScanMode::CRM))
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000581\" name=\"CRM spectrum\" />\n";
+      }
+      if (file_content.contains(InstrumentSettings::ScanMode::PRECURSOR))
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000341\" name=\"precursor ion spectrum\" />\n";
+      }
+      if (file_content.contains(InstrumentSettings::ScanMode::CNG))
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000325\" name=\"constant neutral gain spectrum\" />\n";
+      }
+      if (file_content.contains(InstrumentSettings::ScanMode::CNL))
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000326\" name=\"constant neutral loss spectrum\" />\n";
+      }
+      if (file_content.contains(InstrumentSettings::ScanMode::EMR))
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000804\" name=\"electromagnetic radiation spectrum\" />\n";
+      }
+      if (file_content.contains(InstrumentSettings::ScanMode::EMISSION))
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000805\" name=\"emission spectrum\" />\n";
+      }
+      if (file_content.contains(InstrumentSettings::ScanMode::ABSORPTION))
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000806\" name=\"absorption spectrum\" />\n";
+      }
+      if (file_content.contains(InstrumentSettings::ScanMode::EMC))
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000789\" name=\"enhanced multiply charged spectrum\" />\n";
+      }
+      if (file_content.contains(InstrumentSettings::ScanMode::TDF))
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000790\" name=\"time-delayed fragmentation spectrum\" />\n";
+      }
+      if (file_content.contains(InstrumentSettings::ScanMode::UNKNOWN) || file_content.empty())
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000294\" name=\"mass spectrum\" />\n";
+      }
+      // writeUserParam_(os, exp, 3, "/mzML/fileDescription/fileContent/cvParam/@accession", validator);
+      os << "\t\t</fileContent>\n";
+
+      //--------------------------------------------------------------------------------------------
+      // source file list
+      //--------------------------------------------------------------------------------------------
+      //find out how many spectra source files need to be written
+      UInt sf_sp_count = 0;
+      for (Size i = 0; i < exp.size(); ++i)
+      {
+        if (exp[i].getSourceFile() != SourceFile())
+        {
+          ++sf_sp_count;
+        }
+      }
+      if (!exp.getSourceFiles().empty() || sf_sp_count > 0)
+      {
+        os << "\t\t<sourceFileList count=\"" << exp.getSourceFiles().size() + sf_sp_count << "\">\n";
+
+        //write source file of run
+        for (Size i = 0; i < exp.getSourceFiles().size(); ++i)
+        {
+          writeSourceFile_(os,"sf_ru_" + StringUtils::toStr(i), exp.getSourceFiles()[i], validator);
+        }
+
+        // write source files of spectra
+        if (sf_sp_count > 0)
+        {
+          const SourceFile sf_default;
+          for (Size i = 0; i < exp.size(); ++i)
+          {
+            if (exp[i].getSourceFile() != sf_default)
+            {
+              writeSourceFile_(os,std::string("sf_sp_") + i, exp[i].getSourceFile(), validator);
+            }
+          }
+        }
+
+        os << "\t\t</sourceFileList>\n";
+      }
+
+      //--------------------------------------------------------------------------------------------
+      // contacts
+      //--------------------------------------------------------------------------------------------
+      for (Size i = 0; i < exp.getContacts().size(); ++i)
+      {
+        const ContactPerson& cp = exp.getContacts()[i];
+        os << "\t\t<contact>\n";
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000586\" name=\"contact name\" value=\"" << writeXMLAttribute_(cp.getLastName()) << ", " << writeXMLAttribute_(cp.getFirstName()) << "\" />\n";
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000590\" name=\"contact affiliation\" value=\"" << writeXMLAttribute_(cp.getInstitution()) << "\" />\n";
+
+        if (!cp.getAddress().empty())
+        {
+          os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000587\" name=\"contact address\" value=\"" << writeXMLAttribute_(cp.getAddress()) << "\" />\n";
+        }
+        if (!cp.getURL().empty())
+        {
+          os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000588\" name=\"contact URL\" value=\"" << writeXMLAttribute_(cp.getURL()) << "\" />\n";
+        }
+        if (!cp.getEmail().empty())
+        {
+          os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000589\" name=\"contact email\" value=\"" << writeXMLAttribute_(cp.getEmail()) << "\" />\n";
+        }
+        if (!cp.getContactInfo().empty())
+        {
+          os << "\t\t\t<userParam name=\"contact_info\" type=\"xsd:string\" value=\"" << writeXMLAttribute_(cp.getContactInfo()) << "\" />\n";
+        }
+        writeUserParam_(os, cp, 3, "/mzML/fileDescription/contact/cvParam/@accession", validator);
+        os << "\t\t</contact>\n";
+      }
+      os << "\t</fileDescription>\n";
+
+      //--------------------------------------------------------------------------------------------
+      // sample
+      //--------------------------------------------------------------------------------------------
+      const Sample& sa = exp.getSample();
+      os << "\t<sampleList count=\"1\">\n";
+      os << "\t\t<sample id=\"sa_0\" name=\"" << writeXMLAttribute_(sa.getName()) << "\">\n";
+      if (!sa.getNumber().empty())
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000001\" name=\"sample number\" value=\"" << writeXMLAttribute_(sa.getNumber()) << "\" />\n";
+      }
+      os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000004\" name=\"sample mass\" value=\"" << sa.getMass() << "\" unitAccession=\"UO:0000021\" unitName=\"gram\" unitCvRef=\"UO\" />\n";
+      os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000005\" name=\"sample volume\" value=\"" << sa.getVolume() << "\" unitAccession=\"UO:0000098\" unitName=\"milliliter\" unitCvRef=\"UO\" />\n";
+      os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000006\" name=\"sample concentration\" value=\"" << sa.getConcentration() << "\" unitAccession=\"UO:0000175\" unitName=\"gram per liter\" unitCvRef=\"UO\" />\n";
+      if (sa.getState() == Sample::SampleState::EMULSION)
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000047\" name=\"emulsion\" />\n";
+      }
+      else if (sa.getState() == Sample::SampleState::GAS)
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000048\" name=\"gas\" />\n";
+      }
+      else if (sa.getState() == Sample::SampleState::LIQUID)
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000049\" name=\"liquid\" />\n";
+      }
+      else if (sa.getState() == Sample::SampleState::SOLID)
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000050\" name=\"solid\" />\n";
+      }
+      else if (sa.getState() == Sample::SampleState::SOLUTION)
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000051\" name=\"solution\" />\n";
+      }
+      else if (sa.getState() == Sample::SampleState::SUSPENSION)
+      {
+        os << "\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000052\" name=\"suspension\" />\n";
+      }
+      if (!sa.getComment().empty())
+      {
+        os << "\t\t\t<userParam name=\"comment\" type=\"xsd:string\" value=\"" << writeXMLAttribute_(sa.getComment()) << "\" />\n";
+      }
+      writeUserParam_(os, sa, 3, "/mzML/sampleList/sample/cvParam/@accession", validator);
+      os << "\t\t</sample>\n";
+      os << "\t</sampleList>\n";
+
+      //--------------------------------------------------------------------------------------------
+      // Software
+      //--------------------------------------------------------------------------------------------
+
+      // instrument software and fallback software is always written (see below)
+      Size num_software(2);
+
+      // Create a list of all different data processings: check if the
+      // DataProcessing of the current spectra/chromatogram is already present
+      // and if not, append it to the dps vector
+      for (Size s = 0; s < exp.size(); ++s)
+      {
+        bool already_present = false;
+        for (Size j = 0; j < dps.size(); j++)
+        {
+          already_present = OpenMS::Helpers::cmpPtrContainer(
+              exp[s].getDataProcessing(), dps[j]);
+          if (already_present) break;
+        }
+        if (!already_present)
+        {
+          dps.push_back(exp[s].getDataProcessing());
+          num_software += exp[s].getDataProcessing().size();
+        }
+      }
+      for (Size s = 0; s < exp.getChromatograms().size(); ++s)
+      {
+        bool already_present = false;
+        for (Size j = 0; j < dps.size(); j++)
+        {
+          already_present = OpenMS::Helpers::cmpPtrContainer(
+              exp.getChromatograms()[s].getDataProcessing(), dps[j]);
+          if (already_present) break;
+        }
+        if (!already_present)
+        {
+          dps.push_back(exp.getChromatograms()[s].getDataProcessing());
+          num_software += exp.getChromatograms()[s].getDataProcessing().size();
+        }
+      }
+
+      // count binary data array software
+      Size num_bi_software(0);
+
+      for (Size s = 0; s < exp.size(); ++s)
+      {
+        for (Size m = 0; m < exp[s].getFloatDataArrays().size(); ++m)
+        {
+          for (Size i = 0; i < exp[s].getFloatDataArrays()[m].getDataProcessing().size(); ++i)
+          {
+            ++num_bi_software;
+          }
+        }
+      }
+
+      os << "\t<softwareList count=\"" << num_software + num_bi_software + exp.getInstrumentConfigurations().size() << "\">\n";
+
+      // write instrument software
+      writeSoftware_(os, "so_in_0", exp.getInstrument().getSoftware(), validator);
+      Size configuration_software_index = 0;
+      for (const auto& [id, instrument] : exp.getInstrumentConfigurations())
+      {
+        writeSoftware_(os, "so_configuration_" + std::to_string(configuration_software_index++), instrument.getSoftware(), validator);
+      }
+
+      // write fallback software
+      writeSoftware_(os, "so_default", Software(), validator);
+
+      // write the software of the dps
+      for (Size s1 = 0; s1 != dps.size(); ++s1)
+      {
+        for (Size s2 = 0; s2 != dps[s1].size(); ++s2)
+        {
+          writeSoftware_(os,std::string("so_dp_sp_") + s1 + "_pm_" + s2, dps[s1][s2]->getSoftware(), validator);
+        }
+      }
+
+      //write data processing (for each binary data array)
+      for (Size s = 0; s < exp.size(); ++s)
+      {
+        for (Size m = 0; m < exp[s].getFloatDataArrays().size(); ++m)
+        {
+          for (Size i = 0; i < exp[s].getFloatDataArrays()[m].getDataProcessing().size(); ++i)
+          {
+            writeSoftware_(os,std::string("so_dp_sp_") + s + "_bi_" + m + "_pm_" + i,
+                exp[s].getFloatDataArrays()[m].getDataProcessing()[i]->getSoftware(), validator);
+          }
+        }
+      }
+      os << "\t</softwareList>\n";
+
+      //--------------------------------------------------------------------------------------------
+      // instrument configuration (enclosing ion source, mass analyzer and detector)
+      //--------------------------------------------------------------------------------------------
+      Size additional_instruments = exp.getInstrumentConfigurations().size();
+      os << "\t<instrumentConfigurationList count=\"" << (1 + additional_instruments) << "\">\n";
+      std::string default_configuration_id = "ic_0";
+      while (exp.getInstrumentConfigurations().count(default_configuration_id)) default_configuration_id += "_";
+      writeInstrument_(os, default_configuration_id, exp.getInstrument(), "so_in_0", validator);
+      Size configuration_index = 0;
+      for (const auto& [id, instrument] : exp.getInstrumentConfigurations())
+      {
+        writeInstrument_(os, id, instrument, "so_configuration_" + std::to_string(configuration_index++), validator);
+      }
       os << "\t</instrumentConfigurationList>\n";
 
       //--------------------------------------------------------------------------------------------
@@ -5027,10 +5125,14 @@ namespace OpenMS::Internal
       //--------------------------------------------------------------------------------------------
       // run
       //--------------------------------------------------------------------------------------------
-      os << "\t<run id=\"ru_0\" defaultInstrumentConfigurationRef=\"ic_0\" sampleRef=\"sa_0\"";
+      os << "\t<run id=\"ru_0\" defaultInstrumentConfigurationRef=\"" << default_configuration_id << "\" sampleRef=\"sa_0\"";
       if (exp.getDateTime().isValid())
       {
-        { std::string ts = exp.getDateTime().get(); StringUtils::substitute(ts, ' ', 'T'); os << " startTimeStamp=\"" << ts << "\""; }
+        std::string ts = exp.getDateTime().get();
+        StringUtils::substitute(ts, ' ', 'T');
+        const std::string original = exp.getMetaValue("mzml_start_time_stamp", "").toString();
+        if (original.substr(0, 19) == ts) ts = original;
+        os << " startTimeStamp=\"" << writeXMLAttribute_(ts) << "\"";
       }
       if (!exp.getSourceFiles().empty())
       {
@@ -5044,7 +5146,7 @@ namespace OpenMS::Internal
         os << "\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000858\" name=\"fraction identifier\" value=\"" << exp.getFractionIdentifier() << "\" />\n";
       }
 
-      writeUserParam_(os, exp, 2, "/mzML/run/cvParam/@accession", validator);
+      writeUserParam_(os, exp, 2, "/mzML/run/cvParam/@accession", validator, {"mzml_start_time_stamp"});
 
     }
 
@@ -5066,7 +5168,7 @@ namespace OpenMS::Internal
       spectra_offsets_.emplace_back(native_id, offset + 3);
 
       // IMPORTANT make sure the offset (above) corresponds to the start of the <spectrum tag
-      os << "\t\t\t<spectrum id=\"" << writeXMLEscape(native_id) << "\" index=\"" << s << "\" defaultArrayLength=\"" << spec.size() << "\"";
+      os << "\t\t\t<spectrum id=\"" << writeXMLAttribute_(native_id) << "\" index=\"" << s << "\" defaultArrayLength=\"" << spec.size() << "\"";
       if (spec.getSourceFile() != SourceFile())
       {
         os << " sourceFileRef=\"sf_sp_" << s << "\"";
@@ -5189,7 +5291,8 @@ namespace OpenMS::Internal
         os << "\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000130\" name=\"positive scan\" />\n";
       }
 
-      writeUserParam_(os, spec, 4, "/mzML/run/spectrumList/spectrum/cvParam/@accession", validator);
+      writeUserParam_(os, spec, 4, "/mzML/run/spectrumList/spectrum/cvParam/@accession", validator,
+                      {"mzml coordinate array", "mzml intensity array", "sampled noise m/z array", "sampled noise intensity array", "sampled noise baseline array"});
       //--------------------------------------------------------------------------------------------
       //scan list
       //--------------------------------------------------------------------------------------------
@@ -5216,6 +5319,10 @@ namespace OpenMS::Internal
         {
           os << "externalSpectrumID=\"" << ac.getIdentifier() << "\"";
         }
+        if (ac.metaValueExists("instrument_configuration_ref"))
+        {
+          os << " instrumentConfigurationRef=\"" << writeXMLAttribute_(ac.getMetaValue("instrument_configuration_ref").toString()) << "\"";
+        }
         os << ">\n";
         if (j == 0)
         {
@@ -5225,8 +5332,8 @@ namespace OpenMS::Internal
           if (spec.getDriftTimeUnit() == DriftTimeUnit::FAIMS_COMPENSATION_VOLTAGE)
           {
             os << "\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1001581\" name=\"FAIMS compensation voltage\" value=\"" << spec.getDriftTime()
-                << "\" unitAccession=\"UO:000218\" unitName=\"volt\" unitCvRef=\"UO\" />\n";
-          }          
+                << "\" unitAccession=\"UO:0000218\" unitName=\"volt\" unitCvRef=\"UO\" />\n";
+          }
           else if (spec.getDriftTime() != IMTypes::DRIFTTIME_NOT_SET)// if drift time was never set, don't report it
           {
             if (spec.getDriftTimeUnit() == DriftTimeUnit::MILLISECOND)
@@ -5253,7 +5360,7 @@ namespace OpenMS::Internal
             }
           }
         }
-        writeUserParam_(os, ac, 6, "/mzML/run/spectrumList/spectrum/scanList/scan/cvParam/@accession", validator);
+        writeUserParam_(os, ac, 6, "/mzML/run/spectrumList/spectrum/scanList/scan/cvParam/@accession", validator, {"instrument_configuration_ref"});
 
         if (spec.getInstrumentSettings().getZoomScan())
         {
@@ -5267,9 +5374,12 @@ namespace OpenMS::Internal
           for (Size k = 0; k < spec.getInstrumentSettings().getScanWindows().size(); ++k)
           {
             os << "\t\t\t\t\t\t\t<scanWindow>\n";
-            os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000501\" name=\"scan window lower limit\" value=\"" << spec.getInstrumentSettings().getScanWindows()[k].begin << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
-            os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000500\" name=\"scan window upper limit\" value=\"" << spec.getInstrumentSettings().getScanWindows()[k].end << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
-            writeUserParam_(os, spec.getInstrumentSettings().getScanWindows()[k], 8, "/mzML/run/spectrumList/spectrum/scanList/scan/scanWindowList/scanWindow/cvParam/@accession", validator);
+            const auto& unit = cv_.getTerm(spec.getInstrumentSettings().getScanWindows()[k].getMetaValue("unit_accession", "MS:1000040").toString());
+            os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000501\" name=\"scan window lower limit\" value=\"" << spec.getInstrumentSettings().getScanWindows()[k].begin
+               << "\" unitAccession=\"" << unit.id << "\" unitName=\"" << unit.name << "\" unitCvRef=\"" << unit.id.substr(0, unit.id.find(':')) << "\" />\n";
+            os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000500\" name=\"scan window upper limit\" value=\"" << spec.getInstrumentSettings().getScanWindows()[k].end
+               << "\" unitAccession=\"" << unit.id << "\" unitName=\"" << unit.name << "\" unitCvRef=\"" << unit.id.substr(0, unit.id.find(':')) << "\" />\n";
+            writeUserParam_(os, spec.getInstrumentSettings().getScanWindows()[k], 8, "/mzML/run/spectrumList/spectrum/scanList/scan/scanWindowList/scanWindow/cvParam/@accession", validator, {"unit_accession"});
             os << "\t\t\t\t\t\t\t</scanWindow>\n";
           }
           os << "\t\t\t\t\t\t</scanWindowList>\n";
@@ -5293,9 +5403,12 @@ namespace OpenMS::Internal
           for (Size j = 0; j < spec.getInstrumentSettings().getScanWindows().size(); ++j)
           {
             os << "\t\t\t\t\t\t\t<scanWindow>\n";
-            os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000501\" name=\"scan window lower limit\" value=\"" << spec.getInstrumentSettings().getScanWindows()[j].begin << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
-            os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000500\" name=\"scan window upper limit\" value=\"" << spec.getInstrumentSettings().getScanWindows()[j].end << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
-            writeUserParam_(os, spec.getInstrumentSettings().getScanWindows()[j], 8, "/mzML/run/spectrumList/spectrum/scanList/scan/scanWindowList/scanWindow/cvParam/@accession", validator);
+            const auto& unit = cv_.getTerm(spec.getInstrumentSettings().getScanWindows()[j].getMetaValue("unit_accession", "MS:1000040").toString());
+            os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000501\" name=\"scan window lower limit\" value=\"" << spec.getInstrumentSettings().getScanWindows()[j].begin
+               << "\" unitAccession=\"" << unit.id << "\" unitName=\"" << unit.name << "\" unitCvRef=\"" << unit.id.substr(0, unit.id.find(':')) << "\" />\n";
+            os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000500\" name=\"scan window upper limit\" value=\"" << spec.getInstrumentSettings().getScanWindows()[j].end
+               << "\" unitAccession=\"" << unit.id << "\" unitName=\"" << unit.name << "\" unitCvRef=\"" << unit.id.substr(0, unit.id.find(':')) << "\" />\n";
+            writeUserParam_(os, spec.getInstrumentSettings().getScanWindows()[j], 8, "/mzML/run/spectrumList/spectrum/scanList/scan/scanWindowList/scanWindow/cvParam/@accession", validator, {"unit_accession"});
             os << "\t\t\t\t\t\t\t</scanWindow>\n";
           }
           os << "\t\t\t\t\t\t</scanWindowList>\n";
@@ -5333,13 +5446,22 @@ namespace OpenMS::Internal
       //--------------------------------------------------------------------------------------------
       //binary data array list
       //--------------------------------------------------------------------------------------------
-      if (!spec.empty())
+      const std::vector<std::string> noise_names = {"sampled noise m/z array", "sampled noise intensity array", "sampled noise baseline array"};
+      Size noise_count = 0;
+      for (const auto& name : noise_names) noise_count += spec.metaValueExists(name);
+      if (spec.size() != 0 || noise_count != 0)
       {
         std::string encoded_string;
-        os << "\t\t\t\t<binaryDataArrayList count=\"" << (2 + spec.getFloatDataArrays().size() + spec.getStringDataArrays().size() + spec.getIntegerDataArrays().size()) << "\">\n";
+        os << "\t\t\t\t<binaryDataArrayList count=\"" << (2 + noise_count + spec.getFloatDataArrays().size() + spec.getStringDataArrays().size() + spec.getIntegerDataArrays().size()) << "\">\n";
 
         writeContainerData_<SpectrumType>(os, options_, spec, "mz");
         writeContainerData_<SpectrumType>(os, options_, spec, "intensity");
+        for (const auto& name : noise_names)
+        {
+          if (!spec.metaValueExists(name)) continue;
+          std::vector<double> values = spec.getMetaValue(name).toDoubleList();
+          writeBinaryDataArray_(os, options_, values, false, name);
+        }
 
         std::string compression_term = MzMLHandlerHelper::getCompressionTerm_(options_, options_.getNumpressConfigurationIntensity(), "\t\t\t\t\t\t", false);
         // write float data array
@@ -5414,7 +5536,8 @@ namespace OpenMS::Internal
       // Intensity is the same for chromatograms and spectra, the second
       // dimension is either "time" or "mz" (both of these are controlled by
       // getMz32Bit)
-      bool is32Bit = ((array_type == "intensity" && pf_options_.getIntensity32Bit()) || pf_options_.getMz32Bit());
+      const std::string stored_type = container.getMetaValue(array_type == "intensity" ? "mzml intensity array" : "mzml coordinate array", array_type).toString();
+      bool is32Bit = array_type == "intensity" ? pf_options_.getIntensity32Bit() : pf_options_.getMz32Bit();
       if (!is32Bit || pf_options_.getNumpressConfigurationMassTime().np_compression != MSNumpressCoder::NONE)
       {
         std::vector<double> data_to_encode(container.size());
@@ -5432,7 +5555,7 @@ namespace OpenMS::Internal
             data_to_encode[p] = container[p].getPos();
           }
         }
-        writeBinaryDataArray_(os, pf_options_, data_to_encode, false, array_type);
+        writeBinaryDataArray_(os, pf_options_, data_to_encode, false, stored_type);
       }
       else
       {
@@ -5452,7 +5575,7 @@ namespace OpenMS::Internal
             data_to_encode[p] = container[p].getPos();
           }
         }
-        writeBinaryDataArray_(os, pf_options_, data_to_encode, true, array_type);
+        writeBinaryDataArray_(os, pf_options_, data_to_encode, true, stored_type);
       }
 
     }
@@ -5467,36 +5590,31 @@ namespace OpenMS::Internal
       std::string encoded_string;
       bool no_numpress = true;
 
-      // Compute the array-type and the compression CV term
-      std::string cv_term_type;
-      std::string compression_term;
-      std::string compression_term_no_np;
-      MSNumpressCoder::NumpressConfig np_config;
-      if (array_type == "mz")
+      const bool coordinate = array_type == "mz" || array_type == "time" || array_type == "wavelength" || array_type == "sampled noise m/z array";
+      const bool noise = array_type.rfind("sampled noise ", 0) == 0;
+      const std::map<std::string, std::pair<std::string, std::string>> terms = {
+        {"mz", {"MS:1000514", "MS:1000040"}}, {"time", {"MS:1000595", "UO:0000010"}},
+        {"wavelength", {"MS:1000617", "UO:0000018"}}, {"intensity", {"MS:1000515", "MS:1000131"}},
+        {"absorption", {"MS:1000515", "UO:0000269"}}, {"pressure", {"MS:1000821", "UO:0000109"}},
+        {"flow", {"MS:1000820", "UO:0000270"}}, {"nonstandard", {"MS:1000786", "UO:0000000"}},
+        {"sampled noise m/z array", {"MS:1002743", "MS:1000040"}},
+        {"sampled noise intensity array", {"MS:1002744", "MS:1000131"}},
+        {"sampled noise baseline array", {"MS:1002745", ""}}};
+      const auto term = terms.find(array_type);
+      if (term == terms.end()) throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Unknown array type", array_type);
+      const auto& cv_term = cv_.getTerm(term->second.first);
+      std::string cv_term_type = "\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"" + cv_term.id + "\" name=\"" + cv_term.name + "\"";
+      if (!term->second.second.empty())
       {
-        cv_term_type = "\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000514\" name=\"m/z array\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
-        compression_term = MzMLHandlerHelper::getCompressionTerm_(pf_options_, pf_options_.getNumpressConfigurationMassTime(), "\t\t\t\t\t\t", true);
-        compression_term_no_np = MzMLHandlerHelper::getCompressionTerm_(pf_options_, pf_options_.getNumpressConfigurationMassTime(), "\t\t\t\t\t\t", false);
-        np_config = pf_options_.getNumpressConfigurationMassTime();
+        const auto& unit = cv_.getTerm(term->second.second);
+        cv_term_type += " unitAccession=\"" + unit.id + "\" unitName=\"" + unit.name + "\" unitCvRef=\"" + unit.id.substr(0, unit.id.find(':')) + "\"";
       }
-      else if (array_type == "time")
-      {
-        cv_term_type = "\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000595\" name=\"time array\" unitAccession=\"UO:0000010\" unitName=\"second\" unitCvRef=\"MS\" />\n";
-        compression_term = MzMLHandlerHelper::getCompressionTerm_(pf_options_, pf_options_.getNumpressConfigurationMassTime(), "\t\t\t\t\t\t", true);
-        compression_term_no_np = MzMLHandlerHelper::getCompressionTerm_(pf_options_, pf_options_.getNumpressConfigurationMassTime(), "\t\t\t\t\t\t", false);
-        np_config = pf_options_.getNumpressConfigurationMassTime();
-      }
-      else if (array_type == "intensity")
-      {
-        cv_term_type = "\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000515\" name=\"intensity array\" unitAccession=\"MS:1000131\" unitName=\"number of detector counts\" unitCvRef=\"MS\"/>\n";
-        compression_term = MzMLHandlerHelper::getCompressionTerm_(pf_options_, pf_options_.getNumpressConfigurationIntensity(), "\t\t\t\t\t\t", true);
-        compression_term_no_np = MzMLHandlerHelper::getCompressionTerm_(pf_options_, pf_options_.getNumpressConfigurationIntensity(), "\t\t\t\t\t\t", false);
-        np_config = pf_options_.getNumpressConfigurationIntensity();
-      }
-      else
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Unknown array type", array_type);
-      }
+      if (array_type == "nonstandard") cv_term_type += " value=\"detector signal\"";
+      cv_term_type += " />\n";
+      MSNumpressCoder::NumpressConfig np_config = coordinate ? pf_options_.getNumpressConfigurationMassTime() : pf_options_.getNumpressConfigurationIntensity();
+      if (noise) np_config.np_compression = MSNumpressCoder::NONE;
+      std::string compression_term = MzMLHandlerHelper::getCompressionTerm_(pf_options_, np_config, "\t\t\t\t\t\t", true);
+      std::string compression_term_no_np = MzMLHandlerHelper::getCompressionTerm_(pf_options_, np_config, "\t\t\t\t\t\t", false);
 
       // Try numpress encoding (if it is enabled) and fall back to regular encoding if it fails
       if (np_config.np_compression != MSNumpressCoder::NONE)
@@ -5506,7 +5624,7 @@ namespace OpenMS::Internal
         {
           // numpress succeeded
           no_numpress = false;
-          os << "\t\t\t\t\t<binaryDataArray encodedLength=\"" << encoded_string.size() << "\">\n";
+          os << "\t\t\t\t\t<binaryDataArray arrayLength=\"" << data_to_encode.size() << "\" encodedLength=\"" << encoded_string.size() << "\">\n";
           os << cv_term_type;
           os << "\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000523\" name=\"64-bit float\" />\n";
         }
@@ -5517,7 +5635,7 @@ namespace OpenMS::Internal
       {
         compression_term = compression_term_no_np; // select the no-numpress term
         Base64::encode(data_to_encode, Base64::BYTEORDER_LITTLEENDIAN, encoded_string, pf_options_.getCompression());
-        os << "\t\t\t\t\t<binaryDataArray encodedLength=\"" << encoded_string.size() << "\">\n";
+        os << "\t\t\t\t\t<binaryDataArray arrayLength=\"" << data_to_encode.size() << "\" encodedLength=\"" << encoded_string.size() << "\">\n";
         os << cv_term_type;
         os << "\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000521\" name=\"32-bit float\" />\n";
       }
@@ -5525,7 +5643,7 @@ namespace OpenMS::Internal
       {
         compression_term = compression_term_no_np; // select the no-numpress term
         Base64::encode(data_to_encode, Base64::BYTEORDER_LITTLEENDIAN, encoded_string, pf_options_.getCompression());
-        os << "\t\t\t\t\t<binaryDataArray encodedLength=\"" << encoded_string.size() << "\">\n";
+        os << "\t\t\t\t\t<binaryDataArray arrayLength=\"" << data_to_encode.size() << "\" encodedLength=\"" << encoded_string.size() << "\">\n";
         os << cv_term_type;
         os << "\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000523\" name=\"64-bit float\" />\n";
       }
@@ -5658,10 +5776,14 @@ namespace OpenMS::Internal
 
       // TODO native id with chromatogram=?? prefix?
       // IMPORTANT make sure the offset (above) corresponds to the start of the <chromatogram tag
-      os << "\t\t\t<chromatogram id=\"" << writeXMLEscape(chromatogram.getNativeID()) << "\" index=\"" << c << "\" defaultArrayLength=\"" << chromatogram.size() << "\">" << "\n";
+      os << "\t\t\t<chromatogram id=\"" << writeXMLAttribute_(chromatogram.getNativeID()) << "\" index=\"" << c << "\" defaultArrayLength=\"" << chromatogram.size() << "\">" << "\n";
 
       // write cvParams (chromatogram type)
-      if (chromatogram.getChromatogramType() == ChromatogramSettings::ChromatogramType::MASS_CHROMATOGRAM)
+      if (chromatogram.metaValueExists("chromatogram type accession"))
+      {
+        os << "\t\t\t\t" << cv_.getTerm(chromatogram.getMetaValue("chromatogram type accession").toString()).toXMLString("MS") << "\n";
+      }
+      else if (chromatogram.getChromatogramType() == ChromatogramSettings::ChromatogramType::MASS_CHROMATOGRAM)
       {
         os << "\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000810\" name=\"ion current chromatogram\" />\n";
       }
@@ -5701,6 +5823,12 @@ namespace OpenMS::Internal
       {
         // TODO
       }
+      if (!chromatogram.getName().empty())
+      {
+        os << "\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000809\" name=\"chromatogram title\" value=\"" << writeXMLAttribute_(chromatogram.getName()) << "\" />\n";
+      }
+      writeUserParam_(os, chromatogram, 4, "/mzML/run/chromatogramList/chromatogram/cvParam/@accession", validator,
+                      {"mzml intensity array", "mzml coordinate array", "chromatogram type accession"});
       writePrecursor_(os, chromatogram.getPrecursor(), validator);
       writeProduct_(os, chromatogram.getProduct(), validator);
 

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -18,9 +18,11 @@
 #include <OpenMS/INTERFACES/IMSDataConsumer.h>
 #include <OpenMS/SYSTEM/File.h>
 
+#include <algorithm>
 #include <atomic>
 #include <map>
 #include <xercesc/util/XMLString.hpp>
+#include <xercesc/util/TransService.hpp>
 
 namespace OpenMS::Internal
 {
@@ -28,7 +30,31 @@ namespace OpenMS::Internal
     {
       std::string writeXMLAttribute_(const std::string& value)
       {
-        std::string result = XMLHandler::writeXMLEscape(value);
+        // Emit non-ASCII UTF-8 text as character references. This preserves the
+        // historical ISO-8859-1 declaration without losing Unicode metadata.
+        if (std::all_of(value.begin(), value.end(), [](unsigned char c) { return c < 128; }))
+        {
+          std::string result = XMLHandler::writeXMLEscape(value);
+          StringUtils::substitute(result, "\r", "&#13;");
+          StringUtils::substitute(result, "\n", "&#10;");
+          StringUtils::substitute(result, "\t", "&#9;");
+          return result;
+        }
+        const xercesc::TranscodeFromStr decoded(
+          reinterpret_cast<const XMLByte*>(value.data()), value.size(), "UTF-8");
+        std::string escaped;
+        const XMLCh* chars = decoded.str();
+        for (XMLSize_t i = 0; i < decoded.length(); ++i)
+        {
+          unsigned int code = chars[i];
+          if (code >= 0xD800 && code <= 0xDBFF && i + 1 < decoded.length())
+          {
+            code = 0x10000 + ((code - 0xD800) << 10) + (chars[++i] - 0xDC00);
+          }
+          if (code < 128) { escaped += XMLHandler::writeXMLEscape(std::string(1, static_cast<char>(code))); }
+          else { escaped += "&#" + std::to_string(code) + ";"; }
+        }
+        std::string result = std::move(escaped);
         StringUtils::substitute(result, "\r", "&#13;");
         StringUtils::substitute(result, "\n", "&#10;");
         StringUtils::substitute(result, "\t", "&#9;");
@@ -3391,7 +3417,8 @@ namespace OpenMS::Internal
       }
       else if (parent_tag == "sample")
       {
-        samples_[current_id_].setMetaValue(name, data_value);
+        if (name == "comment") { samples_[current_id_].setComment(value); }
+        else { samples_[current_id_].setMetaValue(name, data_value); }
       }
       else if (parent_tag == "software")
       {
@@ -4763,7 +4790,7 @@ namespace OpenMS::Internal
                                    std::vector<std::vector< ConstDataProcessingPtr > >& dps,
                                    const Internal::MzMLValidator& validator)
     {
-      os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+      os << "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n";
 
       if (options_.getWriteIndex())
       {

--- a/src/openms/source/FORMAT/HANDLERS/StringManager.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/StringManager.cpp
@@ -12,6 +12,7 @@
 #include <OpenMS/SYSTEM/SIMDe.h>
 
 #include <xercesc/util/XMLString.hpp>
+#include <xercesc/util/TransService.hpp>
 
 #include <bit>
 #include <cstdint>
@@ -69,7 +70,8 @@ namespace OpenMS::Internal
     }
     else
     {
-      r = (unique_xerces_ptr<char>(xercesc::XMLString::transcode(reinterpret_cast<const XMLCh*>(str))).get());
+      const xercesc::TranscodeToStr utf8(reinterpret_cast<const XMLCh*>(str), "UTF-8");
+      r.assign(reinterpret_cast<const char*>(utf8.str()), utf8.length());
     }
     return r;
   }
@@ -192,7 +194,7 @@ namespace OpenMS::Internal
     Size remainder = length % 8;
 
     const char16_t* inputPtr = chars;
-    simde__m128i mask = simde_mm_set1_epi16(0xFF00);
+    simde__m128i mask = simde_mm_set1_epi16(0xFF80);
 
     // Process blocks of 8 UTF-16 characters using SIMD
     for (Size i = 0; i < fullBlocks; ++i)
@@ -213,7 +215,7 @@ namespace OpenMS::Internal
     // Check remaining characters individually
     for (Size i = 0; i < remainder; ++i)
     {
-      if (inputPtr[i] & 0xFF00)
+      if (inputPtr[i] & 0xFF80)
       {
         return false;
       }

--- a/src/openms/source/FORMAT/ThermoRawFile.cpp
+++ b/src/openms/source/FORMAT/ThermoRawFile.cpp
@@ -242,7 +242,7 @@ void ThermoRawFile::load(const std::string& path, MSExperiment& exp)
         const Json meta = Json::parse(raw.scan_metadata_json(scan));
         if (meta.at("schema_version") != 1) { throw std::runtime_error("Unsupported Thermo scan metadata schema"); }
         MSSpectrum spectrum;
-        const int level = meta.at("ms_level");
+        const int level = meta.at("ms_level").get<int>();
         spectrum.setMSLevel(level > 0 ? level : 0);
         const std::string order = text(meta, "ms_order_name");
         auto mode = level == 1 ? InstrumentSettings::ScanMode::MS1SPECTRUM : InstrumentSettings::ScanMode::MSNSPECTRUM;
@@ -254,7 +254,7 @@ void ThermoRawFile::load(const std::string& path, MSExperiment& exp)
         spectrum.setNativeID(text(meta, "native_id"));
         const bool centroid = options_.centroid || meta.at("centroid").get<bool>();
         spectrum.setType(centroid ? SpectrumSettings::SpectrumType::CENTROID : SpectrumSettings::SpectrumType::PROFILE);
-        const int polarity = meta.at("polarity");
+        const int polarity = meta.at("polarity").get<int>();
         if (polarity == 1) { spectrum.getInstrumentSettings().setPolarity(IonSource::Polarity::POSITIVE); }
         else if (polarity == 0) { spectrum.getInstrumentSettings().setPolarity(IonSource::Polarity::NEGATIVE); }
         const std::string filter = text(meta, "filter");

--- a/src/openms/source/FORMAT/ThermoRawFile.cpp
+++ b/src/openms/source/FORMAT/ThermoRawFile.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
-// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU
+// Berlin SPDX-License-Identifier: BSD-3-Clause
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Julianus Pfeuffer $
@@ -10,470 +10,525 @@
 
 #ifdef WITH_THERMO_RAW
 
-#include <OpenMS/FORMAT/ThermoRawFile.h>
-#include <OpenMS/CONCEPT/Exception.h>
-#include <OpenMS/CONCEPT/LogStream.h>
-#include <OpenMS/DATASTRUCTURES/DateTime.h>
-#include <OpenMS/KERNEL/MSChromatogram.h>
-#include <OpenMS/KERNEL/MSSpectrum.h>
-#include <OpenMS/METADATA/Acquisition.h>
-#include <OpenMS/METADATA/AcquisitionInfo.h>
-#include <OpenMS/METADATA/Instrument.h>
-#include <OpenMS/METADATA/IonDetector.h>
-#include <OpenMS/METADATA/IonSource.h>
-#include <OpenMS/METADATA/MassAnalyzer.h>
-#include <OpenMS/METADATA/Precursor.h>
-#include <OpenMS/METADATA/Sample.h>
-#include <OpenMS/METADATA/Software.h>
-#include <OpenMS/METADATA/SourceFile.h>
-#include <OpenMS/SYSTEM/File.h>
-
-#include <algorithm>
-#include <cctype>
-#include <filesystem>
-#include <limits>
-#include <set>
-#include <string>
-
-#include <openms_thermo_bridge/thermo_bridge.hpp>
+  #include <OpenMS/CONCEPT/Exception.h>
+  #include <OpenMS/CONCEPT/LogStream.h>
+  #include <OpenMS/DATASTRUCTURES/DateTime.h>
+  #include <OpenMS/FORMAT/HANDLERS/ThermoRawFileMetadata.h>
+  #include <OpenMS/FORMAT/ThermoRawFile.h>
+  #include <OpenMS/KERNEL/MSChromatogram.h>
+  #include <OpenMS/KERNEL/MSSpectrum.h>
+  #include <OpenMS/METADATA/Acquisition.h>
+  #include <OpenMS/METADATA/AcquisitionInfo.h>
+  #include <OpenMS/METADATA/DataProcessing.h>
+  #include <OpenMS/METADATA/Instrument.h>
+  #include <OpenMS/METADATA/IonDetector.h>
+  #include <OpenMS/METADATA/IonSource.h>
+  #include <OpenMS/METADATA/MassAnalyzer.h>
+  #include <OpenMS/METADATA/Precursor.h>
+  #include <OpenMS/METADATA/Sample.h>
+  #include <OpenMS/METADATA/Software.h>
+  #include <OpenMS/METADATA/SourceFile.h>
+  #include <OpenMS/SYSTEM/File.h>
+  #include <algorithm>
+  #include <cctype>
+  #include <filesystem>
+  #include <limits>
+  #include <map>
+  #include <openms_thermo_bridge/cv_mapping.hpp>
+  #include <openms_thermo_bridge/thermo_bridge.hpp>
+  #include <set>
+  #include <string>
 
 namespace OpenMS
 {
-  namespace
+namespace
+{
+  /// Case-insensitive "haystack contains needle".
+  bool containsCI(const std::string& haystack, const std::string& needle)
   {
-    /// Case-insensitive "haystack contains needle".
-    bool containsCI(const std::string& haystack, const std::string& needle)
-    {
-      if (needle.empty()) { return true; }
-      auto it = std::search(haystack.begin(), haystack.end(),
-                            needle.begin(), needle.end(),
-                            [](char a, char b)
-                            { return std::tolower(static_cast<unsigned char>(a)) ==
-                                     std::tolower(static_cast<unsigned char>(b)); });
-      return it != haystack.end();
-    }
+    if (needle.empty()) { return true; }
+    auto it = std::search(haystack.begin(), haystack.end(), needle.begin(), needle.end(),
+                          [](char a, char b) { return std::tolower(static_cast<unsigned char>(a)) == std::tolower(static_cast<unsigned char>(b)); });
+    return it != haystack.end();
+  }
 
-    /// Parse a double, returning false if the string is empty/unparseable.
-    bool parseDouble(const std::string& s, double& out)
-    {
-      if (s.empty()) { return false; }
-      try
-      {
-        size_t pos = 0;
-        out = std::stod(s, &pos);
-        // Reject trailing garbage (e.g. "12.3abc") but tolerate surrounding whitespace.
-        while (pos < s.size() && std::isspace(static_cast<unsigned char>(s[pos]))) { ++pos; }
-        return pos == s.size();
-      }
-      catch (...)
-      {
-        return false;
-      }
-    }
-
-    /// Find the value of the first trailer-extra label that contains @p needle (case-insensitive).
-    /// The bridge matches keys exactly, so we pass the exact label string back to it.
-    std::string trailerValueContaining(const openms::thermo_bridge::RawFile& raw, int scan,
-                                       const std::vector<std::string>& labels, const std::string& needle)
-    {
-      for (const std::string& label : labels)
-      {
-        if (containsCI(label, needle))
-        {
-          return raw.trailer_extra_value(scan, label);
-        }
-      }
-      return "";
-    }
-
-    /// Map a Thermo MassAnalyzerType enum string (e.g. "MassAnalyzerFTMS") to an OpenMS analyzer type.
-    /// FTMS is disambiguated into Orbitrap vs. FT-ICR via the instrument model, mirroring
-    /// the logic in openms-thermo-bridge cv_mapping::cv_mass_analyzer().
-    MassAnalyzer::AnalyzerType mapAnalyzer(const std::string& t, const std::string& model)
-    {
-      if (t == "MassAnalyzerFTMS" || t == "FTMS")
-      {
-        if (containsCI(model, "Orbitrap") || containsCI(model, "Exactive") ||
-            containsCI(model, "Exploris") || containsCI(model, "Astral"))
-        {
-          return MassAnalyzer::AnalyzerType::ORBITRAP;
-        }
-        return MassAnalyzer::AnalyzerType::FOURIERTRANSFORM; // FT-ICR
-      }
-      if (t == "MassAnalyzerITMS") { return MassAnalyzer::AnalyzerType::IT; }            // ion trap (MS:1000264)
-      if (t == "MassAnalyzerTQMS" || t == "MassAnalyzerSQMS") { return MassAnalyzer::AnalyzerType::QUADRUPOLE; }
-      if (t == "MassAnalyzerTOFMS" || t == "MassAnalyzerASTMS") { return MassAnalyzer::AnalyzerType::TOF; }
-      if (t == "MassAnalyzerSector") { return MassAnalyzer::AnalyzerType::SECTOR; }
-      return MassAnalyzer::AnalyzerType::ANALYZERNULL;
-    }
-
-    /// Map a Thermo IonizationModeType enum string (e.g. "ElectroSpray") to an OpenMS ionization method.
-    IonSource::IonizationMethod mapIonization(const std::string& t)
-    {
-      if (t == "ElectroSpray") { return IonSource::IonizationMethod::ESI; }
-      if (t == "NanoSpray" || t == "CardNanoSprayIonization") { return IonSource::IonizationMethod::NESI; }
-      if (t == "AtmosphericPressureChemicalIonization") { return IonSource::IonizationMethod::APCI; }
-      if (t == "ChemicalIonization") { return IonSource::IonizationMethod::CI; }
-      if (t == "MatrixAssistedLaserDesorptionIonization") { return IonSource::IonizationMethod::MALDI; }
-      if (t == "ElectronImpact") { return IonSource::IonizationMethod::EI; }
-      if (t == "FastAtomBombardment") { return IonSource::IonizationMethod::FAB; }
-      if (t == "ThermoSpray") { return IonSource::IonizationMethod::TSP; }
-      if (t == "FieldDesorption") { return IonSource::IonizationMethod::FD; }
-      if (t == "GlowDischarge") { return IonSource::IonizationMethod::GD_MS; }
-      return IonSource::IonizationMethod::IONMETHODNULL;
-    }
-
-    /// Infer the ion detector type from the mass analyzer: Orbitrap/FT-ICR use image-current
-    /// (inductive) detection, while ion traps and quadrupoles use an electron multiplier.
-    /// (The bridge's cv_detector_types() is not exported, so we derive this locally.)
-    IonDetector::Type detectorForAnalyzer(MassAnalyzer::AnalyzerType analyzer)
-    {
-      switch (analyzer)
-      {
-        case MassAnalyzer::AnalyzerType::ORBITRAP:
-        case MassAnalyzer::AnalyzerType::FOURIERTRANSFORM:
-          return IonDetector::Type::INDUCTIVEDETECTOR;
-        case MassAnalyzer::AnalyzerType::IT:
-        case MassAnalyzer::AnalyzerType::QUADRUPOLE:
-          return IonDetector::Type::ELECTRONMULTIPLIER;
-        default:
-          return IonDetector::Type::TYPENULL;
-      }
-    }
-
-    /// Extract the scan window (m/z range) from a Thermo scan filter string, e.g.
-    /// "FTMS + p NSI Full ms [375.0000-1500.0000]" -> (375.0, 1500.0). Returns false if no
-    /// single bracketed range is found (e.g. multi-range SIM filters with a comma are skipped).
-    bool parseScanWindowFromFilter(const std::string& filter, double& lower, double& upper)
-    {
-      const std::string::size_type close = filter.rfind(']');
-      if (close == std::string::npos) { return false; }
-      const std::string::size_type open = filter.rfind('[', close);
-      if (open == std::string::npos) { return false; }
-
-      const std::string inside = filter.substr(open + 1, close - open - 1);
-      if (inside.find(',') != std::string::npos) { return false; } // multiple ranges (e.g. SIM)
-      const std::string::size_type dash = inside.find('-');
-      if (dash == std::string::npos) { return false; }
-
-      if (!parseDouble(inside.substr(0, dash), lower)) { return false; }
-      if (!parseDouble(inside.substr(dash + 1), upper)) { return false; }
-      return upper > lower && lower > 0.0;
-    }
-  } // anonymous namespace
-
-  void ThermoRawFile::load(const std::string& path, MSExperiment& exp)
+  /// Map a Thermo MassAnalyzerType enum string (e.g. "MassAnalyzerFTMS") to an
+  /// OpenMS analyzer type. FTMS is disambiguated into Orbitrap vs. FT-ICR via the
+  /// instrument model, mirroring the logic in openms-thermo-bridge
+  /// cv_mapping::cv_mass_analyzer().
+  MassAnalyzer::AnalyzerType mapAnalyzer(const std::string& t, const std::string& model)
   {
-    // Loaders are expected to populate the output experiment from scratch.
-    exp = MSExperiment();
-
-    if (!File::exists(path))
+    if (t == "MassAnalyzerFTMS" || t == "FTMS")
     {
-      throw Exception::FileNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, path);
+      if (containsCI(model, "Orbitrap") || containsCI(model, "Exactive") || containsCI(model, "Exploris") || containsCI(model, "Astral"))
+      {
+        return MassAnalyzer::AnalyzerType::ORBITRAP;
+      }
+      return MassAnalyzer::AnalyzerType::FOURIERTRANSFORM; // FT-ICR
     }
+    if (t == "MassAnalyzerITMS") { return MassAnalyzer::AnalyzerType::IT; } // ion trap (MS:1000264)
+    if (t == "MassAnalyzerTQMS" || t == "MassAnalyzerSQMS") { return MassAnalyzer::AnalyzerType::QUADRUPOLE; }
+    if (t == "MassAnalyzerTOFMS" || t == "MassAnalyzerASTMS") { return MassAnalyzer::AnalyzerType::TOF; }
+    if (t == "MassAnalyzerSector") { return MassAnalyzer::AnalyzerType::SECTOR; }
+    return MassAnalyzer::AnalyzerType::ANALYZERNULL;
+  }
 
-    std::filesystem::path raw_path(static_cast<std::string>(path));
+  /// Map a Thermo IonizationModeType enum string (e.g. "ElectroSpray") to an
+  /// OpenMS ionization method.
+  IonSource::IonizationMethod mapIonization(const std::string& t)
+  {
+    if (t == "ElectroSpray") { return IonSource::IonizationMethod::ESI; }
+    if (t == "NanoSpray" || t == "CardNanoSprayIonization") { return IonSource::IonizationMethod::NESI; }
+    if (t == "AtmosphericPressureChemicalIonization") { return IonSource::IonizationMethod::APCI; }
+    if (t == "ChemicalIonization") { return IonSource::IonizationMethod::CI; }
+    if (t == "MatrixAssistedLaserDesorptionIonization") { return IonSource::IonizationMethod::MALDI; }
+    if (t == "ElectronImpact") { return IonSource::IonizationMethod::EI; }
+    if (t == "FastAtomBombardment") { return IonSource::IonizationMethod::FAB; }
+    if (t == "ThermoSpray") { return IonSource::IonizationMethod::TSP; }
+    if (t == "FieldDesorption") { return IonSource::IonizationMethod::FD; }
+    if (t == "GlowDischarge") { return IonSource::IonizationMethod::GD_MS; }
+    return IonSource::IonizationMethod::IONMETHODNULL;
+  }
 
-    try
+  /// Infer the ion detector type from the mass analyzer: Orbitrap/FT-ICR use
+  /// image-current (inductive) detection, while ion traps and quadrupoles use an
+  /// electron multiplier. Choose the detector for this scan's analyzer, rather
+  /// than every detector in the instrument.
+  IonDetector::Type detectorForAnalyzer(MassAnalyzer::AnalyzerType analyzer)
+  {
+    switch (analyzer)
     {
-      openms::thermo_bridge::RawFile raw(raw_path);
-
-      // --- Source file metadata ---
-      SourceFile src;
-      src.setNameOfFile(raw_path.filename().string());
-      src.setPathToFile(raw_path.parent_path().string());
-      src.setFileType("Thermo RAW format");
-      src.setNativeIDType("Thermo nativeID format");
-      src.setNativeIDTypeAccession("MS:1000768"); // Thermo nativeID format
-      exp.getSourceFiles().push_back(src);
-
-      // --- Instrument / experiment-level metadata ---
-      const std::string model = raw.instrument_model();
-      if (!model.empty())
-      {
-        exp.getInstrument().setName(raw.instrument_name());
-        exp.getInstrument().setModel(model);
-        exp.getInstrument().setCustomizations(raw.instrument_serial_number());
-      }
-      const std::string sw_version = raw.instrument_software_version();
-      if (!sw_version.empty())
-      {
-        exp.getInstrument().getSoftware().setVersion(sw_version);
-      }
-      const std::string sample_name = raw.sample_name();
-      if (!sample_name.empty())
-      {
-        exp.getSample().setName(sample_name);
-      }
-      const std::string creation_date = raw.creation_date(); // ISO-8601 (e.g. "2018-05-31T12:34:56.789...")
-      if (creation_date.size() >= 19)
-      {
-        // OpenMS DateTime only parses up to seconds; drop fractional seconds / timezone offset.
-        try
-        {
-          exp.setDateTime(DateTime::fromString(creation_date.substr(0, 19), "yyyy-MM-ddThh:mm:ss"));
-        }
-        catch (const Exception::BaseException&)
-        {
-          // leave date-time unset if the format is unexpected
-        }
-      }
-      const std::string file_description = raw.file_description();
-      if (!file_description.empty())
-      {
-        exp.getInstrument().setMetaValue("file description", file_description);
-      }
-
-      // --- Read spectra ---
-      const int scan_count = raw.scan_count();
-      const int first_scan = raw.first_scan_number();
-      const int last_scan = raw.last_scan_number();
-
-      OPENMS_LOG_INFO << "ThermoRawFile: reading " << scan_count << " scans from "
-                      << raw_path.filename().string() << "\n";
-
-      setProgress(0);
-      startProgress(first_scan, last_scan, "Loading Thermo RAW file");
-
-      exp.reserve(scan_count);
-
-      // Distinct mass-analyzer strings and the first ionization mode seen, used to build the
-      // single OpenMS Instrument component lists after the scan loop.
-      std::set<std::string> analyzer_types;
-      std::string ionization_mode;
-
-      for (int scan = first_scan; scan <= last_scan; ++scan)
-      {
-        setProgress(scan);
-
-        MSSpectrum spectrum;
-
-        // RT in seconds (bridge returns minutes)
-        const double rt_minutes = raw.retention_time(scan);
-        spectrum.setRT(rt_minutes * 60.0);
-
-        // MS level
-        const int ms_level = raw.ms_level(scan);
-        spectrum.setMSLevel(ms_level);
-
-        // Native ID
-        spectrum.setNativeID("scan=" + std::to_string(scan));
-
-        // Centroid / profile
-        const bool centroid = raw.is_centroid_scan(scan);
-        spectrum.setType(centroid ? SpectrumSettings::SpectrumType::CENTROID : SpectrumSettings::SpectrumType::PROFILE);
-
-        // Polarity — bridge returns the raw Thermo PolarityType enum value. Verified empirically
-        // against real RAW data: Negative = 0, Positive = 1, Any = 2 (the bridge's own header comment
-        // and cv_polarity() helper claim the opposite and are wrong).
-        const int polarity = raw.polarity(scan);
-        if (polarity == 1)
-        {
-          spectrum.getInstrumentSettings().setPolarity(IonSource::Polarity::POSITIVE);
-        }
-        else if (polarity == 0)
-        {
-          spectrum.getInstrumentSettings().setPolarity(IonSource::Polarity::NEGATIVE);
-        }
-
-        // Scan filter string (PSI-MS MS:1000512). Also collect the analyzer type and the
-        // configured scan window (m/z range) carried inside the filter.
-        const std::string filter = raw.scan_filter(scan);
-        if (!filter.empty())
-        {
-          spectrum.setMetaValue("filter string", filter);
-
-          double win_lower = 0.0;
-          double win_upper = 0.0;
-          if (parseScanWindowFromFilter(filter, win_lower, win_upper))
-          {
-            ScanWindow window;
-            window.begin = win_lower;
-            window.end = win_upper;
-            spectrum.getInstrumentSettings().getScanWindows().push_back(window);
-          }
-        }
-
-        const std::string analyzer = raw.mass_analyzer_type(scan);
-        if (!analyzer.empty()) { analyzer_types.insert(analyzer); }
-        if (ionization_mode.empty()) { ionization_mode = raw.ionization_mode(scan); }
-
-        // Scan statistics (PSI-MS): total ion current, base peak m/z and intensity.
-        spectrum.setMetaValue("total ion current", raw.tic(scan));
-        spectrum.setMetaValue("base peak m/z", raw.base_peak_mass(scan));
-        spectrum.setMetaValue("base peak intensity", raw.base_peak_intensity(scan));
-
-        // Trailer-extra metadata: ion injection time and FAIMS compensation voltage. Neither has a
-        // dedicated bridge accessor; both are discovered by matching the (raw) trailer labels.
-        const std::vector<std::string> trailer_labels = raw.trailer_extra_labels(scan);
-        if (!trailer_labels.empty())
-        {
-          double injection_time = 0.0;
-          if (parseDouble(trailerValueContaining(raw, scan, trailer_labels, "Ion Injection Time"), injection_time))
-          {
-            // Ion injection time (MS:1000927) is a <scan>-level term; storing it on an Acquisition
-            // makes it serialize as a scan cvParam (matching ProteoWizard/msconvert output).
-            Acquisition acq;
-            acq.setMetaValue("ion injection time", injection_time);
-            spectrum.getAcquisitionInfo().push_back(acq);
-          }
-
-          double faims_cv = 0.0;
-          if (parseDouble(trailerValueContaining(raw, scan, trailer_labels, "FAIMS CV"), faims_cv))
-          {
-            spectrum.setDriftTime(faims_cv);
-            spectrum.setDriftTimeUnit(DriftTimeUnit::FAIMS_COMPENSATION_VOLTAGE);
-          }
-        }
-
-        // Precursor info for MSn
-        if (ms_level > 1)
-        {
-          Precursor prec;
-          const double prec_mz = raw.precursor_mass(scan);
-          if (prec_mz > 0.0)
-          {
-            prec.setMZ(prec_mz);
-          }
-          const int charge = raw.precursor_charge(scan);
-          if (charge != 0)
-          {
-            prec.setCharge(charge);
-          }
-          // Map activation type string to OpenMS activation method (independent of collision energy,
-          // so electron-based methods that report no eV still get an activation method).
-          const std::string act_type = raw.activation_type(scan);
-          if (act_type == "CID" || act_type == "CollisionInducedDissociation")
-          {
-            prec.getActivationMethods().insert(Precursor::ActivationMethod::CID);
-          }
-          else if (act_type == "HCD" || act_type == "HigherEnergyCollisionalDissociation")
-          {
-            prec.getActivationMethods().insert(Precursor::ActivationMethod::HCD);
-          }
-          else if (act_type == "ETD" || act_type == "ElectronTransferDissociation")
-          {
-            prec.getActivationMethods().insert(Precursor::ActivationMethod::ETD);
-          }
-          else if (act_type == "ECD" || act_type == "ElectronCaptureDissociation")
-          {
-            prec.getActivationMethods().insert(Precursor::ActivationMethod::ECD);
-          }
-          else if (act_type == "PQD")
-          {
-            prec.getActivationMethods().insert(Precursor::ActivationMethod::PQD);
-          }
-          else if (!act_type.empty())
-          {
-            OPENMS_LOG_WARN << "ThermoRawFile: unknown activation type '" << act_type
-                            << "' for scan " << scan << ", defaulting to CID\n";
-            prec.getActivationMethods().insert(Precursor::ActivationMethod::CID);
-          }
-          const double ce = raw.collision_energy(scan);
-          if (ce > 0.0)
-          {
-            prec.setActivationEnergy(ce);
-          }
-          const double iso_width = raw.isolation_width(scan);
-          if (iso_width > 0.0)
-          {
-            prec.setIsolationWindowLowerOffset(iso_width / 2.0);
-            prec.setIsolationWindowUpperOffset(iso_width / 2.0);
-          }
-          spectrum.getPrecursors().push_back(prec);
-        }
-
-        // Read spectrum data (prefer centroided data for centroid scans)
-        auto data = raw.spectrum_data(scan, centroid);
-
-        // Populate peaks, tracking the lowest/highest observed m/z (PSI-MS MS:1000528/MS:1000527).
-        spectrum.resize(data.mz.size());
-        double lowest_mz = std::numeric_limits<double>::max();
-        double highest_mz = std::numeric_limits<double>::lowest();
-        for (size_t i = 0; i < data.mz.size(); ++i)
-        {
-          const double mz = data.mz[i];
-          spectrum[i].setMZ(mz);
-          spectrum[i].setIntensity(static_cast<Peak1D::IntensityType>(data.intensities[i]));
-          lowest_mz = std::min(lowest_mz, mz);
-          highest_mz = std::max(highest_mz, mz);
-        }
-        if (!data.mz.empty())
-        {
-          spectrum.setMetaValue("lowest observed m/z", lowest_mz);
-          spectrum.setMetaValue("highest observed m/z", highest_mz);
-        }
-
-        exp.addSpectrum(std::move(spectrum));
-      }
-
-      endProgress();
-
-      // --- Instrument component lists (single OpenMS Instrument) ---
-      // OpenMS represents one instrument configuration per experiment, whereas Thermo files may use
-      // several (e.g. FTMS + ion trap). We capture the union of analyzers seen plus the ion source and
-      // detector(s) implied by the instrument model.
-      Instrument& instrument = exp.getInstrument();
-      Int component_order = 1;
-      if (!ionization_mode.empty())
-      {
-        const IonSource::IonizationMethod method = mapIonization(ionization_mode);
-        if (method != IonSource::IonizationMethod::IONMETHODNULL)
-        {
-          IonSource source;
-          source.setIonizationMethod(method);
-          source.setOrder(component_order++);
-          instrument.getIonSources().push_back(source);
-        }
-      }
-      std::set<IonDetector::Type> detector_types;
-      for (const std::string& analyzer : analyzer_types)
-      {
-        const MassAnalyzer::AnalyzerType type = mapAnalyzer(analyzer, model);
-        if (type == MassAnalyzer::AnalyzerType::ANALYZERNULL) { continue; }
-        MassAnalyzer mass_analyzer;
-        mass_analyzer.setType(type);
-        mass_analyzer.setOrder(component_order++);
-        instrument.getMassAnalyzers().push_back(mass_analyzer);
-
-        const IonDetector::Type detector = detectorForAnalyzer(type);
-        if (detector != IonDetector::Type::TYPENULL) { detector_types.insert(detector); }
-      }
-      for (const IonDetector::Type type : detector_types)
-      {
-        IonDetector ion_detector;
-        ion_detector.setType(type);
-        ion_detector.setOrder(component_order++);
-        instrument.getIonDetectors().push_back(ion_detector);
-      }
-
-      // --- TIC chromatogram ---
-      const openms::thermo_bridge::ChromatogramData tic_data = raw.chromatogram_data();
-      if (!tic_data.times.empty())
-      {
-        MSChromatogram tic;
-        tic.setChromatogramType(ChromatogramSettings::ChromatogramType::TOTAL_ION_CURRENT_CHROMATOGRAM);
-        tic.setNativeID("TIC");
-        for (size_t i = 0; i < tic_data.times.size(); ++i)
-        {
-          tic.push_back(ChromatogramPeak(tic_data.times[i] * 60.0, tic_data.intensities[i]));
-        }
-        exp.addChromatogram(std::move(tic));
-      }
-
-      // Sort by RT
-      exp.sortSpectra(true);
-      exp.updateRanges();
-
-      OPENMS_LOG_INFO << "ThermoRawFile: loaded " << exp.size() << " spectra\n";
-    }
-    catch (const openms::thermo_bridge::bridge_error& e)
-    {
-      throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-        path, std::string("Thermo bridge error: ") + e.what());
+      case MassAnalyzer::AnalyzerType::ORBITRAP:
+      case MassAnalyzer::AnalyzerType::FOURIERTRANSFORM:
+        return IonDetector::Type::INDUCTIVEDETECTOR;
+      case MassAnalyzer::AnalyzerType::IT:
+      case MassAnalyzer::AnalyzerType::QUADRUPOLE:
+        return IonDetector::Type::ELECTRONMULTIPLIER;
+      default:
+        return IonDetector::Type::TYPENULL;
     }
   }
 
-} // namespace OpenMS
+} // anonymous namespace
 
+void ThermoRawFile::load(const std::string& path, MSExperiment& exp)
+{
+  exp = MSExperiment();
+  if (! File::exists(path)) { throw Exception::FileNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, path); }
+  const std::filesystem::path raw_path(path);
+  using Json = nlohmann::json;
+  using Metadata = Internal::ThermoRawFileMetadata;
+  auto text = [](const Json& object, const std::string& key) -> std::string {
+    return object.contains(key) && object[key].is_string() ? object[key].get<std::string>() : "";
+  };
+  auto numeric = [](const Json& object, const std::string& key, double fallback = 0.0) -> double {
+    return object.contains(key) && object[key].is_number() ? object[key].get<double>() : fallback;
+  };
+  auto unit_value = [](double value, int unit) -> DataValue {
+    DataValue result(value);
+    result.setUnitType(DataValue::UnitType::UNIT_ONTOLOGY);
+    result.setUnit(unit);
+    return result;
+  };
+  auto ms_unit_value = [](double value, int unit) -> DataValue {
+    DataValue result(value);
+    result.setUnitType(DataValue::UnitType::MS_ONTOLOGY);
+    result.setUnit(unit);
+    return result;
+  };
+  auto copy_values = [](const Json& object, MetaInfoInterface& target, const std::string& prefix = "") {
+    for (const auto& [key, value] : object.items())
+    {
+      if (value.is_number_integer()) { target.setMetaValue(prefix + key, value.get<Int64>()); }
+      else if (value.is_number()) { target.setMetaValue(prefix + key, value.get<double>()); }
+      else if (value.is_string()) { target.setMetaValue(prefix + key, value.get<std::string>()); }
+    }
+  };
+  try
+  {
+    openms::thermo_bridge::RawFile raw(raw_path);
+    const Json metadata = Json::parse(raw.file_metadata_json(options_.instrument_methods, options_.checksum));
+    if (metadata.at("schema_version") != 1) { throw std::runtime_error("Unsupported Thermo metadata schema"); }
+    const auto& file = metadata.at("file");
+    SourceFile source;
+    source.setNameOfFile(raw_path.filename().string());
+    source.setPathToFile(raw_path.parent_path().string());
+    source.setFileType("Thermo RAW format");
+    source.setNativeIDType("Thermo nativeID format");
+    source.setNativeIDTypeAccession("MS:1000768");
+    if (! text(file, "sha1").empty()) { source.setChecksum(text(file, "sha1"), SourceFile::ChecksumType::SHA1); }
+    source.setMetaValue("RAW file revision", file.at("revision").get<int>());
+    source.setMetaValue("file description", text(file, "description"));
+    exp.getSourceFiles().push_back(source);
+    const std::string date = text(file, "creation_date");
+    if (date.size() >= 19)
+    {
+      exp.setDateTime(DateTime::fromString(date.substr(0, 19), "yyyy-MM-ddThh:mm:ss"));
+      exp.setMetaValue("mzml_start_time_stamp", date);
+    }
+    copy_values(metadata.at("sample"), exp.getSample(), "Thermo ");
+    exp.getSample().setName(text(metadata.at("sample"), "sample name"));
+    exp.getSample().setNumber(text(metadata.at("sample"), "sample number"));
+    exp.getSample().setComment(text(metadata.at("sample"), "sample comment"));
+    exp.getSample().setMetaValue("Thermo user sample fields", metadata.at("user_sample_fields").dump());
+    if (options_.instrument_methods) { exp.setMetaValue("Thermo instrument methods", metadata.at("instrument_methods").dump()); }
+    if (metadata.at("run").is_object()) { copy_values(metadata.at("run"), exp, "Thermo run "); }
+    exp.setMetaValue("Thermo RawFileReader version", text(metadata, "reader_version"));
+
+    Instrument instrument;
+    std::string model;
+    if (metadata.at("instrument").is_object())
+    {
+      const auto& info = metadata.at("instrument");
+      model = text(info, "model");
+      instrument.setName(openms::thermo_bridge::cv_instrument_model(model).name);
+      instrument.setModel(model);
+      instrument.setMetaValue("Thermo instrument name", text(info, "name"));
+      instrument.setMetaValue("instrument serial number", text(info, "serial_number"));
+      instrument.setMetaValue("Thermo hardware version", text(info, "hardware_version"));
+      instrument.setMetaValue("Thermo instrument units", text(info, "units"));
+      instrument.getSoftware().setName("Thermo acquisition software");
+      instrument.getSoftware().setVersion(text(info, "software_version"));
+    }
+    exp.setInstrument(instrument);
+    auto processing = std::make_shared<DataProcessing>();
+    processing->getSoftware().setName("OpenMS Thermo RAW reader");
+    processing->getSoftware().setVersion("0.3.0");
+    processing->setMetaValue("Thermo RawFileReader version", text(metadata, "reader_version"));
+    processing->getProcessingActions().insert(DataProcessing::ProcessingAction::FORMAT_CONVERSION);
+    if (options_.centroid) { processing->getProcessingActions().insert(DataProcessing::ProcessingAction::PEAK_PICKING); }
+
+    std::map<std::string, std::string> configurations;
+    Metadata precursor_parser;
+    std::map<int, Size> spectrum_by_scan;
+    auto activation = [&](Precursor& precursor, const Json& reaction, bool supplemental) {
+      const std::string type = text(reaction, "activation");
+      if (reaction.value("collision_energy_valid", false) && reaction.at("collision_energy").is_number())
+      {
+        precursor.setMetaValue(supplemental ? "supplemental collision energy" : "collision energy",
+                               unit_value(numeric(reaction, "collision_energy"), 266));
+      }
+      if (supplemental)
+      {
+        if (type == "HigherEnergyCollisionalDissociation") { precursor.setMetaValue("supplemental beam-type collision-induced dissociation", ""); }
+        else if (type == "CollisionInducedDissociation") { precursor.setMetaValue("supplemental collision-induced dissociation", ""); }
+        else
+        {
+          precursor.setMetaValue("Thermo supplemental activation", type);
+        }
+        return;
+      }
+      static const std::map<std::string, Precursor::ActivationMethod> methods = {
+        {"CollisionInducedDissociation", Precursor::ActivationMethod::CID}, {"HigherEnergyCollisionalDissociation", Precursor::ActivationMethod::HCD},
+        {"ElectronTransferDissociation", Precursor::ActivationMethod::ETD}, {"ElectronCaptureDissociation", Precursor::ActivationMethod::ECD},
+        {"MultiPhotonDissociation", Precursor::ActivationMethod::IMD},      {"PQD", Precursor::ActivationMethod::PQD}};
+      auto it = methods.find(type);
+      if (it != methods.end()) { precursor.getActivationMethods().insert(it->second); }
+      else
+      {
+        const auto term = openms::thermo_bridge::cv_activation_type(type);
+        if (term.accession != "MS:1000044") { precursor.setMetaValue(term.name, ""); }
+        precursor.setMetaValue("Thermo activation type", type);
+      }
+    };
+    if (raw.has_ms_data())
+    {
+      const int first = raw.first_scan_number(), last = raw.last_scan_number();
+      exp.reserve(raw.scan_count());
+      startProgress(first, last, "Loading Thermo RAW file");
+      for (int scan = first; scan <= last; ++scan)
+      {
+        setProgress(scan);
+        const Json meta = Json::parse(raw.scan_metadata_json(scan));
+        if (meta.at("schema_version") != 1) { throw std::runtime_error("Unsupported Thermo scan metadata schema"); }
+        MSSpectrum spectrum;
+        const int level = meta.at("ms_level");
+        spectrum.setMSLevel(level > 0 ? level : 0);
+        const std::string order = text(meta, "ms_order_name");
+        auto mode = level == 1 ? InstrumentSettings::ScanMode::MS1SPECTRUM : InstrumentSettings::ScanMode::MSNSPECTRUM;
+        if (order == "Par") { mode = InstrumentSettings::ScanMode::PRECURSOR; }
+        else if (order == "Nl") { mode = InstrumentSettings::ScanMode::CNL; }
+        else if (order == "Ng") { mode = InstrumentSettings::ScanMode::CNG; }
+        spectrum.getInstrumentSettings().setScanMode(mode);
+        spectrum.setRT(meta.at("retention_time").get<double>() * 60.0);
+        spectrum.setNativeID(text(meta, "native_id"));
+        const bool centroid = options_.centroid || meta.at("centroid").get<bool>();
+        spectrum.setType(centroid ? SpectrumSettings::SpectrumType::CENTROID : SpectrumSettings::SpectrumType::PROFILE);
+        const int polarity = meta.at("polarity");
+        if (polarity == 1) { spectrum.getInstrumentSettings().setPolarity(IonSource::Polarity::POSITIVE); }
+        else if (polarity == 0) { spectrum.getInstrumentSettings().setPolarity(IonSource::Polarity::NEGATIVE); }
+        const std::string filter = text(meta, "filter");
+        Acquisition acquisition;
+        acquisition.setMetaValue("filter string", filter);
+        // Keep the historical spectrum-level accessor as well as the mzML
+        // scan-level term.
+        spectrum.setMetaValue("filter string", filter);
+        if (options_.preserve_trailers) { acquisition.setMetaValue("Thermo trailer extra", meta.at("trailer").dump()); }
+        auto injection = Metadata::number(Metadata::trailer(meta, "Ion Injection Time (ms):"));
+        if (injection.is_number()) { acquisition.setMetaValue("ion injection time", unit_value(injection.get<double>(), 28)); }
+        auto mono = Metadata::number(Metadata::trailer(meta, "Monoisotopic M/Z:"));
+        if (mono.is_number() && mono.get<double>() > 0) { acquisition.setMetaValue("[Thermo Trailer Extra]Monoisotopic M/Z:", mono.get<double>()); }
+        const auto voltage_on = Metadata::number(Metadata::trailer(meta, "FAIMS Voltage On:"));
+        const auto voltage = Metadata::number(Metadata::trailer(meta, "FAIMS CV:"));
+        std::string enabled = Metadata::trailer(meta, "FAIMS Voltage On:");
+        std::transform(enabled.begin(), enabled.end(), enabled.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        if (((voltage_on.is_number() && voltage_on.get<double>() != 0) || (enabled == "true" || enabled == "on" || enabled == "yes"))
+            && voltage.is_number())
+        {
+          spectrum.setDriftTime(voltage.get<double>());
+          spectrum.setDriftTimeUnit(DriftTimeUnit::FAIMS_COMPENSATION_VOLTAGE);
+        }
+        const std::string analyzer = text(meta, "analyzer"), ionization = text(meta, "ionization");
+        const std::string configuration_key = analyzer + ":" + ionization;
+        if (! configurations.count(configuration_key))
+        {
+          const std::string id = configurations.empty() ? "ic_0" : "thermo_ic_" + std::to_string(configurations.size());
+          configurations[configuration_key] = id;
+          Instrument config = instrument;
+          IonSource ion_source;
+          ion_source.setIonizationMethod(mapIonization(ionization));
+          ion_source.setOrder(1);
+          ion_source.setMetaValue("ionization accession", openms::thermo_bridge::cv_ionization_mode(ionization).accession);
+          config.getIonSources().push_back(ion_source);
+          MassAnalyzer mass_analyzer;
+          mass_analyzer.setType(mapAnalyzer(analyzer, model));
+          mass_analyzer.setOrder(2);
+          mass_analyzer.setMetaValue("mass analyzer accession", openms::thermo_bridge::cv_mass_analyzer(analyzer, model).accession);
+          config.getMassAnalyzers().push_back(mass_analyzer);
+          IonDetector detector;
+          detector.setType(analyzer == "MassAnalyzerASTMS" ? IonDetector::Type::CONVERSIONDYNODEELECTRONMULTIPLIER
+                                                           : detectorForAnalyzer(mass_analyzer.getType()));
+          detector.setOrder(3);
+          config.getIonDetectors().push_back(detector);
+          if (id != "ic_0") { exp.getInstrumentConfigurations()[id] = config; }
+          if (configurations.size() == 1) { exp.setInstrument(config); }
+        }
+        if (configurations.at(configuration_key) != "ic_0")
+        {
+          acquisition.setMetaValue("instrument_configuration_ref", configurations.at(configuration_key));
+        }
+        spectrum.getAcquisitionInfo().push_back(acquisition);
+        ScanWindow window;
+        window.begin = numeric(meta, "low_mass");
+        window.end = numeric(meta, "high_mass");
+        if (meta.at("low_mass").is_number() && meta.at("high_mass").is_number() && window.end >= window.begin)
+        {
+          spectrum.getInstrumentSettings().getScanWindows().push_back(window);
+        }
+        if (meta.at("tic").is_number()) { spectrum.setMetaValue("total ion current", numeric(meta, "tic")); }
+        if (meta.at("base_peak_mass").is_number())
+        {
+          spectrum.setMetaValue("base peak m/z", ms_unit_value(numeric(meta, "base_peak_mass"), 1000040));
+        }
+        if (meta.at("base_peak_intensity").is_number())
+        {
+          spectrum.setMetaValue("base peak intensity", ms_unit_value(numeric(meta, "base_peak_intensity"), 1000131));
+        }
+        const bool neutral = order == "Nl" || order == "Ng";
+        if (neutral && ! meta.at("reactions").empty())
+        {
+          const auto& reaction = meta.at("reactions").front();
+          spectrum.setMetaValue(order == "Nl" ? "neutral loss" : "neutral gain", numeric(reaction, "precursor_mass"));
+          Product product;
+          const double width = numeric(reaction, "isolation_width", -1);
+          const double offset = numeric(reaction, "isolation_offset");
+          if (width >= 0 && width / 2 >= std::abs(offset))
+          {
+            product.setIsolationWindowLowerOffset(width / 2 - offset);
+            product.setIsolationWindowUpperOffset(width / 2 + offset);
+          }
+          spectrum.getProducts().push_back(product);
+        }
+        for (const auto& descriptor : neutral ? Json::array() : precursor_parser.precursors(meta))
+        {
+          Precursor precursor;
+          precursor.setMZ(numeric(descriptor, "selected_mz")); // OpenMS default: selected ion
+          precursor.setMetaValue("isolation window target m/z", numeric(descriptor, "target_mz"));
+          precursor.setMetaValue("selected ion m/z", numeric(descriptor, "selected_mz"));
+          if (descriptor.at("charge").is_number()) { precursor.setCharge(static_cast<int>(numeric(descriptor, "charge"))); }
+          if (descriptor.at("width").is_number())
+          {
+            const double lower = numeric(descriptor, "lower_offset"), upper = numeric(descriptor, "upper_offset");
+            if (lower >= 0) { precursor.setIsolationWindowLowerOffset(lower); }
+            if (upper >= 0) { precursor.setIsolationWindowUpperOffset(upper); }
+            if (lower <= 0) { precursor.setMetaValue("isolation window lower offset", lower); }
+            if (upper <= 0) { precursor.setMetaValue("isolation window upper offset", upper); }
+          }
+          if (! text(descriptor, "spectrum_ref").empty()) { precursor.setMetaValue("spectrum_ref", text(descriptor, "spectrum_ref")); }
+          activation(precursor, descriptor.at("activation"), false);
+          if (descriptor.at("supplemental").is_object()) { activation(precursor, descriptor.at("supplemental"), true); }
+          auto parent = spectrum_by_scan.find(descriptor.at("parent_scan").get<int>());
+          if (descriptor.at("estimate_intensity").get<bool>() && parent != spectrum_by_scan.end() && precursor.getMZ() > 0)
+          {
+            // TRFP's precursor-intensity estimate sums the target +/- 1.5 m/z.
+            double intensity = 0;
+            const auto& parent_spectrum = exp[parent->second];
+            const double target = numeric(descriptor, "target_mz");
+            const double half_width = numeric(descriptor, "width") > 0 ? 1.5 : 0.0;
+            for (auto peak = parent_spectrum.MZBegin(target - half_width); peak != parent_spectrum.end() && peak->getMZ() < target + half_width;
+                 ++peak)
+            {
+              intensity += peak->getIntensity();
+            }
+            precursor.setIntensity(intensity);
+            if (intensity == 0) { precursor.setMetaValue("peak intensity", 0.0); }
+            precursor.setMetaValue("peak intensity unit accession", "MS:1000131");
+          }
+          spectrum.getPrecursors().push_back(precursor);
+        }
+        auto data = raw.spectrum_data(scan, options_.centroid);
+        spectrum.resize(data.mz.size());
+        for (Size i = 0; i < data.mz.size(); ++i)
+        {
+          spectrum[i].setMZ(data.mz[i]);
+          spectrum[i].setIntensity(data.intensities[i]);
+        }
+        if (! data.mz.empty())
+        {
+          if (centroid)
+          {
+            const Size basepeak = std::distance(data.intensities.begin(), std::max_element(data.intensities.begin(), data.intensities.end()));
+            spectrum.setMetaValue("base peak m/z", ms_unit_value(data.mz[basepeak], 1000040));
+            spectrum.setMetaValue("base peak intensity", ms_unit_value(data.intensities[basepeak], 1000131));
+          }
+          const auto [lo, hi] = std::minmax_element(data.mz.begin(), data.mz.end());
+          spectrum.setMetaValue("lowest observed m/z", ms_unit_value(*lo, 1000040));
+          spectrum.setMetaValue("highest observed m/z", ms_unit_value(*hi, 1000040));
+        }
+        if (options_.charge_data && options_.centroid)
+        {
+          auto charges = raw.spectrum_auxiliary_array(scan, 0);
+          if (! charges.empty() && charges.size() == spectrum.size())
+          {
+            MSSpectrum::IntegerDataArray array;
+            array.setName("charge array");
+            for (double charge : charges)
+            {
+              array.push_back(static_cast<Int64>(charge));
+            }
+            spectrum.getIntegerDataArrays().push_back(std::move(array));
+          }
+        }
+        // The independently sampled noise grid must not be sorted/filtered with
+        // peaks. Store double lists; MzMLHandler serializes these as 64-bit
+        // binary arrays.
+        if (options_.noise_data)
+        {
+          const char* names[] = {"", "sampled noise m/z array", "sampled noise intensity array", "sampled noise baseline array"};
+          for (int kind = 1; kind <= 3; ++kind)
+          {
+            auto values = raw.spectrum_auxiliary_array(scan, kind);
+            if (! values.empty()) { spectrum.setMetaValue(names[kind], values); }
+          }
+        }
+        spectrum.getDataProcessing().push_back(processing);
+        if (! spectrum.isSorted()) { spectrum.sortByPosition(); }
+        spectrum_by_scan[scan] = exp.size();
+        exp.addSpectrum(std::move(spectrum));
+      }
+      endProgress();
+      const auto data = raw.chromatogram_data();
+      MSChromatogram tic;
+      tic.setNativeID("TIC");
+      tic.setChromatogramType(ChromatogramSettings::ChromatogramType::TOTAL_ION_CURRENT_CHROMATOGRAM);
+      for (Size i = 0; i < data.times.size(); ++i)
+      {
+        tic.push_back(ChromatogramPeak(data.times[i] * 60.0, data.intensities[i]));
+      }
+      tic.getDataProcessing().push_back(processing);
+      if (! tic.empty()) { exp.addChromatogram(std::move(tic)); }
+    }
+    if (options_.all_detectors)
+    {
+      const Json detectors = Json::parse(raw.detector_chromatograms_json());
+      for (const auto& trace : detectors.at("chromatograms"))
+      {
+        MSChromatogram chromatogram;
+        chromatogram.setNativeID(text(trace, "native_id"));
+        chromatogram.setName(text(trace, "label"));
+        const std::string label = text(trace, "label"), device = text(trace, "device");
+        const bool absorption = device == "UV" || device == "Pda";
+        chromatogram.setChromatogramType(absorption ? ChromatogramSettings::ChromatogramType::ABSORPTION_CHROMATOGRAM
+                                                    : ChromatogramSettings::ChromatogramType::MASS_CHROMATOGRAM);
+        chromatogram.setMetaValue("Thermo detector units", text(trace, "units"));
+        if (absorption) { chromatogram.setMetaValue("mzml intensity array", "absorption"); }
+        else if (containsCI(label, "pressure"))
+        {
+          chromatogram.setMetaValue("chromatogram type accession", "MS:1003019");
+          chromatogram.setMetaValue("mzml intensity array", "pressure");
+        }
+        else if (containsCI(label, "flow"))
+        {
+          chromatogram.setMetaValue("chromatogram type accession", "MS:1003020");
+          chromatogram.setMetaValue("mzml intensity array", "flow");
+        }
+        else if (! containsCI(label, "current") && ! containsCI(label, "fid"))
+        {
+          chromatogram.setMetaValue("chromatogram type accession", "MS:1000626");
+          chromatogram.setMetaValue("mzml intensity array", "nonstandard");
+        }
+        const auto times = trace.at("times").get<std::vector<double>>();
+        const auto values = trace.at("intensities").get<std::vector<double>>();
+        if (times.size() != values.size()) { throw std::runtime_error("Inconsistent Thermo detector array lengths"); }
+        for (Size i = 0; i < times.size(); ++i)
+        {
+          chromatogram.push_back(ChromatogramPeak(times[i] * 60.0, values[i]));
+        }
+        chromatogram.getDataProcessing().push_back(processing);
+        exp.addChromatogram(std::move(chromatogram));
+      }
+      for (const auto& controller : metadata.at("controllers"))
+      {
+        if (text(controller, "name") != "Pda") { continue; }
+        raw.select_instrument(controller.at("type").get<int>(), controller.at("number").get<int>());
+        for (int scan = raw.first_scan_number(); scan <= raw.last_scan_number(); ++scan)
+        {
+          const Json meta = Json::parse(raw.scan_metadata_json(scan));
+          MSSpectrum spectrum;
+          spectrum.setNativeID(text(meta, "native_id"));
+          spectrum.setRT(meta.at("retention_time").get<double>() * 60.0);
+          spectrum.setMSLevel(0);
+          spectrum.getInstrumentSettings().setScanMode(InstrumentSettings::ScanMode::ABSORPTION);
+          spectrum.setType(SpectrumSettings::SpectrumType::PROFILE);
+          spectrum.setMetaValue("mzml coordinate array", "wavelength");
+          spectrum.setMetaValue("mzml intensity array", "absorption");
+          Acquisition acquisition;
+          spectrum.getAcquisitionInfo().push_back(acquisition);
+          ScanWindow window;
+          window.begin = numeric(meta, "low_wavelength");
+          window.end = numeric(meta, "high_wavelength");
+          window.setMetaValue("unit_accession", "UO:0000018");
+          if (meta.at("low_wavelength").is_number() && meta.at("high_wavelength").is_number())
+          {
+            spectrum.getInstrumentSettings().getScanWindows().push_back(window);
+          }
+          const auto data = raw.spectrum_data(scan, false);
+          for (Size i = 0; i < data.mz.size(); ++i)
+          {
+            Peak1D peak;
+            peak.setMZ(data.mz[i]);
+            peak.setIntensity(data.intensities[i]);
+            spectrum.push_back(peak);
+          }
+          if (! data.mz.empty())
+          {
+            const auto [lo, hi] = std::minmax_element(data.mz.begin(), data.mz.end());
+            spectrum.setMetaValue("lowest observed wavelength", unit_value(*lo, 18));
+            spectrum.setMetaValue("highest observed wavelength", unit_value(*hi, 18));
+          }
+          spectrum.getDataProcessing().push_back(processing);
+          exp.addSpectrum(std::move(spectrum));
+        }
+      }
+    }
+    exp.sortSpectra(true);
+    exp.updateRanges();
+  }
+  catch (const std::exception& error)
+  {
+    throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, path, std::string("Thermo RAW reader: ") + error.what());
+  }
+}
+
+} // namespace OpenMS
 #endif // WITH_THERMO_RAW

--- a/src/openms/source/METADATA/ExperimentalSettings.cpp
+++ b/src/openms/source/METADATA/ExperimentalSettings.cpp
@@ -23,6 +23,7 @@ namespace OpenMS
            source_files_ == rhs.source_files_ &&
            contacts_ == rhs.contacts_ &&
            instrument_ == rhs.instrument_ &&
+           instrument_configurations_ == rhs.instrument_configurations_ &&
            hplc_ == rhs.hplc_ &&
            datetime_ == rhs.datetime_ &&
            comment_ == rhs.comment_ &&
@@ -94,6 +95,21 @@ namespace OpenMS
   void ExperimentalSettings::setInstrument(const Instrument & instrument)
   {
     instrument_ = instrument;
+  }
+
+  const std::map<std::string, Instrument>& ExperimentalSettings::getInstrumentConfigurations() const
+  {
+    return instrument_configurations_;
+  }
+
+  std::map<std::string, Instrument>& ExperimentalSettings::getInstrumentConfigurations()
+  {
+    return instrument_configurations_;
+  }
+
+  void ExperimentalSettings::setInstrumentConfigurations(const std::map<std::string, Instrument>& configurations)
+  {
+    instrument_configurations_ = configurations;
   }
 
   const DateTime & ExperimentalSettings::getDateTime() const

--- a/src/pyOpenMS/bindings/bind_format.cpp
+++ b/src/pyOpenMS/bindings/bind_format.cpp
@@ -21,6 +21,7 @@
 #include <OpenMS/FORMAT/FLASHDeconvFeatureFile.h>
 #include <OpenMS/FORMAT/FLASHDeconvSpectrumFile.h>
 #include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/FORMAT/ThermoRawFile.h>
 #include <OpenMS/FORMAT/FileInfo.h>
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/MATH/StatisticFunctions.h>
@@ -98,6 +99,26 @@ using namespace nb::literals;
 
 NB_MODULE(_pyopenms_format, m) {
     m.doc() = "pyOpenMS format bindings";
+
+#ifdef WITH_THERMO_RAW
+    nb::class_<OpenMS::ThermoRawFile::Options>(m, "ThermoRawFileOptions", "Options for metadata-preserving Thermo RAW loading")
+        .def(nb::init<>())
+        .def(nb::init<const OpenMS::ThermoRawFile::Options&>())
+        .def_rw("centroid", &OpenMS::ThermoRawFile::Options::centroid)
+        .def_rw("charge_data", &OpenMS::ThermoRawFile::Options::charge_data)
+        .def_rw("noise_data", &OpenMS::ThermoRawFile::Options::noise_data)
+        .def_rw("all_detectors", &OpenMS::ThermoRawFile::Options::all_detectors)
+        .def_rw("preserve_trailers", &OpenMS::ThermoRawFile::Options::preserve_trailers)
+        .def_rw("instrument_methods", &OpenMS::ThermoRawFile::Options::instrument_methods)
+        .def_rw("checksum", &OpenMS::ThermoRawFile::Options::checksum);
+    nb::class_<OpenMS::ThermoRawFile, OpenMS::ProgressLogger>(m, "ThermoRawFile", "Load Thermo RAW spectra and metadata for mzML export")
+        .def(nb::init<>())
+        .def(nb::init<const OpenMS::ThermoRawFile&>())
+        .def("getOptions", &OpenMS::ThermoRawFile::getOptions, nb::rv_policy::copy)
+        .def("setOptions", &OpenMS::ThermoRawFile::setOptions, "options"_a)
+        .def("load", &OpenMS::ThermoRawFile::load, "filename"_a, "experiment"_a, nb::call_guard<nb::gil_scoped_release>());
+#endif
+
 
     // -----------------------------------------------------------------------
     // AbsoluteQuantitationStandardsFile

--- a/src/pyOpenMS/bindings/bind_kernel.cpp
+++ b/src/pyOpenMS/bindings/bind_kernel.cpp
@@ -878,6 +878,8 @@ about an LC-MS/MS injection.
         .def("setContacts", [](OpenMS::ExperimentalSettings& self, const std::vector<OpenMS::ContactPerson>& contacts) { return self.setContacts(contacts); }, "contacts"_a, "Sets the list of contact persons")
         .def("getInstrument", [](OpenMS::ExperimentalSettings& self) -> OpenMS::Instrument { return self.getInstrument(); }, "Returns a copy of the MS instrument description")
         .def("setInstrument", [](OpenMS::ExperimentalSettings& self, const OpenMS::Instrument& instrument) { return self.setInstrument(instrument); }, "instrument"_a, "Sets the MS instrument description")
+        .def("getInstrumentConfigurations", [](const OpenMS::ExperimentalSettings& self) { return self.getInstrumentConfigurations(); })
+        .def("setInstrumentConfigurations", &OpenMS::ExperimentalSettings::setInstrumentConfigurations, "configurations"_a)
         .def("getHPLC", [](OpenMS::ExperimentalSettings& self) -> OpenMS::HPLC { return self.getHPLC(); }, "Returns a copy of the description of the HPLC run")
         .def("setHPLC", [](OpenMS::ExperimentalSettings& self, const OpenMS::HPLC& hplc) { return self.setHPLC(hplc); }, "hplc"_a, "Sets the description of the HPLC run")
         .def("getDateTime", [](const OpenMS::ExperimentalSettings& self) -> OpenMS::DateTime { return self.getDateTime(); }, "Returns the date the experiment was performed")

--- a/src/pyOpenMS/bindings/type_casters/openms_stl_caster.h
+++ b/src/pyOpenMS/bindings/type_casters/openms_stl_caster.h
@@ -261,11 +261,12 @@ public:
 
             // Convert value
             type_caster<V> value_caster;
-            if (!value_caster.from_python(handle(val), flags, cleanup)) {
+            if (!value_caster.from_python(handle(val), flags_for_local_caster<V>(flags), cleanup) ||
+                !value_caster.template can_cast<V>()) {
                 return false;
             }
 
-            value[cpp_key] = std::move(value_caster.value);
+            value.emplace(std::move(cpp_key), value_caster.operator cast_t<V>());
         }
 
         return true;

--- a/src/pyOpenMS/tests/test_ThermoRawFile.py
+++ b/src/pyOpenMS/tests/test_ThermoRawFile.py
@@ -1,0 +1,25 @@
+"""Public options and instrument-configuration API, independent of RAW fixtures."""
+import pytest
+import pyopenms as oms
+
+
+def test_thermo_options():
+    if not hasattr(oms, "ThermoRawFile"):
+        pytest.skip("OpenMS built without Thermo RAW support")
+    reader = oms.ThermoRawFile()
+    options = reader.getOptions()
+    assert options.preserve_trailers and options.instrument_methods and options.checksum
+    assert not options.centroid
+    options.centroid = options.charge_data = options.noise_data = options.all_detectors = True
+    reader.setOptions(options)
+    assert reader.getOptions().centroid
+    assert reader.getOptions().all_detectors
+
+
+def test_instrument_configurations():
+    experiment = oms.MSExperiment()
+    instrument = oms.Instrument()
+    instrument.setName("Orbitrap Astral")
+    experiment.setInstrumentConfigurations({"astral": instrument})
+    configurations = experiment.getInstrumentConfigurations()
+    assert configurations["astral"].getName() == "Orbitrap Astral"

--- a/src/pyOpenMS/tests/test_ThermoRawFile.py
+++ b/src/pyOpenMS/tests/test_ThermoRawFile.py
@@ -23,3 +23,12 @@ def test_instrument_configurations():
     experiment.setInstrumentConfigurations({"astral": instrument})
     configurations = experiment.getInstrumentConfigurations()
     assert configurations["astral"].getName() == "Orbitrap Astral"
+
+    instrument.setName("changed input")
+    assert experiment.getInstrumentConfigurations()["astral"].getName() == "Orbitrap Astral"
+    configurations["astral"].setName("changed copy")
+    assert experiment.getInstrumentConfigurations()["astral"].getName() == "Orbitrap Astral"
+    with pytest.raises(TypeError):
+        experiment.setInstrumentConfigurations({"invalid": None})
+    experiment.setInstrumentConfigurations({})
+    assert experiment.getInstrumentConfigurations() == {}

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -245,6 +245,7 @@ set(format_executables_list
   MzIdentMLFile_test
   MzDataValidator_test
   MzIdentMLValidator_test
+  ThermoRawFileMetadata_test
   MzMLFile_test
   ImzMLFile_test
   ImzMLFile_all_modes_test

--- a/src/tests/class_tests/openms/source/ExperimentalSettings_test.cpp
+++ b/src/tests/class_tests/openms/source/ExperimentalSettings_test.cpp
@@ -353,6 +353,22 @@ END_SECTION
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
+START_SECTION((instrument configurations are copied and compared))
+{
+  ExperimentalSettings original;
+  Instrument instrument;
+  instrument.setName("Orbitrap Astral");
+  original.getInstrumentConfigurations()["astral"] = instrument;
+  ExperimentalSettings copy(original);
+  TEST_EQUAL(copy, original)
+  TEST_EQUAL(copy.getInstrumentConfigurations().at("astral").getName(), "Orbitrap Astral")
+  copy.getInstrumentConfigurations().at("astral").setName("Q Exactive");
+  TEST_NOT_EQUAL(copy, original)
+  copy.setInstrumentConfigurations(original.getInstrumentConfigurations());
+  TEST_EQUAL(copy, original)
+}
+END_SECTION
+
 END_TEST
 
 

--- a/src/tests/class_tests/openms/source/MzMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MzMLFile_test.cpp
@@ -1349,6 +1349,15 @@ END_SECTION
 VALIDATE_TMP_FILES
 
 
+START_SECTION((XML metadata uses UTF-8 and a strict ASCII fast path))
+{
+  TEST_TRUE(Internal::StringManager::isASCII(u"ASCII", 5))
+  TEST_FALSE(Internal::StringManager::isASCII(u"M\u00fcller", 6))
+  TEST_FALSE(Internal::StringManager::isASCII(u"1234567\u00fc", 8))
+  TEST_EQUAL(Internal::StringManager::convert(u"M\u00fcller \u03b1 \U0001f9ea"), "Müller \u03b1 \U0001f9ea")
+}
+END_SECTION
+
 START_SECTION((Thermo metadata survives mzML serialization, sorting, and reloading))
 {
   PeakMap original;
@@ -1356,7 +1365,7 @@ START_SECTION((Thermo metadata survives mzML serialization, sorting, and reloadi
   original.setMetaValue("mzml_start_time_stamp", "2024-01-02T03:04:05.1234567Z");
   original.setMetaValue("Thermo instrument methods", "[\"method\\nsecond line\"]");
   original.getSample().setMetaValue("Thermo sample volume", 2.5);
-  original.getSample().setName("Müller & sample");
+  original.getSample().setName("Müller & sample \u03b1 \U0001f9ea");
   original.getSample().setComment("first line\nsecond line\tend");
   Instrument instrument;
   instrument.setName("Orbitrap Astral");
@@ -1454,10 +1463,12 @@ START_SECTION((Thermo metadata survives mzML serialization, sorting, and reloadi
   }
   TEST_TRUE(StringUtils::hasSubstring(encoded, "2024-01-02T03:04:05.1234567Z"))
   TEST_TRUE(StringUtils::hasSubstring(encoded, "instrumentConfigurationRef=\"astral\""))
+  TEST_TRUE(StringUtils::hasSubstring(encoded, "&#252;"))
+  TEST_TRUE(StringUtils::hasSubstring(encoded, "&#129514;"))
   PeakMap loaded;
   file.loadBuffer(encoded, loaded);
   TEST_EQUAL(loaded.size(), 3)
-  TEST_EQUAL(loaded.getSample().getName(), "Müller & sample")
+  TEST_EQUAL(loaded.getSample().getName(), "Müller & sample \u03b1 \U0001f9ea")
   TEST_EQUAL(loaded.getSample().getComment(), "first line\nsecond line\tend")
   TEST_EQUAL(loaded.getInstrumentConfigurations().size(), 1)
   TEST_EQUAL(loaded.getInstrumentConfigurations().at("astral").getMassAnalyzers()[0].getMetaValue("mass analyzer accession"), "MS:1003379")

--- a/src/tests/class_tests/openms/source/MzMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MzMLFile_test.cpp
@@ -1148,9 +1148,13 @@ START_SECTION((void storeBuffer(std::string & output, const PeakMap& map) const)
     // store map in our output buffer
     std::string out;
     file.storeBuffer(out, exp_original);
-    TEST_EQUAL(out.size(), 38070)
-    TEST_EQUAL(StringUtils::substr(out, 0, 100), "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<indexedmzML xmlns=\"http://psi.hupo.org/ms/mzml\" xmlns:x")
-    TEST_EQUAL(StringUtils::substr(out, 38070 - 99, 38070 - 1), "</indexList>\n<indexListOffset>37622</indexListOffset>\n<fileChecksum>0</fileChecksum>\n</indexedmzML>")
+    TEST_TRUE(out.size() > 0)
+    TEST_TRUE(StringUtils::hasPrefix(out, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"))
+    PeakMap reloaded;
+    file.loadBuffer(out, reloaded);
+    TEST_EQUAL(reloaded.size(), exp_original.size())
+    TEST_EQUAL(reloaded.getChromatograms().size(), exp_original.getChromatograms().size())
+    TEST_TRUE(StringUtils::hasSubstring(out, "</indexedmzML>"))
 
     TEST_EQUAL(StringUtils::hasSubstring(std::string(out), "<spectrumList count=\"4\" defaultDataProcessingRef=\"dp_sp_0\">"), true)
     TEST_EQUAL(StringUtils::hasSubstring(std::string(out), "<chromatogramList count=\"2\" defaultDataProcessingRef=\"dp_sp_0\">"), true)
@@ -1163,9 +1167,12 @@ START_SECTION((void storeBuffer(std::string & output, const PeakMap& map) const)
     //store map
     std::string out;
     file.storeBuffer(out, empty);
-    TEST_EQUAL(out.size(), 3167)
-    TEST_EQUAL(StringUtils::substr(out, 0, 100), "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<indexedmzML xmlns=\"http://psi.hupo.org/ms/mzml\" xmlns:x")
-    TEST_EQUAL(StringUtils::substr(out, 3167-98, 3167-1), "</indexList>\n<indexListOffset>2978</indexListOffset>\n<fileChecksum>0</fileChecksum>\n</indexedmzML>")
+    TEST_TRUE(out.size() > 0)
+    TEST_TRUE(StringUtils::hasPrefix(out, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"))
+    PeakMap reloaded;
+    file.loadBuffer(out, reloaded);
+    TEST_TRUE(reloaded.empty())
+    TEST_TRUE(StringUtils::hasSubstring(out, "</indexedmzML>"))
   }
 
 }
@@ -1341,5 +1348,156 @@ END_SECTION
 /// check the temporary files written above against their XML schema (types without a validator are skipped)
 VALIDATE_TMP_FILES
 
-END_TEST
 
+START_SECTION((Thermo metadata survives mzML serialization, sorting, and reloading))
+{
+  PeakMap original;
+  original.setDateTime(DateTime::fromString("2024-01-02T03:04:05", "yyyy-MM-ddThh:mm:ss"));
+  original.setMetaValue("mzml_start_time_stamp", "2024-01-02T03:04:05.1234567Z");
+  original.setMetaValue("Thermo instrument methods", "[\"method\\nsecond line\"]");
+  original.getSample().setMetaValue("Thermo sample volume", 2.5);
+  original.getSample().setName("Müller & sample");
+  original.getSample().setComment("first line\nsecond line\tend");
+  Instrument instrument;
+  instrument.setName("Orbitrap Astral");
+  instrument.setMetaValue("instrument serial number", "serial-123");
+  IonSource source;
+  source.setOrder(1);
+  source.setIonizationMethod(IonSource::IonizationMethod::ESI);
+  instrument.getIonSources().push_back(source);
+  MassAnalyzer analyzer;
+  analyzer.setOrder(2);
+  analyzer.setType(MassAnalyzer::AnalyzerType::ORBITRAP);
+  instrument.getMassAnalyzers().push_back(analyzer);
+  IonDetector detector;
+  detector.setOrder(3);
+  detector.setType(IonDetector::Type::INDUCTIVEDETECTOR);
+  instrument.getIonDetectors().push_back(detector);
+  original.setInstrument(instrument);
+  instrument.getMassAnalyzers()[0].setMetaValue("mass analyzer accession", "MS:1003379");
+  original.getInstrumentConfigurations()["astral"] = instrument;
+
+  MSSpectrum parent;
+  parent.setNativeID("controllerType=0 controllerNumber=1 scan=10");
+  parent.setRT(1);
+  parent.setMSLevel(1);
+  parent.setType(SpectrumSettings::SpectrumType::CENTROID);
+  Peak1D peak;
+  peak.setMZ(501); peak.setIntensity(10); parent.push_back(peak);
+  peak.setMZ(499); peak.setIntensity(20); parent.push_back(peak);
+  // Three independently sampled points versus two spectrum peaks; double precision matters.
+  const vector<double> noise_mz = {498.123456789012, 500.345678901234, 502.567890123456};
+  parent.setMetaValue("sampled noise m/z array", noise_mz);
+  parent.setMetaValue("sampled noise intensity array", vector<double>{1, 2, 3});
+  parent.setMetaValue("sampled noise baseline array", vector<double>{0.1, 0.2, 0.3});
+  MSSpectrum::IntegerDataArray charges;
+  charges.setName("charge array"); charges.push_back(1); charges.push_back(2);
+  parent.getIntegerDataArrays().push_back(charges);
+  Acquisition acquisition;
+  acquisition.setMetaValue("Thermo trailer extra", "[{\"label\":\"example:\",\"value\":\"a & b\"}]");
+  parent.getAcquisitionInfo().push_back(acquisition);
+  original.addSpectrum(parent);
+
+  MSSpectrum child;
+  child.setNativeID("controllerType=0 controllerNumber=1 scan=11");
+  child.setRT(2); child.setMSLevel(2);
+  child.setType(SpectrumSettings::SpectrumType::CENTROID);
+  child.push_back(peak);
+  acquisition.setMetaValue("instrument_configuration_ref", "astral");
+  child.getAcquisitionInfo().push_back(acquisition);
+  Precursor precursor;
+  precursor.setMZ(500);
+  precursor.setMetaValue("selected ion m/z", 499.5);
+  precursor.setIsolationWindowLowerOffset(0);
+  precursor.setIsolationWindowUpperOffset(2);
+  precursor.setMetaValue("isolation window lower offset", 0.0);
+  precursor.setMetaValue("spectrum_ref", parent.getNativeID());
+  precursor.setIntensity(30);
+  precursor.setMetaValue("peak intensity unit accession", "MS:1000131");
+  precursor.getActivationMethods().insert(Precursor::ActivationMethod::ETD);
+  precursor.setMetaValue("supplemental beam-type collision-induced dissociation", "");
+  DataValue energy(25.0);
+  energy.setUnitType(DataValue::UnitType::UNIT_ONTOLOGY); energy.setUnit(266);
+  precursor.setMetaValue("collision energy", energy);
+  precursor.setMetaValue("supplemental collision energy", energy);
+  child.getPrecursors().push_back(precursor);
+  original.addSpectrum(child);
+
+  MSSpectrum pda;
+  pda.setNativeID("controllerType=4 controllerNumber=1 scan=1");
+  pda.setRT(3); pda.setMSLevel(0); pda.setType(SpectrumSettings::SpectrumType::PROFILE);
+  pda.getInstrumentSettings().setScanMode(InstrumentSettings::ScanMode::ABSORPTION);
+  pda.setMetaValue("mzml coordinate array", "wavelength");
+  pda.setMetaValue("mzml intensity array", "absorption");
+  peak.setMZ(220); peak.setIntensity(0.25); pda.push_back(peak);
+  peak.setMZ(500); peak.setIntensity(0.5); pda.push_back(peak);
+  ScanWindow window;
+  window.begin = 220; window.end = 500; window.setMetaValue("unit_accession", "UO:0000018");
+  pda.getInstrumentSettings().getScanWindows().push_back(window);
+  original.addSpectrum(pda);
+
+  MSChromatogram pressure;
+  pressure.setNativeID("Analog#1_Pressure");
+  pressure.setMetaValue("chromatogram type accession", "MS:1003019");
+  pressure.setMetaValue("mzml intensity array", "pressure");
+  pressure.setMetaValue("Thermo detector units", "bar");
+  pressure.push_back(ChromatogramPeak(1, 200));
+  pressure.push_back(ChromatogramPeak(2, 210));
+  original.addChromatogram(pressure);
+
+  MzMLFile file;
+  string encoded;
+  file.storeBuffer(encoded, original);
+  for (const string& accession : {"MS:1000529", "MS:1003379", "MS:1002678", "MS:1002680", "MS:1002743", "MS:1002744", "MS:1002745", "MS:1000516", "MS:1000617", "MS:1003019", "MS:1000821"})
+  {
+    TEST_TRUE(StringUtils::hasSubstring(encoded, accession))
+  }
+  TEST_TRUE(StringUtils::hasSubstring(encoded, "2024-01-02T03:04:05.1234567Z"))
+  TEST_TRUE(StringUtils::hasSubstring(encoded, "instrumentConfigurationRef=\"astral\""))
+  PeakMap loaded;
+  file.loadBuffer(encoded, loaded);
+  TEST_EQUAL(loaded.size(), 3)
+  TEST_EQUAL(loaded.getSample().getName(), "Müller & sample")
+  TEST_EQUAL(loaded.getSample().getComment(), "first line\nsecond line\tend")
+  TEST_EQUAL(loaded.getInstrumentConfigurations().size(), 1)
+  TEST_EQUAL(loaded.getInstrumentConfigurations().at("astral").getMassAnalyzers()[0].getMetaValue("mass analyzer accession"), "MS:1003379")
+  TEST_EQUAL(loaded[0].getMetaValue("sampled noise m/z array").toDoubleList(), noise_mz)
+  TEST_EQUAL(loaded[0].getFloatDataArrays().size(), 0)
+  TEST_EQUAL(loaded[0].getIntegerDataArrays()[0].size(), 2)
+  TEST_EQUAL(loaded[0].getIntegerDataArrays()[0][0], 2) // charge follows sorted peak
+  TEST_REAL_SIMILAR(loaded[1].getPrecursors()[0].getMZ(), 499.5)
+  TEST_EQUAL(loaded[1].getPrecursors()[0].getMetaValue("isolation window target m/z"), 500.0)
+  TEST_EQUAL(loaded[1].getPrecursors()[0].getMetaValue("spectrum_ref"), parent.getNativeID())
+  TEST_EQUAL(loaded[1].getPrecursors()[0].getMetaValue("peak intensity unit accession"), "MS:1000131")
+  TEST_TRUE(loaded[1].getPrecursors()[0].metaValueExists("supplemental collision energy"))
+  TEST_EQUAL(loaded[2].size(), 2)
+  TEST_REAL_SIMILAR(loaded[2][0].getMZ(), 220)
+  TEST_EQUAL(loaded[2].getMetaValue("mzml intensity array"), "absorption")
+  TEST_EQUAL(loaded.getChromatograms().size(), 1)
+  TEST_EQUAL(loaded.getChromatograms()[0].size(), 2)
+  TEST_EQUAL(loaded.getChromatograms()[0].getMetaValue("mzml intensity array"), "pressure")
+  TEST_EQUAL(loaded.getChromatograms()[0].getMetaValue("Thermo detector units"), "bar")
+  // Re-export must retain CV terms instead of falling back to unrelated generic arrays.
+  string encoded_again;
+  file.storeBuffer(encoded_again, loaded);
+  TEST_TRUE(StringUtils::hasSubstring(encoded_again, "MS:1002743"))
+  TEST_TRUE(StringUtils::hasSubstring(encoded_again, "MS:1000617"))
+  TEST_TRUE(StringUtils::hasSubstring(encoded_again, "MS:1002678"))
+
+  // A zero-valued measurement is distinct from an absent intensity. Editing a
+  // previously zero isolation offset must override its preservation metadata.
+  auto& edited_precursor = loaded[1].getPrecursors()[0];
+  edited_precursor.setIntensity(0);
+  edited_precursor.setMetaValue("peak intensity", 0.0);
+  edited_precursor.setIsolationWindowLowerOffset(1.25);
+  file.storeBuffer(encoded_again, loaded);
+  PeakMap edited;
+  file.loadBuffer(encoded_again, edited);
+  TEST_REAL_SIMILAR(edited[1].getPrecursors()[0].getIsolationWindowLowerOffset(), 1.25)
+  TEST_TRUE(edited[1].getPrecursors()[0].metaValueExists("peak intensity"))
+  TEST_REAL_SIMILAR(edited[1].getPrecursors()[0].getIntensity(), 0)
+  TEST_EQUAL(edited[1].getPrecursors()[0].getMetaValue("peak intensity unit accession"), "MS:1000131")
+}
+END_SECTION
+
+END_TEST

--- a/src/tests/class_tests/openms/source/ThermoRawFileMetadata_test.cpp
+++ b/src/tests/class_tests/openms/source/ThermoRawFileMetadata_test.cpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+// Deliberately independent of libOpenMS and vendor binaries: precursor
+// reconstruction can be tested on all platforms, including builds without
+// WITH_THERMO_RAW.
+#include <OpenMS/FORMAT/HANDLERS/ThermoRawFileMetadata.h>
+#include <iostream>
+#include <stdexcept>
+
+using Json = nlohmann::json;
+using Metadata = OpenMS::Internal::ThermoRawFileMetadata;
+
+namespace
+{
+void check(bool condition, const char* description)
+{
+  if (! condition) { throw std::runtime_error(description); }
+}
+
+Json reaction(double mass, const std::string& activation = "CollisionInducedDissociation", double width = 2.0, double offset = 0.0)
+{
+  return {{"precursor_mass", mass},     {"activation", activation}, {"isolation_width", width},
+          {"isolation_offset", offset}, {"collision_energy", 35.0}, {"collision_energy_valid", true}};
+}
+
+Json scan(int number, int level, const std::string& filter, const Json& reactions = Json::array())
+{
+  return {{"scan_number", number},  {"ms_level", level},        {"filter", filter},
+          {"reactions", reactions}, {"trailer", Json::array()}, {"native_id", "controllerType=0 controllerNumber=1 scan=" + std::to_string(number)}};
+}
+
+void trailer(Json& scan, const std::string& label, const std::string& value)
+{ scan["trailer"].push_back({{"label", label}, {"value", value}}); }
+} // namespace
+
+int main()
+{
+  try
+  {
+    check(Metadata::number("").is_null(), "Missing values remain missing");
+    check(Metadata::number("NaN").is_null(), "Nonfinite values remain missing");
+    check(Metadata::number("2,5").is_null(), "Do not guess decimal separators");
+    check(Metadata::number(" 0 ") == 0.0, "Zero is not missing");
+    check(Metadata::selectedIon(500, 499.5, 2) == 499.5, "Retain plausible monoisotopic ion");
+    check(Metadata::selectedIon(500, 490, 2) == 500, "Reject unrelated trailer monoisotopic mass");
+    check(Metadata::selectedIon(500, 497, 10) == 497, "Wide-window selected ion rule");
+
+    Metadata parser;
+    check(parser.precursors(scan(10, 1, "FTMS + p NSI Full ms [200-2000]")).empty(), "MS1 has no precursors");
+    auto ms2 = scan(11, 2, "FTMS + c NSI Full ms2 500.00@etd35.00 500.00@hcd20.00 [100-1000]",
+                    Json::array({reaction(500, "ElectronTransferDissociation", 2, 0.25), reaction(500, "HigherEnergyCollisionalDissociation")}));
+    trailer(ms2, "Master Scan Number:", "10");
+    trailer(ms2, "Monoisotopic M/Z:", "499.5");
+    trailer(ms2, "Charge State:", "3");
+    trailer(ms2, "MS2 Isolation Width:", "4");
+    auto p2 = parser.precursors(ms2);
+    check(p2.size() == 1, "Supplemental activation is not an extra precursor");
+    check(p2[0]["target_mz"] == 500 && p2[0]["selected_mz"] == 499.5, "Separate selected ion and isolation target");
+    check(p2[0]["lower_offset"] == 1.75 && p2[0]["upper_offset"] == 2.25, "Preserve asymmetric window and trailer width override");
+    check(p2[0]["charge"] == 3 && p2[0]["parent_scan"] == 10, "Preserve charge and parent scan");
+    check(p2[0]["supplemental"]["activation"] == "HigherEnergyCollisionalDissociation", "Preserve supplemental HCD");
+
+    auto ms3
+      = scan(12, 3,
+             "ITMS + c NSI Full ms3 500.00@etd35.00 500.00@hcd20.00 "
+             "300.00@cid35.00 [80-600]",
+             Json::array({reaction(500, "ElectronTransferDissociation"), reaction(500, "HigherEnergyCollisionalDissociation"), reaction(300)}));
+    trailer(ms3, "Master Scan Number:", "11");
+    trailer(ms3, "SPS Masses:", "300, 310,");
+    trailer(ms3, "SPS Masses Continued:", "320");
+    auto p3 = parser.precursors(ms3);
+    check(p3.size() == 4, "Primary selection, two SPS selections, and MS2 ancestor");
+    check(p3[0]["target_mz"] == 300 && p3[0]["parent_scan"] == 11, "Use current MS3 reaction, not reaction zero");
+    check(p3[1]["target_mz"] == 310 && p3[2]["target_mz"] == 320, "Continued SPS list preserved");
+    check(p3[0]["estimate_intensity"] == true && p3[1]["estimate_intensity"] == false,
+          "Only the primary SPS selection receives an intensity estimate");
+    check(p3[3]["target_mz"] == 500 && p3[3]["parent_scan"] == 10, "Ancestor references its own parent");
+    check(p3[0]["charge"].is_null(), "Missing charge remains missing");
+
+    Metadata fallback;
+    fallback.precursors(scan(1, 1, "FTMS + p NSI Full ms [200-2000]"));
+    auto simple = scan(2, 2, "ITMS + c NSI Full ms2 500.00@cid35.00 [100-1000]", Json::array({reaction(500)}));
+    check(fallback.precursors(simple)[0]["parent_scan"] == 1, "MS2 parent from most recent MS1");
+    auto third = scan(3, 3, "ITMS + c NSI Full ms3 500.00@cid35.00 300.00@cid35.00 [80-600]", Json::array({reaction(500), reaction(300)}));
+    trailer(third, "Master Scan Number:", "999");
+    trailer(third, "SPS Mass 1:", "300");
+    trailer(third, "SPS Mass 2:", "310");
+    auto p = fallback.precursors(third);
+    check(p[0]["parent_scan"] == 2 && p.size() == 3, "Invalid master falls back to filter hierarchy; legacy SPS retained");
+
+    Metadata isolated;
+    auto orphan = scan(100, 3, "ITMS + c NSI Full ms3 500.00@cid35.00 300.00@cid35.00 [80-600]",
+                       Json::array({reaction(500), reaction(300, "CollisionInducedDissociation", -1)}));
+    auto op = isolated.precursors(orphan);
+    check(op[0]["target_mz"] == 300, "Truncated file starts at last reaction");
+    check(op[0]["spectrum_ref"] == "" && op[0]["width"].is_null(), "No fabricated parent or negative width");
+
+    auto unusual = scan(13, 2, "ITMS + c NSI Full ms2 500.00@cid35.00 500.00@hcd20.00 [100-1000]",
+                        Json::array({reaction(500), reaction(500, "HigherEnergyCollisionalDissociation")}));
+    trailer(unusual, "Master Scan Number:", "10");
+    check(parser.precursors(unusual)[0]["supplemental"].is_object(), "Retain supplemental reactions with unexpected main activation types");
+    std::cout << "Thermo precursor metadata regression tests passed\n";
+    return 0;
+  }
+  catch (const std::exception& error)
+  {
+    std::cerr << error.what() << '\n';
+    return 1;
+  }
+}

--- a/src/tests/class_tests/openms/source/ThermoRawFileMetadata_test.cpp
+++ b/src/tests/class_tests/openms/source/ThermoRawFileMetadata_test.cpp
@@ -9,6 +9,7 @@
 // Deliberately independent of libOpenMS and vendor binaries: precursor
 // reconstruction can be tested on all platforms, including builds without
 // WITH_THERMO_RAW.
+#define JSON_USE_IMPLICIT_CONVERSIONS 0
 #include <OpenMS/FORMAT/HANDLERS/ThermoRawFileMetadata.h>
 #include <iostream>
 #include <stdexcept>

--- a/src/tests/class_tests/openms/source/ThermoRawFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ThermoRawFile_test.cpp
@@ -79,6 +79,36 @@ START_SECTION(round-trip load raw -> mzML -> reload MSExperiment)
   MzMLFile().load(tmp_mzml, reloaded);
   File::remove(tmp_mzml);
 
+  TEST_EQUAL(original.getSourceFiles()[0].getChecksum().size(), 40)
+  TEST_EQUAL(reloaded.getSourceFiles()[0].getChecksum(), original.getSourceFiles()[0].getChecksum())
+  TEST_EQUAL(reloaded.getInstrument().getMetaValue("instrument serial number"), original.getInstrument().getMetaValue("instrument serial number"))
+  TEST_EQUAL(reloaded.getMetaValue("Thermo instrument methods"), original.getMetaValue("Thermo instrument methods"))
+  TEST_TRUE(original.getSample().metaValueExists("Thermo injection volume"))
+  TEST_EQUAL(reloaded.getSample().getMetaValue("Thermo injection volume"), original.getSample().getMetaValue("Thermo injection volume"))
+  bool saw_supplemental = false;
+  for (Size i = 0; i < original.size(); ++i)
+  {
+    TEST_EQUAL(original[i].getNativeID(), reloaded[i].getNativeID())
+    TEST_EQUAL(original[i].getPrecursors().size(), reloaded[i].getPrecursors().size())
+    TEST_EQUAL(original[i].getAcquisitionInfo()[0].getMetaValue("Thermo trailer extra"), reloaded[i].getAcquisitionInfo()[0].getMetaValue("Thermo trailer extra"))
+    for (Size j = 0; j < original[i].getPrecursors().size(); ++j)
+    {
+      const auto& before = original[i].getPrecursors()[j];
+      const auto& after = reloaded[i].getPrecursors()[j];
+      TEST_REAL_SIMILAR(before.getMZ(), after.getMZ())
+      TEST_REAL_SIMILAR(before.getMetaValue("selected ion m/z"), after.getMetaValue("selected ion m/z", after.getMZ()))
+      TEST_REAL_SIMILAR(before.getIsolationWindowLowerOffset(), after.getIsolationWindowLowerOffset())
+      TEST_REAL_SIMILAR(before.getIsolationWindowUpperOffset(), after.getIsolationWindowUpperOffset())
+      TEST_EQUAL(before.getMetaValue("spectrum_ref"), after.getMetaValue("spectrum_ref"))
+      if (before.metaValueExists("supplemental collision energy"))
+      {
+        saw_supplemental = true;
+        TEST_EQUAL(before.getMetaValue("supplemental collision energy"), after.getMetaValue("supplemental collision energy"))
+      }
+    }
+  }
+  TEST_TRUE(saw_supplemental)
+
   TEST_EQUAL(original.size(), reloaded.size())
   TEST_EQUAL(original.getSourceFiles().size(), reloaded.getSourceFiles().size())
 

--- a/vcpkg-overlays/ports/openms-thermo-bridge/portfile.cmake
+++ b/vcpkg-overlays/ports/openms-thermo-bridge/portfile.cmake
@@ -2,21 +2,29 @@ if(NOT VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 endif()
 
+# Pin both native and managed sources to the same reviewed revision. Build the
+# managed component locally until a matching 0.3.0 release asset is available.
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OpenMS/openms-thermo-bridge
-    REF e05aa5853474943a43819151e403325860f00168
-    SHA512 b0e9f78dc90d748edba51145b2b1a07d3adf9cb4f3f4274388b008f72b8b927a36ab6f0e10f80155ba58dfdcc3bb405b5f37643af1c92a73dbe58a2db4441fff
+    REF 4c0edddf5a49879e0470b0ca08cfe9955ceba3c9
+    SHA512 9fac239823fde8ddab1fb51aa5bf480189a6d85a68e6f3b832df0cd138b0d1c97de0a50a9a66280846eb3293a99f8c9e5c377fbdbc333671a90116144ca609d4
     HEAD_REF main
     PATCHES
         vcpkg-nethost-use.patch
 )
 
+find_program(DOTNET_EXECUTABLE NAMES dotnet
+    HINTS "$ENV{DOTNET_ROOT}" "$ENV{ProgramFiles}/dotnet"
+          "/opt/homebrew/opt/dotnet/bin" REQUIRED)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
     -DBUILD_TESTING=OFF
-    -DOPENMS_THERMO_BRIDGE_DOWNLOAD_PREBUILT_MANAGED=ON
+    "-DDOTNET_EXECUTABLE=${DOTNET_EXECUTABLE}"
+    -DOPENMS_THERMO_BRIDGE_DOWNLOAD_PREBUILT_MANAGED=OFF
+    -DOPENMS_THERMO_BRIDGE_ENABLE_VENDOR_DOWNLOAD=ON
     -DOPENMS_THERMO_BRIDGE_BUILD_CLI=OFF
 )
 

--- a/vcpkg-overlays/ports/openms-thermo-bridge/vcpkg.json
+++ b/vcpkg-overlays/ports/openms-thermo-bridge/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "openms-thermo-bridge",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Minimal C++ bridge to read Thermo .raw files via .NET embedding",
   "homepage": "https://github.com/OpenMS/openms-thermo-bridge",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Thermo RAW loading currently loses metadata needed for comparable mzML output to ThermoRawFileParser. This consumes bridge 0.3.0 snapshots and carries source, sample, method, trailer, precursor and instrument metadata through OpenMS's data model and mzML reader/writer. Optional exports include native charges, independent 64-bit noise grids, PDA spectra and detector chromatograms.

The change adds reader options and Python bindings, additional instrument configurations with scan references, MSn/SPS hierarchy reconstruction, distinct selected-ion/isolation targets, supplemental activation, correct array types and units, and preservation of full timestamps and XML attribute whitespace.

A second review fixed zero precursor intensity export, editable isolation offsets, SPS intensity semantics, unexpected supplemental activation, acquisition representation and FID classification.

Paired bridge PR: https://github.com/OpenMS/openms-thermo-bridge/pull/11. Both dependency paths pin its published commit `4c0edddf5a49879e0470b0ca08cfe9955ceba3c9`. The vcpkg overlay uses a verified SHA-512 source archive and builds matching managed sources with a host .NET SDK; it does not require an unreleased 0.3.0 binary asset.

Validation: standalone precursor tests pass; changed core files and class tests pass C++23 syntax checks. Bridge and CV suites pass 136 cases, with four fixture-related skips. The low-resolution centroid regression fails before the bridge fix and passes on both TRFP small.RAW and small2.RAW afterward. The nethost patch applies to the bridge source, and the downloaded archive's files match the published bridge commit. The published OpenMS tree matches the reviewed local tree.

OpenMS was not built or linked because AGENTS.md requires an explicit build request. Synthetic mzML round-trip tests, RAW integration tests and Python API tests are included but require runtime execution in CI/an authorized build. End-to-end parity with TRFP output is not yet verified; float32 intensity storage, software records, time units and XML layout can differ.

The comparison reference is ThermoRawFileParser commit cf548e4a3fadcc796291a01fdbd088af986a5d72.