### PR TITLE
Fixed Deisotoper dropping fragment clusters when precursor charge is unknown

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1227,6 +1227,12 @@ OpenMS Library:
     - Iterator patterns, container checks and memory allocation optimized in hot paths (#8656)
 
 Fixes:
+  - Fix: Deisotoper::deisotopeAndSingleCharge() and deisotopeWithAveragineModel() discarded every fragment
+    isotope cluster when the spectrum carried a precursor with unknown charge (0). The precursor-mass
+    constraint was derived from that charge, so the neutral mass came out as 0 and all positive-mass
+    fragments were rejected -- emptying the spectrum with keep_only_deisotoped=true and leaving peaks
+    unprocessed otherwise. The constraint now activates only for a known charge that yields a valid
+    positive mass (#10067)
   - Fix: Biosaur2Algorithm::run() left the stored MS data empty on FAIMS input -- the per-CV split moves
     the spectra out of ms_data_ and nothing put them back, so getMSData() handed the caller a cleared
     experiment. ProteomicsLFQ with -Seeding:algorithm biosaur2 passed exactly that on to

--- a/src/openms/source/PROCESSING/DEISOTOPING/Deisotoper.cpp
+++ b/src/openms/source/PROCESSING/DEISOTOPING/Deisotoper.cpp
@@ -122,9 +122,16 @@ void Deisotoper::deisotopeWithAveragineModel(MSSpectrum& spec,
   double precursor_mass(0);
   if (old_spectrum.getPrecursors().size() == 1)
   {
-    has_precursor_data = true;
-    int precursor_charge = old_spectrum.getPrecursors()[0].getCharge();
-    precursor_mass = (old_spectrum.getPrecursors()[0].getMZ() * precursor_charge) - (Constants::PROTON_MASS_U * precursor_charge);
+    // A charge of 0 means the precursor charge is unknown (see Precursor.h).
+    // Only apply the precursor-mass constraint when a known charge yields a
+    // valid positive neutral mass; otherwise the mass would be 0 (or negative)
+    // and every positive-mass fragment cluster would be wrongly rejected.
+    const int precursor_charge = old_spectrum.getPrecursors()[0].getCharge();
+    if (precursor_charge != 0)
+    {
+      precursor_mass = (old_spectrum.getPrecursors()[0].getMZ() * precursor_charge) - (Constants::PROTON_MASS_U * precursor_charge);
+      has_precursor_data = (precursor_mass > 0);
+    }
   }
 
   for (size_t current_peak = 0; current_peak != old_spectrum.size(); ++current_peak)
@@ -417,9 +424,16 @@ void Deisotoper::deisotopeAndSingleCharge(MSSpectrum& spec,
   double precursor_mass(0);
   if (old_spectrum.getPrecursors().size() == 1)
   {
-    has_precursor_data = true;
-    int precursor_charge = old_spectrum.getPrecursors()[0].getCharge();
-    precursor_mass = (old_spectrum.getPrecursors()[0].getMZ() * precursor_charge) - (Constants::PROTON_MASS * precursor_charge);
+    // A charge of 0 means the precursor charge is unknown (see Precursor.h).
+    // Only apply the precursor-mass constraint when a known charge yields a
+    // valid positive neutral mass; otherwise the mass would be 0 (or negative)
+    // and every positive-mass fragment cluster would be wrongly rejected.
+    const int precursor_charge = old_spectrum.getPrecursors()[0].getCharge();
+    if (precursor_charge != 0)
+    {
+      precursor_mass = (old_spectrum.getPrecursors()[0].getMZ() * precursor_charge) - (Constants::PROTON_MASS * precursor_charge);
+      has_precursor_data = (precursor_mass > 0);
+    }
   }
 
   for (size_t current_peak = 0; current_peak != old_spectrum.size(); ++current_peak)

--- a/src/tests/class_tests/openms/source/Deisotoper_test.cpp
+++ b/src/tests/class_tests/openms/source/Deisotoper_test.cpp
@@ -208,6 +208,7 @@ START_SECTION(static void deisotopeAndSingleChargeMSSpectrum(MSSpectrum& in,
      TEST_EQUAL(s.size(), 1);
 
      // (c) known precursor charge large enough to keep the fragment cluster: cluster retained
+     //     and annotated with the detected charge (2)
      s = base;
      Precursor prec_known;
      prec_known.setMZ(2000.0);
@@ -215,6 +216,35 @@ START_SECTION(static void deisotopeAndSingleChargeMSSpectrum(MSSpectrum& in,
      s.setPrecursors({prec_known});
      Deisotoper::deisotopeAndSingleCharge(s, 10.0, true, 1, 2, true, 2, 10, false, true);
      TEST_EQUAL(s.size(), 1);
+     TEST_EQUAL(s.getIntegerDataArrays().size(), 1);
+     TEST_EQUAL(s.getIntegerDataArrays()[0].size(), 1);
+     TEST_EQUAL(s.getIntegerDataArrays()[0][0], 2);
+
+     // (d) known precursor charge whose neutral mass is below the fragment cluster: the
+     //     constraint is still functional and rejects the cluster (empty with keep_only)
+     s = base;
+     Precursor prec_low;
+     prec_low.setMZ(100.0);
+     prec_low.setCharge(1);
+     s.setPrecursors({prec_low});
+     Deisotoper::deisotopeAndSingleCharge(s, 10.0, true, 1, 2, true, 2, 10, false, true);
+     TEST_EQUAL(s.size(), 0);
+
+     // (e) retention mode (keep_only_deisotoped=false) with an unassigned peak and unknown
+     //     precursor charge: the cluster collapses to its monoisotopic peak and the
+     //     unrelated peak is retained rather than dropped
+     MSSpectrum base_plus = base;
+     Peak1D lone;
+     lone.setIntensity(1.0);
+     lone.setMZ(600.0);
+     base_plus.push_back(lone);
+     base_plus.sortByPosition();
+     s = base_plus;
+     s.setPrecursors({prec_unknown});
+     Deisotoper::deisotopeAndSingleCharge(s, 10.0, true, 1, 2, false, 2, 10, false, true);
+     TEST_EQUAL(s.size(), 2);
+     TEST_REAL_SIMILAR(s[0].getMZ(), 200.0);
+     TEST_REAL_SIMILAR(s[1].getMZ(), 600.0);
    }
 }
 END_SECTION
@@ -411,13 +441,41 @@ START_SECTION(static void deisotopeWithAveragineModel(MSSpectrum& spectrum,
     TEST_EQUAL(s.size(), 1);
 
     // (c) known precursor charge large enough to keep the fragment cluster: cluster retained
+    //     and annotated with the detected charge (2)
     s = base;
     Precursor prec_known;
     prec_known.setMZ(2000.0);
     prec_known.setCharge(2);
     s.setPrecursors({prec_known});
-    Deisotoper::deisotopeWithAveragineModel(s, 10.0, true, 5000, 1, 3, true);
+    Deisotoper::deisotopeWithAveragineModel(s, 10.0, true, 5000, 1, 3, true, 2, 10, true, true);// annotate charge
     TEST_EQUAL(s.size(), 1);
+    TEST_EQUAL(s.getIntegerDataArrays().size(), 1);
+    TEST_EQUAL(s.getIntegerDataArrays()[0].size(), 1);
+    TEST_EQUAL(s.getIntegerDataArrays()[0][0], 2);
+
+    // (d) known precursor charge whose neutral mass is below the fragment cluster: the
+    //     constraint is still functional and rejects the cluster (empty with keep_only)
+    s = base;
+    Precursor prec_low;
+    prec_low.setMZ(100.0);
+    prec_low.setCharge(1);
+    s.setPrecursors({prec_low});
+    Deisotoper::deisotopeWithAveragineModel(s, 10.0, true, 5000, 1, 3, true);
+    TEST_EQUAL(s.size(), 0);
+
+    // (e) retention mode (keep_only_deisotoped=false) with an unassigned peak and unknown
+    //     precursor charge: the unrelated peak is retained rather than dropped
+    MSSpectrum base_plus = base;
+    Peak1D lone;
+    lone.setIntensity(50.0);
+    lone.setMZ(800.0);
+    base_plus.push_back(lone);
+    base_plus.sortByPosition();
+    s = base_plus;
+    s.setPrecursors({prec_unknown});
+    Deisotoper::deisotopeWithAveragineModel(s, 10.0, true, -1, 1, 3, false);// keep unassigned peaks
+    TEST_EQUAL(s.size(), 2);
+    TEST_REAL_SIMILAR(s[0].getMZ(), 800.0);// the unassigned peak survived (sorts before the converted monoisotopic peak)
   }
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/Deisotoper_test.cpp
+++ b/src/tests/class_tests/openms/source/Deisotoper_test.cpp
@@ -19,6 +19,7 @@
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/METADATA/Precursor.h>
 #include <OpenMS/SYSTEM/File.h>
 
 ///////////////////////////
@@ -179,6 +180,42 @@ START_SECTION(static void deisotopeAndSingleChargeMSSpectrum(MSSpectrum& in,
    std::string temp_file2 = File::getTempDirectory() + "/" + File::getUniqueName() + "_Deisotoper_output2.mzML";
    MzMLFile().store(temp_file2, input2);
    File::remove(temp_file2);
+
+   // Regression test for issue #10067: a precursor with unknown charge (0) must
+   // not activate the precursor-mass constraint (which would use a zero mass and
+   // reject every fragment cluster, emptying the spectrum with keep_only_deisotoped).
+   {
+     MSSpectrum base;
+     Peak1D pk;
+     pk.setIntensity(1.0);
+     // one doubly-charged isotope cluster (0.5 Da spacing)
+     pk.setMZ(200.0);                                          base.push_back(pk);
+     pk.setMZ(200.0 + 0.5 * Constants::C13C12_MASSDIFF_U);     base.push_back(pk);
+     pk.setMZ(200.0 + 1.0 * Constants::C13C12_MASSDIFF_U);     base.push_back(pk);
+
+     // (a) no precursor: cluster is detected and collapsed to its monoisotopic peak
+     MSSpectrum s = base;
+     Deisotoper::deisotopeAndSingleCharge(s, 10.0, true, 1, 2, true, 2, 10, false, true);
+     TEST_EQUAL(s.size(), 1);
+
+     // (b) precursor present but charge unknown (0): must behave like (a), not empty the spectrum
+     s = base;
+     Precursor prec_unknown;
+     prec_unknown.setMZ(200.0);
+     prec_unknown.setCharge(0);
+     s.setPrecursors({prec_unknown});
+     Deisotoper::deisotopeAndSingleCharge(s, 10.0, true, 1, 2, true, 2, 10, false, true);
+     TEST_EQUAL(s.size(), 1);
+
+     // (c) known precursor charge large enough to keep the fragment cluster: cluster retained
+     s = base;
+     Precursor prec_known;
+     prec_known.setMZ(2000.0);
+     prec_known.setCharge(2);
+     s.setPrecursors({prec_known});
+     Deisotoper::deisotopeAndSingleCharge(s, 10.0, true, 1, 2, true, 2, 10, false, true);
+     TEST_EQUAL(s.size(), 1);
+   }
 }
 END_SECTION
 
@@ -338,6 +375,50 @@ START_SECTION(static void deisotopeWithAveragineModel(MSSpectrum& spectrum,
   // Test if the algorithm also works if we do not remove the low (and zero) intensity peaks
   Deisotoper::deisotopeWithAveragineModel(theo1, 10.0, true, -1, 1, 3, true);// do not remove low intensity peaks beforehand, but keep only deisotoped
   TEST_EQUAL(theo1.size(), 104);
+
+  // Regression test for issue #10067: a precursor with unknown charge (0) must
+  // not activate the precursor-mass constraint (which would use a zero mass and
+  // reject every fragment cluster, emptying the spectrum with keep_only_deisotoped).
+  {
+    // build a single doubly-charged isotope cluster (~m/z 500) that matches the averagine model
+    CoarseIsotopePatternGenerator cluster_gen(5);
+    IsotopeDistribution cluster_distr = cluster_gen.estimateFromPeptideWeight(1000);
+    MSSpectrum base;
+    for (auto it = cluster_distr.begin(); it != cluster_distr.end(); ++it)
+    {
+      if (it->getIntensity() != 0)
+      {
+        Peak1D pk;
+        pk.setMZ((it->getMZ() + Constants::PROTON_MASS_U) / 2.0);// charge 2
+        pk.setIntensity(it->getIntensity() * 10);
+        base.push_back(pk);
+      }
+    }
+    base.sortByPosition();
+
+    // (a) no precursor: cluster is detected and collapsed to its monoisotopic peak
+    MSSpectrum s = base;
+    Deisotoper::deisotopeWithAveragineModel(s, 10.0, true, 5000, 1, 3, true);// keep only deisotoped
+    TEST_EQUAL(s.size(), 1);
+
+    // (b) precursor present but charge unknown (0): must behave like (a), not empty the spectrum
+    s = base;
+    Precursor prec_unknown;
+    prec_unknown.setMZ(500.0);
+    prec_unknown.setCharge(0);
+    s.setPrecursors({prec_unknown});
+    Deisotoper::deisotopeWithAveragineModel(s, 10.0, true, 5000, 1, 3, true);
+    TEST_EQUAL(s.size(), 1);
+
+    // (c) known precursor charge large enough to keep the fragment cluster: cluster retained
+    s = base;
+    Precursor prec_known;
+    prec_known.setMZ(2000.0);
+    prec_known.setCharge(2);
+    s.setPrecursors({prec_known});
+    Deisotoper::deisotopeWithAveragineModel(s, 10.0, true, 5000, 1, 3, true);
+    TEST_EQUAL(s.size(), 1);
+  }
 }
 END_SECTION
 


### PR DESCRIPTION
## Description

@timosachsenberg 

Both deisotopeAndSingleCharge() and deisotopeWithAveragineModel() turned on the precursor mass constraint whenever a single precursor was present, and derived the neutral mass from the precursor charge. When that charge is 0 (unknown, per Precursor.h) the mass came out as 0, so every positive mass fragment cluster was above the limit and got rejected. With keep_only_deisotoped=true this emptied the spectrum, and otherwise it left peaks unprocessed.

The constraint now activates only whena known charge produces a valid positive neutral mass. For unknown charge it falls back to the normal fragment charge search, which is the previous no precursor behaviour. The positive mass guard also covers negative and invalid values.

Added regression tests for both algorithms covering an absent precursor, an unknown charge of 0, and a known charge. The unknown charge case reproduces the empty spectrum before the change.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

Closes #10067 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fragment isotope clusters are now retained when precursor charge information is unavailable or invalid.
  * Deisotoping no longer applies an unusable precursor-mass constraint that could remove valid results.
* **Tests**
  * Added regression coverage for spectra with no precursor, unknown precursor charge, valid precursor charge, and invalid precursor-mass conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->