### PR TITLE
[FIX] Use atomic mass units in Deisotoper precursor filtering

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1227,6 +1227,9 @@ OpenMS Library:
     - Iterator patterns, container checks and memory allocation optimized in hot paths (#8656)
 
 Fixes:
+  - Fix: Deisotoper::deisotopeAndSingleCharge now uses the proton mass in atomic mass units
+    for both precursor and fragment neutral masses. The previous kg constant shifted the
+    precursor-mass cutoff when precursor and fragment charges differed.
   - Fix: Deisotoper::deisotopeAndSingleCharge() and deisotopeWithAveragineModel() discarded every fragment
     isotope cluster when the spectrum carried a precursor with unknown charge (0). The precursor-mass
     constraint was derived from that charge, so the neutral mass came out as 0 and all positive-mass

--- a/src/openms/source/PROCESSING/DEISOTOPING/Deisotoper.cpp
+++ b/src/openms/source/PROCESSING/DEISOTOPING/Deisotoper.cpp
@@ -431,7 +431,7 @@ void Deisotoper::deisotopeAndSingleCharge(MSSpectrum& spec,
     const int precursor_charge = old_spectrum.getPrecursors()[0].getCharge();
     if (precursor_charge != 0)
     {
-      precursor_mass = (old_spectrum.getPrecursors()[0].getMZ() * precursor_charge) - (Constants::PROTON_MASS * precursor_charge);
+      precursor_mass = (old_spectrum.getPrecursors()[0].getMZ() * precursor_charge) - (Constants::PROTON_MASS_U * precursor_charge);
       has_precursor_data = (precursor_mass > 0);
     }
   }
@@ -458,7 +458,7 @@ void Deisotoper::deisotopeAndSingleCharge(MSSpectrum& spec,
         // do not bother testing charges q (and masses m) with: m/q > precursor_mass/q (or m > precursor_mass)
         if (has_precursor_data)
         {
-          double current_theo_mass = (current_mz * q) - (Constants::PROTON_MASS * q);
+          double current_theo_mass = (current_mz * q) - (Constants::PROTON_MASS_U * q);
           if (current_theo_mass > (precursor_mass + tolerance_dalton))
           {
             continue;

--- a/src/tests/class_tests/openms/source/Deisotoper_test.cpp
+++ b/src/tests/class_tests/openms/source/Deisotoper_test.cpp
@@ -499,4 +499,59 @@ END_SECTION
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 
+
+START_SECTION((regression: precursor mass constraint uses atomic mass units for unequal charges))
+{
+  // A precursor at m/z 500 with charge 2 has neutral mass 997.985447 Da.
+  // Singly charged fragments at m/z 998.5 and 999.5 lie below and above
+  // that mass, respectively. Using the proton mass in kg accepts both.
+  Precursor precursor;
+  precursor.setMZ(500.0);
+  precursor.setCharge(2);
+
+  for (const double fragment_mz : {998.5, 999.5})
+  {
+    MSSpectrum base;
+    for (Size i = 0; i < 3; ++i)
+    {
+      Peak1D peak;
+      peak.setMZ(fragment_mz + i * Constants::C13C12_MASSDIFF_U);
+      peak.setIntensity(100.0 / (i + 1));
+      base.push_back(peak);
+    }
+
+    // Ensure the isotope pattern itself is detected without a precursor limit.
+    MSSpectrum unconstrained = base;
+    Deisotoper::deisotopeAndSingleCharge(unconstrained, 10.0, true, 1, 1, true, 3, 10, false, true);
+    TEST_EQUAL(unconstrained.size(), 1);
+    TEST_REAL_SIMILAR(unconstrained[0].getMZ(), fragment_mz);
+    TEST_EQUAL(unconstrained.getIntegerDataArrays()[0][0], 1);
+
+    for (const bool fragment_unit_ppm : {false, true})
+    {
+      for (const bool keep_only_deisotoped : {false, true})
+      {
+        MSSpectrum spectrum = base;
+        spectrum.setPrecursors({precursor});
+        Deisotoper::deisotopeAndSingleCharge(spectrum,
+          fragment_unit_ppm ? 10.0 : 0.01, fragment_unit_ppm,
+          1, 1, keep_only_deisotoped, 3, 10, false, true);
+
+        const bool below_precursor_mass = fragment_mz == 998.5;
+        const Size expected_size = below_precursor_mass ? 1 : (keep_only_deisotoped ? 0 : 3);
+        TEST_EQUAL(spectrum.size(), expected_size);
+        TEST_EQUAL(spectrum.getIntegerDataArrays().size(), 1);
+        TEST_EQUAL(spectrum.getIntegerDataArrays()[0].getName(), "charge");
+        TEST_EQUAL(spectrum.getIntegerDataArrays()[0].size(), expected_size);
+        for (Size i = 0; i < spectrum.size(); ++i)
+        {
+          TEST_REAL_SIMILAR(spectrum[i].getMZ(), base[i].getMZ());
+          TEST_EQUAL(spectrum.getIntegerDataArrays()[0][i], below_precursor_mass ? 1 : 0);
+        }
+      }
+    }
+  }
+}
+END_SECTION
+
 END_TEST


### PR DESCRIPTION
`deisotopeAndSingleCharge()` subtracts `Constants::PROTON_MASS` (kg) when calculating precursor and fragment neutral masses from m/z. The correction is effectively zero, and the resulting cutoff is wrong when precursor and fragment charges differ.

For example, a precursor at m/z 500, charge 2 has neutral mass 997.985447 Da. A singly charged fragment at m/z 999.5 has neutral mass 998.492724 Da and must be rejected at 10 ppm. The old calculation compares approximately 999.5 with 1000 and accepts it.

This PR replaces the constant with `PROTON_MASS_U` in both calculations, matching `deisotopeWithAveragineModel()`. It adds a regression using clusters just below and above the precursor mass, both retention modes, and both ppm and Da tolerances. The below-limit case also guards against correcting only the precursor calculation. A precursor-free control verifies that each cluster can be detected.

Validation:
- Reproduced the incorrect above-limit acceptance with pyOpenMS 3.5.0 in all four tolerance/retention combinations; the below-limit control passed.
- Added C++ regression coverage in `Deisotoper_test`; execution of the patched code is pending CI. No local OpenMS build was run.

Follow-up to the review of #10073. This PR contains only the unit correction, its regression test, and a changelog entry; the unknown-charge test extension is tracked separately in #10074.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected neutral-mass calculations during deisotoping to use proton mass in atomic mass units.
  * Fixed precursor-mass cutoff behavior when precursor and fragment charges differ.
* **Tests**
  * Added regression coverage for precursor-mass filtering across tolerance modes and deisotoping options.
* **Documentation**
  * Added release notes describing the mass-calculation correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->