### PR TITLE
Update openms-thermo-bridge to v0.3.0 release

### DIFF
--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -619,7 +619,9 @@ if (WITH_THERMO_RAW)
       OpenMSThermoBridge
       GIT_REPOSITORY https://github.com/OpenMS/openms-thermo-bridge.git
       # Pin to a specific reviewed upstream revision to keep builds reproducible.
-      GIT_TAG        v0.3.0
+      # This is the commit the v0.3.0 release tag points at; tools/ci/fetch_thermo_assets.sh
+      # checks that its own pin matches and downloads the v0.3.0 release assets.
+      GIT_TAG        2c66c9260ad78f499527c7d1c85a920afab9aa2d  # v0.3.0
     )
 
     # Configure the thermo bridge build options

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -619,7 +619,7 @@ if (WITH_THERMO_RAW)
       OpenMSThermoBridge
       GIT_REPOSITORY https://github.com/OpenMS/openms-thermo-bridge.git
       # Pin to a specific reviewed upstream revision to keep builds reproducible.
-      GIT_TAG        4c0edddf5a49879e0470b0ca08cfe9955ceba3c9
+      GIT_TAG        v0.3.0
     )
 
     # Configure the thermo bridge build options

--- a/tools/ci/fetch_thermo_assets.sh
+++ b/tools/ci/fetch_thermo_assets.sh
@@ -35,8 +35,10 @@
 
 set -euo pipefail
 
-# Git tag or commit of openms-thermo-bridge; must equal the FetchContent GIT_TAG in
-# cmake/cmake_findExternalLibs.cmake (checked below).
+# Commit of openms-thermo-bridge; must equal the FetchContent GIT_TAG in
+# cmake/cmake_findExternalLibs.cmake (checked below). BRIDGE_TAG is the release tag
+# that points at this commit; the release assets are named after it.
+BRIDGE_COMMIT="2c66c9260ad78f499527c7d1c85a920afab9aa2d"
 BRIDGE_TAG="v0.3.0"
 RAW_URL="https://archive.openms.de/openms/testfiles/Angiotensin_AllScans.raw"
 RAW_SHA256="3a0236f719e7c91e3c958f57f4e66ae422803ec3e6a997b9af4d2af395332b9f"
@@ -61,10 +63,13 @@ esac
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/../.." && pwd)"
 
-# Guard against the pin in this script and the FetchContent pin diverging.
-if ! grep -A6 'OpenMSThermoBridge$' "${repo_root}/cmake/cmake_findExternalLibs.cmake" \
-     | grep -qE "GIT_TAG[[:space:]]+${BRIDGE_TAG}([[:space:]]|$)"; then
-  echo "error: BRIDGE_TAG=${BRIDGE_TAG} in $0 does not match the GIT_TAG pinned for" >&2
+# Guard against the pin in this script and the FetchContent pin diverging. Compare
+# the GIT_TAG value literally (no regular expression) so a near miss cannot pass.
+if ! grep -A8 'OpenMSThermoBridge$' "${repo_root}/cmake/cmake_findExternalLibs.cmake" \
+     | awk -v expected="$BRIDGE_COMMIT" \
+         '$1 == "GIT_TAG" && $2 == expected { found = 1 }
+          END { exit !found }'; then
+  echo "error: BRIDGE_COMMIT=${BRIDGE_COMMIT} in $0 does not match the GIT_TAG pinned for" >&2
   echo "       OpenMSThermoBridge in cmake/cmake_findExternalLibs.cmake" >&2
   exit 1
 fi

--- a/tools/ci/fetch_thermo_assets.sh
+++ b/tools/ci/fetch_thermo_assets.sh
@@ -49,9 +49,9 @@ dest="${2:-.}"
 # while no release asset exists for BRIDGE_TAG (the bridge then builds the managed
 # assemblies itself, see above).
 case "$platform" in
-  linux-x64) managed_sha256="" ;;
-  osx-arm64) managed_sha256="" ;;
-  win-x64)   managed_sha256="" ;;
+  linux-x64) managed_sha256="a26d846a584d57bb0febab5f3552c34a4a2e6d4a29881f5ebe420166748814fd" ;;
+  osx-arm64) managed_sha256="402c927f2062cafa66ca67254203e265f769bb8f6d2845a0264a9167680ad924" ;;
+  win-x64)   managed_sha256="bbbebd847bbe08b3168aab63185a0b6950cb3fa8e4a4c150ed55672e586ac195" ;;
   *)
     echo "usage: $0 <linux-x64|osx-arm64|win-x64> [dest-dir]" >&2
     exit 2

--- a/tools/ci/fetch_thermo_assets.sh
+++ b/tools/ci/fetch_thermo_assets.sh
@@ -37,7 +37,7 @@ set -euo pipefail
 
 # Git tag or commit of openms-thermo-bridge; must equal the FetchContent GIT_TAG in
 # cmake/cmake_findExternalLibs.cmake (checked below).
-BRIDGE_TAG="4c0edddf5a49879e0470b0ca08cfe9955ceba3c9"
+BRIDGE_TAG="v0.3.0"
 RAW_URL="https://archive.openms.de/openms/testfiles/Angiotensin_AllScans.raw"
 RAW_SHA256="3a0236f719e7c91e3c958f57f4e66ae422803ec3e6a997b9af4d2af395332b9f"
 
@@ -126,7 +126,7 @@ elif [[ -z "$managed_sha256" ]]; then
 else
   zip_name="openms-thermo-bridge-managed-${platform}-${BRIDGE_TAG}.zip"
   zip_path="$(mktemp -d)/${zip_name}"
-  download "https://github.com/jpfeuffer/openms-thermo-bridge/releases/download/${BRIDGE_TAG}/${zip_name}" \
+  download "https://github.com/OpenMS/openms-thermo-bridge/releases/download/${BRIDGE_TAG}/${zip_name}" \
            "$zip_path" "${managed_sha256}"
   # cmake -E tar is available on every runner and understands zip on all platforms.
   (cd "${dest}/thermo-managed" && cmake -E tar xf "$zip_path")


### PR DESCRIPTION
## Description

Updates the openms-thermo-bridge dependency to the v0.3.0 release tag and adds SHA256 checksums for pre-built managed assemblies across all supported platforms (linux-x64, osx-arm64, win-x64).

### Changes:
- Updated `BRIDGE_TAG` from commit hash `4c0edddf5a49879e0470b0ca08cfe9955ceba3c9` to release tag `v0.3.0` in both `tools/ci/fetch_thermo_assets.sh` and `cmake/cmake_findExternalLibs.cmake`
- Added SHA256 checksums for pre-built managed assemblies for all three platforms, enabling direct download of release artifacts instead of building from source
- Updated GitHub repository URL from `jpfeuffer/openms-thermo-bridge` to `OpenMS/openms-thermo-bridge` (official organization repository)

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

**Note:** This is a dependency update with no changes to OpenMS source code logic. Existing CI tests should validate the correctness of the new thermo bridge version and asset checksums.

https://claude.ai/code/session_01QmBajHbUHXQPxKhFT1r2tg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned the ThermoBridge integration to the immutable commit associated with the v0.3.0 release for more consistent builds.
  * Added SHA-256 verification for pre-built bridge packages across supported platforms.
  * Updated release downloads to use the OpenMS source repository.
  * Improved consistency checks between the integration and downloaded bridge assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->