### PR TITLE
Update CHANGELOG: add missing PR reference for Deisotoper mass-unit fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1249,7 +1249,7 @@ OpenMS Library:
 Fixes:
   - Fix: Deisotoper::deisotopeAndSingleCharge now uses the proton mass in atomic mass units
     for both precursor and fragment neutral masses. The previous kg constant shifted the
-    precursor-mass cutoff when precursor and fragment charges differed.
+    precursor-mass cutoff when precursor and fragment charges differed (#10075)
   - Fix: Deisotoper::deisotopeAndSingleCharge() and deisotopeWithAveragineModel() discarded every fragment
     isotope cluster when the spectrum carried a precursor with unknown charge (0). The precursor-mass
     constraint was derived from that charge, so the neutral mass came out as 0 and all positive-mass


### PR DESCRIPTION
## Description

Reviewed recently merged PRs against the CHANGELOG's "3.6.0 (under development)" section. Everything is up to date except one small gap:

- #10075 ("[FIX] Use atomic mass units in Deisotoper precursor filtering") added its own CHANGELOG entry, but the bullet is missing the closing `(#10075)` citation that every other entry has. This PR adds it.

No other recently merged PRs (#10077, #10074, #10079, ...) needed a CHANGELOG addition:
- #10077 (Thermo metadata through mzML) already carries its own detailed CHANGELOG entry.
- #10074 is test-only (extends regression coverage for #10073, which already has a CHANGELOG entry citing #10067).
- #10079 is an internal CI/build change (pins openms-thermo-bridge to the `v0.3.0` release tag instead of a commit hash, adds release-asset checksums) with no user-facing behavior change; the required bridge version (0.3.0) is already documented.

## Checklist
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] New and existing unit tests pass locally with my changes (no code changes, CHANGELOG only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLNSSjy4JT6WK9GyR59zpx

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLNSSjy4JT6WK9GyR59zpx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the OpenMS 3.6.0 changelog to reference the relevant GitHub pull request for the corrected precursor-mass cutoff behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->