### PR TITLE
[API,FIX,TEST] Remove nlohmann::json from OpenMS headers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,11 @@ General:
     no longer derives from xercesc::DefaultHandler; subclasses must migrate to the native callbacks
     onStartElement(const char16_t*, const XMLAttributes&) / onEndElement() / onCharacters()
     (#8547, #8558, #9712, #9737)
+  - Fix: nlohmann::json no longer leaks out of libOpenMS. ThermoRawFileMetadata gained a typed API
+    (ThermoScan / ThermoReaction / ThermoPrecursor) with its implementation compiled into the library, and
+    the ProForma JSON serializers moved to a private header, so builds whose json headers are not on the
+    public include path (e.g. Nix) compile the class tests again. A configure-time check now rejects
+    installed headers that include nlohmann/json (#10084)
   - Arrow/Parquet is now a required dependency on all platforms; the WITH_PARQUET CMake option was
     removed (#8370, #8422, #8991)
   - macOS Intel builds discontinued and the deployment target raised to macOS 14; Ubuntu CI runners

--- a/cmake/install_macros.cmake
+++ b/cmake/install_macros.cmake
@@ -32,6 +32,22 @@ endmacro()
 # @param header_list List of headers to install
 macro(install_headers header_list component)
   foreach(_header ${header_list})
+    # nlohmann::json is a PRIVATE dependency of libOpenMS: downstream builds do not have its
+    # include directory, so no installed header may include it (configure-time check only).
+    # Header lists are relative to the calling source directory, like install(FILES) resolves them.
+    # Generated headers in the build tree may not exist yet at this point; they come from OpenMS'
+    # own templates, so only what is already on disk is scanned.
+    set(_header_to_scan "${_header}")
+    if (NOT IS_ABSOLUTE "${_header_to_scan}")
+      set(_header_to_scan "${CMAKE_CURRENT_SOURCE_DIR}/${_header_to_scan}")
+    endif()
+    if (EXISTS "${_header_to_scan}" AND NOT IS_DIRECTORY "${_header_to_scan}")
+      file(STRINGS "${_header_to_scan}" _nlohmann_json_hits REGEX "nlohmann/json")
+      if (_nlohmann_json_hits)
+        message(FATAL_ERROR "Installed header ${_header} includes nlohmann/json. Keep JSON types out of "
+                            "public headers: move the header under source/ or expose value types instead.")
+      endif()
+    endif()
     set(_relative_header_path)
 
     get_filename_component(_target_path ${_header} PATH)

--- a/src/openms/include/OpenMS/CHEMISTRY/sources.cmake
+++ b/src/openms/include/OpenMS/CHEMISTRY/sources.cmake
@@ -35,7 +35,6 @@ NASequence.h
 NucleicAcidSpectrumGenerator.h
 OBODataProvider.h
 ProForma.h
-ProFormaDataJson.h
 ProteaseDB.h
 ProteaseDigestion.h
 Residue.h

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/ThermoRawFileMetadata.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/ThermoRawFileMetadata.h
@@ -7,48 +7,77 @@
 // --------------------------------------------------------------------------
 #pragma once
 
-#include <cmath>
-#include <locale>
+#include <OpenMS/OpenMSConfig.h>
+
+#include <cstddef>
 #include <map>
-#include <nlohmann/json.hpp>
-#include <regex>
-#include <sstream>
+#include <optional>
 #include <string>
 #include <vector>
 
 namespace OpenMS::Internal
 {
+/// One "trailer extra" label/value pair of a Thermo scan.
+struct OPENMS_DLLAPI ThermoTrailerEntry
+{
+  std::string label; ///< e.g. "Monoisotopic M/Z:"
+  std::string value; ///< as reported by the instrument, numbers included
+};
+
+/// One reaction (isolation plus activation step) of a Thermo MSn scan event.
+struct OPENMS_DLLAPI ThermoReaction
+{
+  std::optional<double> precursor_mass;   ///< isolation target m/z
+  std::optional<double> isolation_width;  ///< isolation window width (Th)
+  std::optional<double> isolation_offset; ///< isolation window offset from the target (Th)
+  std::string activation;                 ///< vendor activation type name, e.g. "HigherEnergyCollisionalDissociation"
+  std::optional<double> collision_energy; ///< vendor value; meaningful only if collision_energy_valid
+  bool collision_energy_valid = false;    ///< vendor flag for collision_energy
+};
+
+/// The per-scan metadata needed to reconstruct the precursor hierarchy.
+struct OPENMS_DLLAPI ThermoScan
+{
+  int scan_number = 0;                     ///< 1-based scan number within the controller
+  int ms_level = 0;                        ///< MS order (1 for full scans)
+  std::string filter;                      ///< scan filter string, e.g. "FTMS + c NSI Full ms2 500.00@hcd30.00 [100-1000]"
+  std::string native_id;                   ///< e.g. "controllerType=0 controllerNumber=1 scan=12"
+  std::vector<ThermoTrailerEntry> trailer; ///< trailer-extra entries in file order
+  std::vector<ThermoReaction> reactions;   ///< reactions in acquisition order (MS2 first)
+};
+
+/// One precursor of an MSn scan as reconstructed by ThermoRawFileMetadata::precursors().
+struct OPENMS_DLLAPI ThermoPrecursor
+{
+  double target_mz = 0.0;         ///< isolation window target m/z
+  double selected_mz = 0.0;       ///< monoisotopic m/z when plausible, otherwise the target
+  std::optional<int> charge;      ///< unset if unknown or not positive
+  std::optional<double> width;    ///< isolation width; unset if unknown or negative
+  double lower_offset = 0.0;      ///< width / 2 - isolation offset (0 if the width is unknown)
+  double upper_offset = 0.0;      ///< width / 2 + isolation offset
+  int parent_scan = 0;            ///< scan this precursor was isolated from (0 if unknown)
+  bool estimate_intensity = true; ///< false for additional SPS selections
+  std::string spectrum_ref;       ///< native ID of the parent scan ("" if unknown)
+  ThermoReaction activation;      ///< primary reaction
+  std::optional<ThermoReaction> supplemental; ///< supplemental activation (e.g. the HCD step of EThcD)
+};
+
 /** @brief Resolve the precursor hierarchy from bridge metadata without fetching
    peaks. Keeps isolation targets distinct from selected ions, and retains SPS
    selections and supplemental reactions. The filter fallback follows
    ThermoRawFileParser. */
-class ThermoRawFileMetadata
+class OPENMS_DLLAPI ThermoRawFileMetadata
 {
 public:
-  /// Value of the trailer-extra entry with exactly this @p label, or "" if absent / not a string.
-  static std::string trailer(const nlohmann::json& scan, const std::string& label)
-  {
-    for (const auto& entry : scan.at("trailer"))
-    {
-      if (entry.at("label") == label && entry.at("value").is_string()) { return entry.at("value").get<std::string>(); }
-    }
-    return "";
-  }
+  /// Value of the trailer-extra entry with exactly this @p label, or "" if absent.
+  static std::string trailer(const ThermoScan& scan, const std::string& label);
 
   /**
     @brief Parse a trailer value as a number.
-    @return the number, or JSON null when the value is empty, not fully numeric (e.g. "2,5"
+    @return the number, or an empty optional when the value is empty, not fully numeric (e.g. "2,5"
             or "12.3abc") or not finite. A literal zero is a valid number, not "missing".
   */
-  static nlohmann::json number(const std::string& value)
-  {
-    std::istringstream stream(value);
-    stream.imbue(std::locale::classic());
-    double result;
-    if (! (stream >> result) || ! std::isfinite(result)) { return nullptr; }
-    stream >> std::ws;
-    return stream.eof() ? nlohmann::json(result) : nlohmann::json(nullptr);
-  }
+  static std::optional<double> number(const std::string& value);
 
   /**
     @brief Selected ion m/z of a precursor (ThermoRawFileParser rule).
@@ -58,198 +87,40 @@ public:
     @return the monoisotopic m/z when it is set and plausibly inside the isolation window
             (narrow windows accept -3.0 / +2.5 Th around the target), otherwise the target
   */
-  static double selectedIon(double target, const nlohmann::json& mono, double width)
-  {
-    if (! mono.is_number() || mono.get<double>() <= 1e-8) { return target; }
-    double mz = mono.get<double>();
-    if (std::abs(mz - target) <= 0.0001) { return target; }
-    double half = width / 2;
-    if (half <= 2.0) { return mz >= target - 3.0 && mz <= target + 2.5 ? mz : target; }
-    return mz >= target - half && mz <= target + half ? mz : target;
-  }
+  static double selectedIon(double target, std::optional<double> mono, double width);
 
   /**
     @brief Precursor descriptors of one scan; scans must be passed in acquisition order.
 
-    MS1 scans return an empty array and are only recorded as potential parents. For MSn
-    scans the array holds the scan's own precursor (isolation target, selected ion, charge,
+    MS1 scans return an empty vector and are only recorded as potential parents. For MSn
+    scans the vector holds the scan's own precursor (isolation target, selected ion, charge,
     window, parent scan / spectrum reference, activation and supplemental activation),
     followed by further SPS selections and then the precursors of every ancestor scan, so
     an MS3 scan lists its MS2 parent's precursor as well. Only each scan's own precursors
     are retained internally; ancestors are resolved through parent links on request.
   */
-  nlohmann::json precursors(const nlohmann::json& scan)
-  {
-    const int scan_number = scan.at("scan_number").get<int>();
-    const int level = scan.at("ms_level").get<int>();
-    const auto& reactions = scan.at("reactions");
-    State state;
-    state.level = level;
-    state.native_id = scan.at("native_id").get<std::string>();
-    if (level == 1)
-    {
-      filters_[""] = scan_number;
-      scans_[scan_number] = state;
-      return nlohmann::json::array();
-    }
-    std::smatch match;
-    const std::string filter = scan.at("filter").get<std::string>();
-    std::string key;
-    static const std::regex filter_pattern(R"(ms\d+ (.+?) \[)");
-    if (std::regex_search(filter, match, filter_pattern)) { key = match[1]; }
-    int fallback = parentFromFilter_(key);
-    auto master = number(trailer(scan, "Master Scan Number:"));
-    int parent
-      = master.is_number() && master.get<double>() > 0 && master.get<double>() < scan_number ? static_cast<int>(master.get<double>()) : fallback;
-    auto parent_it = scans_.find(parent);
-    // A master scan of the same MS order is a sibling (Tribrid decision trees, or several
-    // activations of one isolation such as HCD / ETD / EThcD scans of the same precursor).
-    // Its reactions do not apply here; descend from the scan the sibling was triggered by.
-    if (parent_it != scans_.end() && parent_it->second.level == level)
-    {
-      parent = parent_it->second.parent;
-      parent_it = scans_.find(parent);
-    }
-    std::size_t index = parent_it == scans_.end() ? lastReaction_(reactions) : parent_it->second.reactions;
-    if (index >= reactions.size() && parent_it != scans_.end())
-    {
-      parent = fallback;
-      parent_it = scans_.find(parent);
-      index = parent_it == scans_.end() ? lastReaction_(reactions) : parent_it->second.reactions;
-    }
-    state.parent = parent_it == scans_.end() ? 0 : parent;
-    nlohmann::json result = nlohmann::json::array();
-    if (index < reactions.size())
-    {
-      const auto& reaction = reactions[index];
-      auto width = number(trailer(scan, "MS" + std::to_string(level) + " Isolation Width:"));
-      if (width.is_null()) { width = reaction.at("isolation_width"); }
-      if (width.is_number() && width.get<double>() < 0) { width = nullptr; }
-      const double target = reaction.at("precursor_mass").get<double>();
-      const double w = width.is_number() ? width.get<double>() : 0.0;
-      const double offset = reaction.at("isolation_offset").is_number() ? reaction.at("isolation_offset").get<double>() : 0.0;
-      auto charge = number(trailer(scan, "Charge State:"));
-      if (charge.is_number() && charge.get<double>() <= 0) { charge = nullptr; }
-      nlohmann::json precursor = {{"target_mz", target},
-                                  {"selected_mz", selectedIon(target, number(trailer(scan, "Monoisotopic M/Z:")), w)},
-                                  {"charge", charge},
-                                  {"width", width},
-                                  {"lower_offset", w / 2 - offset},
-                                  {"upper_offset", w / 2 + offset},
-                                  {"parent_scan", parent_it == scans_.end() ? 0 : parent},
-                                  {"estimate_intensity", true},
-                                  {"spectrum_ref", parent_it == scans_.end() ? "" : parent_it->second.native_id},
-                                  {"activation", reaction},
-                                  {"supplemental", nullptr}};
-      ++index;
-      // The parent's consumed reactions already account for earlier MS levels.
-      // Like TRFP, retain the remaining reaction as supplemental activation even
-      // when the vendor's activation flag or type is unexpected.
-      if (index < reactions.size()) { precursor["supplemental"] = reactions[index++]; }
-      state.own.push_back(precursor);
-      auto masses = spsMasses_(scan);
-      // First SPS selection is represented by the primary reaction.
-      for (std::size_t i = 1; i < masses.size(); ++i)
-      {
-        auto sps = precursor;
-        sps["target_mz"] = masses[i];
-        sps["selected_mz"] = masses[i];
-        sps["charge"] = nullptr;
-        sps["estimate_intensity"] = false;
-        state.own.push_back(std::move(sps));
-      }
-      state.reactions = index;
-      result = state.own;
-      // Ancestors are resolved through the parent chain (MS3 -> MS2 -> MS1) instead of being
-      // copied into every scan, so retained metadata stays one descriptor per MSn scan.
-      for (int ancestor = state.parent; ancestor != 0;)
-      {
-        const auto it = scans_.find(ancestor);
-        if (it == scans_.end()) { break; }
-        for (const auto& descriptor : it->second.own)
-        {
-          result.push_back(descriptor);
-        }
-        ancestor = it->second.parent;
-      }
-    }
-    if (! key.empty()) { filters_[key] = scan_number; }
-    scans_[scan_number] = std::move(state);
-    return result;
-  }
+  std::vector<ThermoPrecursor> precursors(const ThermoScan& scan);
 
 private:
+  /// What is retained per seen scan to resolve later scans' parents.
   struct State
   {
-    int level = 1;
-    int parent = 0;              ///< scan this one descends from (0 if unknown)
-    std::size_t reactions = 0;   ///< reactions consumed up to and including this scan
-    std::string native_id;
-    nlohmann::json own = nlohmann::json::array(); ///< this scan's own precursor descriptors
+    int level = 1;             ///< MS order
+    int parent = 0;            ///< scan this one descends from (0 if unknown)
+    std::size_t reactions = 0; ///< reactions consumed up to and including this scan
+    std::string native_id;     ///< spectrum reference for descendants
+    std::vector<ThermoPrecursor> own; ///< this scan's own precursor descriptors
   };
-  std::map<int, State> scans_;
-  std::map<std::string, int> filters_;
+  std::map<int, State> scans_;         ///< seen scans by scan number
+  std::map<std::string, int> filters_; ///< most recent scan per filter key ("" for MS1)
 
-  static bool supplemental_(const nlohmann::json& first, const nlohmann::json& second)
-  {
-    const std::string a = first.at("activation").get<std::string>(), b = second.at("activation").get<std::string>();
-    return first.at("precursor_mass").is_number() && second.at("precursor_mass").is_number()
-           && std::abs(first.at("precursor_mass").get<double>() - second.at("precursor_mass").get<double>()) < 0.0001
-           && (a == "ElectronTransferDissociation" || a == "ElectronCaptureDissociation")
-           && (b == "HigherEnergyCollisionalDissociation" || b == "CollisionInducedDissociation");
-  }
-  static std::size_t lastReaction_(const nlohmann::json& reactions)
-  {
-    if (reactions.empty()) { return 0; }
-    std::size_t index = reactions.size() - 1;
-    if (index > 0 && supplemental_(reactions[index - 1], reactions[index])) { --index; }
-    return index;
-  }
-  int parentFromFilter_(const std::string& key) const
-  {
-    std::istringstream stream(key);
-    std::vector<std::string> parts;
-    for (std::string part; stream >> part;)
-    {
-      parts.push_back(part);
-    }
-    if (! parts.empty())
-    {
-      const auto mass = parts.back().substr(0, parts.back().find('@'));
-      while (! parts.empty() && parts.back().substr(0, parts.back().find('@')) == mass)
-      {
-        parts.pop_back();
-      }
-    }
-    std::string parent_key;
-    for (const auto& part : parts)
-    {
-      if (! parent_key.empty()) { parent_key += ' '; }
-      parent_key += part;
-    }
-    auto it = filters_.find(parent_key);
-    return it == filters_.end() ? 0 : it->second;
-  }
-  static std::vector<double> spsMasses_(const nlohmann::json& scan)
-  {
-    std::vector<double> result;
-    const bool modern = ! trailer(scan, "SPS Masses:").empty();
-    static const std::regex legacy_pattern(R"(SPS Mass\s+\d+:)");
-    static const std::regex modern_pattern(R"(SPS Masses(?:\s+Continued)?:)");
-    for (const auto& entry : scan.at("trailer"))
-    {
-      const std::string label = entry.at("label").get<std::string>();
-      if ((! modern && std::regex_match(label, legacy_pattern)) || (modern && std::regex_match(label, modern_pattern)))
-      {
-        std::istringstream values(entry.at("value").get<std::string>());
-        for (std::string value; std::getline(values, value, ',');)
-        {
-          auto mass = number(value);
-          if (mass.is_number() && mass.get<double>() > 0) { result.push_back(mass.get<double>()); }
-        }
-      }
-    }
-    return result;
-  }
+  /// True if @p second is the supplemental (HCD / CID) step of an ETD / ECD reaction @p first on the same target.
+  static bool supplemental_(const ThermoReaction& first, const ThermoReaction& second);
+  /// Index of the reaction that isolated this scan's precursor when no parent is known.
+  static std::size_t lastReaction_(const std::vector<ThermoReaction>& reactions);
+  /// Most recent scan whose filter key is the parent of @p key (0 if none).
+  int parentFromFilter_(const std::string& key) const;
+  /// SPS target masses from the legacy ("SPS Mass N:") or modern ("SPS Masses:") trailer labels.
+  static std::vector<double> spsMasses_(const ThermoScan& scan);
 };
 } // namespace OpenMS::Internal

--- a/src/openms/source/CHEMISTRY/ProForma.cpp
+++ b/src/openms/source/CHEMISTRY/ProForma.cpp
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/CHEMISTRY/ProForma.h>
-#include <OpenMS/CHEMISTRY/ProFormaDataJson.h>
+#include "ProFormaDataJson.h"
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 #include <OpenMS/CHEMISTRY/ResidueModification.h>

--- a/src/openms/source/CHEMISTRY/ProFormaDataJson.h
+++ b/src/openms/source/CHEMISTRY/ProFormaDataJson.h
@@ -5,6 +5,9 @@
 // $Maintainer: Timo Sachsenberg $
 // $Authors: Timo Sachsenberg $
 // --------------------------------------------------------------------------
+//
+// Private header: nlohmann::json ADL serializers for the ProForma data model. Included only
+// by ProForma.cpp and never installed, which keeps nlohmann::json a PRIVATE dependency of libOpenMS.
 
 #pragma once
 
@@ -952,8 +955,7 @@ namespace OpenMS
   /// @}
 
 
-  // Note: The convenience functions toJSON(), peptidoformFromJSON(), peptidoformIonFromJSON()
-  // are declared in ProFormaData.h and implemented in ProFormaDataJson.cpp.
-  // This header provides the nlohmann::json ADL overloads needed by those implementations.
+  // The convenience functions ProForma::toJSON(), peptidoformFromJSON() and peptidoformIonFromJSON()
+  // are declared in ProForma.h and implemented in ProForma.cpp on top of these ADL overloads.
 
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/HANDLERS/ThermoRawFileMetadata.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ThermoRawFileMetadata.cpp
@@ -1,0 +1,211 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/FORMAT/HANDLERS/ThermoRawFileMetadata.h>
+
+#include <cmath>
+#include <locale>
+#include <regex>
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+
+namespace OpenMS::Internal
+{
+std::string ThermoRawFileMetadata::trailer(const ThermoScan& scan, const std::string& label)
+{
+  for (const auto& entry : scan.trailer)
+  {
+    if (entry.label == label) { return entry.value; }
+  }
+  return "";
+}
+
+std::optional<double> ThermoRawFileMetadata::number(const std::string& value)
+{
+  std::istringstream stream(value);
+  stream.imbue(std::locale::classic());
+  double result;
+  if (! (stream >> result) || ! std::isfinite(result)) { return std::nullopt; }
+  stream >> std::ws;
+  if (! stream.eof()) { return std::nullopt; }
+  return result;
+}
+
+double ThermoRawFileMetadata::selectedIon(double target, std::optional<double> mono, double width)
+{
+  if (! mono || *mono <= 1e-8) { return target; }
+  const double mz = *mono;
+  if (std::abs(mz - target) <= 0.0001) { return target; }
+  const double half = width / 2;
+  if (half <= 2.0) { return mz >= target - 3.0 && mz <= target + 2.5 ? mz : target; }
+  return mz >= target - half && mz <= target + half ? mz : target;
+}
+
+std::vector<ThermoPrecursor> ThermoRawFileMetadata::precursors(const ThermoScan& scan)
+{
+  const int scan_number = scan.scan_number;
+  const int level = scan.ms_level;
+  const auto& reactions = scan.reactions;
+  State state;
+  state.level = level;
+  state.native_id = scan.native_id;
+  if (level == 1)
+  {
+    filters_[""] = scan_number;
+    scans_[scan_number] = state;
+    return {};
+  }
+  std::smatch match;
+  std::string key;
+  static const std::regex filter_pattern(R"(ms\d+ (.+?) \[)");
+  if (std::regex_search(scan.filter, match, filter_pattern)) { key = match[1]; }
+  const int fallback = parentFromFilter_(key);
+  const auto master = number(trailer(scan, "Master Scan Number:"));
+  int parent = master && *master > 0 && *master < scan_number ? static_cast<int>(*master) : fallback;
+  auto parent_it = scans_.find(parent);
+  // A master scan of the same MS order is a sibling (Tribrid decision trees, or several
+  // activations of one isolation such as HCD / ETD / EThcD scans of the same precursor).
+  // Its reactions do not apply here; descend from the scan the sibling was triggered by.
+  if (parent_it != scans_.end() && parent_it->second.level == level)
+  {
+    parent = parent_it->second.parent;
+    parent_it = scans_.find(parent);
+  }
+  std::size_t index = parent_it == scans_.end() ? lastReaction_(reactions) : parent_it->second.reactions;
+  if (index >= reactions.size() && parent_it != scans_.end())
+  {
+    parent = fallback;
+    parent_it = scans_.find(parent);
+    index = parent_it == scans_.end() ? lastReaction_(reactions) : parent_it->second.reactions;
+  }
+  state.parent = parent_it == scans_.end() ? 0 : parent;
+  std::vector<ThermoPrecursor> result;
+  if (index < reactions.size())
+  {
+    const auto& reaction = reactions[index];
+    if (! reaction.precursor_mass)
+    {
+      throw std::runtime_error("Thermo scan " + std::to_string(scan_number) + ": reaction without precursor mass");
+    }
+    auto width = number(trailer(scan, "MS" + std::to_string(level) + " Isolation Width:"));
+    if (! width) { width = reaction.isolation_width; }
+    if (width && *width < 0) { width.reset(); }
+    const double target = *reaction.precursor_mass;
+    const double w = width.value_or(0.0);
+    const double offset = reaction.isolation_offset.value_or(0.0);
+    const auto charge = number(trailer(scan, "Charge State:"));
+    ThermoPrecursor precursor;
+    precursor.target_mz = target;
+    precursor.selected_mz = selectedIon(target, number(trailer(scan, "Monoisotopic M/Z:")), w);
+    if (charge && *charge > 0) { precursor.charge = static_cast<int>(*charge); }
+    precursor.width = width;
+    precursor.lower_offset = w / 2 - offset;
+    precursor.upper_offset = w / 2 + offset;
+    precursor.parent_scan = state.parent;
+    precursor.estimate_intensity = true;
+    precursor.spectrum_ref = parent_it == scans_.end() ? "" : parent_it->second.native_id;
+    precursor.activation = reaction;
+    ++index;
+    // The parent's consumed reactions already account for earlier MS levels.
+    // Like TRFP, retain the remaining reaction as supplemental activation even
+    // when the vendor's activation flag or type is unexpected.
+    if (index < reactions.size()) { precursor.supplemental = reactions[index++]; }
+    state.own.push_back(precursor);
+    const auto masses = spsMasses_(scan);
+    // First SPS selection is represented by the primary reaction.
+    for (std::size_t i = 1; i < masses.size(); ++i)
+    {
+      auto sps = precursor;
+      sps.target_mz = masses[i];
+      sps.selected_mz = masses[i];
+      sps.charge.reset();
+      sps.estimate_intensity = false;
+      state.own.push_back(std::move(sps));
+    }
+    state.reactions = index;
+    result = state.own;
+    // Ancestors are resolved through the parent chain (MS3 -> MS2 -> MS1) instead of being
+    // copied into every scan, so retained metadata stays one descriptor per MSn scan.
+    for (int ancestor = state.parent; ancestor != 0;)
+    {
+      const auto it = scans_.find(ancestor);
+      if (it == scans_.end()) { break; }
+      result.insert(result.end(), it->second.own.begin(), it->second.own.end());
+      ancestor = it->second.parent;
+    }
+  }
+  if (! key.empty()) { filters_[key] = scan_number; }
+  scans_[scan_number] = std::move(state);
+  return result;
+}
+
+bool ThermoRawFileMetadata::supplemental_(const ThermoReaction& first, const ThermoReaction& second)
+{
+  const std::string& a = first.activation;
+  const std::string& b = second.activation;
+  return first.precursor_mass && second.precursor_mass && std::abs(*first.precursor_mass - *second.precursor_mass) < 0.0001
+         && (a == "ElectronTransferDissociation" || a == "ElectronCaptureDissociation")
+         && (b == "HigherEnergyCollisionalDissociation" || b == "CollisionInducedDissociation");
+}
+
+std::size_t ThermoRawFileMetadata::lastReaction_(const std::vector<ThermoReaction>& reactions)
+{
+  if (reactions.empty()) { return 0; }
+  std::size_t index = reactions.size() - 1;
+  if (index > 0 && supplemental_(reactions[index - 1], reactions[index])) { --index; }
+  return index;
+}
+
+int ThermoRawFileMetadata::parentFromFilter_(const std::string& key) const
+{
+  std::istringstream stream(key);
+  std::vector<std::string> parts;
+  for (std::string part; stream >> part;)
+  {
+    parts.push_back(part);
+  }
+  if (! parts.empty())
+  {
+    const auto mass = parts.back().substr(0, parts.back().find('@'));
+    while (! parts.empty() && parts.back().substr(0, parts.back().find('@')) == mass)
+    {
+      parts.pop_back();
+    }
+  }
+  std::string parent_key;
+  for (const auto& part : parts)
+  {
+    if (! parent_key.empty()) { parent_key += ' '; }
+    parent_key += part;
+  }
+  const auto it = filters_.find(parent_key);
+  return it == filters_.end() ? 0 : it->second;
+}
+
+std::vector<double> ThermoRawFileMetadata::spsMasses_(const ThermoScan& scan)
+{
+  std::vector<double> result;
+  const bool modern = ! trailer(scan, "SPS Masses:").empty();
+  static const std::regex legacy_pattern(R"(SPS Mass\s+\d+:)");
+  static const std::regex modern_pattern(R"(SPS Masses(?:\s+Continued)?:)");
+  for (const auto& entry : scan.trailer)
+  {
+    if ((! modern && std::regex_match(entry.label, legacy_pattern)) || (modern && std::regex_match(entry.label, modern_pattern)))
+    {
+      std::istringstream values(entry.value);
+      for (std::string value; std::getline(values, value, ',');)
+      {
+        const auto mass = number(value);
+        if (mass && *mass > 0) { result.push_back(*mass); }
+      }
+    }
+  }
+  return result;
+}
+} // namespace OpenMS::Internal

--- a/src/openms/source/FORMAT/HANDLERS/sources.cmake
+++ b/src/openms/source/FORMAT/HANDLERS/sources.cmake
@@ -26,6 +26,7 @@ set(sources_list
   PASEFHillCentroider.cpp
   PTMXMLHandler.cpp
   ParamXMLHandler.cpp
+  ThermoRawFileMetadata.cpp
   ToolDescriptionHandler.cpp
   TraMLHandler.cpp
   UnimodXMLHandler.cpp

--- a/src/openms/source/FORMAT/ThermoRawFile.cpp
+++ b/src/openms/source/FORMAT/ThermoRawFile.cpp
@@ -36,6 +36,7 @@
   #include <filesystem>
   #include <limits>
   #include <map>
+  #include <nlohmann/json.hpp>
   #include <optional>
   #include <openms_thermo_bridge/cv_mapping.hpp>
   #include <openms_thermo_bridge/thermo_bridge.hpp>
@@ -158,6 +159,47 @@ namespace
     }
   }
 
+  /**
+    Typed view of one scan's bridge metadata (schema version 1) for the precursor parser.
+    Trailer entries whose label or value is not a string are dropped; numeric reaction
+    fields the bridge reports as null stay unset.
+  */
+  Internal::ThermoScan toThermoScan(const nlohmann::json& meta)
+  {
+    auto string_or_empty = [](const nlohmann::json& object, const char* key) -> std::string {
+      return object.contains(key) && object[key].is_string() ? object[key].get<std::string>() : std::string();
+    };
+    auto number_or_unset = [](const nlohmann::json& object, const char* key) -> std::optional<double> {
+      if (object.contains(key) && object[key].is_number()) { return object[key].get<double>(); }
+      return std::nullopt;
+    };
+    Internal::ThermoScan scan;
+    scan.scan_number = meta.at("scan_number").get<int>();
+    scan.ms_level = meta.at("ms_level").get<int>();
+    scan.filter = string_or_empty(meta, "filter");
+    scan.native_id = string_or_empty(meta, "native_id");
+    for (const auto& entry : meta.at("trailer"))
+    {
+      if (entry.at("label").is_string() && entry.at("value").is_string())
+      {
+        scan.trailer.push_back({entry.at("label").get<std::string>(), entry.at("value").get<std::string>()});
+      }
+    }
+    for (const auto& reaction : meta.at("reactions"))
+    {
+      Internal::ThermoReaction converted;
+      converted.precursor_mass = number_or_unset(reaction, "precursor_mass");
+      converted.isolation_width = number_or_unset(reaction, "isolation_width");
+      converted.isolation_offset = number_or_unset(reaction, "isolation_offset");
+      converted.activation = string_or_empty(reaction, "activation");
+      converted.collision_energy = number_or_unset(reaction, "collision_energy");
+      converted.collision_energy_valid = reaction.contains("collision_energy_valid") && reaction["collision_energy_valid"].is_boolean()
+                                         && reaction["collision_energy_valid"].get<bool>();
+      scan.reactions.push_back(std::move(converted));
+    }
+    return scan;
+  }
+
 } // anonymous namespace
 
 void ThermoRawFile::load(const std::string& path, MSExperiment& exp)
@@ -261,12 +303,12 @@ void ThermoRawFile::load(const std::string& path, MSExperiment& exp)
     std::map<std::string, std::string> configurations;
     Metadata precursor_parser;
     std::map<int, Size> spectrum_by_scan;
-    auto activation = [&](Precursor& precursor, const Json& reaction, bool supplemental) {
-      const std::string type = text(reaction, "activation");
-      if (reaction.value("collision_energy_valid", false) && reaction.at("collision_energy").is_number())
+    auto activation = [&](Precursor& precursor, const Internal::ThermoReaction& reaction, bool supplemental) {
+      const std::string& type = reaction.activation;
+      if (reaction.collision_energy_valid && reaction.collision_energy)
       {
         precursor.setMetaValue(supplemental ? "supplemental collision energy" : "collision energy",
-                               unit_value(numeric(reaction, "collision_energy"), 266));
+                               unit_value(*reaction.collision_energy, 266));
       }
       if (supplemental)
       {
@@ -311,6 +353,7 @@ void ThermoRawFile::load(const std::string& path, MSExperiment& exp)
         setProgress(scan);
         const Json meta = Json::parse(raw.scan_metadata_json(scan));
         if (meta.at("schema_version") != 1) { throw std::runtime_error("Unsupported Thermo scan metadata schema"); }
+        const Internal::ThermoScan parsed = toThermoScan(meta);
         MSSpectrum spectrum;
         const int level = meta.at("ms_level").get<int>();
         spectrum.setMSLevel(level > 0 ? level : 0);
@@ -334,18 +377,17 @@ void ThermoRawFile::load(const std::string& path, MSExperiment& exp)
         // scan-level term.
         spectrum.setMetaValue("filter string", filter);
         if (options_.preserve_trailers) { acquisition.setMetaValue("Thermo trailer extra", meta.at("trailer").dump()); }
-        auto injection = Metadata::number(Metadata::trailer(meta, "Ion Injection Time (ms):"));
-        if (injection.is_number()) { acquisition.setMetaValue("ion injection time", unit_value(injection.get<double>(), 28)); }
-        auto mono = Metadata::number(Metadata::trailer(meta, "Monoisotopic M/Z:"));
-        if (mono.is_number() && mono.get<double>() > 0) { acquisition.setMetaValue("[Thermo Trailer Extra]Monoisotopic M/Z:", mono.get<double>()); }
-        const auto voltage_on = Metadata::number(Metadata::trailer(meta, "FAIMS Voltage On:"));
-        const auto voltage = Metadata::number(Metadata::trailer(meta, "FAIMS CV:"));
-        std::string enabled = Metadata::trailer(meta, "FAIMS Voltage On:");
+        const auto injection = Metadata::number(Metadata::trailer(parsed, "Ion Injection Time (ms):"));
+        if (injection) { acquisition.setMetaValue("ion injection time", unit_value(*injection, 28)); }
+        const auto mono = Metadata::number(Metadata::trailer(parsed, "Monoisotopic M/Z:"));
+        if (mono && *mono > 0) { acquisition.setMetaValue("[Thermo Trailer Extra]Monoisotopic M/Z:", *mono); }
+        const auto voltage_on = Metadata::number(Metadata::trailer(parsed, "FAIMS Voltage On:"));
+        const auto voltage = Metadata::number(Metadata::trailer(parsed, "FAIMS CV:"));
+        std::string enabled = Metadata::trailer(parsed, "FAIMS Voltage On:");
         std::transform(enabled.begin(), enabled.end(), enabled.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-        if (((voltage_on.is_number() && voltage_on.get<double>() != 0) || (enabled == "true" || enabled == "on" || enabled == "yes"))
-            && voltage.is_number())
+        if (((voltage_on && *voltage_on != 0) || (enabled == "true" || enabled == "on" || enabled == "yes")) && voltage)
         {
-          spectrum.setDriftTime(voltage.get<double>());
+          spectrum.setDriftTime(*voltage);
           spectrum.setDriftTimeUnit(DriftTimeUnit::FAIMS_COMPENSATION_VOLTAGE);
         }
         const std::string analyzer = text(meta, "analyzer"), ionization = text(meta, "ionization");
@@ -409,32 +451,32 @@ void ThermoRawFile::load(const std::string& path, MSExperiment& exp)
           }
           spectrum.getProducts().push_back(product);
         }
-        for (const auto& descriptor : neutral ? Json::array() : precursor_parser.precursors(meta))
+        for (const auto& descriptor : neutral ? std::vector<Internal::ThermoPrecursor>() : precursor_parser.precursors(parsed))
         {
           Precursor precursor;
-          precursor.setMZ(numeric(descriptor, "selected_mz")); // OpenMS default: selected ion
-          precursor.setMetaValue("isolation window target m/z", numeric(descriptor, "target_mz"));
-          precursor.setMetaValue("selected ion m/z", numeric(descriptor, "selected_mz"));
-          if (descriptor.at("charge").is_number()) { precursor.setCharge(static_cast<int>(numeric(descriptor, "charge"))); }
-          if (descriptor.at("width").is_number())
+          precursor.setMZ(descriptor.selected_mz); // OpenMS default: selected ion
+          precursor.setMetaValue("isolation window target m/z", descriptor.target_mz);
+          precursor.setMetaValue("selected ion m/z", descriptor.selected_mz);
+          if (descriptor.charge) { precursor.setCharge(*descriptor.charge); }
+          if (descriptor.width)
           {
-            const double lower = numeric(descriptor, "lower_offset"), upper = numeric(descriptor, "upper_offset");
+            const double lower = descriptor.lower_offset, upper = descriptor.upper_offset;
             if (lower >= 0) { precursor.setIsolationWindowLowerOffset(lower); }
             if (upper >= 0) { precursor.setIsolationWindowUpperOffset(upper); }
             if (lower <= 0) { precursor.setMetaValue("isolation window lower offset", lower); }
             if (upper <= 0) { precursor.setMetaValue("isolation window upper offset", upper); }
           }
-          if (! text(descriptor, "spectrum_ref").empty()) { precursor.setMetaValue("spectrum_ref", text(descriptor, "spectrum_ref")); }
-          activation(precursor, descriptor.at("activation"), false);
-          if (descriptor.at("supplemental").is_object()) { activation(precursor, descriptor.at("supplemental"), true); }
-          auto parent = spectrum_by_scan.find(descriptor.at("parent_scan").get<int>());
-          if (descriptor.at("estimate_intensity").get<bool>() && parent != spectrum_by_scan.end() && precursor.getMZ() > 0)
+          if (! descriptor.spectrum_ref.empty()) { precursor.setMetaValue("spectrum_ref", descriptor.spectrum_ref); }
+          activation(precursor, descriptor.activation, false);
+          if (descriptor.supplemental) { activation(precursor, *descriptor.supplemental, true); }
+          auto parent = spectrum_by_scan.find(descriptor.parent_scan);
+          if (descriptor.estimate_intensity && parent != spectrum_by_scan.end() && precursor.getMZ() > 0)
           {
             // TRFP's precursor-intensity estimate sums the target +/- 1.5 m/z.
             double intensity = 0;
             const auto& parent_spectrum = exp[parent->second];
-            const double target = numeric(descriptor, "target_mz");
-            const double half_width = numeric(descriptor, "width") > 0 ? 1.5 : 0.0;
+            const double target = descriptor.target_mz;
+            const double half_width = descriptor.width.value_or(0.0) > 0 ? 1.5 : 0.0;
             for (auto peak = parent_spectrum.MZBegin(target - half_width); peak != parent_spectrum.end() && peak->getMZ() < target + half_width;
                  ++peak)
             {

--- a/src/tests/class_tests/openms/source/ThermoRawFileMetadata_test.cpp
+++ b/src/tests/class_tests/openms/source/ThermoRawFileMetadata_test.cpp
@@ -6,124 +6,214 @@
 // $Authors: Timo Sachsenberg $
 // --------------------------------------------------------------------------
 
-// Deliberately independent of libOpenMS and vendor binaries: precursor
-// reconstruction can be tested on all platforms, including builds without
-// WITH_THERMO_RAW.
-#include <OpenMS/FORMAT/HANDLERS/ThermoRawFileMetadata.h>
-#include <iostream>
-#include <stdexcept>
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
 
-using Json = nlohmann::json;
-using Metadata = OpenMS::Internal::ThermoRawFileMetadata;
+///////////////////////////
+#include <OpenMS/FORMAT/HANDLERS/ThermoRawFileMetadata.h>
+///////////////////////////
+
+#include <optional>
+#include <string>
+#include <vector>
+
+using namespace OpenMS;
+using namespace OpenMS::Internal;
+
+// Precursor reconstruction from synthetic scan metadata. Needs neither a RAW file nor the
+// vendor bridge, so it runs on every platform including builds without WITH_THERMO_RAW.
 
 namespace
 {
-void check(bool condition, const char* description)
+ThermoReaction reaction(double mass, const std::string& activation = "CollisionInducedDissociation", double width = 2.0, double offset = 0.0)
 {
-  if (! condition) { throw std::runtime_error(description); }
+  ThermoReaction result;
+  result.precursor_mass = mass;
+  result.activation = activation;
+  result.isolation_width = width;
+  result.isolation_offset = offset;
+  result.collision_energy = 35.0;
+  result.collision_energy_valid = true;
+  return result;
 }
 
-Json reaction(double mass, const std::string& activation = "CollisionInducedDissociation", double width = 2.0, double offset = 0.0)
+ThermoScan scan(int number, int level, const std::string& filter, std::vector<ThermoReaction> reactions = {})
 {
-  return {{"precursor_mass", mass},     {"activation", activation}, {"isolation_width", width},
-          {"isolation_offset", offset}, {"collision_energy", 35.0}, {"collision_energy_valid", true}};
+  ThermoScan result;
+  result.scan_number = number;
+  result.ms_level = level;
+  result.filter = filter;
+  result.reactions = std::move(reactions);
+  result.native_id = "controllerType=0 controllerNumber=1 scan=" + std::to_string(number);
+  return result;
 }
 
-Json scan(int number, int level, const std::string& filter, const Json& reactions = Json::array())
+void trailer(ThermoScan& scan, const std::string& label, const std::string& value)
 {
-  return {{"scan_number", number},  {"ms_level", level},        {"filter", filter},
-          {"reactions", reactions}, {"trailer", Json::array()}, {"native_id", "controllerType=0 controllerNumber=1 scan=" + std::to_string(number)}};
+  scan.trailer.push_back({label, value});
 }
-
-void trailer(Json& scan, const std::string& label, const std::string& value)
-{ scan["trailer"].push_back({{"label", label}, {"value", value}}); }
 } // namespace
 
-int main()
+START_TEST(ThermoRawFileMetadata, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+START_SECTION((static std::optional<double> number(const std::string& value)))
 {
-  try
-  {
-    check(Metadata::number("").is_null(), "Missing values remain missing");
-    check(Metadata::number("NaN").is_null(), "Nonfinite values remain missing");
-    check(Metadata::number("2,5").is_null(), "Do not guess decimal separators");
-    check(Metadata::number(" 0 ") == 0.0, "Zero is not missing");
-    check(Metadata::selectedIon(500, 499.5, 2) == 499.5, "Retain plausible monoisotopic ion");
-    check(Metadata::selectedIon(500, 490, 2) == 500, "Reject unrelated trailer monoisotopic mass");
-    check(Metadata::selectedIon(500, 497, 10) == 497, "Wide-window selected ion rule");
-
-    Metadata parser;
-    check(parser.precursors(scan(10, 1, "FTMS + p NSI Full ms [200-2000]")).empty(), "MS1 has no precursors");
-    auto ms2 = scan(11, 2, "FTMS + c NSI Full ms2 500.00@etd35.00 500.00@hcd20.00 [100-1000]",
-                    Json::array({reaction(500, "ElectronTransferDissociation", 2, 0.25), reaction(500, "HigherEnergyCollisionalDissociation")}));
-    trailer(ms2, "Master Scan Number:", "10");
-    trailer(ms2, "Monoisotopic M/Z:", "499.5");
-    trailer(ms2, "Charge State:", "3");
-    trailer(ms2, "MS2 Isolation Width:", "4");
-    auto p2 = parser.precursors(ms2);
-    check(p2.size() == 1, "Supplemental activation is not an extra precursor");
-    check(p2[0]["target_mz"] == 500 && p2[0]["selected_mz"] == 499.5, "Separate selected ion and isolation target");
-    check(p2[0]["lower_offset"] == 1.75 && p2[0]["upper_offset"] == 2.25, "Preserve asymmetric window and trailer width override");
-    check(p2[0]["charge"] == 3 && p2[0]["parent_scan"] == 10, "Preserve charge and parent scan");
-    check(p2[0]["supplemental"]["activation"] == "HigherEnergyCollisionalDissociation", "Preserve supplemental HCD");
-
-    auto ms3
-      = scan(12, 3,
-             "ITMS + c NSI Full ms3 500.00@etd35.00 500.00@hcd20.00 "
-             "300.00@cid35.00 [80-600]",
-             Json::array({reaction(500, "ElectronTransferDissociation"), reaction(500, "HigherEnergyCollisionalDissociation"), reaction(300)}));
-    trailer(ms3, "Master Scan Number:", "11");
-    trailer(ms3, "SPS Masses:", "300, 310,");
-    trailer(ms3, "SPS Masses Continued:", "320");
-    auto p3 = parser.precursors(ms3);
-    check(p3.size() == 4, "Primary selection, two SPS selections, and MS2 ancestor");
-    check(p3[0]["target_mz"] == 300 && p3[0]["parent_scan"] == 11, "Use current MS3 reaction, not reaction zero");
-    check(p3[1]["target_mz"] == 310 && p3[2]["target_mz"] == 320, "Continued SPS list preserved");
-    check(p3[0]["estimate_intensity"] == true && p3[1]["estimate_intensity"] == false,
-          "Only the primary SPS selection receives an intensity estimate");
-    check(p3[3]["target_mz"] == 500 && p3[3]["parent_scan"] == 10, "Ancestor references its own parent");
-    check(p3[0]["charge"].is_null(), "Missing charge remains missing");
-
-    Metadata fallback;
-    fallback.precursors(scan(1, 1, "FTMS + p NSI Full ms [200-2000]"));
-    auto simple = scan(2, 2, "ITMS + c NSI Full ms2 500.00@cid35.00 [100-1000]", Json::array({reaction(500)}));
-    check(fallback.precursors(simple)[0]["parent_scan"] == 1, "MS2 parent from most recent MS1");
-    auto third = scan(3, 3, "ITMS + c NSI Full ms3 500.00@cid35.00 300.00@cid35.00 [80-600]", Json::array({reaction(500), reaction(300)}));
-    trailer(third, "Master Scan Number:", "999");
-    trailer(third, "SPS Mass 1:", "300");
-    trailer(third, "SPS Mass 2:", "310");
-    auto p = fallback.precursors(third);
-    check(p[0]["parent_scan"] == 2 && p.size() == 3, "Invalid master falls back to filter hierarchy; legacy SPS retained");
-
-    Metadata isolated;
-    auto orphan = scan(100, 3, "ITMS + c NSI Full ms3 500.00@cid35.00 300.00@cid35.00 [80-600]",
-                       Json::array({reaction(500), reaction(300, "CollisionInducedDissociation", -1)}));
-    auto op = isolated.precursors(orphan);
-    check(op[0]["target_mz"] == 300, "Truncated file starts at last reaction");
-    check(op[0]["spectrum_ref"] == "" && op[0]["width"].is_null(), "No fabricated parent or negative width");
-
-    // Lumos/Tribrid files can point the master scan of an MS2 at a sibling MS2 of the same
-    // precursor (e.g. HCD scan first, then EThcD). The sibling's reaction must not be consumed.
-    auto sibling = scan(14, 2, "FTMS + c ESI d Full ms2 432.90@hcd30.00 [100-1300]", Json::array({reaction(432.9, "HigherEnergyCollisionalDissociation")}));
-    trailer(sibling, "Master Scan Number:", "10");
-    check(parser.precursors(sibling)[0]["parent_scan"] == 10, "Sibling descends from the MS1");
-    auto ethcd = scan(15, 2, "FTMS + c ESI d sa Full ms2 432.90@etd54.00 432.90@hcd30.00 [100-1300]",
-                      Json::array({reaction(432.9, "ElectronTransferDissociation"), reaction(432.9, "HigherEnergyCollisionalDissociation")}));
-    trailer(ethcd, "Master Scan Number:", "14");
-    auto pe = parser.precursors(ethcd);
-    check(pe.size() == 1 && pe[0]["activation"]["activation"] == "ElectronTransferDissociation", "Same-order master does not consume the primary reaction");
-    check(pe[0]["supplemental"].is_object() && pe[0]["supplemental"]["activation"] == "HigherEnergyCollisionalDissociation", "Supplemental HCD retained");
-    check(pe[0]["parent_scan"] == 10 && pe[0]["spectrum_ref"] == "controllerType=0 controllerNumber=1 scan=10", "Resolve the sibling's own parent");
-
-    auto unusual = scan(13, 2, "ITMS + c NSI Full ms2 500.00@cid35.00 500.00@hcd20.00 [100-1000]",
-                        Json::array({reaction(500), reaction(500, "HigherEnergyCollisionalDissociation")}));
-    trailer(unusual, "Master Scan Number:", "10");
-    check(parser.precursors(unusual)[0]["supplemental"].is_object(), "Retain supplemental reactions with unexpected main activation types");
-    std::cout << "Thermo precursor metadata regression tests passed\n";
-    return 0;
-  }
-  catch (const std::exception& error)
-  {
-    std::cerr << error.what() << '\n';
-    return 1;
-  }
+  TEST_FALSE(ThermoRawFileMetadata::number("").has_value())        // missing values remain missing
+  TEST_FALSE(ThermoRawFileMetadata::number("NaN").has_value())     // nonfinite values remain missing
+  TEST_FALSE(ThermoRawFileMetadata::number("2,5").has_value())     // do not guess decimal separators
+  TEST_FALSE(ThermoRawFileMetadata::number("12.3abc").has_value()) // trailing garbage is not a number
+  TEST_TRUE(ThermoRawFileMetadata::number(" 0 ").has_value())      // zero is not missing
+  TEST_EQUAL(ThermoRawFileMetadata::number(" 0 ").value(), 0.0)
+  TEST_EQUAL(ThermoRawFileMetadata::number("499.5").value(), 499.5)
 }
+END_SECTION
+
+START_SECTION((static double selectedIon(double target, std::optional<double> mono, double width)))
+{
+  TEST_EQUAL(ThermoRawFileMetadata::selectedIon(500, 499.5, 2), 499.5)       // retain plausible monoisotopic ion
+  TEST_EQUAL(ThermoRawFileMetadata::selectedIon(500, 490, 2), 500)           // reject unrelated trailer monoisotopic mass
+  TEST_EQUAL(ThermoRawFileMetadata::selectedIon(500, 497, 10), 497)          // wide-window selected ion rule
+  TEST_EQUAL(ThermoRawFileMetadata::selectedIon(500, std::nullopt, 2), 500)  // missing monoisotopic mass
+  TEST_EQUAL(ThermoRawFileMetadata::selectedIon(500, 0.0, 2), 500)           // unset (zero) monoisotopic mass
+}
+END_SECTION
+
+START_SECTION((std::vector<ThermoPrecursor> precursors(const ThermoScan& scan)))
+{
+  ThermoRawFileMetadata parser;
+  TEST_TRUE(parser.precursors(scan(10, 1, "FTMS + p NSI Full ms [200-2000]")).empty()) // MS1 has no precursors
+
+  // MS2 with supplemental activation and trailer overrides for charge, monoisotopic m/z and width
+  auto ms2 = scan(11, 2, "FTMS + c NSI Full ms2 500.00@etd35.00 500.00@hcd20.00 [100-1000]",
+                  {reaction(500, "ElectronTransferDissociation", 2, 0.25), reaction(500, "HigherEnergyCollisionalDissociation")});
+  trailer(ms2, "Master Scan Number:", "10");
+  trailer(ms2, "Monoisotopic M/Z:", "499.5");
+  trailer(ms2, "Charge State:", "3");
+  trailer(ms2, "MS2 Isolation Width:", "4");
+  const auto p2 = parser.precursors(ms2);
+  TEST_EQUAL(p2.size(), 1) // supplemental activation is not an extra precursor
+  ABORT_IF(p2.empty())
+  TEST_EQUAL(p2[0].target_mz, 500)     // separate selected ion and isolation target
+  TEST_EQUAL(p2[0].selected_mz, 499.5)
+  TEST_TRUE(p2[0].width.has_value())   // trailer width overrides the reaction width
+  TEST_EQUAL(p2[0].width.value(), 4)
+  TEST_EQUAL(p2[0].lower_offset, 1.75) // preserve asymmetric window
+  TEST_EQUAL(p2[0].upper_offset, 2.25)
+  TEST_TRUE(p2[0].charge.has_value())
+  TEST_EQUAL(p2[0].charge.value(), 3)
+  TEST_EQUAL(p2[0].parent_scan, 10)
+  TEST_STRING_EQUAL(p2[0].spectrum_ref, "controllerType=0 controllerNumber=1 scan=10")
+  TEST_TRUE(p2[0].estimate_intensity)
+  TEST_STRING_EQUAL(p2[0].activation.activation, "ElectronTransferDissociation")
+  TEST_TRUE(p2[0].supplemental.has_value()) // preserve supplemental HCD
+  TEST_STRING_EQUAL(p2[0].supplemental.value().activation, "HigherEnergyCollisionalDissociation")
+
+  // MS3 with modern SPS trailer labels; lists its own selections and then the MS2 ancestor
+  auto ms3 = scan(12, 3, "ITMS + c NSI Full ms3 500.00@etd35.00 500.00@hcd20.00 300.00@cid35.00 [80-600]",
+                  {reaction(500, "ElectronTransferDissociation"), reaction(500, "HigherEnergyCollisionalDissociation"), reaction(300)});
+  trailer(ms3, "Master Scan Number:", "11");
+  trailer(ms3, "SPS Masses:", "300, 310,");
+  trailer(ms3, "SPS Masses Continued:", "320");
+  const auto p3 = parser.precursors(ms3);
+  TEST_EQUAL(p3.size(), 4) // primary selection, two SPS selections, and the MS2 ancestor
+  ABORT_IF(p3.size() != 4)
+  TEST_EQUAL(p3[0].target_mz, 300) // use the current MS3 reaction, not reaction zero
+  TEST_EQUAL(p3[0].parent_scan, 11)
+  TEST_EQUAL(p3[1].target_mz, 310) // continued SPS list preserved
+  TEST_EQUAL(p3[2].target_mz, 320)
+  TEST_TRUE(p3[0].estimate_intensity) // only the primary SPS selection receives an intensity estimate
+  TEST_FALSE(p3[1].estimate_intensity)
+  TEST_FALSE(p3[2].estimate_intensity)
+  TEST_EQUAL(p3[3].target_mz, 500) // ancestor references its own parent
+  TEST_EQUAL(p3[3].parent_scan, 10)
+  TEST_FALSE(p3[0].charge.has_value()) // missing charge remains missing
+}
+END_SECTION
+
+START_SECTION([EXTRA] invalid master scan falls back to the filter hierarchy)
+{
+  ThermoRawFileMetadata parser;
+  parser.precursors(scan(1, 1, "FTMS + p NSI Full ms [200-2000]"));
+  const auto simple = parser.precursors(scan(2, 2, "ITMS + c NSI Full ms2 500.00@cid35.00 [100-1000]", {reaction(500)}));
+  TEST_EQUAL(simple.size(), 1)
+  ABORT_IF(simple.empty())
+  TEST_EQUAL(simple[0].parent_scan, 1) // MS2 parent from the most recent MS1
+
+  auto third = scan(3, 3, "ITMS + c NSI Full ms3 500.00@cid35.00 300.00@cid35.00 [80-600]", {reaction(500), reaction(300)});
+  trailer(third, "Master Scan Number:", "999");
+  trailer(third, "SPS Mass 1:", "300");
+  trailer(third, "SPS Mass 2:", "310");
+  const auto p = parser.precursors(third);
+  TEST_EQUAL(p.size(), 3) // legacy SPS labels retained
+  ABORT_IF(p.empty())
+  TEST_EQUAL(p[0].parent_scan, 2) // invalid master falls back to the filter hierarchy
+  TEST_EQUAL(p[0].target_mz, 300)
+}
+END_SECTION
+
+START_SECTION([EXTRA] truncated file starts at the last reaction)
+{
+  ThermoRawFileMetadata parser;
+  const auto orphan = scan(100, 3, "ITMS + c NSI Full ms3 500.00@cid35.00 300.00@cid35.00 [80-600]",
+                           {reaction(500), reaction(300, "CollisionInducedDissociation", -1)});
+  const auto op = parser.precursors(orphan);
+  TEST_EQUAL(op.size(), 1)
+  ABORT_IF(op.empty())
+  TEST_EQUAL(op[0].target_mz, 300)
+  TEST_EQUAL(op[0].parent_scan, 0)          // no fabricated parent
+  TEST_TRUE(op[0].spectrum_ref.empty())
+  TEST_FALSE(op[0].width.has_value())       // negative width is unknown
+  TEST_EQUAL(op[0].lower_offset, 0.0)
+  TEST_EQUAL(op[0].upper_offset, 0.0)
+}
+END_SECTION
+
+START_SECTION([EXTRA] same-order master scan is a sibling)
+{
+  // Lumos/Tribrid files can point the master scan of an MS2 at a sibling MS2 of the same
+  // precursor (e.g. HCD scan first, then EThcD). The sibling's reaction must not be consumed.
+  ThermoRawFileMetadata parser;
+  parser.precursors(scan(10, 1, "FTMS + p NSI Full ms [200-2000]"));
+  auto sibling = scan(14, 2, "FTMS + c ESI d Full ms2 432.90@hcd30.00 [100-1300]", {reaction(432.9, "HigherEnergyCollisionalDissociation")});
+  trailer(sibling, "Master Scan Number:", "10");
+  const auto ps = parser.precursors(sibling);
+  TEST_EQUAL(ps.size(), 1)
+  ABORT_IF(ps.empty())
+  TEST_EQUAL(ps[0].parent_scan, 10) // sibling descends from the MS1
+
+  auto ethcd = scan(15, 2, "FTMS + c ESI d sa Full ms2 432.90@etd54.00 432.90@hcd30.00 [100-1300]",
+                    {reaction(432.9, "ElectronTransferDissociation"), reaction(432.9, "HigherEnergyCollisionalDissociation")});
+  trailer(ethcd, "Master Scan Number:", "14");
+  const auto pe = parser.precursors(ethcd);
+  TEST_EQUAL(pe.size(), 1)
+  ABORT_IF(pe.empty())
+  TEST_STRING_EQUAL(pe[0].activation.activation, "ElectronTransferDissociation") // same-order master does not consume the primary reaction
+  TEST_TRUE(pe[0].supplemental.has_value()) // supplemental HCD retained
+  TEST_STRING_EQUAL(pe[0].supplemental.value().activation, "HigherEnergyCollisionalDissociation")
+  TEST_EQUAL(pe[0].parent_scan, 10) // resolve the sibling's own parent
+  TEST_STRING_EQUAL(pe[0].spectrum_ref, "controllerType=0 controllerNumber=1 scan=10")
+}
+END_SECTION
+
+START_SECTION([EXTRA] supplemental reaction retained for unexpected main activation types)
+{
+  ThermoRawFileMetadata parser;
+  parser.precursors(scan(10, 1, "FTMS + p NSI Full ms [200-2000]"));
+  auto unusual = scan(13, 2, "ITMS + c NSI Full ms2 500.00@cid35.00 500.00@hcd20.00 [100-1000]",
+                      {reaction(500), reaction(500, "HigherEnergyCollisionalDissociation")});
+  trailer(unusual, "Master Scan Number:", "10");
+  const auto pu = parser.precursors(unusual);
+  TEST_EQUAL(pu.size(), 1)
+  ABORT_IF(pu.empty())
+  TEST_STRING_EQUAL(pu[0].activation.activation, "CollisionInducedDissociation")
+  TEST_TRUE(pu[0].supplemental.has_value())
+  TEST_STRING_EQUAL(pu[0].supplemental.value().activation, "HigherEnergyCollisionalDissociation")
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST


### PR DESCRIPTION
## Description

Fixes the build failure reported on #10079: a Nix build of 3.6.0 dies with `ThermoRawFileMetadata.h:13:10: fatal error: nlohmann/json.hpp: No such file or directory`. `nlohmann_json::nlohmann_json` is a PRIVATE dependency of libOpenMS, but two headers under `include/` pulled it in, and `ThermoRawFileMetadata_test` (built unconditionally, linked only against libOpenMS and the test framework) compiled one of them. vcpkg CI hides this because every dependency header lives in the one install prefix that `Boost_INCLUDE_DIRS` already puts on the include path.

After this PR no header under `src/openms/include` mentions nlohmann.

### 1. Typed API for `ThermoRawFileMetadata`

- `ThermoRawFileMetadata.h` has no external includes. The JSON-typed functions became a typed API over new value types in `OpenMS::Internal`: `ThermoTrailerEntry`, `ThermoReaction`, `ThermoScan`, `ThermoPrecursor`. `number()` returns `std::optional<double>` instead of a JSON null-or-number; `precursors()` returns `std::vector<ThermoPrecursor>`. The class is `OPENMS_DLLAPI`.
- The implementation moved to `source/FORMAT/HANDLERS/ThermoRawFileMetadata.cpp`, compiled unconditionally (no bridge dependency). The logic is carried over one-to-one: filter-key regex, master-scan validation, same-order sibling handling, reaction-index fallback, supplemental detection, SPS mass parsing for legacy and modern labels, ancestor resolution through the parent chain.
- The JSON boundary stays in `ThermoRawFile.cpp`: a file-local `toThermoScan()` converts each parsed scan object (schema version 1: `scan_number`, `ms_level`, `filter`, `native_id`, `trailer[{label,value}]`, `reactions[{precursor_mass, isolation_width, isolation_offset, activation, collision_energy, collision_energy_valid}]`, nullable numbers) once, right after `Json::parse`. Trailer lookups, the activation lambda and the precursor loop read struct fields.
- The class test is rewritten on the ClassTest framework against the structs. Every previous assertion carries over; it no longer includes nlohmann and needs no extra link line.

### 2. `ProFormaDataJson.h` is private

Moved to `source/CHEMISTRY/ProFormaDataJson.h` (precedent: `ANALYSIS/ID/PercolatorImpl.h`, `FORMAT/DATAACCESS/ParquetReaderHelpers.h`), removed from the installed header list, included as `"ProFormaDataJson.h"` from `ProForma.cpp`. The stale trailing comment that referred to a non-existent `ProFormaData.h` / `ProFormaDataJson.cpp` is fixed.

### 3. Regression guard

`install_headers` in `cmake/install_macros.cmake` now scans every header it installs with `file(STRINGS ... REGEX "nlohmann/json")` and stops configuration with a `FATAL_ERROR` naming the file. Configure-time only. Header lists are relative to the calling source directory, so paths are resolved against `CMAKE_CURRENT_SOURCE_DIR` before scanning.

### Validation

- Fresh configure without vcpkg and with `-DWITH_THERMO_RAW=OFF` (the failing configuration): `ThermoRawFileMetadata_test` builds and passes. Its compile line carries no nlohmann include directory, and the preprocessed test translation unit contains zero occurrences of `nlohmann`. The second check matters because the json headers are installed system-wide on this machine, so the include-directory check alone would not prove anything.
- `WITH_THERMO_RAW=ON` (bridge 0.3.0 built from source): `ThermoRawFileMetadata_test` and `ThermoRawFile_test` pass. `FileConverter -test -RawToMzML:reader inprocess` on `Angiotensin_AllScans.raw` (1775 spectra, 3377 precursor elements, 1688 spectrum references and supplemental activations) writes an mzML that is byte-identical to the one written by current `develop` (00ed02c6ae) from the same binary options; the baseline was generated twice to confirm determinism.
- Full class-test and TOPP suites (2851 tests; pyOpenMS and tutorial tests excluded): 2843 passed, 8 failed, all pre-existing and environmental on this machine and each verified from its log: 6x `TOPP_CometAdapter_*_out1` (a Comet 2023.01 binary from an old install vs. references written with Comet 2025.01), `TOPP_PercolatorAdapter_1_subprocess_out` (external percolator q-value), `Doxygen_Warning_test` (`HAVE_DOT` not set, no Graphviz).
- Guard: with `ProFormaDataJson.h` still installed, configure stops with `Installed header include/OpenMS/CHEMISTRY/ProFormaDataJson.h includes nlohmann/json`; a temporary `#include <nlohmann/json.hpp>` appended to `ThermoRawFile.h` stops it naming that file; with both removed, configure passes. Two things the red runs caught: the header lists are relative paths, so a first version that checked `if(EXISTS)` silently scanned nothing, and a fresh tree showed that build-time-generated headers (`build_config.h`) do not exist at configure time, so the scan is limited to files already on disk.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
