### PR TITLE
[ARCHITECTURE] Remove ConsensusMap's dependency on QC

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,8 @@ PR - Pull Request (on GitHub), i.e. integration of a new feature or bugfix
 ------------------------------------------------------------------------------------------
 
 General:
+  - Move the IsobaricAnalyzer provenance query to DataProcessingUtils so ConsensusMap no longer
+    depends on QCBase; retain the existing QCBase entry point and labeling convention.
   - Fix: XML metadata decoding now preserves UTF-8, including Latin-1 characters that previously
     entered the ASCII fast path. mzML sample comments and attribute whitespace survive round trips (#10072)
   - Thermo RAW imports preserve sample/method/trailer metadata, SHA-1 provenance, per-scan instrument

--- a/src/openms/include/OpenMS/METADATA/DataProcessingUtils.h
+++ b/src/openms/include/OpenMS/METADATA/DataProcessingUtils.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/METADATA/DataProcessing.h>
+
+#include <vector>
+
+namespace OpenMS
+{
+  /**
+    @brief Queries on data-processing provenance records.
+
+    These queries do not require a feature map or a quality-control metric.
+  */
+  class OPENMS_DLLAPI DataProcessingUtils
+  {
+  public:
+    /**
+      @brief Whether a processing record names IsobaricAnalyzer as its software.
+
+      This preserves the historical QCBase/ConsensusMap convention. It does not
+      attempt to identify every kind of labeled experiment.
+
+      @param[in] processing Processing records to inspect (an empty list returns false).
+    */
+    static bool hasIsobaricAnalyzer(const std::vector<DataProcessing>& processing);
+  };
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/METADATA/sources.cmake
+++ b/src/openms/include/OpenMS/METADATA/sources.cmake
@@ -14,6 +14,7 @@ ChromatogramSettings.h
 ContactPerson.h
 DataArrays.h
 DataProcessing.h
+DataProcessingUtils.h
 DocumentIdentifier.h
 ExperimentalDesign.h
 ExperimentalSettings.h
@@ -61,4 +62,3 @@ endforeach(i)
 source_group("Header Files\\OpenMS\\METADATA" FILES ${sources_h})
 
 set(OpenMS_sources_h ${OpenMS_sources_h} ${sources_h})
-

--- a/src/openms/source/KERNEL/ConsensusMap.cpp
+++ b/src/openms/source/KERNEL/ConsensusMap.cpp
@@ -15,7 +15,7 @@
 #include <OpenMS/METADATA/DataProcessing.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
-#include <OpenMS/QC/QCBase.h>
+#include <OpenMS/METADATA/DataProcessingUtils.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 
@@ -707,7 +707,7 @@ OPENMS_THREAD_CRITICAL(LOGSTREAM)
     std::vector<FeatureMap>fmaps(numbr_exps);
 
     // Check for Isobaric Analyzer
-    bool iso_analyze = QCBase::isLabeledExperiment(*this);
+    bool iso_analyze = DataProcessingUtils::hasIsobaricAnalyzer(getDataProcessing());
 
     for (const auto& cf : *this)
     {

--- a/src/openms/source/METADATA/DataProcessingUtils.cpp
+++ b/src/openms/source/METADATA/DataProcessingUtils.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/METADATA/DataProcessingUtils.h>
+
+#include <algorithm>
+
+namespace OpenMS
+{
+  bool DataProcessingUtils::hasIsobaricAnalyzer(const std::vector<DataProcessing>& processing)
+  {
+    return std::any_of(processing.begin(), processing.end(), [](const DataProcessing& dp)
+    {
+      return dp.getSoftware().getName() == "IsobaricAnalyzer";
+    });
+  }
+} // namespace OpenMS

--- a/src/openms/source/METADATA/sources.cmake
+++ b/src/openms/source/METADATA/sources.cmake
@@ -14,6 +14,7 @@ ChromatogramSettings.cpp
 ContactPerson.cpp
 DataArrays.cpp
 DataProcessing.cpp
+DataProcessingUtils.cpp
 DocumentIdentifier.cpp
 ExperimentalDesign.cpp
 ExperimentalSettings.cpp
@@ -60,4 +61,3 @@ set(OpenMS_sources ${OpenMS_sources} ${sources})
 
 ### source group definition
 source_group("Source Files\\METADATA" FILES ${sources})
-

--- a/src/openms/source/QC/QCBase.cpp
+++ b/src/openms/source/QC/QCBase.cpp
@@ -10,6 +10,7 @@
 #include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/QC/QCBase.h>
+#include <OpenMS/METADATA/DataProcessingUtils.h>
 
 namespace OpenMS
 {
@@ -81,13 +82,7 @@ namespace OpenMS
 
   bool QCBase::isLabeledExperiment(const ConsensusMap& cm)
   {
-    bool iso_analyze = true;
-    auto cm_dp = cm.getDataProcessing(); // get a copy to avoid calling .begin() and .end() on two different temporaries
-    if (all_of(cm_dp.begin(), cm_dp.end(), [](const OpenMS::DataProcessing& dp) { return (dp.getSoftware().getName() != "IsobaricAnalyzer"); }))
-    {
-      iso_analyze = false;
-    }
-    return iso_analyze;
+    return DataProcessingUtils::hasIsobaricAnalyzer(cm.getDataProcessing());
   }
 
 } // namespace OpenMS

--- a/src/tests/class_tests/openms/source/QCBase_test.cpp
+++ b/src/tests/class_tests/openms/source/QCBase_test.cpp
@@ -12,6 +12,8 @@
 ///////////////////////////
 
 #include <OpenMS/QC/QCBase.h>
+#include <OpenMS/METADATA/DataProcessingUtils.h>
+#include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 
 ///////////////////////////
@@ -90,5 +92,24 @@ START_TEST(SpectraMap, "$Id$")
   }
   END_SECTION
 
-END_TEST
+START_SECTION((isLabeledExperiment preserves the IsobaricAnalyzer provenance convention))
+  ConsensusMap map;
+  TEST_FALSE(QCBase::isLabeledExperiment(map))
+  TEST_FALSE(DataProcessingUtils::hasIsobaricAnalyzer(map.getDataProcessing()))
+  DataProcessing processing;
+  map.getDataProcessing().push_back(processing);
+  for (const std::string name : {"", "FeatureFinder", "isobaricanalyzer", "IsobaricAnalyzer extra"})
+  {
+    map.getDataProcessing()[0].getSoftware().setName(name);
+    TEST_FALSE(QCBase::isLabeledExperiment(map))
+    TEST_FALSE(DataProcessingUtils::hasIsobaricAnalyzer(map.getDataProcessing()))
+  }
+  processing.getSoftware().setName("IsobaricAnalyzer");
+  map.getDataProcessing().push_back(processing);
+  map.getDataProcessing().push_back(DataProcessing());
+  TEST_TRUE(QCBase::isLabeledExperiment(map))
+  TEST_TRUE(DataProcessingUtils::hasIsobaricAnalyzer(map.getDataProcessing()))
+  TEST_EQUAL(map.getDataProcessing().size(), 3)
+END_SECTION
 
+END_TEST


### PR DESCRIPTION
Part 7 of #10083.

ConsensusMap::split reaches into QCBase solely to identify IsobaricAnalyzer processing provenance. Add DataProcessingUtils::hasIsobaricAnalyzer, which accepts processing records, and use it from ConsensusMap and the existing QCBase compatibility entry point.

The convention stays deliberately narrow: an exact software-name match, with false for empty/unrelated histories. It does not reclassify other labeled workflows. The helper is installed and its source is registered.

Validation: extend QCBase_test with empty, unrelated, case-sensitive, partial-name and mixed histories, checking both entry points. Existing ConsensusMap split tests remain registered. Source checks confirm the QC include is gone; all 1,365 histories of up to five representative names preserve the old predicate result. The initial-core baseline is unchanged because ConsensusMap is outside that manifest; git diff --check passes. Draft pending C++ PR CI; no local OpenMS build under AGENTS.md.