### PR TITLE
[ARCHITECTURE] Move alignment model defaults into the analysis layer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,8 @@ PR - Pull Request (on GitHub), i.e. integration of a new feature or bugfix
 ------------------------------------------------------------------------------------------
 
 General:
+  - Share alignment model defaults through TransformationModelDefaults in the analysis layer;
+    tree-guided alignment no longer depends on MapAlignerBase/TOPPBase for parameter construction.
   - Fix: XML metadata decoding now preserves UTF-8, including Latin-1 characters that previously
     entered the ASCII fast path. mzML sample comments and attribute whitespace survive round trips (#10072)
   - Thermo RAW imports preserve sample/method/trailer metadata, SHA-1 provenance, per-scan instrument

--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/TransformationModelDefaults.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/TransformationModelDefaults.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/DATASTRUCTURES/Param.h>
+
+namespace OpenMS
+{
+  /**
+    @brief Shared transformation-model parameters for alignment algorithms and tools.
+
+    Parameter values, constraints and descriptions follow the individual models.
+  */
+  class OPENMS_DLLAPI TransformationModelDefaults
+  {
+  public:
+    /**
+      @brief Assemble model selection and parameters for all supported models.
+
+      @param[in] default_model Initial selection; an additional name (such as
+      "none") is prepended to the allowed selections, preserving the tool convention.
+    */
+    static Param getDefaults(const std::string& default_model);
+  };
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/sources.cmake
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/sources.cmake
@@ -33,6 +33,7 @@ QTClusterFinder.h
 StablePairFinder.h
 TransformationDescription.h
 TransformationModel.h
+TransformationModelDefaults.h
 TransformationModelBSpline.h
 TransformationModelLinear.h
 TransformationModelLowess.h
@@ -49,4 +50,3 @@ endforeach(i)
 source_group("Header Files\\OpenMS\\ANALYSIS\\MAPMATCHING" FILES ${sources_h})
 
 set(OpenMS_sources_h ${OpenMS_sources_h} ${sources_h})
-

--- a/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmTreeGuided.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmTreeGuided.cpp
@@ -21,7 +21,7 @@
 #include <OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmIdentification.h>
 
 #include <OpenMS/CONCEPT/LogStream.h>
-#include <include/OpenMS/APPLICATIONS/MapAlignerBase.h>
+#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelDefaults.h>
 
 using namespace std;
 
@@ -32,7 +32,7 @@ namespace OpenMS
           DefaultParamHandler("MapAlignmentAlgorithmTreeGuided"),
           ProgressLogger()
   {
-    defaults_.insert("model:", MapAlignerBase::getModelDefaults("b_spline"));
+    defaults_.insert("model:", TransformationModelDefaults::getDefaults("b_spline"));
     defaults_.setValue("model_type", "b_spline", "Options to control the modeling of retention time transformations from data");
     defaults_.setValidStrings("model_type", {"linear","b_spline","lowess","interpolated"});
     defaults_.insert("align_algorithm:", MapAlignmentAlgorithmIdentification().getDefaults());

--- a/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelDefaults.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelDefaults.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Marc Sturm, Clemens Groepl, Hendrik Weisser, Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelDefaults.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelBSpline.h>
+#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLinear.h>
+#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLowess.h>
+#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.h>
+
+namespace OpenMS
+{
+  Param TransformationModelDefaults::getDefaults(const std::string& default_model)
+  {
+    Param params;
+    params.setValue("type", default_model, "Type of model");
+    // TODO: avoid referring to each TransformationModel subclass explicitly
+    std::vector<std::string> model_types = {"linear","b_spline","lowess","interpolated"};
+    if (!ListUtils::contains(model_types, default_model))
+    {
+      model_types.insert(model_types.begin(), default_model);
+    }
+    params.setValidStrings("type", model_types);
+
+    Param model_params;
+    TransformationModelLinear::getDefaultParameters(model_params);
+    params.insert("linear:", model_params);
+    params.setSectionDescription("linear", "Parameters for 'linear' model");
+
+    TransformationModelBSpline::getDefaultParameters(model_params);
+    params.insert("b_spline:", model_params);
+    params.setSectionDescription("b_spline", "Parameters for 'b_spline' model");
+
+    TransformationModelLowess::getDefaultParameters(model_params);
+    params.insert("lowess:", model_params);
+    params.setSectionDescription("lowess", "Parameters for 'lowess' model");
+
+    TransformationModelInterpolated::getDefaultParameters(model_params);
+    params.insert("interpolated:", model_params);
+    params.setSectionDescription("interpolated",
+                                "Parameters for 'interpolated' model");
+    return params;
+  }
+
+} // namespace OpenMS

--- a/src/openms/source/ANALYSIS/MAPMATCHING/sources.cmake
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/sources.cmake
@@ -31,6 +31,7 @@ QTClusterFinder.cpp
 StablePairFinder.cpp
 TransformationDescription.cpp
 TransformationModel.cpp
+TransformationModelDefaults.cpp
 TransformationModelBSpline.cpp
 TransformationModelLowess.cpp
 TransformationModelLinear.cpp
@@ -55,4 +56,3 @@ endif()
 
 ### source group definition
 source_group("Source Files\\ANALYSIS\\MAPMATCHING" FILES ${sources})
-

--- a/src/openms/source/APPLICATIONS/MapAlignerBase.cpp
+++ b/src/openms/source/APPLICATIONS/MapAlignerBase.cpp
@@ -7,14 +7,11 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/APPLICATIONS/MapAlignerBase.h>
+#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelDefaults.h>
 
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentTransformer.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelBSpline.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLinear.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLowess.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.h>
 
 using namespace std;
 
@@ -23,34 +20,7 @@ namespace OpenMS
 
   Param MapAlignerBase::getModelDefaults(const std::string& default_model)
   {
-    Param params;
-    params.setValue("type", default_model, "Type of model");
-    // TODO: avoid referring to each TransformationModel subclass explicitly
-    std::vector<std::string> model_types = {"linear","b_spline","lowess","interpolated"};
-    if (!ListUtils::contains(model_types, default_model))
-    {
-      model_types.insert(model_types.begin(), default_model);
-    }
-    params.setValidStrings("type", model_types);
-
-    Param model_params;
-    TransformationModelLinear::getDefaultParameters(model_params);
-    params.insert("linear:", model_params);
-    params.setSectionDescription("linear", "Parameters for 'linear' model");
-
-    TransformationModelBSpline::getDefaultParameters(model_params);
-    params.insert("b_spline:", model_params);
-    params.setSectionDescription("b_spline", "Parameters for 'b_spline' model");
-
-    TransformationModelLowess::getDefaultParameters(model_params);
-    params.insert("lowess:", model_params);
-    params.setSectionDescription("lowess", "Parameters for 'lowess' model");
-
-    TransformationModelInterpolated::getDefaultParameters(model_params);
-    params.insert("interpolated:", model_params);
-    params.setSectionDescription("interpolated",
-                                "Parameters for 'interpolated' model");
-    return params;
+    return TransformationModelDefaults::getDefaults(default_model);
   }
 
   void TOPPMapAlignerBase::registerOptionsAndFlagsMapAligners_(const std::string& file_formats,

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -647,6 +647,7 @@ set(analysis_executables_list
   PercolatorFeatureSetHelper_test
   TransformationDescription_test
   TransformationModel_test
+  TransformationModelDefaults_test
   TransformationModelBSpline_test
   TransformationModelLowess_test
   TransformationModelInterpolated_test

--- a/src/tests/class_tests/openms/source/TransformationModelDefaults_test.cpp
+++ b/src/tests/class_tests/openms/source/TransformationModelDefaults_test.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelDefaults.h>
+#include <OpenMS/APPLICATIONS/MapAlignerBase.h>
+#include <OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmTreeGuided.h>
+#include <OpenMS/CONCEPT/ClassTest.h>
+
+using namespace OpenMS;
+
+START_TEST(TransformationModelDefaults, "$Id$")
+
+START_SECTION((model selection and compatibility parameter trees))
+  const std::vector<std::string> models = {"linear", "b_spline", "lowess", "interpolated"};
+  for (const std::string selected : {"linear", "b_spline", "lowess", "interpolated", "none", "custom"})
+  {
+    const Param params = TransformationModelDefaults::getDefaults(selected);
+    TEST_TRUE(params == MapAlignerBase::getModelDefaults(selected))
+    TEST_EQUAL(params.getValue("type"), selected)
+    TEST_EQUAL(params.getDescription("type"), "Type of model")
+    auto expected = models;
+    if (selected == "none" || selected == "custom")
+    {
+      expected.insert(expected.begin(), selected);
+    }
+    TEST_TRUE(params.getValidStrings("type") == expected)
+    for (const auto& model : models)
+    {
+      TEST_EQUAL(params.getSectionDescription(model), "Parameters for '" + model + "' model")
+    }
+    TEST_EQUAL(params.getValue("b_spline:num_nodes"), 5)
+    TEST_EQUAL(params.getValue("b_spline:boundary_condition"), 2)
+    TEST_REAL_SIMILAR(static_cast<double>(params.getValue("lowess:span")), 2.0 / 3.0)
+    TEST_EQUAL(params.getMinFloat("lowess:span"), 0.0)
+    TEST_EQUAL(params.getMaxFloat("lowess:span"), 1.0)
+    TEST_EQUAL(params.getValue("interpolated:interpolation_type"), "cspline")
+  }
+END_SECTION
+
+START_SECTION((tree-guided alignment retains its model parameter subtree))
+  MapAlignmentAlgorithmTreeGuided algorithm;
+  const Param model = algorithm.getDefaults().copy("model:", true);
+  TEST_TRUE(model == TransformationModelDefaults::getDefaults("b_spline"))
+END_SECTION
+
+END_TEST

--- a/src/tests/class_tests/openms/source/TransformationModelDefaults_test.cpp
+++ b/src/tests/class_tests/openms/source/TransformationModelDefaults_test.cpp
@@ -36,8 +36,8 @@ START_SECTION((model selection and compatibility parameter trees))
     TEST_EQUAL(params.getValue("b_spline:num_nodes"), 5)
     TEST_EQUAL(params.getValue("b_spline:boundary_condition"), 2)
     TEST_REAL_SIMILAR(static_cast<double>(params.getValue("lowess:span")), 2.0 / 3.0)
-    TEST_EQUAL(params.getMinFloat("lowess:span"), 0.0)
-    TEST_EQUAL(params.getMaxFloat("lowess:span"), 1.0)
+    TEST_EQUAL(params.getEntry("lowess:span").min_float, 0.0)
+    TEST_EQUAL(params.getEntry("lowess:span").max_float, 1.0)
     TEST_EQUAL(params.getValue("interpolated:interpolation_type"), "cspline")
   }
 END_SECTION


### PR DESCRIPTION
Part 8 of #10083.

MapAlignmentAlgorithmTreeGuided currently includes APPLICATIONS/MapAlignerBase.h, and therefore TOPPBase, just to construct transformation-model parameters. Extract that construction into TransformationModelDefaults in ANALYSIS/MAPMATCHING. Keep MapAlignerBase::getModelDefaults as a forwarding compatibility entry point.

The complete construction body is moved unchanged apart from its class/method name, preserving all values, constraints, descriptions, section names and selection ordering, including additional selections such as none. Register the new installed header, implementation and class test.

Validation: exact comparison confirms the moved body is preserved and the algorithm has no application-layer include. Regression tests cover all built-in selections, extra selections, descriptions, representative values/constraints, compatibility trees and the tree-guided algorithm's model subtree. git diff --check passes. The initial-core baseline is unaffected. Draft pending C++ PR CI; no local OpenMS build under AGENTS.md.

This replaces the nonstandard include spelling also normalized by #10086; keep the new analysis include when reconciling that overlap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Alignment tools now share consistent default settings for transformation models.
  * Transformation model selections support built-in, custom, and “none” options while retaining model-specific defaults.
  * Tree-guided alignment continues to use B-spline defaults consistently with other alignment workflows.

* **Tests**
  * Added coverage to verify transformation model parameters and tree-guided alignment defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->