### PR TITLE
[ARCHITECTURE] Test installed CMake consumers and narrow dependency exports

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -254,6 +254,11 @@ runs:
       shell: bash
       run: ctest --preset "${{ steps.preset.outputs.name }}"
 
+    - name: Test installed CMake consumer
+      if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+      shell: bash
+      run: python tools/ci/test_installed_consumer.py "build/${{ steps.preset.outputs.name }}"
+
     ############################################################################
     # Saved on every event, including pull requests.  A cache written by a pull
     # request run is scoped to that pull request, so it only speeds up later

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,9 @@ PR - Pull Request (on GitHub), i.e. integration of a new feature or bugfix
 ------------------------------------------------------------------------------------------
 
 General:
+  - Keep CURL and OpenSwathAlgo's Boost headers private in CMake usage requirements, and stop
+    requiring CURL/Xerces development packages for shared-library consumers. CI now installs
+    OpenMS and builds/runs the external consumer with discovery of those packages disabled.
   - Fix: XML metadata decoding now preserves UTF-8, including Latin-1 characters that previously
     entered the ASCII fast path. mzML sample comments and attribute whitespace survive round trips (#10072)
   - Thermo RAW imports preserve sample/method/trailer metadata, SHA-1 provenance, per-scan instrument

--- a/cmake/OpenMSConfig.cmake.in
+++ b/cmake/OpenMSConfig.cmake.in
@@ -22,8 +22,8 @@ endif()
 #------------------------------------------------------------------------------
 
 #TODO somehow add the same/compatible versions that were found by OpenMS? And what about static vs dynamic? E.g. if we link to static zlib in OpenMS(.dll) what (if at all) can/should the consumer link against?
-find_dependency(CURL)
-find_dependency(XercesC)
+# CURL and XercesC are implementation dependencies of the shared library.
+# Consumers need their runtime libraries, but not their CMake development packages.
 # Boost::boost (header-only) is part of OpenMS's PUBLIC link interface because
 # the installed public header config.h includes <boost/current_function.hpp>
 # (via Macros.h). Its imported target must therefore exist before the targets
@@ -33,7 +33,7 @@ find_dependency(XercesC)
 # compiled components (date_time/iostreams/regex) stay PRIVATE and are not
 # needed here.
 find_dependency(Boost 1.81.0)
-# Find Eigen
+# Keep Eigen discovery: installed headers such as MatrixEigen.h still use it.
 # Try the version range first (CMake 3.19+ with compatible Eigen config)
 # Use find_package instead of find_dependency so QUIET failures don't abort
 find_package(Eigen3 3.4.0...<6 QUIET)

--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -75,7 +75,6 @@ add_subdirectory(thirdparty/percolator)
 ## public — it propagates include dirs but no link libraries; the compiled Boost
 ## components (date_time/iostreams/regex) stay PRIVATE below.
 set(OPENMS_DEP_LIBRARIES
-  CURL::libcurl
   Boost::boost
 )
 
@@ -85,6 +84,7 @@ set(OPENMS_DEP_LIBRARIES
 ## Note: LibSVM::LibSVM is PRIVATE because LIBSVM types are not exposed in the public API;
 ##       they are fully encapsulated by the SimpleSVM wrapper (Pimpl) (see #8547).
 set(OPENMS_DEP_PRIVATE_LIBRARIES
+  CURL::libcurl
   XercesC::XercesC
   $<$<BOOL:${WITH_HDF5}>:HDF5::HDF5>
   ${LPTARGET}

--- a/src/openswathalgo/CMakeLists.txt
+++ b/src/openswathalgo/CMakeLists.txt
@@ -29,8 +29,7 @@ openms_add_library(TARGET_NAME OpenSwathAlgo
                    SOURCE_FILES ${OpenSwathAlgoFiles}
                    HEADER_FILES ${OpenSwathAlgoHeaders}
                    INTERNAL_INCLUDES ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
-                   EXTERNAL_INCLUDES ${Boost_INCLUDE_DIRS}
-                   PRIVATE_LINK_LIBRARIES Eigen3::Eigen $<$<BOOL:${OPENMP_FOUND}>:OpenMP::OpenMP_CXX>
+                   PRIVATE_LINK_LIBRARIES Boost::boost Eigen3::Eigen $<$<BOOL:${OPENMP_FOUND}>:OpenMP::OpenMP_CXX>
                    DLL_EXPORT_PATH "OpenMS/OPENSWATHALGO/")
 
 openms_doc_path("${PROJECT_SOURCE_DIR}/include")

--- a/src/tests/external/CMakeLists.txt
+++ b/src/tests/external/CMakeLists.txt
@@ -1,8 +1,10 @@
 ## Use CMake 3.17 to correctly find OpenMP on macOS
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 ### example CMakeLists.txt to develop programs using OpenMS
 project("OpenMS_ExternalCodeTest")
+
+include(CTest)
 
 message("Received CMAKE_PREFIX_PATH: ${CMAKE_PREFIX_PATH}")
 if (DEFINED OPENMS_CONTRIB_LIBS)
@@ -21,11 +23,23 @@ set(my_sources
 )
 
 ## find OpenMS package and register target "OpenMS" (our library)
-## Note: This is customized to fit the nightly test scenario. In a
-##       regular build find_package(OpenMS) should be sufficient.
-## This will also try to find all dependencies of OpenMS, so make sure
-##  they are findable by e.g. providing CMAKE_PREFIX_PATH
-find_package(OpenMS PATHS "$ENV{OPENMS_BUILD_TREE}" NO_CMAKE_PACKAGE_REGISTRY)
+## Select an installation with OpenMS_DIR or CMAKE_PREFIX_PATH. CI explicitly
+## supplies the installed config directory and disables the package registries.
+find_package(OpenMS CONFIG REQUIRED)
+
+if(DEFINED OPENMS_EXPECTED_PREFIX)
+  # Catch accidental consumption of the build tree or a different installation.
+  foreach(_target IN ITEMS OpenMS OpenSwathAlgo)
+    get_target_property(_configs ${_target} IMPORTED_CONFIGURATIONS)
+    foreach(_config IN LISTS _configs)
+      get_target_property(_location ${_target} IMPORTED_LOCATION_${_config})
+      cmake_path(IS_PREFIX OPENMS_EXPECTED_PREFIX "${_location}" NORMALIZE _installed)
+      if(NOT _installed)
+        message(FATAL_ERROR "${_target} is not from the tested installation: ${_location}")
+      endif()
+    endforeach()
+  endforeach()
+endif()
 
 # check whether the OpenMS package was found
 if (OpenMS_FOUND)
@@ -33,6 +47,10 @@ if (OpenMS_FOUND)
   ## library with additional classes from above
   add_library(my_custom_lib STATIC ${my_sources})
   target_link_libraries(my_custom_lib OpenMS)
+  if(DEFINED OPENMS_EXPECTED_PREFIX)
+    target_compile_definitions(my_custom_lib PRIVATE
+      OPENMS_EXPECTED_DATA_DIR="${OPENMS_EXPECTED_PREFIX}/share/OpenMS")
+  endif()
   ## disable auto-linking of boost (mainly needed for Windows. CMake takes care of choosing the right library)
   target_compile_definitions(my_custom_lib PUBLIC BOOST_ALL_NO_LIB)
 
@@ -63,5 +81,4 @@ else(OpenMS_FOUND)
 endif(OpenMS_FOUND)
 
 ## Enable testing - for Nightly Build log
-include(Dart)
 add_test(TestExternalCode TestExternalCode)

--- a/src/tests/external/ExampleLibraryFile.cpp
+++ b/src/tests/external/ExampleLibraryFile.cpp
@@ -11,6 +11,10 @@
 #include <OpenMS/KERNEL/Feature.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/SYSTEM/File.h>
+
+#include <filesystem>
+#include <stdexcept>
 
 using namespace std;
 using namespace OpenMS;
@@ -25,6 +29,12 @@ namespace OpenMSExternal
 
   void ExampleLibraryFile::loadAndSaveFeatureXML()
   {
+#ifdef OPENMS_EXPECTED_DATA_DIR
+    if (!std::filesystem::equivalent(File::getOpenMSDataPath(), OPENMS_EXPECTED_DATA_DIR))
+    {
+      throw std::runtime_error("OpenMS did not use the installed runtime data directory");
+    }
+#endif
     FeatureMap fm;
     Feature feature;
     fm.push_back(feature);
@@ -32,6 +42,10 @@ namespace OpenMSExternal
     FileHandler().storeFeatures(tmpfilename, fm, {FileTypes::FEATUREXML});
 
     FeatureMap fm2;
-    FileHandler().storeFeatures(tmpfilename, fm2, {FileTypes::FEATUREXML});
+    FileHandler().loadFeatures(tmpfilename, fm2, {FileTypes::FEATUREXML});
+    if (fm2.size() != fm.size())
+    {
+      throw std::runtime_error("Installed consumer featureXML round trip lost features");
+    }
   }
 }

--- a/tools/ci/test_installed_consumer.py
+++ b/tools/ci/test_installed_consumer.py
@@ -83,9 +83,6 @@ def main():
         for key, flag in (("CMAKE_GENERATOR_PLATFORM", "-A"), ("CMAKE_GENERATOR_TOOLSET", "-T")):
             if cache.get(key):
                 command.extend([flag, cache[key]])
-        run(command)
-        run([cmake, "--build", str(consumer), "--config", config, "--parallel", "2"])
-
         env = os.environ.copy()
         dependency_prefixes = [Path(p) for p in cache.get("CMAKE_PREFIX_PATH", "").split(";") if p]
         if cache.get("VCPKG_INSTALLED_DIR") and cache.get("VCPKG_TARGET_TRIPLET"):
@@ -98,6 +95,11 @@ def main():
         for key in ("PATH", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"):
             env[key] = os.pathsep.join([str(p) for p in runtime] + ([env[key]] if env.get(key) else []))
         env.pop("OPENMS_DATA_PATH", None)
+
+        # Native linkers also need to locate the shared library's private
+        # dependencies, before we get to running the consumer executable.
+        run(command, env=env)
+        run([cmake, "--build", str(consumer), "--config", config, "--parallel", "2"], env=env)
 
         # File's development fallback otherwise finds the source data directory,
         # hiding missing install rules. Restore it even when the consumer fails.

--- a/tools/ci/test_installed_consumer.py
+++ b/tools/ci/test_installed_consumer.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# $Maintainer: Timo Sachsenberg $
+# $Authors: Timo Sachsenberg $
+
+"""Install an existing CI build and compile/run the external CMake consumer."""
+
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def read_cache(path):
+    """Read CMake cache values, preserving spaces and embedded equals signs."""
+    values = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith(("#", "//")) or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        name, separator, _ = key.partition(":")
+        if separator:
+            values[name] = value
+    return values
+
+
+def run(command, env=None):
+    print(subprocess.list2cmdline([str(arg) for arg in command]), flush=True)
+    subprocess.run(command, check=True, env=env)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("build_dir", type=Path, help="Configured and already built OpenMS CI directory")
+    parser.add_argument("--config", default="Release", help="Configuration for a multi-config build")
+    args = parser.parse_args()
+    build = args.build_dir.resolve()
+    cache = read_cache(build / "CMakeCache.txt")
+    source = Path(cache["CMAKE_HOME_DIRECTORY"])
+    prefix = Path(cache["CMAKE_INSTALL_PREFIX"])
+    config = cache.get("CMAKE_BUILD_TYPE") or args.config
+    cmake = cache.get("CMAKE_COMMAND", "cmake")
+    ctest = cache.get("CMAKE_CTEST_COMMAND", "ctest")
+
+    # Reuse the completed library build. Avoid application, documentation and
+    # redistribution components: this test is a development-package consumer.
+    for component in ("library", "OpenMS_headers", "OpenSwathAlgo_headers", "cmake", "share"):
+        run([cmake, "--install", str(build), "--config", config, "--component", component])
+
+    package_dir = prefix / cache["INSTALL_CMAKE_DIR"]
+    if not (package_dir / "OpenMSConfig.cmake").is_file():
+        raise RuntimeError(f"Installed OpenMSConfig.cmake is missing from {package_dir}")
+
+    with tempfile.TemporaryDirectory(prefix="openms-consumer-") as temporary:
+        consumer = Path(temporary) / "build"
+        command = [
+            cmake, "-S", str(source / "src/tests/external"), "-B", str(consumer),
+            "-G", cache["CMAKE_GENERATOR"],
+            f"-DOpenMS_DIR={package_dir.as_posix()}",
+            f"-DOPENMS_EXPECTED_PREFIX={prefix.as_posix()}",
+            f"-DCMAKE_BUILD_TYPE={config}",
+            f"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY={prefix.as_posix()}/bin",
+            f"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{config.upper()}={prefix.as_posix()}/bin",
+            "-DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF",
+            "-DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF",
+            "-DCMAKE_DISABLE_FIND_PACKAGE_CURL=ON",
+            "-DCMAKE_DISABLE_FIND_PACKAGE_XercesC=ON",
+            "-DVCPKG_MANIFEST_MODE=OFF",
+        ]
+        # Reuse the compiler and dependency installation, without installing a
+        # second vcpkg manifest or propagating OpenMS build-tree include paths.
+        for key in (
+            "CMAKE_TOOLCHAIN_FILE", "VCPKG_INSTALLED_DIR", "VCPKG_TARGET_TRIPLET",
+            "VCPKG_HOST_TRIPLET", "CMAKE_PREFIX_PATH", "CMAKE_C_COMPILER",
+            "CMAKE_CXX_COMPILER", "CMAKE_MSVC_RUNTIME_LIBRARY", "CMAKE_OSX_ARCHITECTURES",
+            "CMAKE_OSX_DEPLOYMENT_TARGET", "CMAKE_OSX_SYSROOT",
+        ):
+            if cache.get(key):
+                command.append(f"-D{key}={cache[key]}")
+        for key, flag in (("CMAKE_GENERATOR_PLATFORM", "-A"), ("CMAKE_GENERATOR_TOOLSET", "-T")):
+            if cache.get(key):
+                command.extend([flag, cache[key]])
+        run(command)
+        run([cmake, "--build", str(consumer), "--config", config, "--parallel", "2"])
+
+        env = os.environ.copy()
+        dependency_prefixes = [Path(p) for p in cache.get("CMAKE_PREFIX_PATH", "").split(";") if p]
+        if cache.get("VCPKG_INSTALLED_DIR") and cache.get("VCPKG_TARGET_TRIPLET"):
+            dependency_prefixes.append(Path(cache["VCPKG_INSTALLED_DIR"]) / cache["VCPKG_TARGET_TRIPLET"])
+        runtime = [prefix / cache["INSTALL_LIB_DIR"], prefix / "bin"]
+        for dep in dependency_prefixes:
+            if config.lower() == "debug":
+                runtime.extend([dep / "debug/bin", dep / "debug/lib"])
+            runtime.extend([dep / "bin", dep / "lib"])
+        for key in ("PATH", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"):
+            env[key] = os.pathsep.join([str(p) for p in runtime] + ([env[key]] if env.get(key) else []))
+        env.pop("OPENMS_DATA_PATH", None)
+
+        # File's development fallback otherwise finds the source data directory,
+        # hiding missing install rules. Restore it even when the consumer fails.
+        source_data = source / "share/OpenMS"
+        with tempfile.TemporaryDirectory(prefix="consumer-data-", dir=source_data.parent) as backup:
+            saved_data = Path(backup) / "OpenMS"
+            source_data.rename(saved_data)
+            try:
+                run([ctest, "--test-dir", str(consumer), "-C", config,
+                     "--output-on-failure", "--no-tests=error"], env=env)
+            finally:
+                saved_data.rename(source_data)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Part 9 of #10083, including the requested CI acceptance test.

The existing external-code example is not exercised by repository CI and defaults to the build tree. Wire it into the Build and Test composite action after a successful OpenMS build. A small Python driver installs the development components, configures a separate consumer with OpenMS_DIR pointing at that installation, builds it and runs CTest. It reuses the configured compiler and vcpkg installation; it does not rebuild OpenMS or install another dependency manifest.

The consumer disables CURL/Xerces package discovery and both CMake package registries, verifies the imported OpenMS/OpenSwathAlgo libraries come from the install prefix, and checks featureXML/mzML use through the installed library. Fix the existing featureXML example to load its output rather than overwrite it. Runtime tests execute from the install bin directory and verify installed data resolution; source data is temporarily moved aside and restored in a finally block so the development fallback cannot mask a missing install rule. The existing explicit Qt consumer remains enabled when Qt is available.

With that gate in place, make CURL private, remove unconditional CURL/Xerces find_dependency calls, and replace OpenSwathAlgo's public raw Boost include directory with private Boost::boost usage. OpenMS still exposes Boost headers. Keep Eigen discovery because installed headers still use Eigen. Arrow/public API redesign is outside this change.

Validation: Python syntax/CLI and orchestration smoke checks pass, including restoration of source data after a simulated consumer failure. git diff --check is clean. Actual installed configuration, linking and runtime behavior must pass PR CI; no local OpenMS build under AGENTS.md. Draft until that gate passes.

Coordination: #9972 and #10063 are the existing CMake/vcpkg cleanup PRs. This PR keeps its changes confined to the identified usage requirements and installed-consumer gate; reconcile overlaps with those PRs before merging.