### PR TITLE
[BUILD] Make AUTOMOC explicit for core libraries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,8 @@ PR - Pull Request (on GitHub), i.e. integration of a new feature or bugfix
 ------------------------------------------------------------------------------------------
 
 General:
+  - Explicitly disable AUTOMOC for OpenMS and OpenSwathAlgo even when Qt is found;
+    GUI libraries retain their own AUTOMOC setting.
   - Fix: XML metadata decoding now preserves UTF-8, including Latin-1 characters that previously
     entered the ASCII fast path. mzML sample comments and attribute whitespace survive round trips (#10072)
   - Thermo RAW imports preserve sample/method/trailer metadata, SHA-1 provenance, per-scan instrument

--- a/cmake/add_library_macros.cmake
+++ b/cmake/add_library_macros.cmake
@@ -128,9 +128,8 @@ function(openms_add_library)
 
   set_target_properties(${openms_add_library_TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
   set_target_properties(${openms_add_library_TARGET_NAME} PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
-  if(TARGET Qt6::moc)
-    set_target_properties(${openms_add_library_TARGET_NAME} PROPERTIES AUTOMOC ON)
-  endif()
+  # AUTOMOC is chosen by the library's own CMakeLists.txt. Merely finding Qt
+  # elsewhere must not enable Qt code generation for non-GUI libraries.
 
   #------------------------------------------------------------------------------
   # Include directories

--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -306,6 +306,9 @@ openms_add_library(TARGET_NAME  OpenMS
                    PRIVATE_LINK_LIBRARIES ${OPENMS_DEP_PRIVATE_LIBRARIES}
                    DLL_EXPORT_PATH "OpenMS/")
 
+# The core library has no QObject classes, including in builds that also find Qt.
+set_target_properties(OpenMS PROPERTIES AUTOMOC OFF)
+
 # The vendored percolator headers (#include "X.h", no subdir) are used only by
 # libOpenMS's Percolator pimpl TU. Their directory is made visible via the
 # PUBLIC include dir propagated from the linked OpenMS_Percolator target (see

--- a/src/openswathalgo/CMakeLists.txt
+++ b/src/openswathalgo/CMakeLists.txt
@@ -33,4 +33,7 @@ openms_add_library(TARGET_NAME OpenSwathAlgo
                    PRIVATE_LINK_LIBRARIES Eigen3::Eigen $<$<BOOL:${OPENMP_FOUND}>:OpenMP::OpenMP_CXX>
                    DLL_EXPORT_PATH "OpenMS/OPENSWATHALGO/")
 
+# Keep this algorithm library independent of Qt code generation in GUI builds.
+set_target_properties(OpenSwathAlgo PROPERTIES AUTOMOC OFF)
+
 openms_doc_path("${PROJECT_SOURCE_DIR}/include")


### PR DESCRIPTION
Part 10 of #10083.

The shared library helper currently enables AUTOMOC whenever Qt6::moc exists, causing OpenMS and OpenSwathAlgo to run Qt code generation in GUI-enabled builds. Remove that ambient decision and explicitly set AUTOMOC OFF on both core targets.

OpenMS_GUI already sets CMAKE_AUTOMOC ON before creating its target, and keeps that behavior. The generic helper continues to honor each caller's setting.

Validation: source checks confirm both core target properties and the GUI opt-in, with git diff --check clean. Existing PR CI covers GUI-enabled builds and pyOpenMS configurations. No new C++ behavior or local OpenMS build; draft until CI passes.

Coordinate the small CMake overlaps with #10093 and the existing vcpkg work in #9972/#10063.