### PR TITLE
[BUILD] Make AUTOMOC explicit for core libraries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,8 @@ PR - Pull Request (on GitHub), i.e. integration of a new feature or bugfix
 General:
   - Share alignment model defaults through TransformationModelDefaults in the analysis layer;
     tree-guided alignment no longer depends on MapAlignerBase/TOPPBase for parameter construction.
+  - Explicitly disable AUTOMOC for OpenMS and OpenSwathAlgo even when Qt is found;
+    GUI libraries retain their own AUTOMOC setting.
   - Fix: XML metadata decoding now preserves UTF-8, including Latin-1 characters that previously
     entered the ASCII fast path. mzML sample comments and attribute whitespace survive round trips (#10072)
   - Thermo RAW imports preserve sample/method/trailer metadata, SHA-1 provenance, per-scan instrument

--- a/cmake/add_library_macros.cmake
+++ b/cmake/add_library_macros.cmake
@@ -128,9 +128,8 @@ function(openms_add_library)
 
   set_target_properties(${openms_add_library_TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
   set_target_properties(${openms_add_library_TARGET_NAME} PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
-  if(TARGET Qt6::moc)
-    set_target_properties(${openms_add_library_TARGET_NAME} PROPERTIES AUTOMOC ON)
-  endif()
+  # AUTOMOC is chosen by the library's own CMakeLists.txt. Merely finding Qt
+  # elsewhere must not enable Qt code generation for non-GUI libraries.
 
   #------------------------------------------------------------------------------
   # Include directories

--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -306,6 +306,9 @@ openms_add_library(TARGET_NAME  OpenMS
                    PRIVATE_LINK_LIBRARIES ${OPENMS_DEP_PRIVATE_LIBRARIES}
                    DLL_EXPORT_PATH "OpenMS/")
 
+# The core library has no QObject classes, including in builds that also find Qt.
+set_target_properties(OpenMS PROPERTIES AUTOMOC OFF)
+
 # The vendored percolator headers (#include "X.h", no subdir) are used only by
 # libOpenMS's Percolator pimpl TU. Their directory is made visible via the
 # PUBLIC include dir propagated from the linked OpenMS_Percolator target (see

--- a/src/openswathalgo/CMakeLists.txt
+++ b/src/openswathalgo/CMakeLists.txt
@@ -33,4 +33,7 @@ openms_add_library(TARGET_NAME OpenSwathAlgo
                    PRIVATE_LINK_LIBRARIES Eigen3::Eigen $<$<BOOL:${OPENMP_FOUND}>:OpenMP::OpenMP_CXX>
                    DLL_EXPORT_PATH "OpenMS/OPENSWATHALGO/")
 
+# Keep this algorithm library independent of Qt code generation in GUI builds.
+set_target_properties(OpenSwathAlgo PROPERTIES AUTOMOC OFF)
+
 openms_doc_path("${PROJECT_SOURCE_DIR}/include")


### PR DESCRIPTION
## Description

Supersedes #10094 (same change, rebased onto current `develop` on an OpenMS-hosted branch). Part 10 of #10083.

The shared library helper currently enables AUTOMOC whenever `Qt6::moc` exists, causing OpenMS and OpenSwathAlgo to run Qt code generation in GUI-enabled builds. This removes that ambient decision from `openms_add_library` and explicitly sets `AUTOMOC OFF` on both core targets.

OpenMS_GUI already sets `CMAKE_AUTOMOC ON` before creating its target and keeps that behavior. The generic helper continues to honor each caller's setting.

Changes:
- `cmake/add_library_macros.cmake`: drop the `if(TARGET Qt6::moc)` AUTOMOC opt-in.
- `src/openms/CMakeLists.txt`: `set_target_properties(OpenMS PROPERTIES AUTOMOC OFF)`.
- `src/openswathalgo/CMakeLists.txt`: `set_target_properties(OpenSwathAlgo PROPERTIES AUTOMOC OFF)`.
- `CHANGELOG`: entry under General.

The only difference from #10094 is the CHANGELOG conflict resolution against the entry added by #10092.

Validation: source checks confirm both core target properties and the GUI opt-in, with `git diff --check` clean. Existing PR CI covers GUI-enabled builds and pyOpenMS configurations. No new C++ behavior; draft until CI passes.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZQkUDThbLAQqdNBRCKAbK

---
_Generated by [Claude Code](https://claude.ai/code/session_015ZQkUDThbLAQqdNBRCKAbK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build Improvements**
  - Prevented automatic Qt code generation for the OpenMS and OpenSwathAlgo libraries, keeping these non-GUI components independent of Qt’s AUTOMOC feature.
  - GUI libraries continue to control AUTOMOC explicitly through their own build settings.
  - Qt detection alone no longer enables automatic code generation for libraries that do not require it.

- **Documentation**
  - Updated the OpenMS 3.6.0 changelog to document the revised AUTOMOC behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->