### PR TITLE
[API,INTERNAL,TEST] Move settings and temporary-file policy out of File

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -271,6 +271,10 @@ PyOpenMS:
     were built without the reader and the macOS wheel shipped the bridge without its managed half.
     Linux aarch64 wheels stay without Thermo support (no vendor libraries for that platform). New
     test_ThermoRawFile.py exercises a real RAW file when PYOPENMS_THERMO_RAW_TEST_FILE is set (#10070)
+  - New SystemSettings, TempDir and TempFiles classes expose the OpenMS.ini directory policy and
+    temporary directories/files; File.getSystemParameters(), File.getTempDirectory(),
+    File.getUserDirectory(), File.findDatabase(), File.getOpenMSHomePath() and File.getTemporaryFile()
+    keep working as forwarders (#10083, step 6)
 
 TOPP tools:
   Changes:
@@ -1062,6 +1066,11 @@ OpenMS Library:
       -write_* options and log-file initialization refined. No change to tool CLI behavior (#9621)
     - FAIMS-aware adapter for converting pre-loaded MSExperiment/PeakMap data into the existing OpenSWATH SwathMap abstraction (#9932)
   Changes:
+    - File no longer owns the OpenMS.ini settings and temporary-file policy: SystemSettings holds
+      getSystemParameters(), getTempDirectory(), getUserDirectory(), findDatabase(), getOpenMSHomePath()
+      and getOpenMSConfigDir(); TempDir is a top-level class and TempFiles::getTemporaryFile() replaces
+      File::getTemporaryFile(). The File entry points remain as [[deprecated]] forwarders (and File::TempDir
+      as a deprecated alias) for one release; all in-tree callers were migrated (#10083, step 6)
     - Fix: AASequence::setModificationByDiffMonoMass (and the four other call sites that write an
       unknown mass-shift modification: three in AASequence, one in Residue, one in PepXMLFile) built
       its ModificationsDB lookup key with a signed bracket but created the modification from an

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -272,9 +272,9 @@ PyOpenMS:
     Linux aarch64 wheels stay without Thermo support (no vendor libraries for that platform). New
     test_ThermoRawFile.py exercises a real RAW file when PYOPENMS_THERMO_RAW_TEST_FILE is set (#10070)
   - New SystemSettings, TempDir and TempFiles classes expose the OpenMS.ini directory policy and
-    temporary directories/files; File.getSystemParameters(), File.getTempDirectory(),
+    temporary directories/files; the Python-level File.getSystemParameters(), File.getTempDirectory(),
     File.getUserDirectory(), File.findDatabase(), File.getOpenMSHomePath() and File.getTemporaryFile()
-    keep working as forwarders (#10083, step 6)
+    keep working and now call the new classes (#10083, step 6)
 
 TOPP tools:
   Changes:
@@ -1066,11 +1066,11 @@ OpenMS Library:
       -write_* options and log-file initialization refined. No change to tool CLI behavior (#9621)
     - FAIMS-aware adapter for converting pre-loaded MSExperiment/PeakMap data into the existing OpenSWATH SwathMap abstraction (#9932)
   Changes:
-    - File no longer owns the OpenMS.ini settings and temporary-file policy: SystemSettings holds
-      getSystemParameters(), getTempDirectory(), getUserDirectory(), findDatabase(), getOpenMSHomePath()
-      and getOpenMSConfigDir(); TempDir is a top-level class and TempFiles::getTemporaryFile() replaces
-      File::getTemporaryFile(). The File entry points remain as [[deprecated]] forwarders (and File::TempDir
-      as a deprecated alias) for one release; all in-tree callers were migrated (#10083, step 6)
+    - BREAKING: File no longer owns the OpenMS.ini settings and temporary-file policy. SystemSettings
+      holds getSystemParameters(), getTempDirectory(), getUserDirectory(), findDatabase(),
+      getOpenMSHomePath() and getOpenMSConfigDir(); TempDir is a top-level class and
+      TempFiles::getTemporaryFile() replaces File::getTemporaryFile(). The former File entry points and
+      the nested File::TempDir are removed, and File.h no longer depends on Param (#10083, step 6)
     - Fix: AASequence::setModificationByDiffMonoMass (and the four other call sites that write an
       unknown mass-shift modification: three in AASequence, one in Residue, one in PepXMLFile) built
       its ModificationsDB lookup key with a signed bracket but created the modification from an

--- a/doc/code_examples/Tutorial_ImzMLFile.cpp
+++ b/doc/code_examples/Tutorial_ImzMLFile.cpp
@@ -16,6 +16,7 @@
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/KERNEL/OnDiscImzMLExperiment.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/openms_data_path.h> // OPENMS_DOC_PATH (location of bundled tutorial data)
 
 #include <algorithm>
@@ -181,7 +182,7 @@ int main(int argc, const char** argv)
   // Mode 6: export (store) and reload
   // ------------------------------------------------------------------
   std::cout << "\n=== Mode 6: ImzMLFile::store round-trip ===\n";
-  std::string tmp_imzml = File::getTemporaryFile("Tutorial_ImzMLFile_export.imzML");
+  std::string tmp_imzml = TempFiles::getTemporaryFile("Tutorial_ImzMLFile_export.imzML");
   loader.store(tmp_imzml, exp);
   MSImagingExperiment reloaded_img;
   loader.load(tmp_imzml, reloaded_img);

--- a/doc/code_examples/Tutorial_MSExperiment.cpp
+++ b/doc/code_examples/Tutorial_MSExperiment.cpp
@@ -8,6 +8,7 @@
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <iostream>
 
 using namespace OpenMS;
@@ -72,7 +73,7 @@ int main()
 
   // Store the spectra to a mzML file with:
   FileHandler fh;
-  auto tmp_filename = File::getTemporaryFile();
+  auto tmp_filename = TempFiles::getTemporaryFile();
   fh.storeExperiment(tmp_filename, exp, {FileTypes::MZML});
 
   // And load it with

--- a/doc/doxygen/parameters/TOPPDocumenter.cpp
+++ b/doc/doxygen/parameters/TOPPDocumenter.cpp
@@ -10,6 +10,7 @@
 
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 
 #include <OpenMS/FORMAT/XMLFile.h>
 #include <OpenMS/FORMAT/ParamXMLFile.h>
@@ -272,7 +273,7 @@ bool generate(const ToolListType& tools, const std::string& prefix, const std::s
     if (it->first != "TOPPView" && // do not support -write_ini
         it->first != "TOPPAS")
     {
-      std::string tmp_file = File::getTempDirectory() + "/" + File::getUniqueName() + "_" + it->first + ".ini";
+      std::string tmp_file = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "_" + it->first + ".ini";
       const std::vector<std::string> ini_command_args = {"-write_ini", tmp_file};
 
       ExternalProcess ep([&](const std::string& s) { f << s; }, [&](const std::string& s) { f << s; });

--- a/src/openms/include/OpenMS/APPLICATIONS/SearchEngineBase.h
+++ b/src/openms/include/OpenMS/APPLICATIONS/SearchEngineBase.h
@@ -97,7 +97,7 @@ namespace OpenMS
       Returns @p db if non-empty, otherwise the value of the
       @c -database parameter. If the resulting path is not directly
       readable, the OpenMS database search paths (see
-      @ref OpenMS::File::findDatabase) are scanned.
+      @ref OpenMS::SystemSettings::findDatabase) are scanned.
 
       @param[in] db Optional explicit database name; used in place of
                     the @c -database parameter when non-empty

--- a/src/openms/include/OpenMS/FORMAT/ZipArchiveFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ZipArchiveFile.h
@@ -11,6 +11,7 @@
 #include <OpenMS/config.h>
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 #include <memory>
 #include <string>
@@ -46,7 +47,7 @@ namespace OpenMS
     /**
       @brief Unpack a zip archive into a temporary directory and return the usable path
 
-      Extracts the archive into a newly created File::TempDir and returns the path to
+      Extracts the archive into a newly created TempDir and returns the path to
       the unpacked directory. This function protects against path traversal and
       absolute paths in archive entries. If the provided path already points to a
       directory it is returned unchanged and no TempDir is created.
@@ -58,7 +59,7 @@ namespace OpenMS
       @throws Exception::InvalidValue on archive extraction errors.
       @throws Exception::NotImplemented if libzip support is unavailable.
     */
-    static std::string unzipDirectory(const std::string& input_path, std::unique_ptr<File::TempDir>& temp_dir);
+    static std::string unzipDirectory(const std::string& input_path, std::unique_ptr<TempDir>& temp_dir);
 
     /**
       @brief Add or replace an entry inside an existing zip archive from a file on disk
@@ -119,7 +120,7 @@ namespace OpenMS
       @throws Exception::FileNotFound if the archive or entry is not found
       @throws Exception::InvalidValue on extraction errors
     */
-    static std::string extractEntryToTempFile(const std::string& archive_path, const std::string& entry_name, std::unique_ptr<File::TempDir>& temp_dir);
+    static std::string extractEntryToTempFile(const std::string& archive_path, const std::string& entry_name, std::unique_ptr<TempDir>& temp_dir);
 
   };
 

--- a/src/openms/include/OpenMS/FORMAT/ZipRandomAccessFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ZipRandomAccessFile.h
@@ -8,6 +8,7 @@
 
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <arrow/io/api.h>
 
 namespace OpenMS
@@ -29,7 +30,7 @@ struct OPENMS_DLLAPI ZipRandomAccessFile
 {
   static arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> Open(const std::string& archive_path,
                                                                          const std::string& entry_name,
-                                                                         std::unique_ptr<File::TempDir>& temp_dir);
+                                                                         std::unique_ptr<TempDir>& temp_dir);
 };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -9,9 +9,9 @@
 #pragma once
 
 #include <OpenMS/DATASTRUCTURES/StringListUtils.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/config.h>
 #include <cstdlib>
-#include <mutex>
 
 
 namespace OpenMS
@@ -27,41 +27,8 @@ namespace OpenMS
   class OPENMS_DLLAPI File
   {
 public:
-    /**
-      @brief Class representing a temporary directory
-    
-    */
-    class OPENMS_DLLAPI TempDir
-    {
-    public:
-      
-      /// Construct temporary folder under system temp directory
-      /// If keep_dir is set to true, the folder will not be deleted on destruction of the object.
-      TempDir(bool keep_dir = false);
-
-      /// Construct temporary folder under a custom base directory
-      /// Creates a unique subdirectory with a generated name under base_dir.
-      /// If keep_dir is set to true, the folder will not be deleted on destruction of the object.
-      /// @param base_dir The base directory under which to create the temp folder (e.g., user-specified temp path)
-      /// @param keep_dir If true, the folder will not be deleted on destruction
-      TempDir(const std::string& base_dir, bool keep_dir = false);
-
-      /// Destroy temporary folder (can be prohibited in Constructor)
-      ~TempDir();
-
-      /// delete all means to copy or move a TempDir
-      TempDir(const TempDir&) = delete;
-      TempDir& operator=(const TempDir&) = delete;
-      TempDir(TempDir&&) = delete;
-      TempDir& operator=(TempDir&&) = delete;
-
-      /// Return path to temporary folder
-      const std::string& getPath() const;
-
-    private:
-      std::string temp_dir_;
-      bool keep_dir_;
-    };
+    /// @deprecated Use OpenMS::TempDir from OpenMS/SYSTEM/TempFiles.h; this alias is kept for one release.
+    using TempDir [[deprecated("use OpenMS::TempDir from OpenMS/SYSTEM/TempFiles.h")]] = OpenMS::TempDir;
 
     /// Retrieve path of current executable (useful to find other TOPP tools)
     /// The returned path is either just an EMPTY string if the call to system subroutines failed
@@ -244,41 +211,28 @@ public:
     */
     static const std::string& getOpenMSDataPathSource();
 
-    /// Returns the OpenMS home path (environment variable overwrites the default home path)
+    /// @deprecated Use SystemSettings::getOpenMSHomePath(); forwarder kept for one release.
+    [[deprecated("use SystemSettings::getOpenMSHomePath()")]]
     static std::string getOpenMSHomePath();
 
-    /// @brief Returns the per-user OpenMS configuration directory (the directory that holds OpenMS.ini)
-    ///
-    /// Follows the XDG base directory specification on unix-like systems
-    /// (&lt;XDG_CONFIG_HOME&gt;/OpenMS or &lt;home&gt;/.config/OpenMS) and uses &lt;home&gt;/.OpenMS otherwise.
-    /// The returned path has no trailing separator and the directory is not guaranteed to exist.
-    /// @return String containing the per-user OpenMS configuration directory path
+    /// @deprecated Use SystemSettings::getOpenMSConfigDir(); forwarder kept for one release.
+    [[deprecated("use SystemSettings::getOpenMSConfigDir()")]]
     static std::string getOpenMSConfigDir();
 
-    /// The current OpenMS temporary data path (for temporary files).
-    /// Looks up the following locations, taking the first one which is non-null:
-    ///   - environment variable OPENMS_TMPDIR
-    ///   - 'temp_dir' in the ~/OpenMS.ini file
-    ///   - System temp directory (usually defined by environment 'TMP' or 'TEMP'
+    /// @deprecated Use SystemSettings::getTempDirectory(); forwarder kept for one release.
+    [[deprecated("use SystemSettings::getTempDirectory()")]]
     static std::string getTempDirectory();
 
-    /// The current OpenMS user data path (for result files)
-    /// Tries to set the user directory in following order:
-    ///   1. OPENMS_HOME_DIR if environmental variable set
-    ///   2. "home_dir" entry in OpenMS.ini
-    ///   3. user home directory
+    /// @deprecated Use SystemSettings::getUserDirectory(); forwarder kept for one release.
+    [[deprecated("use SystemSettings::getUserDirectory()")]]
     static std::string getUserDirectory();
 
-    /// get the system's default OpenMS.ini file in the users home directory (&lt;home&gt;/OpenMS/OpenMS.ini)
-    /// or create/repair it if required
-    /// order:
-    ///   1. &lt;OPENMS_HOME_DIR&gt;/OpenMS/OpenMS.ini if environmental variable set
-    ///   2. user home directory &lt;home&gt;/OpenMS/OpenMS.ini
+    /// @deprecated Use SystemSettings::getSystemParameters(); forwarder kept for one release.
+    [[deprecated("use SystemSettings::getSystemParameters()")]]
     static Param getSystemParameters();
 
-    /// uses File::find() to search for a file names @p db_name
-    /// in the 'id_db_dir' param of the OpenMS system parameters
-    /// @exception FileNotFound is thrown, if the file is not found
+    /// @deprecated Use SystemSettings::findDatabase(); forwarder kept for one release.
+    [[deprecated("use SystemSettings::findDatabase()")]]
     static std::string findDatabase(const std::string& db_name);
 
     /**
@@ -325,24 +279,9 @@ public:
     */
     static std::string findSiblingTOPPExecutable(const std::string& toolName);
 
-    /**
-      @brief Obtain a temporary filename, ensuring automatic deletion upon exit
-
-      The file is not actually created and only deleted at exit if it exists.
-      
-      However, if 'alternative_file' is given and not empty, no temporary filename
-      is created and 'alternative_file' is returned (and not destroyed upon exit).
-      This is useful if you have an optional
-      output file, which may, or may not be requested, but you need its content regardless,
-      e.g. for intermediate plotting with R.
-      Thus you can just call this function to get a file which can be used and gets automatically
-      destroyed if needed.
-
-      @param[in] alternative_file If this string is not empty, no action is taken and it is used as return value
-      @return Full path to a temporary file
-    */
+    /// @deprecated Use TempFiles::getTemporaryFile(); forwarder kept for one release.
+    [[deprecated("use TempFiles::getTemporaryFile()")]]
     static std::string getTemporaryFile(const std::string& alternative_file = "");
-
 
     enum class MatchingFileListsStatus 
     {
@@ -372,9 +311,6 @@ public:
                                                        bool ignore_extension = true);
 
 private:
-
-    /// get defaults for the system's Temp-path, user home directory etc.
-    static Param getSystemParameterDefaults_();
 
     /// Check if the given path is a valid OPENMS_DATA_PATH
     static bool isOpenMSDataPath_(const std::string& path);
@@ -410,27 +346,5 @@ private:
     */
     static StringList executableExtensions_(const std::string& ext);
 #endif
-
-    /**
-      @brief Internal helper class, which holds temporary filenames and deletes these files at program exit
-    */
-    class TemporaryFiles_
-    {
-      public:
-        TemporaryFiles_(const TemporaryFiles_&) = delete; // copy is forbidden
-        TemporaryFiles_& operator=(const TemporaryFiles_&) = delete;
-        TemporaryFiles_();
-        /// create a new filename and queue internally for deletion
-        std::string newFile();
-
-        ~TemporaryFiles_();
-      private:
-        StringList filenames_;
-        std::mutex mtx_;
-    };
-
-
-    /// private list of temporary filenames, which are deleted upon program exit
-    static TemporaryFiles_ temporary_files_;
   };
 }

--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -9,14 +9,12 @@
 #pragma once
 
 #include <OpenMS/DATASTRUCTURES/StringListUtils.h>
-#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/config.h>
 #include <cstdlib>
 
 
 namespace OpenMS
 {
-  class Param;
   class TOPPBase;
 
   /**
@@ -27,9 +25,6 @@ namespace OpenMS
   class OPENMS_DLLAPI File
   {
 public:
-    /// @deprecated Use OpenMS::TempDir from OpenMS/SYSTEM/TempFiles.h; this alias is kept for one release.
-    using TempDir [[deprecated("use OpenMS::TempDir from OpenMS/SYSTEM/TempFiles.h")]] = OpenMS::TempDir;
-
     /// Retrieve path of current executable (useful to find other TOPP tools)
     /// The returned path is either just an EMPTY string if the call to system subroutines failed
     /// or the complete path including a trailing "/", to enable usage of this function as
@@ -211,30 +206,6 @@ public:
     */
     static const std::string& getOpenMSDataPathSource();
 
-    /// @deprecated Use SystemSettings::getOpenMSHomePath(); forwarder kept for one release.
-    [[deprecated("use SystemSettings::getOpenMSHomePath()")]]
-    static std::string getOpenMSHomePath();
-
-    /// @deprecated Use SystemSettings::getOpenMSConfigDir(); forwarder kept for one release.
-    [[deprecated("use SystemSettings::getOpenMSConfigDir()")]]
-    static std::string getOpenMSConfigDir();
-
-    /// @deprecated Use SystemSettings::getTempDirectory(); forwarder kept for one release.
-    [[deprecated("use SystemSettings::getTempDirectory()")]]
-    static std::string getTempDirectory();
-
-    /// @deprecated Use SystemSettings::getUserDirectory(); forwarder kept for one release.
-    [[deprecated("use SystemSettings::getUserDirectory()")]]
-    static std::string getUserDirectory();
-
-    /// @deprecated Use SystemSettings::getSystemParameters(); forwarder kept for one release.
-    [[deprecated("use SystemSettings::getSystemParameters()")]]
-    static Param getSystemParameters();
-
-    /// @deprecated Use SystemSettings::findDatabase(); forwarder kept for one release.
-    [[deprecated("use SystemSettings::findDatabase()")]]
-    static std::string findDatabase(const std::string& db_name);
-
     /**
       @brief Extract list of directories from a concatenated string (usually $PATH).
 
@@ -278,10 +249,6 @@ public:
       @exception FileNotFound is thrown, if the tool executable was not found.
     */
     static std::string findSiblingTOPPExecutable(const std::string& toolName);
-
-    /// @deprecated Use TempFiles::getTemporaryFile(); forwarder kept for one release.
-    [[deprecated("use TempFiles::getTemporaryFile()")]]
-    static std::string getTemporaryFile(const std::string& alternative_file = "");
 
     enum class MatchingFileListsStatus 
     {

--- a/src/openms/include/OpenMS/SYSTEM/SystemSettings.h
+++ b/src/openms/include/OpenMS/SYSTEM/SystemSettings.h
@@ -43,24 +43,24 @@ public:
     static std::string getOpenMSConfigDir();
 
     /// The current OpenMS temporary data path (for temporary files).
-    /// Looks up the following locations, taking the first one which is non-null:
-    ///   - environment variable OPENMS_TMPDIR
-    ///   - 'temp_dir' in the ~/OpenMS.ini file
-    ///   - System temp directory (usually defined by environment 'TMP' or 'TEMP'
+    /// Looks up the following locations, taking the first one which is set:
+    ///   - the OPENMS_TMPDIR environment variable
+    ///   - a non-empty 'temp_dir' entry in the OpenMS.ini read by getSystemParameters()
+    ///   - the system temp directory (usually defined by environment 'TMP' or 'TEMP')
+    /// The path is returned as configured; it is not checked for existence.
     static std::string getTempDirectory();
 
-    /// The current OpenMS user data path (for result files)
-    /// Tries to set the user directory in following order:
-    ///   1. OPENMS_HOME_DIR if environmental variable set
-    ///   2. "home_dir" entry in OpenMS.ini
-    ///   3. user home directory
+    /// The current OpenMS user data path (for result files), with a trailing '/'.
+    /// Resolved in the following order, taking the first one which is set:
+    ///   1. the OPENMS_HOME_PATH environment variable
+    ///   2. a non-empty "home_dir" entry in the OpenMS.ini read by getSystemParameters()
+    ///   3. the user's home directory (HOME, or USERPROFILE on Windows)
     static std::string getUserDirectory();
 
-    /// get the system's default OpenMS.ini file in the users home directory (&lt;home&gt;/OpenMS/OpenMS.ini)
-    /// or create/repair it if required
-    /// order:
-    ///   1. &lt;OPENMS_HOME_DIR&gt;/OpenMS/OpenMS.ini if environmental variable set
-    ///   2. user home directory &lt;home&gt;/OpenMS/OpenMS.ini
+    /// Returns the OpenMS.ini system parameters, read from getOpenMSConfigDir() + "/OpenMS.ini".
+    /// If that file does not exist, the built-in defaults are returned. If it exists but its
+    /// 'version' is missing or outdated, missing entries are filled in from the defaults (the
+    /// file itself is not rewritten).
     static Param getSystemParameters();
 
     /// uses File::find() to search for a file names @p db_name

--- a/src/openms/include/OpenMS/SYSTEM/SystemSettings.h
+++ b/src/openms/include/OpenMS/SYSTEM/SystemSettings.h
@@ -23,8 +23,8 @@ namespace OpenMS
     Every lookup honours the environment overrides (OPENMS_HOME_PATH, OPENMS_TMPDIR,
     XDG_CONFIG_HOME) before consulting OpenMS.ini and the platform defaults.
 
-    This class depends on File and Param; File does not depend on it. The former
-    File entry points remain as deprecated forwarders.
+    This class depends on File and Param; File does not depend on it. These
+    lookups used to be static members of File.
 
     @ingroup System
   */

--- a/src/openms/include/OpenMS/SYSTEM/SystemSettings.h
+++ b/src/openms/include/OpenMS/SYSTEM/SystemSettings.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Andreas Bertsch, Chris Bielow, Marc Sturm $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/config.h>
+
+#include <string>
+
+namespace OpenMS
+{
+  class Param;
+
+  /**
+    @brief Per-user OpenMS configuration: the OpenMS.ini system parameters and the
+    home, temporary and database directories derived from them.
+
+    Every lookup honours the environment overrides (OPENMS_HOME_PATH, OPENMS_TMPDIR,
+    XDG_CONFIG_HOME) before consulting OpenMS.ini and the platform defaults.
+
+    This class depends on File and Param; File does not depend on it. The former
+    File entry points remain as deprecated forwarders.
+
+    @ingroup System
+  */
+  class OPENMS_DLLAPI SystemSettings
+  {
+public:
+    /// Returns the OpenMS home path (environment variable overwrites the default home path)
+    static std::string getOpenMSHomePath();
+
+    /// @brief Returns the per-user OpenMS configuration directory (the directory that holds OpenMS.ini)
+    ///
+    /// Follows the XDG base directory specification on unix-like systems
+    /// (&lt;XDG_CONFIG_HOME&gt;/OpenMS or &lt;home&gt;/.config/OpenMS) and uses &lt;home&gt;/.OpenMS otherwise.
+    /// The returned path has no trailing separator and the directory is not guaranteed to exist.
+    /// @return String containing the per-user OpenMS configuration directory path
+    static std::string getOpenMSConfigDir();
+
+    /// The current OpenMS temporary data path (for temporary files).
+    /// Looks up the following locations, taking the first one which is non-null:
+    ///   - environment variable OPENMS_TMPDIR
+    ///   - 'temp_dir' in the ~/OpenMS.ini file
+    ///   - System temp directory (usually defined by environment 'TMP' or 'TEMP'
+    static std::string getTempDirectory();
+
+    /// The current OpenMS user data path (for result files)
+    /// Tries to set the user directory in following order:
+    ///   1. OPENMS_HOME_DIR if environmental variable set
+    ///   2. "home_dir" entry in OpenMS.ini
+    ///   3. user home directory
+    static std::string getUserDirectory();
+
+    /// get the system's default OpenMS.ini file in the users home directory (&lt;home&gt;/OpenMS/OpenMS.ini)
+    /// or create/repair it if required
+    /// order:
+    ///   1. &lt;OPENMS_HOME_DIR&gt;/OpenMS/OpenMS.ini if environmental variable set
+    ///   2. user home directory &lt;home&gt;/OpenMS/OpenMS.ini
+    static Param getSystemParameters();
+
+    /// uses File::find() to search for a file names @p db_name
+    /// in the 'id_db_dir' param of the OpenMS system parameters
+    /// @exception FileNotFound is thrown, if the file is not found
+    static std::string findDatabase(const std::string& db_name);
+
+private:
+    /// get defaults for the system's Temp-path, user home directory etc.
+    static Param getSystemParameterDefaults_();
+  };
+}

--- a/src/openms/include/OpenMS/SYSTEM/TempFiles.h
+++ b/src/openms/include/OpenMS/SYSTEM/TempFiles.h
@@ -1,0 +1,108 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Andreas Bertsch, Chris Bielow, Marc Sturm $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/config.h>
+
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace OpenMS
+{
+  /**
+    @brief A uniquely named temporary directory, removed when the object is destroyed.
+
+    The directory is created below SystemSettings::getTempDirectory() unless an
+    explicit base directory is given. Destruction removes it recursively unless
+    @p keep_dir was set.
+
+    @ingroup System
+  */
+  class OPENMS_DLLAPI TempDir
+  {
+  public:
+    /// Construct temporary folder under system temp directory
+    /// If keep_dir is set to true, the folder will not be deleted on destruction of the object.
+    TempDir(bool keep_dir = false);
+
+    /// Construct temporary folder under a custom base directory
+    /// Creates a unique subdirectory with a generated name under base_dir.
+    /// If keep_dir is set to true, the folder will not be deleted on destruction of the object.
+    /// @param base_dir The base directory under which to create the temp folder (e.g., user-specified temp path)
+    /// @param keep_dir If true, the folder will not be deleted on destruction
+    TempDir(const std::string& base_dir, bool keep_dir = false);
+
+    /// Destroy temporary folder (can be prohibited in Constructor)
+    ~TempDir();
+
+    /// delete all means to copy or move a TempDir
+    TempDir(const TempDir&) = delete;
+    TempDir& operator=(const TempDir&) = delete;
+    TempDir(TempDir&&) = delete;
+    TempDir& operator=(TempDir&&) = delete;
+
+    /// Return path to temporary folder
+    const std::string& getPath() const;
+
+  private:
+    std::string temp_dir_;
+    bool keep_dir_;
+  };
+
+  /**
+    @brief Temporary files that live until the process exits.
+
+    Names are allocated below SystemSettings::getTempDirectory() and every file
+    that still exists at exit is removed.
+
+    @ingroup System
+  */
+  class OPENMS_DLLAPI TempFiles
+  {
+  public:
+    /**
+      @brief Obtain a temporary filename, ensuring automatic deletion upon exit
+
+      The file is not actually created and only deleted at exit if it exists.
+
+      However, if 'alternative_file' is given and not empty, no temporary filename
+      is created and 'alternative_file' is returned (and not destroyed upon exit).
+      This is useful if you have an optional
+      output file, which may, or may not be requested, but you need its content regardless,
+      e.g. for intermediate plotting with R.
+      Thus you can just call this function to get a file which can be used and gets automatically
+      destroyed if needed.
+
+      @param[in] alternative_file If this string is not empty, no action is taken and it is used as return value
+      @return Full path to a temporary file
+    */
+    static std::string getTemporaryFile(const std::string& alternative_file = "");
+
+  private:
+    /// Holds the allocated filenames and deletes the files at program exit
+    class Registry_
+    {
+    public:
+      Registry_(const Registry_&) = delete; // copy is forbidden
+      Registry_& operator=(const Registry_&) = delete;
+      Registry_();
+      /// create a new filename and queue internally for deletion
+      std::string newFile();
+
+      ~Registry_();
+    private:
+      std::vector<std::string> filenames_;
+      std::mutex mtx_;
+    };
+
+    /// filenames handed out so far, deleted upon program exit
+    static Registry_ registry_;
+  };
+}

--- a/src/openms/include/OpenMS/SYSTEM/sources.cmake
+++ b/src/openms/include/OpenMS/SYSTEM/sources.cmake
@@ -30,6 +30,8 @@ RWrapper.h
 SIMDe.h
 StopWatch.h
 SysInfo.h
+SystemSettings.h
+TempFiles.h
 UpdateCheck.h
 )
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWParquetReader.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWParquetReader.cpp
@@ -11,6 +11,7 @@
 #include <OpenMS/FORMAT/ZipArchiveFile.h>
 #include <OpenMS/FORMAT/ZipRandomAccessFile.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 
@@ -31,7 +32,7 @@ void OpenSwathOSWParquetReader::load(const std::string& oswpq_dir)
   rows_.clear();
   // remember the provided path for later fetch calls
   oswpq_dir_ = oswpq_dir;
-  std::unique_ptr<File::TempDir> temp_dir;
+  std::unique_ptr<TempDir> temp_dir;
   // Extract small library and runs index files only; per-run parquet files will be
   // read on-demand from the archive when possible to avoid unpacking the whole archive.
 
@@ -143,7 +144,7 @@ void OpenSwathOSWParquetReader::load(const std::string& oswpq_dir)
 OpenSwathOSWParquetReader::PeakGroupFeatureScoresResult OpenSwathOSWParquetReader::fetchPeakGroupFeatures(const std::string& oswpq_dir, const std::string& level, const std::string& main_score) const
 {
   PeakGroupFeatureScoresResult result;
-  std::unique_ptr<File::TempDir> temp_dir;
+  std::unique_ptr<TempDir> temp_dir;
   // Use RandomAccessFile-backed reads when possible; fall back to extracting
   // entries to temp files when not available.
   auto open_table_from_entry = [&](const std::string& entry) -> std::shared_ptr<arrow::Table>
@@ -403,7 +404,7 @@ OpenSwathOSWParquetReader::PeakGroupFeatureScoresResult OpenSwathOSWParquetReade
 OpenSwathOSWParquetReader::TransitionFeaturesResult OpenSwathOSWParquetReader::fetchTransitionFeatures(const std::string& oswpq_dir) const
 {
   TransitionFeaturesResult result;
-  std::unique_ptr<File::TempDir> temp_dir;
+  std::unique_ptr<TempDir> temp_dir;
   // Use RandomAccessFile-backed reads when possible; fall back to extraction when not.
   auto open_table_from_entry = [&](const std::string& entry) -> std::shared_ptr<arrow::Table>
   {
@@ -654,7 +655,7 @@ OpenSwathOSWParquetReader::TransitionFeaturesResult OpenSwathOSWParquetReader::f
 OpenSwathOSWParquetReader::UnscoredResult OpenSwathOSWParquetReader::fetchUnscoredData(const std::string& oswpq_dir) const
 {
   UnscoredResult result;
-  std::unique_ptr<File::TempDir> temp_dir;
+  std::unique_ptr<TempDir> temp_dir;
   // Use RandomAccessFile-backed reads when possible; fall back to extraction when not.
   auto open_table_from_entry = [&](const std::string& entry) -> std::shared_ptr<arrow::Table>
   {

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWParquetWriter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWParquetWriter.cpp
@@ -18,6 +18,7 @@
 #include <OpenMS/FORMAT/ZipArchiveFile.h>
 #include <OpenMS/FORMAT/SqliteConnector_impl.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/TransitionExperiment.h>
 
 #include <fstream>
@@ -324,7 +325,7 @@ namespace OpenMS
 
     const UInt64 run_id_clean = Internal::SqliteHelper::clearSignBit(run_id);
     const bool output_is_dir = File::isDirectory(output_path);
-    std::unique_ptr<File::TempDir> temp_dir;
+    std::unique_ptr<TempDir> temp_dir;
     std::string base_dir = output_path;
     if (!output_is_dir)
     {
@@ -339,7 +340,7 @@ namespace OpenMS
       }
       else
       {
-        temp_dir = std::make_unique<File::TempDir>();
+        temp_dir = std::make_unique<TempDir>();
         base_dir = temp_dir->getPath() + "/oswpq_output";
       }
     }

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathPercolatorScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathPercolatorScoring.cpp
@@ -21,6 +21,7 @@
 #include <OpenMS/FORMAT/SqliteConnector_impl.h>
 #include <OpenMS/FORMAT/ZipArchiveFile.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 #include <arrow/api.h>
 #include <sqlite3.h>
@@ -92,7 +93,7 @@ namespace OpenMS
       String base_dir;
       String output_path;
       bool output_is_archive = false;
-      std::unique_ptr<File::TempDir> temp_dir;
+      std::unique_ptr<TempDir> temp_dir;
     };
 
     template <typename K>

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionParquetFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionParquetFile.cpp
@@ -21,6 +21,7 @@
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/TransitionExperiment.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/CONCEPT/VersionInfo.h>
 
 #include <fstream>
@@ -220,7 +221,7 @@ namespace OpenMS
     {
       *source_ids = OpenSwathLibraryIDNormalizer::SourceIDMapping{};
     }
-    std::unique_ptr<File::TempDir> temp_dir;
+    std::unique_ptr<TempDir> temp_dir;
 
     // Try to open parquet entries directly from the archive using a RandomAccessFile.
     // If that fails (e.g., compressed entry or libzip not available), fall back to
@@ -449,11 +450,11 @@ namespace OpenMS
     OpenSwathLibraryIDNormalizer::validateCanonicalIDs(targeted_exp);
 
     const bool output_is_dir = File::isDirectory(oswpq_path);
-    std::unique_ptr<File::TempDir> temp_dir;
+    std::unique_ptr<TempDir> temp_dir;
     std::string base_dir = oswpq_path;
     if (!output_is_dir)
     {
-      temp_dir = std::make_unique<File::TempDir>();
+      temp_dir = std::make_unique<TempDir>();
       base_dir = temp_dir->getPath() + "/oswpq_output";
       File::makeDir(base_dir);
     }

--- a/src/openms/source/APPLICATIONS/SearchEngineBase.cpp
+++ b/src/openms/source/APPLICATIONS/SearchEngineBase.cpp
@@ -15,6 +15,7 @@
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 
 using namespace std;
 
@@ -93,7 +94,7 @@ namespace OpenMS
     std::string db_name(db.empty() ? getStringOption_("database") : db);
     if (!File::readable(db_name))
     {
-      db_name = File::findDatabase(db_name);
+      db_name = SystemSettings::findDatabase(db_name);
     }
     return db_name;
   }

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -39,6 +39,7 @@
 #include <OpenMS/KERNEL/MSExperiment.h>
 
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 #include <OpenMS/SYSTEM/StopWatch.h>
 #include <OpenMS/SYSTEM/SysInfo.h>
 #include <OpenMS/SYSTEM/UpdateCheck.h>
@@ -75,7 +76,7 @@ namespace OpenMS
 
   using namespace Exception;
 
-  std::string TOPPBase::topp_ini_file_ = File::getOpenMSHomePath() + "/.TOPP.ini";
+  std::string TOPPBase::topp_ini_file_ = SystemSettings::getOpenMSHomePath() + "/.TOPP.ini";
   const Citation TOPPBase::cite_openms
     = {"Pfeuffer, J., Bielow, C., Wein, S. et al.", "OpenMS 3 enables reproducible analysis of large-scale mass spectrometry data",
        "Nat Methods (2024)", "10.1038/s41592-024-02197-7"};
@@ -2269,7 +2270,7 @@ namespace OpenMS
   Param TOPPBase::getToolUserDefaults_(const std::string& tool_name) const
   {
     Param p;
-    std::string ini_name(File::getUserDirectory() + "/" + tool_name + ".ini");
+    std::string ini_name(SystemSettings::getUserDirectory() + "/" + tool_name + ".ini");
     if (File::readable(ini_name))
     {
       ParamXMLFile paramFile;

--- a/src/openms/source/FORMAT/FileHandler.cpp
+++ b/src/openms/source/FORMAT/FileHandler.cpp
@@ -7,6 +7,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/FORMAT/FileNameUtils.h>
 #include <OpenMS/ANALYSIS/MAPMATCHING/TransformationDescription.h>
 #include <OpenMS/CONCEPT/LogStream.h>
@@ -961,7 +962,7 @@ namespace OpenMS
       case FileTypes::BRUKER_TDF:
       {
         // If the input is a .d.zip archive, extract to a temp directory first.
-        std::unique_ptr<File::TempDir> temp_dir;
+        std::unique_ptr<TempDir> temp_dir;
         std::string load_path = filename;
         if (!File::isDirectory(filename) && StringUtils::hasSuffix(StringUtils::toLowered(filename), ".zip"))
         {

--- a/src/openms/source/FORMAT/SwathFile.cpp
+++ b/src/openms/source/FORMAT/SwathFile.cpp
@@ -24,6 +24,7 @@
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/METADATA/ExperimentalSettings.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 
 #ifdef WITH_OPENTIMS
 #include <OpenMS/FORMAT/BrukerTimsFile.h>
@@ -434,7 +435,7 @@ namespace OpenMS
     const std::string& file,
     std::shared_ptr<ExperimentalSettings>& exp_meta)
   {
-    return loadBrukerTdf(file, File::getTempDirectory(), exp_meta, "normal");
+    return loadBrukerTdf(file, SystemSettings::getTempDirectory(), exp_meta, "normal");
   }
 #endif
 

--- a/src/openms/source/FORMAT/ZipArchiveFile.cpp
+++ b/src/openms/source/FORMAT/ZipArchiveFile.cpp
@@ -11,6 +11,7 @@
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 #ifdef __has_include
 #if __has_include(<zip.h>)
@@ -87,7 +88,7 @@ void ZipArchiveFile::zipDirectory(const std::string& directory_path, const std::
 #endif
 }
 
-std::string ZipArchiveFile::unzipDirectory(const std::string& input_path, std::unique_ptr<File::TempDir>& temp_dir)
+std::string ZipArchiveFile::unzipDirectory(const std::string& input_path, std::unique_ptr<TempDir>& temp_dir)
 {
 #if defined(OPENMS_HAVE_LIBZIP)
   if (File::isDirectory(input_path))
@@ -100,7 +101,7 @@ std::string ZipArchiveFile::unzipDirectory(const std::string& input_path, std::u
     throw Exception::FileNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, input_path);
   }
 
-  temp_dir = std::make_unique<File::TempDir>();
+  temp_dir = std::make_unique<TempDir>();
   const std::string unpack_dir = temp_dir->getPath() + "/parquet_unpacked";
   File::makeDir(unpack_dir);
 
@@ -405,7 +406,7 @@ void ZipArchiveFile::writeSidecarIndex(const std::string& archive_path)
 #endif
 }
 
-std::string ZipArchiveFile::extractEntryToTempFile(const std::string& archive_path, const std::string& entry_name, std::unique_ptr<File::TempDir>& temp_dir)
+std::string ZipArchiveFile::extractEntryToTempFile(const std::string& archive_path, const std::string& entry_name, std::unique_ptr<TempDir>& temp_dir)
 {
 #if defined(OPENMS_HAVE_LIBZIP)
   // If archive_path is actually a directory (tests create a .oswpq directory),
@@ -449,7 +450,7 @@ std::string ZipArchiveFile::extractEntryToTempFile(const std::string& archive_pa
                                   "Failed to open zip entry", entry_name);
   }
 
-  if (!temp_dir) temp_dir = std::make_unique<File::TempDir>();
+  if (!temp_dir) temp_dir = std::make_unique<TempDir>();
   const std::string base = temp_dir->getPath();
 
   // construct output path and create parent dirs

--- a/src/openms/source/FORMAT/ZipRandomAccessFile.cpp
+++ b/src/openms/source/FORMAT/ZipRandomAccessFile.cpp
@@ -5,6 +5,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/ZipRandomAccessFile.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/FORMAT/ZipArchiveFile.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <filesystem>
@@ -120,7 +121,7 @@ private:
 
 arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> ZipRandomAccessFile::Open(const std::string& archive_path,
 																																											const std::string& entry_name,
-											std::unique_ptr<File::TempDir>& temp_dir)
+											std::unique_ptr<TempDir>& temp_dir)
 {
     // temp_dir is only used on the extraction fallback path; silence unused-parameter
     // warnings when building with libzip support enabled.

--- a/src/openms/source/PROCESSING/CALIBRATION/InternalCalibration.cpp
+++ b/src/openms/source/PROCESSING/CALIBRATION/InternalCalibration.cpp
@@ -15,6 +15,7 @@
 #include <OpenMS/MATH/StatisticFunctions.h>
 #include <OpenMS/MATH/MathFunctions.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/SYSTEM/RWrapper.h>
 
 #include <vector>
@@ -417,7 +418,7 @@ namespace OpenMS
     //
     if (!file_models.empty() || !file_models_plot.empty())
     {
-      std::string out_table = File::getTemporaryFile(file_models);
+      std::string out_table = TempFiles::getTemporaryFile(file_models);
       { // we need this scope, to ensure that SVOutStream writes its cache, before we call RWrapper!
         SVOutStream sv(out_table, ", ", ", ", OpenMS::QuotingMethod::NONE);
 
@@ -462,7 +463,7 @@ namespace OpenMS
     std::string out_table_residuals;
     if (!file_residuals.empty() || !file_residuals_plot.empty())
     {
-      out_table_residuals = File::getTemporaryFile(file_residuals);
+      out_table_residuals = TempFiles::getTemporaryFile(file_residuals);
       sv = new SVOutStream(out_table_residuals, ", ", ", ", OpenMS::QuotingMethod::NONE);
     }
 

--- a/src/openms/source/QC/DBSuitability.cpp
+++ b/src/openms/source/QC/DBSuitability.cpp
@@ -26,6 +26,7 @@
 #include <OpenMS/QC/DBSuitability.h>
 #include <OpenMS/SYSTEM/ExternalProcess.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 #include <random>
 
@@ -312,7 +313,7 @@ namespace OpenMS
 
     // temporary folder for search in- und output files
     bool keep_files = param_.getValue("keep_search_files").toBool();
-    File::TempDir tmp_dir(keep_files);
+    TempDir tmp_dir(keep_files);
     std::string mzml_path = tmp_dir.getPath() + "spectra.mzML";
     std::string db_path = tmp_dir.getPath() + "database.FASTA";
     std::string out_path = tmp_dir.getPath() + "out.idXML";

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -8,8 +8,7 @@
 
 // This file holds the basic filesystem and shared-data operations of File.
 // The OpenMS.ini settings and path policy live in SystemSettings, and
-// temporary directories and files in TempFiles (both in OpenMS/SYSTEM/).
-// The deprecated File forwarders to them are defined next to their targets,
+// temporary directories and files in TempFiles (both in OpenMS/SYSTEM/),
 // which keeps Param and ParamXMLFile out of this translation unit.
 
 #include <OpenMS/SYSTEM/File.h>

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -7,11 +7,10 @@
 // --------------------------------------------------------------------------
 
 // This file holds the basic filesystem and shared-data operations of File.
-// The remaining File members are defined in sibling files:
-//   - FileConfig.cpp: OpenMS.ini settings and user/temp/database path policy
-//     (getSystemParameters, getTempDirectory, getUserDirectory, findDatabase, ...)
-//   - FileTemp.cpp:   TempDir, getTemporaryFile and the temporary-file registry
-// Keeping them apart keeps Param and ParamXMLFile out of this translation unit.
+// The OpenMS.ini settings and path policy live in SystemSettings, and
+// temporary directories and files in TempFiles (both in OpenMS/SYSTEM/).
+// The deprecated File forwarders to them are defined next to their targets,
+// which keeps Param and ParamXMLFile out of this translation unit.
 
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/SYSTEM/PathUtils.h>

--- a/src/openms/source/SYSTEM/SystemSettings.cpp
+++ b/src/openms/source/SYSTEM/SystemSettings.cpp
@@ -177,14 +177,4 @@ namespace OpenMS
     return p;
   }
 
-  // --------------------------------------------------------------------------
-  // Deprecated File forwarders (kept for one release; see SystemSettings)
-  // --------------------------------------------------------------------------
-  std::string File::getOpenMSHomePath() { return SystemSettings::getOpenMSHomePath(); }
-  std::string File::getOpenMSConfigDir() { return SystemSettings::getOpenMSConfigDir(); }
-  std::string File::getTempDirectory() { return SystemSettings::getTempDirectory(); }
-  std::string File::getUserDirectory() { return SystemSettings::getUserDirectory(); }
-  Param File::getSystemParameters() { return SystemSettings::getSystemParameters(); }
-  std::string File::findDatabase(const std::string& db_name) { return SystemSettings::findDatabase(db_name); }
-
 } // namespace OpenMS

--- a/src/openms/source/SYSTEM/SystemSettings.cpp
+++ b/src/openms/source/SYSTEM/SystemSettings.cpp
@@ -6,6 +6,7 @@
 // $Authors: Andreas Bertsch, Chris Bielow, Marc Sturm $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/SYSTEM/SystemSettings.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
@@ -25,7 +26,7 @@ using std::getenv;
 
 namespace OpenMS
 {
-  std::string File::getTempDirectory()
+  std::string SystemSettings::getTempDirectory()
   {
     Param p = getSystemParameters();
     std::string dir;
@@ -45,7 +46,7 @@ namespace OpenMS
   }
 
   /// The current OpenMS user data path (for result files)
-  std::string File::getUserDirectory()
+  std::string SystemSettings::getUserDirectory()
   {
     Param p = getSystemParameters();
     std::string dir;
@@ -71,13 +72,13 @@ namespace OpenMS
     return dir;
   }
 
-  std::string File::findDatabase(const std::string& db_name)
+  std::string SystemSettings::findDatabase(const std::string& db_name)
   {
     Param sys_p = getSystemParameters();
     std::string full_db_name;
     try
     {
-      full_db_name = find(db_name, ListUtils::toStringList<std::string>(sys_p.getValue("id_db_dir")));
+      full_db_name = File::find(db_name, ListUtils::toStringList<std::string>(sys_p.getValue("id_db_dir")));
       OPENMS_LOG_INFO << "Augmenting database name '" << db_name << "' with path given in 'OpenMS.ini:id_db_dir'. Full name is now: '" << full_db_name << "'\n";
     }
     catch (Exception::FileNotFound& e)
@@ -89,7 +90,7 @@ namespace OpenMS
     return full_db_name;
   }
 
-  std::string File::getOpenMSHomePath()
+  std::string SystemSettings::getOpenMSHomePath()
   {
     std::string home_path;
     // set path where OpenMS.ini is found from environment or use default
@@ -110,7 +111,7 @@ namespace OpenMS
     return home_path;
   }
 
-  std::string File::getOpenMSConfigDir()
+  std::string SystemSettings::getOpenMSConfigDir()
   {
     // Comply with https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html on unix identifying systems.
     // This is the single source of truth for the per-user config dir (OpenMS.ini, update-check .ver files, ...).
@@ -119,15 +120,15 @@ namespace OpenMS
       {
         return std::string(getenv("XDG_CONFIG_HOME")) + "/OpenMS";
       }
-      return File::getOpenMSHomePath() + "/.config/OpenMS";
+      return SystemSettings::getOpenMSHomePath() + "/.config/OpenMS";
     #else
-      return File::getOpenMSHomePath() + "/.OpenMS";
+      return SystemSettings::getOpenMSHomePath() + "/.OpenMS";
     #endif
   }
 
-  Param File::getSystemParameters()
+  Param SystemSettings::getSystemParameters()
   {
-    std::string filename = File::getOpenMSConfigDir() + "/OpenMS.ini";
+    std::string filename = SystemSettings::getOpenMSConfigDir() + "/OpenMS.ini";
 
     Param p;
     if (!File::readable(filename)) // no file, lets keep it that way
@@ -160,7 +161,7 @@ namespace OpenMS
     return p;
   }
 
-  Param File::getSystemParameterDefaults_()
+  Param SystemSettings::getSystemParameterDefaults_()
   {
     Param p;
     p.setValue("version", VersionInfo::getVersion());
@@ -175,5 +176,15 @@ namespace OpenMS
 
     return p;
   }
+
+  // --------------------------------------------------------------------------
+  // Deprecated File forwarders (kept for one release; see SystemSettings)
+  // --------------------------------------------------------------------------
+  std::string File::getOpenMSHomePath() { return SystemSettings::getOpenMSHomePath(); }
+  std::string File::getOpenMSConfigDir() { return SystemSettings::getOpenMSConfigDir(); }
+  std::string File::getTempDirectory() { return SystemSettings::getTempDirectory(); }
+  std::string File::getUserDirectory() { return SystemSettings::getUserDirectory(); }
+  Param File::getSystemParameters() { return SystemSettings::getSystemParameters(); }
+  std::string File::findDatabase(const std::string& db_name) { return SystemSettings::findDatabase(db_name); }
 
 } // namespace OpenMS

--- a/src/openms/source/SYSTEM/TempFiles.cpp
+++ b/src/openms/source/SYSTEM/TempFiles.cpp
@@ -192,12 +192,4 @@ namespace
 
   TempFiles::Registry_ TempFiles::registry_;
 
-  // --------------------------------------------------------------------------
-  // Deprecated File forwarder (kept for one release; see TempFiles)
-  // --------------------------------------------------------------------------
-  std::string File::getTemporaryFile(const std::string& alternative_file)
-  {
-    return TempFiles::getTemporaryFile(alternative_file);
-  }
-
 } // namespace OpenMS

--- a/src/openms/source/SYSTEM/TempFiles.cpp
+++ b/src/openms/source/SYSTEM/TempFiles.cpp
@@ -6,7 +6,9 @@
 // $Authors: Andreas Bertsch, Chris Bielow, Marc Sturm $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 #include <OpenMS/SYSTEM/PathUtils.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
@@ -113,15 +115,15 @@ namespace
   }
 }
 
-  File::TempDir::TempDir(bool keep_dir)
+  TempDir::TempDir(bool keep_dir)
     : keep_dir_(keep_dir)
   {
-    std::string prefix = File::getTempDirectory() + "/" +File::getUniqueName();
+    std::string prefix = SystemSettings::getTempDirectory() + "/" +File::getUniqueName();
     temp_dir_ = createUniqueDir_(prefix);
     OPENMS_LOG_DEBUG << "Creating temporary directory '" << temp_dir_ << "'\n";
   };
 
-  File::TempDir::TempDir(const std::string& base_dir, bool keep_dir)
+  TempDir::TempDir(const std::string& base_dir, bool keep_dir)
     : keep_dir_(keep_dir)
   {
     std::string prefix = base_dir;
@@ -134,7 +136,7 @@ namespace
     OPENMS_LOG_DEBUG << "Creating temporary directory '" << temp_dir_ << "'\n";
   };
 
-  File::TempDir::~TempDir()
+  TempDir::~TempDir()
   {
     if (keep_dir_)
     {
@@ -145,12 +147,12 @@ namespace
     File::removeDirRecursively(temp_dir_);
   };
 
-  const std::string& File::TempDir::getPath() const
+  const std::string& TempDir::getPath() const
   {
     return temp_dir_;
   }
 
-  std::string File::getTemporaryFile(const std::string& alternative_file)
+  std::string TempFiles::getTemporaryFile(const std::string& alternative_file)
   {
     // take no action
     if (!alternative_file.empty())
@@ -158,36 +160,44 @@ namespace
       return alternative_file;
     }
     // create temporary (and schedule for deletion)
-    return temporary_files_.newFile();
+    return registry_.newFile();
   }
 
 
-  File::TemporaryFiles_::TemporaryFiles_()
+  TempFiles::Registry_::Registry_()
     : filenames_()
   {
   }
 
-  std::string File::TemporaryFiles_::newFile()
+  std::string TempFiles::Registry_::newFile()
   {
-    std::string s = getTempDirectory(); StringUtils::ensureLastChar(s, '/'); s += getUniqueName();
+    std::string s = SystemSettings::getTempDirectory(); StringUtils::ensureLastChar(s, '/'); s += File::getUniqueName();
     std::lock_guard<std::mutex> _(mtx_);
     filenames_.push_back(s);
     // do NOT return filenames_.back() by ref, since another thread might resize the vector and invalidate the reference!
     return s; // uses RVO, so its efficient
   }
 
-  File::TemporaryFiles_::~TemporaryFiles_()
+  TempFiles::Registry_::~Registry_()
   {
     std::lock_guard<std::mutex> _(mtx_);
-    for (Size i = 0; i < filenames_.size(); ++i)
+    for (const std::string& filename : filenames_)
     {
-      if (File::exists(filenames_[i]) && !File::remove(filenames_[i]))
+      if (File::exists(filename) && !File::remove(filename))
       {
-        std::cerr << "Warning: unable to remove temporary file '" << filenames_[i] << "'" << std::endl;
+        std::cerr << "Warning: unable to remove temporary file '" << filename << "'" << std::endl;
       }
     }
   }
 
-  File::TemporaryFiles_ File::temporary_files_;
+  TempFiles::Registry_ TempFiles::registry_;
+
+  // --------------------------------------------------------------------------
+  // Deprecated File forwarder (kept for one release; see TempFiles)
+  // --------------------------------------------------------------------------
+  std::string File::getTemporaryFile(const std::string& alternative_file)
+  {
+    return TempFiles::getTemporaryFile(alternative_file);
+  }
 
 } // namespace OpenMS

--- a/src/openms/source/SYSTEM/UpdateCheck.cpp
+++ b/src/openms/source/SYSTEM/UpdateCheck.cpp
@@ -8,6 +8,7 @@
 
 #include <OpenMS/SYSTEM/UpdateCheck.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 #include <OpenMS/SYSTEM/PathUtils.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 
@@ -61,7 +62,7 @@ namespace OpenMS
     // e.g.: OpenMS_Default_Win_64_FeatureFinderCentroided_2.0.0
     std::string tool_version_string;
     // resolve the per-user OpenMS config dir (same location as OpenMS.ini)
-    std::string config_path = File::getOpenMSConfigDir();
+    std::string config_path = SystemSettings::getOpenMSConfigDir();
     tool_version_string =std::string("OpenMS") + "_" + "Default_" + platform + "_" + architecture + "_" + tool_name + "_" + version;
 
     std::string version_file_name = config_path + "/" + tool_name + ".ver";

--- a/src/openms/source/SYSTEM/sources.cmake
+++ b/src/openms/source/SYSTEM/sources.cmake
@@ -7,8 +7,6 @@ BuildInfo.cpp
 CurlInit.cpp
 ExternalProcess.cpp
 File.cpp
-FileConfig.cpp
-FileTemp.cpp
 JavaInfo.cpp
 Network.cpp
 NetworkGetRequest.cpp
@@ -16,6 +14,8 @@ PythonInfo.cpp
 RWrapper.cpp
 StopWatch.cpp
 SysInfo.cpp
+SystemSettings.cpp
+TempFiles.cpp
 UpdateCheck.cpp
 )
 

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/ExecutePipeline.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/ExecutePipeline.cpp
@@ -10,6 +10,7 @@
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 #include <OpenMS/VISUAL/TOPPASScene.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/VISUAL/TOPPASResources.h>
@@ -101,7 +102,7 @@ protected:
 
     //set & create temporary path -- make sure its a new subdirectory, as it will be deleted later
     QString new_tmp_dir = toQString(File::getUniqueName());
-    QDir qd(toQString(File::getTempDirectory()));
+    QDir qd(toQString(SystemSettings::getTempDirectory()));
     qd.mkdir(new_tmp_dir);
     qd.cd(new_tmp_dir);
     QString tmp_path = qd.absolutePath();
@@ -162,7 +163,7 @@ protected:
     {
       // delete temporary files
       // safety measure: only delete if subdirectory of Temp path; we do not want to delete / or c:
-      if (StringUtils::hasPrefix(StringUtils::substituted(fromQString(tmp_path), "\\", "/"), StringUtils::substituted(File::getTempDirectory(), "\\", "/") + "/"))
+      if (StringUtils::hasPrefix(StringUtils::substituted(fromQString(tmp_path), "\\", "/"), StringUtils::substituted(SystemSettings::getTempDirectory(), "\\", "/") + "/"))
       {
         File::removeDirRecursively(fromQString(tmp_path));
       }

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPASBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPASBase.cpp
@@ -16,6 +16,7 @@
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/FORMAT/ParamXMLFile.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 
 #include <OpenMS/VISUAL/APPLICATIONS/MISC/QApplicationTOPP.h>
 #include <OpenMS/VISUAL/EnhancedWorkspace.h>
@@ -248,7 +249,7 @@ namespace OpenMS
 
     // set & create temporary path -- make sure its a new subdirectory, as it will be deleted later
     QString new_tmp_dir = toQString(File::getUniqueName(false));
-    QDir qd(toQString(File::getTempDirectory()));
+    QDir qd(toQString(SystemSettings::getTempDirectory()));
     qd.mkdir(new_tmp_dir);
     qd.cd(new_tmp_dir);
     tmp_path_ = fromQString(qd.absolutePath());
@@ -279,7 +280,7 @@ namespace OpenMS
     savePreferences();
     // delete temporary files (TODO: make this a user dialog and ask - for later resume)
     // safety measure: only delete if subdirectory of Temp path; we do not want to delete / or c:
-    if (StringUtils::hasPrefix(StringUtils::substituted(std::string(tmp_path_), "\\", "/"), StringUtils::substituted(File::getTempDirectory(), "\\", "/") + "/"))
+    if (StringUtils::hasPrefix(StringUtils::substituted(std::string(tmp_path_), "\\", "/"), StringUtils::substituted(SystemSettings::getTempDirectory(), "\\", "/") + "/"))
     {
       File::removeDirRecursively(tmp_path_);
     }

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -25,6 +25,7 @@
 #include <OpenMS/KERNEL/OnDiscMSExperiment.h>
 #include <OpenMS/METADATA/Precursor.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 #include <OpenMS/VISUAL/FileWatcher.h>
 #include <OpenMS/VISUAL/AxisWidget.h>
 #include <OpenMS/VISUAL/DataSelectionTabs.h>
@@ -1635,7 +1636,7 @@ namespace OpenMS
     }
 
     // create and store unique file name prefix for files
-    topp_.file_name = File::getTempDirectory() + "/TOPPView_" + File::getUniqueName();
+    topp_.file_name = SystemSettings::getTempDirectory() + "/TOPPView_" + File::getUniqueName();
     // Figure out the correct extension to give the temp file TODO start using OMS and cachedmzml
 
     if (!File::writable(topp_.file_name + "_ini"))
@@ -1810,14 +1811,14 @@ namespace OpenMS
     {
       log_->appendNewHeader(LogWindow::LogState::CRITICAL, fromQString(QString("Execution of '%1' not successful!").arg(toQString(topp_.tool))),
                       fromQString(QString("The tool crashed during execution. If you want to debug this crash, check the input files in '%1'"
-                              " or enable 'debug' mode in the TOPP ini file.").arg(toQString(File::getTempDirectory()))));
+                              " or enable 'debug' mode in the TOPP ini file.").arg(toQString(SystemSettings::getTempDirectory()))));
     }
     else if (topp_.process->exitCode() != 0) // NormalExit with non-zero exit code
     {
       log_->appendNewHeader(LogWindow::LogState::CRITICAL, fromQString(QString("Execution of '%1' not successful!").arg(toQString(topp_.tool))),
                             fromQString(QString("The tool ended with a non-zero exit code of '%1'. ").arg(topp_.process->exitCode()) +
                             QString("If you want to debug this, check the input files in '%1' or"
-                                    " enable 'debug' mode in the TOPP ini file.").arg(toQString(File::getTempDirectory()))));
+                                    " enable 'debug' mode in the TOPP ini file.").arg(toQString(SystemSettings::getTempDirectory()))));
     }
     else if (!topp_.out.empty())
     {

--- a/src/openms_gui/source/VISUAL/DIALOGS/TOPPASToolConfigDialog.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/TOPPASToolConfigDialog.cpp
@@ -12,6 +12,7 @@
 #include <OpenMS/VISUAL/ParamEditor.h>
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 #include <OpenMS/FORMAT/ParamXMLFile.h>
 #include <OpenMS/VISUAL/MISC/Qt5Port.h>
 
@@ -159,7 +160,7 @@ namespace OpenMS
     arg_param_.insert(tool_name_ + ":1:", *param_);
     try
     {
-      QString tmp_ini_file = toQString(File::getTempDirectory()) + QDir::separator() + "TOPPAS_" + toQString(tool_name_) + "_";
+      QString tmp_ini_file = toQString(SystemSettings::getTempDirectory()) + QDir::separator() + "TOPPAS_" + toQString(tool_name_) + "_";
       if (!tool_type_.empty())
       {
         tmp_ini_file += toQString(tool_type_) + "_";

--- a/src/openms_gui/source/VISUAL/TOPPASScene.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASScene.cpp
@@ -23,6 +23,7 @@
 #include <OpenMS/CONCEPT/VersionInfo.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 #include <OpenMS/FORMAT/ParamXMLFile.h>
 
 #include <QApplication>
@@ -58,7 +59,7 @@ namespace OpenMS
     file_name_(),
     tmp_path_(tmp_path),
     gui_(gui),
-    out_dir_(toQString(File::getUserDirectory())),
+    out_dir_(toQString(SystemSettings::getUserDirectory())),
     changed_(false),
     running_(false),
     error_occured_(false),

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -13,6 +13,7 @@
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/ParamXMLFile.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/VISUAL/TOPPASInputFileListVertex.h>
 #include <OpenMS/VISUAL/TOPPASOutputFileListVertex.h>
 #include <OpenMS/VISUAL/TOPPASScene.h>
@@ -101,7 +102,7 @@ namespace OpenMS
   bool TOPPASToolVertex::initParam_(const QString& old_ini_file)
   {
     // this is the only exception for writing directly to the tmpDir, instead of a subdir of tmpDir, as scene()->getTempDir() might not be available yet
-    QString ini_file = toQString(File::getTemporaryFile());
+    QString ini_file = toQString(TempFiles::getTemporaryFile());
     QString program = toQString(File::findSiblingTOPPExecutable(name_));
     QStringList arguments;
     arguments << "-write_ini" << ini_file;

--- a/src/openms_gui/source/VISUAL/TVToolDiscovery.cpp
+++ b/src/openms_gui/source/VISUAL/TVToolDiscovery.cpp
@@ -16,6 +16,7 @@
 #include <OpenMS/FORMAT/FileHandler.h>
 
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/SYSTEM/ExternalProcess.h>
 #include <OpenMS/VISUAL/MISC/Qt5Port.h>
 
@@ -74,7 +75,7 @@ namespace OpenMS
   {
     static std::mutex io_mutex;
     // Temporary file path and arguments
-    std::string path = File::getTemporaryFile();
+    std::string path = TempFiles::getTemporaryFile();
     std::string working_dir = StringUtils::prefix(path, path.find_last_of('/'));
     std::vector<std::string> args{"-write_ini", path};
     Param tool_param;

--- a/src/pyOpenMS/bindings/bind_misc.cpp
+++ b/src/pyOpenMS/bindings/bind_misc.cpp
@@ -187,6 +187,8 @@
 #include <OpenMS/PROCESSING/SPECTRAMERGING/SpectraMerger.h>
 #include <OpenMS/SYSTEM/BuildInfo.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/SYSTEM/JavaInfo.h>
 #include <iomanip>
 #include <nanobind/make_iterator.h>
@@ -935,11 +937,11 @@ FeatureGroupingAlgorithm
         .def_static("fileList", [](const std::string& dir, const std::string& file_pattern, bool full_path) { std::vector<std::string> output; OpenMS::File::fileList(dir, file_pattern, output, full_path); return output; }, "dir"_a, "file_pattern"_a, "full_path"_a = false, "Returns list of files matching @p file_pattern in @p dir (returns filenames without paths unless @p full_path is true)")
         .def_static("findDoc", [](const std::string& filename) { return OpenMS::File::findDoc(filename); }, "filename"_a)
         .def_static("getOpenMSDataPath", []() { return OpenMS::File::getOpenMSDataPath(); })
-        .def_static("getOpenMSHomePath", []() { return OpenMS::File::getOpenMSHomePath(); })
-        .def_static("getSystemParameters", []() { return OpenMS::File::getSystemParameters(); })
-        .def_static("findDatabase", [](const std::string& db_name) { return OpenMS::File::findDatabase(db_name); }, "db_name"_a)
+        .def_static("getOpenMSHomePath", []() { return OpenMS::SystemSettings::getOpenMSHomePath(); })
+        .def_static("getSystemParameters", []() { return OpenMS::SystemSettings::getSystemParameters(); })
+        .def_static("findDatabase", [](const std::string& db_name) { return OpenMS::SystemSettings::findDatabase(db_name); }, "db_name"_a)
         .def_static("findExecutable", [](std::string& exe_filename) { return OpenMS::File::findExecutable(exe_filename); }, "exe_filename"_a)
-        .def_static("getTemporaryFile", [](const std::string& alternative_file) { return OpenMS::File::getTemporaryFile(alternative_file); }, "alternative_file"_a)
+        .def_static("getTemporaryFile", [](const std::string& alternative_file) { return OpenMS::TempFiles::getTemporaryFile(alternative_file); }, "alternative_file"_a)
 
         .def_static("exists", [](const std::string& file) {
             return OpenMS::File::exists(file);
@@ -970,11 +972,11 @@ FeatureGroupingAlgorithm
         }, "file"_a, "Get the absolute path")
 
         .def_static("getTempDirectory", []() {
-            return OpenMS::File::getTempDirectory();
+            return OpenMS::SystemSettings::getTempDirectory();
         }, "Get the temp directory")
 
         .def_static("getUserDirectory", []() {
-            return OpenMS::File::getUserDirectory();
+            return OpenMS::SystemSettings::getUserDirectory();
         }, "Get the user home directory")
 
         .def_static("getUniqueName", [](bool include_hostname) {
@@ -983,6 +985,31 @@ FeatureGroupingAlgorithm
         .def_static("getUniqueName", []() {
             return OpenMS::File::getUniqueName();
         }, "Get a unique name")
+        ;
+
+    // -----------------------------------------------------------------------
+    // SystemSettings
+    // -----------------------------------------------------------------------
+    nb::class_<OpenMS::SystemSettings>(m, "SystemSettings", "Per-user OpenMS configuration: the OpenMS.ini parameters and the home, temp and database directories derived from them")
+        .def_static("getOpenMSHomePath", []() { return OpenMS::SystemSettings::getOpenMSHomePath(); }, "Get the OpenMS home path (OPENMS_HOME_PATH overrides the default)")
+        .def_static("getOpenMSConfigDir", []() { return OpenMS::SystemSettings::getOpenMSConfigDir(); }, "Get the per-user configuration directory that holds OpenMS.ini")
+        .def_static("getTempDirectory", []() { return OpenMS::SystemSettings::getTempDirectory(); }, "Get the temp directory (OPENMS_TMPDIR, then OpenMS.ini temp_dir, then the system temp directory)")
+        .def_static("getUserDirectory", []() { return OpenMS::SystemSettings::getUserDirectory(); }, "Get the user data directory (OPENMS_HOME_PATH, then OpenMS.ini home_dir, then the user home)")
+        .def_static("getSystemParameters", []() { return OpenMS::SystemSettings::getSystemParameters(); }, "Get the OpenMS.ini system parameters, completed with defaults where entries are missing")
+        .def_static("findDatabase", [](const std::string& db_name) { return OpenMS::SystemSettings::findDatabase(db_name); }, "db_name"_a, "Resolve a database filename against the OpenMS.ini id_db_dir entries")
+        ;
+
+    // -----------------------------------------------------------------------
+    // TempDir / TempFiles
+    // -----------------------------------------------------------------------
+    nb::class_<OpenMS::TempDir>(m, "TempDir", "A uniquely named temporary directory, removed when the object is destroyed unless keep_dir is set")
+        .def(nb::init<bool>(), "keep_dir"_a = false, "Create a temporary directory below SystemSettings.getTempDirectory()")
+        .def(nb::init<const std::string&, bool>(), "base_dir"_a, "keep_dir"_a = false, "Create a temporary directory below base_dir")
+        .def("getPath", [](const OpenMS::TempDir& self) { return self.getPath(); }, "Path of the temporary directory, with a trailing slash")
+        ;
+
+    nb::class_<OpenMS::TempFiles>(m, "TempFiles", "Temporary files that are removed when the process exits")
+        .def_static("getTemporaryFile", [](const std::string& alternative_file) { return OpenMS::TempFiles::getTemporaryFile(alternative_file); }, "alternative_file"_a = "", "Return a fresh temporary filename that is deleted at exit, or alternative_file unchanged if it is not empty")
         ;
 
     // -----------------------------------------------------------------------

--- a/src/pyOpenMS/bindings/bind_misc.cpp
+++ b/src/pyOpenMS/bindings/bind_misc.cpp
@@ -941,7 +941,7 @@ FeatureGroupingAlgorithm
         .def_static("getSystemParameters", []() { return OpenMS::SystemSettings::getSystemParameters(); })
         .def_static("findDatabase", [](const std::string& db_name) { return OpenMS::SystemSettings::findDatabase(db_name); }, "db_name"_a)
         .def_static("findExecutable", [](std::string& exe_filename) { return OpenMS::File::findExecutable(exe_filename); }, "exe_filename"_a)
-        .def_static("getTemporaryFile", [](const std::string& alternative_file) { return OpenMS::TempFiles::getTemporaryFile(alternative_file); }, "alternative_file"_a)
+        .def_static("getTemporaryFile", [](const std::string& alternative_file) { return OpenMS::TempFiles::getTemporaryFile(alternative_file); }, "alternative_file"_a = "")
 
         .def_static("exists", [](const std::string& file) {
             return OpenMS::File::exists(file);

--- a/src/pyOpenMS/tests/unittests/test_StaticMethods.py
+++ b/src/pyOpenMS/tests/unittests/test_StaticMethods.py
@@ -139,6 +139,8 @@ class TestFileStaticMethods(unittest.TestCase):
         """Test File.getTemporaryFile static method."""
         result = pyopenms.File.getTemporaryFile("")
         self.assertGreater(len(str(result)), 0)
+        # the alternative_file argument is optional
+        self.assertGreater(len(str(pyopenms.File.getTemporaryFile())), 0)
 
 class TestBuildInfoStaticMethods(unittest.TestCase):
     """Test static methods of the OpenMSBuildInfo and OpenMSOSInfo classes."""
@@ -807,7 +809,6 @@ class TestSystemSettingsStaticMethods(unittest.TestCase):
     def test_getTempDirectory(self):
         result = pyopenms.SystemSettings.getTempDirectory()
         self.assertGreater(len(str(result)), 0)
-        self.assertTrue(os.path.isdir(str(result)))
 
     def test_getUserDirectory(self):
         result = pyopenms.SystemSettings.getUserDirectory()

--- a/src/pyOpenMS/tests/unittests/test_StaticMethods.py
+++ b/src/pyOpenMS/tests/unittests/test_StaticMethods.py
@@ -801,5 +801,62 @@ class TestIonDetectorEnumStaticMethods(unittest.TestCase):
             self.assertEqual(pyopenms.IonDetector.toAcquisitionMode(name), mode)
 
 
+class TestSystemSettingsStaticMethods(unittest.TestCase):
+    """Test static methods of SystemSettings (OpenMS.ini and directory policy)."""
+
+    def test_getTempDirectory(self):
+        result = pyopenms.SystemSettings.getTempDirectory()
+        self.assertGreater(len(str(result)), 0)
+        self.assertTrue(os.path.isdir(str(result)))
+
+    def test_getUserDirectory(self):
+        result = pyopenms.SystemSettings.getUserDirectory()
+        self.assertGreater(len(str(result)), 0)
+
+    def test_getOpenMSHomePath(self):
+        result = pyopenms.SystemSettings.getOpenMSHomePath()
+        self.assertGreater(len(str(result)), 0)
+
+    def test_getOpenMSConfigDir(self):
+        result = str(pyopenms.SystemSettings.getOpenMSConfigDir())
+        self.assertTrue(result.endswith("OpenMS"))
+
+    def test_getSystemParameters(self):
+        p = pyopenms.SystemSettings.getSystemParameters()
+        self.assertTrue(p.exists("version"))
+        self.assertTrue(p.exists("temp_dir"))
+
+    def test_matches_deprecated_File_forwarders(self):
+        self.assertEqual(str(pyopenms.SystemSettings.getTempDirectory()), str(pyopenms.File.getTempDirectory()))
+        self.assertEqual(str(pyopenms.SystemSettings.getUserDirectory()), str(pyopenms.File.getUserDirectory()))
+
+
+class TestTempFiles(unittest.TestCase):
+    """Test TempDir and TempFiles."""
+
+    def test_getTemporaryFile(self):
+        first = str(pyopenms.TempFiles.getTemporaryFile())
+        second = str(pyopenms.TempFiles.getTemporaryFile())
+        self.assertGreater(len(first), 0)
+        self.assertNotEqual(first, second)
+        self.assertEqual(str(pyopenms.TempFiles.getTemporaryFile("keep-me")), "keep-me")
+
+    def test_TempDir_is_removed_on_destruction(self):
+        d = pyopenms.TempDir()
+        path = str(d.getPath())
+        self.assertTrue(os.path.isdir(path))
+        del d
+        self.assertFalse(os.path.exists(path))
+
+    def test_TempDir_below_base_dir(self):
+        with tempfile.TemporaryDirectory() as base:
+            d = pyopenms.TempDir(base, False)
+            path = str(d.getPath())
+            self.assertTrue(os.path.isdir(path))
+            self.assertTrue(os.path.realpath(path).startswith(os.path.realpath(base)))
+            del d
+            self.assertFalse(os.path.exists(path))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/pyOpenMS/tests/unittests/test_StaticMethods.py
+++ b/src/pyOpenMS/tests/unittests/test_StaticMethods.py
@@ -826,7 +826,7 @@ class TestSystemSettingsStaticMethods(unittest.TestCase):
         self.assertTrue(p.exists("version"))
         self.assertTrue(p.exists("temp_dir"))
 
-    def test_matches_deprecated_File_forwarders(self):
+    def test_matches_File_static_methods(self):
         self.assertEqual(str(pyopenms.SystemSettings.getTempDirectory()), str(pyopenms.File.getTempDirectory()))
         self.assertEqual(str(pyopenms.SystemSettings.getUserDirectory()), str(pyopenms.File.getUserDirectory()))
 

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -151,6 +151,8 @@ set(system_executables_list
   RWrapper_test
   StopWatch_test
   SysInfo_test
+  SystemSettings_test
+  TempFiles_test
   UpdateCheck_test
 )
 

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitationMethodFile_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitationMethodFile_test.cpp
@@ -10,6 +10,7 @@
 #include <OpenMS/CONCEPT/ClassTest.h>
 #include <OpenMS/test_config.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 ///////////////////////////
 
@@ -38,7 +39,7 @@ AbsoluteQuantitationMethodFile* ptr = nullptr;
 AbsoluteQuantitationMethodFile* nullPointer = nullptr;
 const std::string in_file_1 = OPENMS_GET_TEST_DATA_PATH("AbsoluteQuantitationMethodFile_in_1.csv");
 const std::string in_file_2 = OPENMS_GET_TEST_DATA_PATH("AbsoluteQuantitationMethodFile_in_2.csv");
-const std::string out_file = File::getTemporaryFile();
+const std::string out_file = TempFiles::getTemporaryFile();
 
 START_SECTION((AbsoluteQuantitationMethodFile()))
 	ptr = new AbsoluteQuantitationMethodFile();

--- a/src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp
+++ b/src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp
@@ -18,6 +18,7 @@
 #include <OpenMS/IONMOBILITY/IMTypes.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 #include <OpenMS/FORMAT/DATAACCESS/SwathFileConsumer.h>
 
 using namespace OpenMS;
@@ -664,7 +665,7 @@ START_SECTION(DDA round-trip test: load .d -> write mzML -> reload -> verify)
   // Write to temporary mzML — avoid NEW_TMP_FILE because the test
   // framework validates all registered .mzML files, and the IM data
   // array CV term MS:1003008 fails semantic validation (known issue).
-  std::string tmp_mzml = File::getTempDirectory() + "/" + File::getUniqueName() + "_dda_roundtrip.mzML";
+  std::string tmp_mzml = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "_dda_roundtrip.mzML";
   MzMLFile().store(tmp_mzml, orig);
 
   // Reload from mzML
@@ -1204,7 +1205,7 @@ START_SECTION(DIA round-trip test: load .d -> write mzML -> reload -> verify)
   f.load(OPENTIMS_DIA_TEST_DATA, orig);
 
   // Write to temporary mzML — avoid NEW_TMP_FILE (see DDA round-trip comment)
-  std::string tmp_mzml = File::getTempDirectory() + "/" + File::getUniqueName() + "_dia_roundtrip.mzML";
+  std::string tmp_mzml = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "_dia_roundtrip.mzML";
   MzMLFile().store(tmp_mzml, orig);
 
   // Reload from mzML

--- a/src/tests/class_tests/openms/source/BrukerTimsImagingFile_test.cpp
+++ b/src/tests/class_tests/openms/source/BrukerTimsImagingFile_test.cpp
@@ -12,6 +12,7 @@
 #include <OpenMS/FORMAT/SqliteConnector.h>
 #include <OpenMS/IMAGING/MSImagingExperiment.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 #include <filesystem>
 
@@ -78,7 +79,7 @@ namespace
 
 START_TEST(BrukerTimsImagingFile, "$Id$")
 
-File::TempDir tmp(false);
+TempDir tmp(false);
 
 START_SECTION(static bool isImagingDataset(const String& path))
 {

--- a/src/tests/class_tests/openms/source/ChromeleonFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ChromeleonFile_test.cpp
@@ -13,6 +13,7 @@
 #include <OpenMS/FORMAT/ChromeleonFile.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 ///////////////////////////
 
 using namespace OpenMS;
@@ -73,7 +74,7 @@ START_SECTION(void load(const std::string& filename, MSExperiment& experiment) c
   TEST_REAL_SIMILAR(c[3300].getIntensity(), -0.130904)
 
   MzMLFile mzml;
-  const std::string output_filepath = File::getTemporaryFile();
+  const std::string output_filepath = TempFiles::getTemporaryFile();
   mzml.store(output_filepath, experiment);
   MSExperiment read_exp;
   mzml.load(output_filepath, read_exp);
@@ -128,7 +129,7 @@ START_SECTION(load_with_new_raw_data_header)
   TEST_REAL_SIMILAR(c[9].getIntensity(), 4.930000)
 
   MzMLFile mzml;
-  const std::string output_filepath = File::getTemporaryFile();
+  const std::string output_filepath = TempFiles::getTemporaryFile();
   mzml.store(output_filepath, experiment);
   MSExperiment read_exp;
   mzml.load(output_filepath, read_exp);

--- a/src/tests/class_tests/openms/source/ConsensusMapArrowIO_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapArrowIO_test.cpp
@@ -13,6 +13,7 @@
 ///////////////////////////
 #include <OpenMS/FORMAT/ConsensusMapArrowIO.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 ///////////////////////////
 
 #include <OpenMS/config.h>
@@ -1034,7 +1035,7 @@ START_SECTION(([EXTRA] a failed write leaves no partial .parquet behind))
   cf.setIntensity(1000.0f);
   cmap.push_back(cf);
 
-  const std::string dir = File::getTempDirectory() + "/" + File::getUniqueName() + "_cmio";
+  const std::string dir = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "_cmio";
   TEST_TRUE(File::makeDir(dir))
 
   TEST_TRUE(ConsensusMapArrowIO::exportToParquet(cmap, dir))

--- a/src/tests/class_tests/openms/source/CsvFile_test.cpp
+++ b/src/tests/class_tests/openms/source/CsvFile_test.cpp
@@ -15,6 +15,7 @@
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/DATASTRUCTURES/ListUtilsIO.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 ///////////////////////////
 
@@ -90,7 +91,7 @@ START_SECTION(void store(const std::string& filename))
 	StringList list;
 
 	f1.load(OPENMS_GET_TEST_DATA_PATH("CsvFile_2.csv"), '\t', true); // load from a file
-	std::string tmpfile = File::getTemporaryFile();
+	std::string tmpfile = TempFiles::getTemporaryFile();
   f1.store(tmpfile);          // store into a new one
 	f2.load(tmpfile, '\t', true); // load the new one
 	f2.getRow(0,list);
@@ -108,7 +109,7 @@ START_SECTION(void addRow(const StringList& list))
 	f1.addRow(ListUtils::create<std::string>("first,second,third"));
 	f1.addRow(ListUtils::create<std::string>("4,5,6"));
   
-  std::string tmpfile = File::getTemporaryFile();
+  std::string tmpfile = TempFiles::getTemporaryFile();
 	f1.store(tmpfile);
 	f2.load(tmpfile, ',', false);
 	f2.getRow(0,list);

--- a/src/tests/class_tests/openms/source/Deisotoper_test.cpp
+++ b/src/tests/class_tests/openms/source/Deisotoper_test.cpp
@@ -21,6 +21,7 @@
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/METADATA/Precursor.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 
 ///////////////////////////
 
@@ -147,7 +148,7 @@ START_SECTION(static void deisotopeAndSingleChargeMSSpectrum(MSSpectrum& in,
        true, // decreasing isotope model
        2, // enforce only starting from second peak
        true);
-   std::string temp_file1 = File::getTempDirectory() + "/" + File::getUniqueName() + "_Deisotoper_output1.mzML";
+   std::string temp_file1 = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "_Deisotoper_output1.mzML";
    MzMLFile().store(temp_file1, input1);
    File::remove(temp_file1);
 
@@ -177,7 +178,7 @@ START_SECTION(static void deisotopeAndSingleChargeMSSpectrum(MSSpectrum& in,
        true, // decreasing isotope model
        2, // enforce only starting from second peak
        true);
-   std::string temp_file2 = File::getTempDirectory() + "/" + File::getUniqueName() + "_Deisotoper_output2.mzML";
+   std::string temp_file2 = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "_Deisotoper_output2.mzML";
    MzMLFile().store(temp_file2, input2);
    File::remove(temp_file2);
 

--- a/src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp
+++ b/src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp
@@ -19,6 +19,7 @@
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <fstream>
 ///////////////////////////
 
@@ -688,7 +689,7 @@ START_SECTION((Size annotateColumnHeaders(ConsensusMap& cmap) const))
   }
 
   // Both files in fraction group 1, as fractions 1 and 2; one sample per channel.
-  const std::string design_path = File::getTemporaryFile();
+  const std::string design_path = TempFiles::getTemporaryFile();
   {
     std::ofstream os(design_path.c_str());
     os << "Fraction_Group\tFraction\tSpectra_Filepath\tLabel\tSample\n";
@@ -766,7 +767,7 @@ START_SECTION(([EXTRA] annotateColumnHeaders - headers that collapse onto one de
     cmap.getColumnHeaders()[i] = h;
   }
 
-  const std::string design_path = File::getTemporaryFile();
+  const std::string design_path = TempFiles::getTemporaryFile();
   {
     std::ofstream os(design_path.c_str());
     os << "Fraction_Group\tFraction\tSpectra_Filepath\tLabel\tSample\n";

--- a/src/tests/class_tests/openms/source/ExternalProcess_test.cpp
+++ b/src/tests/class_tests/openms/source/ExternalProcess_test.cpp
@@ -15,6 +15,7 @@
 
 #include <OpenMS/config.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 #include <filesystem>
 #include <fstream>
@@ -59,7 +60,7 @@ START_SECTION(RETURNSTATE run(const std::string& exe, const std::vector<std::str
   // run everything in a private working directory: the test binary runs in a directory
   // shared by all tests, and under 'ctest --parallel' the other tests' temp files appear
   // and vanish while 'ls -l' walks it, making it print errors and exit non-zero (#9948)
-  File::TempDir tmp_dir;
+  TempDir tmp_dir;
   { // one stable entry, so 'ls -l' has something to list
     std::ofstream file(tmp_dir.getPath() + "some_file.txt");
     file << "content\n";

--- a/src/tests/class_tests/openms/source/FIAMSDataProcessor_test.cpp
+++ b/src/tests/class_tests/openms/source/FIAMSDataProcessor_test.cpp
@@ -7,6 +7,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/test_config.h>
 
 ///////////////////////////
@@ -45,7 +46,7 @@ END_SECTION
 
 std::string filename = "SerumTest";
 
-File::TempDir temp_dir;
+TempDir temp_dir;
 
 FIAMSDataProcessor fia_processor;
 Param p;

--- a/src/tests/class_tests/openms/source/FeatureMapArrowIO_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureMapArrowIO_test.cpp
@@ -13,6 +13,7 @@
 ///////////////////////////
 #include <OpenMS/FORMAT/FeatureMapArrowIO.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 ///////////////////////////
 
 #include <OpenMS/CHEMISTRY/AASequence.h>
@@ -1538,7 +1539,7 @@ START_SECTION(([EXTRA] a failed write leaves no partial .parquet behind))
   f.setIntensity(1000.0f);
   fmap.push_back(f);
 
-  const std::string dir = File::getTempDirectory() + "/" + File::getUniqueName() + "_fmio";
+  const std::string dir = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "_fmio";
   TEST_TRUE(File::makeDir(dir))
 
   TEST_TRUE(FeatureMapArrowIO::exportToParquet(fmap, dir))
@@ -1581,7 +1582,7 @@ START_SECTION(([EXTRA] exportToParquet / importFromParquet - the map level uniqu
   f.setUniqueId(42);
   fm.push_back(f);
 
-  const std::string dir = File::getTempDirectory() + "/" + File::getUniqueName() + "_fmuid";
+  const std::string dir = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "_fmuid";
   TEST_TRUE(File::makeDir(dir))
   TEST_TRUE(FeatureMapArrowIO::exportToParquet(fm, dir))
 
@@ -1732,7 +1733,7 @@ START_SECTION(([EXTRA] exportToParquet / importFromParquet - a ProteomicsLFQ-sha
   un_pid.insertHit(un_hit);
   fm.setUnassignedPeptideIdentifications({un_pid});
 
-  const std::string dir = File::getTempDirectory() + "/" + File::getUniqueName() + "_plfq";
+  const std::string dir = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "_plfq";
   TEST_TRUE(File::makeDir(dir))
   TEST_TRUE(FeatureMapArrowIO::exportToParquet(fm, dir))
 

--- a/src/tests/class_tests/openms/source/FileHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/FileHandler_test.cpp
@@ -22,6 +22,7 @@
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/METADATA/PeptideIdentificationList.h>
@@ -296,7 +297,7 @@ TEST_STRING_EQUAL(exp.getSourceFiles()[0].getChecksum(), "d50d5144cc3805749b9e8d
   // Use u8"" for portable path construction. Only use Latin-1 characters (ä, ü) that are
   // representable in Windows-1252 so that path::string() round-trips correctly on Windows.
   // CJK characters would fail because Windows path::string() uses the Active Code Page.
-  fs::path nonascii_dir = fs::path(std::string(File::getTempDirectory())) / u8"openms_t\u00e4st_\u00fc";
+  fs::path nonascii_dir = fs::path(std::string(SystemSettings::getTempDirectory())) / u8"openms_t\u00e4st_\u00fc";
   std::error_code ec;
   fs::create_directories(nonascii_dir, ec);
   if (!ec)

--- a/src/tests/class_tests/openms/source/FileInfo_test.cpp
+++ b/src/tests/class_tests/openms/source/FileInfo_test.cpp
@@ -13,6 +13,7 @@
 
 #include <OpenMS/FORMAT/FileInfo.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 
 #include <string>
 
@@ -130,7 +131,7 @@ START_SECTION((forced type selects the parse branch for an unrecognized extensio
   // content sniffing). A wrong-but-known extension (e.g. .mzML) would
   // therefore throw, so it cannot be used to demonstrate a "bypass" here.
   std::string src_path = OPENMS_GET_TEST_DATA_PATH("AccurateMassSearchEngine_input1.featureXML");
-  std::string tmp_path = File::getTempDirectory() + "/test_forced_type.tmp";
+  std::string tmp_path = SystemSettings::getTempDirectory() + "/test_forced_type.tmp";
 
   bool copy_success = File::copy(src_path, tmp_path);
   TEST_EQUAL(copy_success, true)

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -13,6 +13,8 @@
 
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/DATASTRUCTURES/Param.h>
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/CONCEPT/VersionInfo.h>
@@ -140,7 +142,7 @@ START_SECTION((static bool writable(const std::string &file)))
   // requirement is the same and is checked against reality rather than against an
   // expected answer: if the file can actually be created, writable() must say true.
   {
-    File::TempDir long_path_dir;
+    TempDir long_path_dir;
     std::error_code ec;
     std::string deep = long_path_dir.getPath();
     const std::string chunk(60, 'd');
@@ -336,7 +338,7 @@ END_SECTION
 
 START_SECTION((static StringList listDirectories(const std::string &dir)))
   // create temp structure with subdirectories
-  File::TempDir tdir;
+  TempDir tdir;
   std::string base = tdir.getPath();
   File::makeDir(base + "/subA");
   File::makeDir(base + "/subB");
@@ -400,7 +402,7 @@ END_SECTION
 START_SECTION(static bool copyDirRecursively(const std::string &fromDir, const std::string &toDir, File::CopyOptions option = CopyOptions::OVERWRITE))
   // folder OpenMS/src/tests/class_tests/openms/data/XMassFile_test 
   std::string source_name = OPENMS_GET_TEST_DATA_PATH("XMassFile_test");
-  std::string target_name = File::getTempDirectory() + "/" + File::getUniqueName() + "/"; 
+  std::string target_name = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "/";
   // test canonical path
   // Rejecting the self-copy is reported on the error log. That report is expected here -- the
   // assertion below is what checks it -- so keep it off the console: an 'Error:' line in the
@@ -449,7 +451,7 @@ START_SECTION(static bool copyDirRecursively(const std::string &fromDir, const s
 END_SECTION
 
 START_SECTION(static bool removeDirRecursively(const std::string &dir_name))
-  std::string dirname = File::getTempDirectory() + "/" + File::getUniqueName() + "/" + File::getUniqueName() + "/";
+  std::string dirname = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "/" + File::getUniqueName() + "/";
   TEST_TRUE(File::makeDir(dirname));
   TextFile tf;
   tf.store(dirname + "test.txt");
@@ -457,7 +459,7 @@ START_SECTION(static bool removeDirRecursively(const std::string &dir_name))
   END_SECTION
 
 START_SECTION(static bool makeDir(const std::string& dir_name))
-  File::TempDir tdir;
+  TempDir tdir;
   std::string dirname = tdir.getPath() + "/" + File::getUniqueName() + "/" + File::getUniqueName() + "/";
   // absolute path
   TEST_FALSE(File::isDirectory(dirname))
@@ -473,72 +475,6 @@ START_SECTION(static bool makeDir(const std::string& dir_name))
   TEST_FALSE(File::makeDir("c:\\te:st")) // ':' is not allowed in path on Windows; Unix pretty much allows everything
 #endif
   std::filesystem::current_path(current_path); // reset current path (enable deletion of dirname)
-END_SECTION
-
-START_SECTION(static std::string getTempDirectory())
-  TEST_NOT_EQUAL(File::getTempDirectory(), std::string())
-  TEST_EQUAL(File::exists(File::getTempDirectory()), true)
-END_SECTION
-
-START_SECTION(static std::string getUserDirectory())
-  TEST_NOT_EQUAL(File::getUserDirectory(), std::string())
-  TEST_EQUAL(File::exists(File::getUserDirectory()), true)
-
-  // set user directory to a path set by environmental variable and test that
-  // it is correctly set (no changes on the file system occur)
-  std::string dirname = File::getTempDirectory() + "/" + File::getUniqueName() + "/";
-  TEST_EQUAL(File::makeDir(dirname), true);
-#ifdef OPENMS_WINDOWSPLATFORM
-  _putenv_s("OPENMS_HOME_PATH", dirname.c_str());  
-#else
-  setenv("OPENMS_HOME_PATH", dirname.c_str(), 0);  
-#endif
-  TEST_EQUAL(File::getUserDirectory(), dirname)
-  // Note: this does not guarantee any more that the user directory or an
-  // OpenMS.ini file exists at the new location.
-END_SECTION
-
-START_SECTION((static std::string getOpenMSConfigDir()))
-  std::string config_dir = File::getOpenMSConfigDir();
-  TEST_NOT_EQUAL(config_dir, std::string())
-  // every platform branch resolves to a folder named "OpenMS" with no trailing separator
-  TEST_EQUAL(StringUtils::hasSuffix(config_dir, "OpenMS"), true)
-  TEST_EQUAL(StringUtils::hasSuffix(config_dir, "/"), false)
-#ifdef __unix__
-  // on unix-like systems, XDG_CONFIG_HOME takes precedence when set
-  const char* xdg_backup = getenv("XDG_CONFIG_HOME");
-  setenv("XDG_CONFIG_HOME", "/tmp/openms_xdg_test", 1);
-  TEST_EQUAL(File::getOpenMSConfigDir(), "/tmp/openms_xdg_test/OpenMS")
-  // restore previous environment to avoid side effects on later tests
-  if (xdg_backup) { setenv("XDG_CONFIG_HOME", xdg_backup, 1); }
-  else { unsetenv("XDG_CONFIG_HOME"); }
-#endif
-END_SECTION
-
-START_SECTION(static Param getSystemParameters())
-  Param p = File::getSystemParameters();
-  TEST_EQUAL(!p.empty(), true)
-  TEST_EQUAL(p.getValue("version"), VersionInfo::getVersion())
-END_SECTION
-
-START_SECTION(static std::string findDatabase(const std::string &db_name))
-
-  // findDatabase() logs the miss before rethrowing; the exception is what this asserts on.
-  {
-    Logger::LogSinkGuard quiet(getThreadLocalLogError(), std::cerr);
-    TEST_EXCEPTION(Exception::FileNotFound, File::findDatabase("filedoesnotexists"))
-  }
-  // The success path is chatty too -- it announces the resolved path on the info log (which goes
-  // to stdout, so the stderr check above does not cover it), and since nothing flushes it until
-  // teardown it surfaces *after* the test's PASSED banner. Same packaging-log noise as the errors.
-  std::string db;
-  {
-    Logger::LogSinkGuard quiet(getThreadLocalLogInfo(), std::cout);
-    db = File::findDatabase("./CV/unimod.obo");
-  }
-  //TEST_EQUAL(db,"wtf")
-  TEST_EQUAL(StringUtils::hasSubstring(db, "share/OpenMS"), true)
-
 END_SECTION
 
 START_SECTION(static bool findExecutable(std::string& exe_filename))
@@ -603,55 +539,6 @@ START_SECTION(static std::string findSiblingTOPPExecutable(const std::string& to
 #endif
 }
 END_SECTION
-
-START_SECTION(File::TempDir(bool keep_dir = false))
-{
-  File::TempDir* dir = new File::TempDir();
-  File::TempDir* nullPointer = nullptr;
-  TEST_NOT_EQUAL(dir, nullPointer)
-  TEST_EQUAL(File::exists((*dir).getPath()),1)
-  delete dir;
-}
-END_SECTION
-
-START_SECTION((TempDir with explicit parent and temporary filename registry))
-  File::TempDir parent;
-  std::string child_path;
-  {
-    File::TempDir child(parent.getPath(), false);
-    child_path = child.getPath();
-    TEST_TRUE(File::isDirectory(child_path))
-    TEST_EQUAL(child_path.find(parent.getPath()), 0)
-  }
-  TEST_FALSE(File::exists(child_path))
-  TEST_TRUE(File::exists(parent.getPath()))
-  const std::string first = File::getTemporaryFile();
-  const std::string second = File::getTemporaryFile();
-  TEST_FALSE(first.empty())
-  TEST_NOT_EQUAL(first, second)
-  TEST_EQUAL(File::getTemporaryFile("retain-this-filename"), "retain-this-filename")
-END_SECTION
-
-START_SECTION(File::~TempDir())
-{
-  std::string path;
-  {
-    File::TempDir dir;
-    path = dir.getPath();
-    TEST_EQUAL(File::exists(path), 1)
-  }
-  TEST_EQUAL(File::exists(path), 0)
-  if (File::exists(path)) File::removeDir(path);
-  {
-    File::TempDir dir2(true);
-    path = dir2.getPath();
-    TEST_EQUAL(File::exists(path), 1)
-  }
-  TEST_EQUAL(File::exists(path), 1)
-  if (File::exists(path)) File::removeDir(path);
-}
-END_SECTION
-
 
 START_SECTION(static File::MatchingFileListsStatus validateMatchingFileNames(const StringList& sl1, const StringList& sl2, bool basename, bool ignore_extension))
 {

--- a/src/tests/class_tests/openms/source/MQEvidenceExporter_test.cpp
+++ b/src/tests/class_tests/openms/source/MQEvidenceExporter_test.cpp
@@ -11,6 +11,7 @@
 #include <OpenMS/FORMAT/FeatureXMLFile.h>
 #include <OpenMS/QC/MQEvidenceExporter.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/FORMAT/FASTAFile.h>
 #include <map>
@@ -27,7 +28,7 @@ using namespace OpenMS;
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 
-File::TempDir dir;
+TempDir dir;
 const std::string path = dir.getPath();
 
 START_SECTION(MQEvidence())

--- a/src/tests/class_tests/openms/source/MQMsmsExporter_test.cpp
+++ b/src/tests/class_tests/openms/source/MQMsmsExporter_test.cpp
@@ -11,6 +11,7 @@
 #include <OpenMS/FORMAT/FeatureXMLFile.h>
 #include <OpenMS/QC/MQMsmsExporter.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 
 #include <OpenMS/test_config.h>
@@ -26,7 +27,7 @@ using namespace OpenMS;
 /////////////////////////////////////////////////////////////
 
 
-File::TempDir dir;
+TempDir dir;
 const std::string path = dir.getPath();
 
 

--- a/src/tests/class_tests/openms/source/MRMFeatureQCFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMFeatureQCFile_test.cpp
@@ -9,6 +9,7 @@
 #include <OpenMS/test_config.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/MRMFeatureQC.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 #include <OpenMS/FORMAT/MRMFeatureQCFile.h>
 
@@ -249,8 +250,8 @@ START_SECTION(void store(const std::string& filename, MRMFeatureQC& mrmfqc, cons
 {
   MRMFeatureQCFile mrmfqcfile;
   MRMFeatureQC mrmfqc, mrmfqc_test;
-  std::string file_comp = File::getTemporaryFile();
-  std::string file_comp_group = File::getTemporaryFile();
+  std::string file_comp = TempFiles::getTemporaryFile();
+  std::string file_comp_group = TempFiles::getTemporaryFile();
 
   mrmfqcfile.store(file_comp, mrmfqc, false); // empty components file
   mrmfqcfile.store(file_comp_group, mrmfqc, true); // empty component groups file

--- a/src/tests/class_tests/openms/source/MSChromatogramParquetConsumer_test.cpp
+++ b/src/tests/class_tests/openms/source/MSChromatogramParquetConsumer_test.cpp
@@ -17,6 +17,7 @@
 #include <OpenMS/FORMAT/TraMLFile.h>
 #include <OpenMS/FORMAT/XICParquetFile.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 
 using namespace OpenMS;
 using namespace std;
@@ -142,7 +143,7 @@ START_SECTION(MSChromatogramParquetConsumer_destructor_no_throw)
   OpenSwath::LightTargetedExperiment light_exp;
   OpenSwathDataAccessHelper::convertTargetedExp(targeted_exp, light_exp);
 
-  std::string out = File::getTempDirectory() + "/openms_missing_dir/xic_out.xic";
+  std::string out = SystemSettings::getTempDirectory() + "/openms_missing_dir/xic_out.xic";
   bool caught = false;
   try
   {

--- a/src/tests/class_tests/openms/source/Network_test.cpp
+++ b/src/tests/class_tests/openms/source/Network_test.cpp
@@ -13,6 +13,7 @@
 
 #include <OpenMS/SYSTEM/Network.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 
 #include <filesystem>
 
@@ -31,7 +32,7 @@ START_SECTION(static void downloadFile(const std::string& url, const std::string
   std::string fixture_path = OPENMS_GET_TEST_DATA_PATH("Network_test_fixture.txt");
   std::string url = "file://" + fixture_path;
 
-  std::string folder = File::getTempDirectory();
+  std::string folder = SystemSettings::getTempDirectory();
 
   Network::downloadFile(url, folder);
   std::string output_file_path = folder + "/Network_test_fixture.txt";

--- a/src/tests/class_tests/openms/source/OpenSwathOSWParquetReader_test.cpp
+++ b/src/tests/class_tests/openms/source/OpenSwathOSWParquetReader_test.cpp
@@ -11,6 +11,7 @@
 
 #include <OpenMS/ANALYSIS/OPENSWATH/OpenSwathOSWParquetReader.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <iostream>
 #include <cmath>
 
@@ -66,7 +67,7 @@ END_SECTION
 START_SECTION(void load(const std::string& oswpq_dir))
 {
   // Create a minimal .oswpq directory with library, runs and features
-  File::TempDir tmp_dir;
+  TempDir tmp_dir;
   const std::string base_dir = tmp_dir.getPath() + "/test.oswpq";
   const std::string library_dir = base_dir + "/library";
   const std::string runs_dir = base_dir + "/runs";

--- a/src/tests/class_tests/openms/source/OpenSwathOSWParquetRoundTrip_test.cpp
+++ b/src/tests/class_tests/openms/source/OpenSwathOSWParquetRoundTrip_test.cpp
@@ -15,6 +15,7 @@
 #include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.h>
 #include <OpenMS/FORMAT/TraMLFile.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/FORMAT/ZipArchiveFile.h>
 #include <OpenMS/FORMAT/ZipRandomAccessFile.h>
@@ -41,7 +42,7 @@ START_SECTION(void round-trip write/read .oswpq archive using RAF path)
   TEST_EQUAL(light_exp.compounds.size() > 0, true)
 
   // Write to a single .oswpq archive (do NOT create a directory) to exercise archive writer path
-  File::TempDir tmp_dir;
+  TempDir tmp_dir;
   const std::string out_archive = tmp_dir.getPath() + "/roundtrip.oswpq";
 
   const auto source_ids = OpenSwathLibraryIDNormalizer::normalizeSourceIDs(light_exp);
@@ -61,7 +62,7 @@ START_SECTION(void round-trip write/read .oswpq archive using RAF path)
 
   // Verify the RAF path works: ZipRandomAccessFile::Open should succeed directly on the archive
   {
-    std::unique_ptr<File::TempDir> raf_tmp;
+    std::unique_ptr<TempDir> raf_tmp;
     auto ra_res = ZipRandomAccessFile::Open(out_archive, "library/precursors.parquet", raf_tmp);
 #if __has_include(<zip.h>)
     TEST_EQUAL(ra_res.ok(), true)

--- a/src/tests/class_tests/openms/source/OpenSwathOSWParquetWriter_test.cpp
+++ b/src/tests/class_tests/openms/source/OpenSwathOSWParquetWriter_test.cpp
@@ -15,6 +15,7 @@
 #include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
 #include <OpenMS/FORMAT/DATAACCESS/MSChromatogramParquetConsumer.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/KERNEL/MSChromatogram.h>
 
@@ -43,10 +44,10 @@ START_SECTION(void write(const std::string&, const OpenSwath::LightTargetedExper
   fmap.push_back(f1);
   fmap.push_back(f2);
 
-  // Use File::TempDir so the temporary directory is removed automatically
+  // Use TempDir so the temporary directory is removed automatically
   // even if the test aborts early. Create a subdirectory for the .oswpq
   // content so it is contained inside the TempDir.
-  File::TempDir tmp_dir;
+  TempDir tmp_dir;
   std::string base = tmp_dir.getPath() + "/oswpq";
   if (File::exists(base)) File::removeDirRecursively(base);
   File::makeDir(base);

--- a/src/tests/class_tests/openms/source/OpenSwathOSWWriter_test.cpp
+++ b/src/tests/class_tests/openms/source/OpenSwathOSWWriter_test.cpp
@@ -12,6 +12,7 @@
 #include <OpenMS/DATASTRUCTURES/DataValue.h>
 #include <OpenMS/FORMAT/SqliteConnector.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 #include <string>
 
@@ -44,7 +45,7 @@ START_SECTION(bool isActive() const)
   OpenSwathOSWWriter inactive_writer("", false);
   TEST_EQUAL(inactive_writer.isActive(), false)
 
-  std::string temp_file = File::getTemporaryFile();
+  std::string temp_file = TempFiles::getTemporaryFile();
   OpenSwathOSWWriter active_writer(temp_file, false);
   TEST_EQUAL(active_writer.isActive(), true)
   File::remove(temp_file);
@@ -62,7 +63,7 @@ START_SECTION([EXTRA] RUN.ID is stored as INTEGER not BLOB (regression test for 
   //   1. typeof(RUN.ID) == 'integer'     (was 'blob' before the fix)
   //   2. A JOIN between RUN and FEATURE on run_id returns rows when expected
 
-  std::string temp_file = File::getTemporaryFile();
+  std::string temp_file = TempFiles::getTemporaryFile();
 
   // Use a large 64-bit value that previously triggered the BLOB storage bug
   const UInt64 large_run_id = 6130996817540441879ULL;
@@ -118,7 +119,7 @@ END_SECTION
 
 START_SECTION([EXTRA] prepareLine indexes masserror_ppm by MS2 subordinate position)
 {
-  std::string temp_file = File::getTemporaryFile();
+  std::string temp_file = TempFiles::getTemporaryFile();
 
   {
     OpenSwathOSWWriter writer(temp_file, false);
@@ -172,7 +173,7 @@ END_SECTION
 
 START_SECTION([EXTRA] prepareLine uses available UIS transition names instead of reported count)
 {
-  std::string temp_file = File::getTemporaryFile();
+  std::string temp_file = TempFiles::getTemporaryFile();
 
   {
     OpenSwathOSWWriter writer(temp_file, true);

--- a/src/tests/class_tests/openms/source/OpenSwathPercolatorScoring_test.cpp
+++ b/src/tests/class_tests/openms/source/OpenSwathPercolatorScoring_test.cpp
@@ -14,6 +14,7 @@
 #include <OpenMS/FORMAT/ParquetFile.h>
 #include <OpenMS/FORMAT/ZipArchiveFile.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 #include <arrow/api.h>
 #include <sqlite3.h>
@@ -76,7 +77,7 @@ namespace
   struct ExtractedArchive
   {
     std::string base_dir;
-    std::unique_ptr<File::TempDir> temp_dir;
+    std::unique_ptr<TempDir> temp_dir;
   };
 
   ExtractedArchive unzipArchive_(const std::string& archive_path)

--- a/src/tests/class_tests/openms/source/PercolatorAdapter_parity_test.cpp
+++ b/src/tests/class_tests/openms/source/PercolatorAdapter_parity_test.cpp
@@ -26,6 +26,7 @@
 #include <OpenMS/METADATA/PeptideIdentificationList.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 #include <algorithm>
 #include <cmath>
@@ -100,8 +101,8 @@ int runAdapter(const std::string& adapter_bin,
                const std::string& out_idxml,
                const std::string& extra_args = "")
 {
-  const std::string stdout_log = File::getTemporaryFile();
-  const std::string stderr_log = File::getTemporaryFile();
+  const std::string stdout_log = TempFiles::getTemporaryFile();
+  const std::string stderr_log = TempFiles::getTemporaryFile();
 
   std::ostringstream cmd;
   cmd << "\"" << adapter_bin << "\""
@@ -164,8 +165,8 @@ START_SECTION([EXTRA] adapter parity: -use_subprocess true vs false on same idXM
     const std::string in_idxml =
       OPENMS_GET_TEST_DATA_PATH("../../../topp/THIRDPARTY/CometAdapter_4_out.idXML");
 
-    const std::string out_sub = File::getTemporaryFile() + ".idxml";
-    const std::string out_inp = File::getTemporaryFile() + ".idxml";
+    const std::string out_sub = TempFiles::getTemporaryFile() + ".idxml";
+    const std::string out_inp = TempFiles::getTemporaryFile() + ".idxml";
 
     TEST_EQUAL(runAdapter(adapter_bin, percolator_bin, /*use_subprocess=*/true,
                           in_idxml, out_sub,

--- a/src/tests/class_tests/openms/source/Percolator_subprocess_parity_test.cpp
+++ b/src/tests/class_tests/openms/source/Percolator_subprocess_parity_test.cpp
@@ -25,6 +25,7 @@
 #include <OpenMS/METADATA/PeptideIdentificationList.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 #include <algorithm>
 #include <cmath>
@@ -318,10 +319,10 @@ SubprocessOut runSubprocess(const std::string& bin,
                             const std::string& pin_path,
                             const std::string& extra_args = "")
 {
-  const std::string target_pout = File::getTemporaryFile();
-  const std::string decoy_pout  = File::getTemporaryFile();
-  const std::string stdout_log  = File::getTemporaryFile();
-  const std::string stderr_log  = File::getTemporaryFile();
+  const std::string target_pout = TempFiles::getTemporaryFile();
+  const std::string decoy_pout  = TempFiles::getTemporaryFile();
+  const std::string stdout_log  = TempFiles::getTemporaryFile();
+  const std::string stderr_log  = TempFiles::getTemporaryFile();
 
   std::ostringstream cmd;
   cmd << "\"" << bin << "\""
@@ -479,7 +480,7 @@ START_SECTION([EXTRA] PIN file content equals stamped meta values)
   const std::string enz = "no_enzyme";
 
   // (a) Write PIN via store(). This also internally stamps, then serializes.
-  const std::string pin_path = File::getTemporaryFile();
+  const std::string pin_path = TempFiles::getTemporaryFile();
   PercolatorInfile::store(pin_path, pids, feature_set, enz, min_charge, max_charge);
 
   // (b) Stamp an independent copy so we can read back the meta values
@@ -610,7 +611,7 @@ START_SECTION([EXTRA] scores and FDR-threshold counts match subprocess)
     RescoreInput ri;
     generateSyntheticData(ri, rng);
 
-    const std::string pin_path = File::getTemporaryFile();
+    const std::string pin_path = TempFiles::getTemporaryFile();
     writePinFile(pin_path, ri);
 
     SubprocessOut sub = runSubprocess(bin, pin_path, "-S 1");
@@ -688,7 +689,7 @@ START_SECTION([EXTRA] ranking parity at q &lt;= 0.01 / 0.05 / 0.10)
     RescoreInput ri;
     generateSyntheticData(ri, rng);
 
-    const std::string pin_path = File::getTemporaryFile();
+    const std::string pin_path = TempFiles::getTemporaryFile();
     writePinFile(pin_path, ri);
 
     SubprocessOut sub = runSubprocess(bin, pin_path, "-S 1");
@@ -802,7 +803,7 @@ START_SECTION([EXTRA] parameter matrix: each flag flows through to the SVM)
       std::mt19937 rng(2026);
       RescoreInput ri;
       generateSyntheticData(ri, rng);
-      const std::string pin_path = File::getTemporaryFile();
+      const std::string pin_path = TempFiles::getTemporaryFile();
       writePinFile(pin_path, ri);
 
       SubprocessOut sub = runSubprocess(bin, pin_path, tc.extra_args);
@@ -890,11 +891,11 @@ START_SECTION([EXTRA] SVM weights match average of per-fold subprocess weights)
     std::mt19937 rng(2026);
     RescoreInput ri;
     generateSyntheticData(ri, rng);
-    const std::string pin_path = File::getTemporaryFile();
+    const std::string pin_path = TempFiles::getTemporaryFile();
     writePinFile(pin_path, ri);
 
     // Ask percolator to dump weights.
-    const std::string wfile = File::getTemporaryFile();
+    const std::string wfile = TempFiles::getTemporaryFile();
     SubprocessOut sub = runSubprocess(
       bin, pin_path, "-S 1 -w \"" + wfile + "\"");
     TEST_EQUAL(sub.exit_code, 0)
@@ -1017,7 +1018,7 @@ START_SECTION([EXTRA] realistic idXML parity at library layer)
     const std::string enz = "trypsin";
 
     // Write .pin (also stamps meta values under the hood).
-    const std::string pin_path = File::getTemporaryFile();
+    const std::string pin_path = TempFiles::getTemporaryFile();
     PercolatorInfile::store(pin_path, pids, feature_set, enz, min_charge, max_charge);
 
     // Parse .pin back to build RescoreInput that matches subprocess input
@@ -1162,7 +1163,7 @@ START_SECTION([EXTRA] reservoir-sampling parity at 20k rows)
     generateSyntheticData(ri, rng, /*size_mult=*/10.0);
     TEST_EQUAL(ri.features.size(), 20000)
 
-    const std::string pin_path = File::getTemporaryFile();
+    const std::string pin_path = TempFiles::getTemporaryFile();
     writePinFile(pin_path, ri);
 
     SubprocessOut sub = runSubprocess(bin, pin_path, "-S 1 -N 5000");
@@ -1280,7 +1281,7 @@ START_SECTION([EXTRA] multi-file PIN parity)
       ri.spec_file_numbers[i] = (i < half) ? 0 : 1;
     }
 
-    const std::string pin_path = File::getTemporaryFile();
+    const std::string pin_path = TempFiles::getTemporaryFile();
     writePinFile(pin_path, ri, /*emit_filename=*/true);
 
     SubprocessOut sub = runSubprocess(bin, pin_path, "-S 1");

--- a/src/tests/class_tests/openms/source/PythonInfo_test.cpp
+++ b/src/tests/class_tests/openms/source/PythonInfo_test.cpp
@@ -14,6 +14,7 @@
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/SYSTEM/PythonInfo.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
             
 #include <fstream>
 #include <filesystem>
@@ -34,7 +35,7 @@ START_SECTION((static bool canRun(std::string& python_executable, std::string& e
   TEST_EQUAL(PythonInfo::canRun(py, error_msg), false)
   TEST_EQUAL(StringUtils::hasSubstring(error_msg, "Python not found at"), true)
 
-  auto tmp_file = File::getTemporaryFile();
+  auto tmp_file = TempFiles::getTemporaryFile();
   ofstream f(tmp_file); // create the file
   f.close(); 
   TEST_EQUAL(PythonInfo::canRun(tmp_file, error_msg), false)

--- a/src/tests/class_tests/openms/source/QPXCollectionExport_test.cpp
+++ b/src/tests/class_tests/openms/source/QPXCollectionExport_test.cpp
@@ -27,6 +27,7 @@
 #include <OpenMS/METADATA/ProteinHit.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 
 #include <fstream>
 
@@ -437,7 +438,7 @@ START_SECTION(([EXTRA] Transaction removes a partially written collection unless
   // then, and a directory holding quantms.feature.parquet but no quantms.psm.parquet reads as a
   // complete export of a smaller dataset. Transaction is what makes the collection
   // all-or-nothing.
-  const std::string dir = File::getTempDirectory() + "/" + File::getUniqueName() + "_qpx_txn";
+  const std::string dir = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "_qpx_txn";
   TEST_TRUE(File::makeDir(dir))
 
   const std::vector<std::string> files{dir + "/quantms.feature.parquet",

--- a/src/tests/class_tests/openms/source/SwathFileConsumer_test.cpp
+++ b/src/tests/class_tests/openms/source/SwathFileConsumer_test.cpp
@@ -12,6 +12,7 @@
 
 #include <OpenMS/FORMAT/DATAACCESS/SwathFileConsumer.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 
 ///////////////////////////
 
@@ -424,7 +425,7 @@ CachedSwathFileConsumer* cached_sfc_ptr = nullptr;
 CachedSwathFileConsumer* cached_sfc_nullPointer = nullptr;
 
 START_SECTION(([EXTRA] CachedSwathFileConsumer()))
-  cached_sfc_ptr = new CachedSwathFileConsumer(File::getTempDirectory() + "/", "tmp_osw_cached", 0, std::vector<int>());
+  cached_sfc_ptr = new CachedSwathFileConsumer(SystemSettings::getTempDirectory() + "/", "tmp_osw_cached", 0, std::vector<int>());
   TEST_NOT_EQUAL(cached_sfc_ptr, cached_sfc_nullPointer)
 END_SECTION
 
@@ -438,7 +439,7 @@ START_SECTION(([EXTRA] consumeAndRetrieve))
   //int nr_swath = 1;
   int nr_swath = 2;
   std::vector<int> nr_ms2_spectra(nr_swath,1);
-  cached_sfc_ptr = new CachedSwathFileConsumer(File::getTempDirectory() + "/", "tmp_osw_cached", 1, nr_ms2_spectra);
+  cached_sfc_ptr = new CachedSwathFileConsumer(SystemSettings::getTempDirectory() + "/", "tmp_osw_cached", 1, nr_ms2_spectra);
   PeakMap exp;
   getSwathFile(exp, nr_swath);
   // Consume all the spectra
@@ -476,7 +477,7 @@ START_SECTION(([EXTRA] consumeAndRetrieve_noMS1))
   // 2 SWATH should be sufficient for the test
   int nr_swath = 2;
   std::vector<int> nr_ms2_spectra(nr_swath,1);
-  cached_sfc_ptr = new CachedSwathFileConsumer(File::getTempDirectory() + "/", "tmp_osw_cached", 1, nr_ms2_spectra);
+  cached_sfc_ptr = new CachedSwathFileConsumer(SystemSettings::getTempDirectory() + "/", "tmp_osw_cached", 1, nr_ms2_spectra);
   PeakMap exp;
   getSwathFile(exp, nr_swath, false);
   // Consume all the spectra
@@ -508,7 +509,7 @@ START_SECTION(([EXTRA] consumeAndRetrieve_noMS2))
 {
   int nr_swath = 0;
   std::vector<int> nr_ms2_spectra(nr_swath,1);
-  cached_sfc_ptr = new CachedSwathFileConsumer(File::getTempDirectory() + "/", "tmp_osw_cached", 1, nr_ms2_spectra);
+  cached_sfc_ptr = new CachedSwathFileConsumer(SystemSettings::getTempDirectory() + "/", "tmp_osw_cached", 1, nr_ms2_spectra);
   PeakMap exp;
   getSwathFile(exp, nr_swath, true);
   // Consume all the spectra

--- a/src/tests/class_tests/openms/source/SwathFile_test.cpp
+++ b/src/tests/class_tests/openms/source/SwathFile_test.cpp
@@ -12,6 +12,7 @@
 
 #include <OpenMS/FORMAT/SwathFile.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 
 ///////////////////////////
 #include <OpenMS/FORMAT/MzMLFile.h>
@@ -192,7 +193,7 @@ START_SECTION(std::vector< OpenSwath::SwathMap > loadMzML(std::string file, std:
   Size nr_swathes = 6;
   storeSwathFile("swathFile_1.tmp", nr_swathes);
   std::shared_ptr<ExperimentalSettings> meta = std::shared_ptr<ExperimentalSettings>(new ExperimentalSettings());
-  std::vector< OpenSwath::SwathMap > maps = SwathFile().loadMzML("swathFile_1.tmp", File::getTempDirectory() + "/", meta);
+  std::vector< OpenSwath::SwathMap > maps = SwathFile().loadMzML("swathFile_1.tmp", SystemSettings::getTempDirectory() + "/", meta);
 
   TEST_EQUAL(maps.size(), nr_swathes+1)
   TEST_EQUAL(maps[0].ms1, true)
@@ -215,7 +216,7 @@ START_SECTION([EXTRA]std::vector< OpenSwath::SwathMap > loadMzML(std::string fil
   Size nr_swathes = 2;
   storeSwathFile("swathFile_1.tmp", nr_swathes);
   std::shared_ptr<ExperimentalSettings> meta = std::shared_ptr<ExperimentalSettings>(new ExperimentalSettings());
-  std::vector< OpenSwath::SwathMap > maps = SwathFile().loadMzML("swathFile_1.tmp", File::getTempDirectory() + "/", meta, "cache");
+  std::vector< OpenSwath::SwathMap > maps = SwathFile().loadMzML("swathFile_1.tmp", SystemSettings::getTempDirectory() + "/", meta, "cache");
 
   TEST_EQUAL(maps.size(), nr_swathes+1)
   TEST_EQUAL(maps[0].ms1, true)
@@ -244,7 +245,7 @@ START_SECTION(std::vector< OpenSwath::SwathMap > loadSplit(StringList file_list,
   }
   storeSplitSwathFile(swath_filenames);
   std::shared_ptr<ExperimentalSettings> meta = std::shared_ptr<ExperimentalSettings>(new ExperimentalSettings());
-  std::vector< OpenSwath::SwathMap > maps = SwathFile().loadSplit(swath_filenames, File::getTempDirectory() + "/", meta);
+  std::vector< OpenSwath::SwathMap > maps = SwathFile().loadSplit(swath_filenames, SystemSettings::getTempDirectory() + "/", meta);
 
   // ensure they are sorted ... 
   std::sort(maps.begin(), maps.end(), sortSwathMaps);
@@ -277,7 +278,7 @@ START_SECTION([EXTRA]std::vector< OpenSwath::SwathMap > loadSplit(StringList fil
   }
   storeSplitSwathFile(swath_filenames);
   std::shared_ptr<ExperimentalSettings> meta = std::shared_ptr<ExperimentalSettings>(new ExperimentalSettings());
-  std::vector< OpenSwath::SwathMap > maps = SwathFile().loadSplit(swath_filenames, File::getTempDirectory() + "/", meta, "cache");
+  std::vector< OpenSwath::SwathMap > maps = SwathFile().loadSplit(swath_filenames, SystemSettings::getTempDirectory() + "/", meta, "cache");
   // ensure they are sorted ... 
   std::sort(maps.begin(), maps.end(), sortSwathMaps);
 
@@ -303,7 +304,7 @@ START_SECTION((std::vector<FAIMSSwathMapGroup> loadFromMSExperimentByFAIMSCV(Pea
   std::shared_ptr<ExperimentalSettings> meta;
 
   auto groups = SwathFile().loadFromMSExperimentByFAIMSCV(
-    std::move(exp), File::getTempDirectory() + "/", meta, "normal");
+    std::move(exp), SystemSettings::getTempDirectory() + "/", meta, "normal");
 
   TEST_EQUAL(groups.size(), 1)
   TEST_EQUAL(std::isnan(groups[0].faims_cv), true)
@@ -324,7 +325,7 @@ START_SECTION((std::vector<FAIMSSwathMapGroup> loadFromMSExperimentByFAIMSCV(Pea
   std::shared_ptr<ExperimentalSettings> meta;
 
   auto groups = SwathFile().loadFromMSExperimentByFAIMSCV(
-    std::move(exp), File::getTempDirectory() + "/", meta, "normal");
+    std::move(exp), SystemSettings::getTempDirectory() + "/", meta, "normal");
 
   TEST_EQUAL(groups.size(), 1)
   TEST_REAL_SIMILAR(groups[0].faims_cv, -45.0)
@@ -354,7 +355,7 @@ START_SECTION((std::vector<FAIMSSwathMapGroup> loadFromMSExperimentByFAIMSCV(Pea
 
   std::shared_ptr<ExperimentalSettings> meta;
   auto groups = SwathFile().loadFromMSExperimentByFAIMSCV(
-    std::move(exp), File::getTempDirectory() + "/", meta, "normal");
+    std::move(exp), SystemSettings::getTempDirectory() + "/", meta, "normal");
 
   TEST_EQUAL(groups.size(), 2)
   TEST_REAL_SIMILAR(groups[0].faims_cv, -55.0)

--- a/src/tests/class_tests/openms/source/SwathQC_test.cpp
+++ b/src/tests/class_tests/openms/source/SwathQC_test.cpp
@@ -19,6 +19,7 @@
 #include <OpenMS/FORMAT/TextFile.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 
 using namespace OpenMS;
@@ -147,9 +148,9 @@ START_SECTION((static void storeJSON(const std::string& filename)))
   }
 
   // getChargeDistribution(swath_maps, 10, 0.04);
-  std::string tmp_json = File::getTemporaryFile();
+  std::string tmp_json = TempFiles::getTemporaryFile();
   qc.storeJSON(tmp_json);
-  std::string tmp_expected = File::getTemporaryFile();
+  std::string tmp_expected = TempFiles::getTemporaryFile();
   TextFile tf;
   tf.addLine(R"({
   "ChargeDistributionMS1": [

--- a/src/tests/class_tests/openms/source/SystemSettings_test.cpp
+++ b/src/tests/class_tests/openms/source/SystemSettings_test.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Andreas Bertsch, Chris Bielow, Marc Sturm $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+#include <OpenMS/SYSTEM/SystemSettings.h>
+///////////////////////////
+
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/CONCEPT/VersionInfo.h>
+#include <OpenMS/DATASTRUCTURES/Param.h>
+#include <OpenMS/DATASTRUCTURES/StringUtils.h>
+#include <OpenMS/SYSTEM/File.h>
+
+#include <cstdlib>
+#include <iostream>
+
+using namespace OpenMS;
+using namespace std;
+
+START_TEST(SystemSettings, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+START_SECTION(static std::string getTempDirectory())
+  TEST_NOT_EQUAL(SystemSettings::getTempDirectory(), std::string())
+  TEST_EQUAL(File::exists(SystemSettings::getTempDirectory()), true)
+END_SECTION
+
+START_SECTION(static std::string getUserDirectory())
+  TEST_NOT_EQUAL(SystemSettings::getUserDirectory(), std::string())
+  TEST_EQUAL(File::exists(SystemSettings::getUserDirectory()), true)
+
+  // set user directory to a path set by environmental variable and test that
+  // it is correctly set (no changes on the file system occur)
+  std::string dirname = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "/";
+  TEST_EQUAL(File::makeDir(dirname), true);
+#ifdef OPENMS_WINDOWSPLATFORM
+  _putenv_s("OPENMS_HOME_PATH", dirname.c_str());
+#else
+  setenv("OPENMS_HOME_PATH", dirname.c_str(), 0);
+#endif
+  TEST_EQUAL(SystemSettings::getUserDirectory(), dirname)
+  // Note: this does not guarantee any more that the user directory or an
+  // OpenMS.ini file exists at the new location.
+END_SECTION
+
+START_SECTION(static std::string getOpenMSHomePath())
+  // OPENMS_HOME_PATH was set in the section above and takes precedence
+  TEST_NOT_EQUAL(SystemSettings::getOpenMSHomePath(), std::string())
+  TEST_EQUAL(SystemSettings::getOpenMSHomePath(), std::string(getenv("OPENMS_HOME_PATH")))
+END_SECTION
+
+START_SECTION(static std::string getOpenMSConfigDir())
+  std::string config_dir = SystemSettings::getOpenMSConfigDir();
+  TEST_NOT_EQUAL(config_dir, std::string())
+  // every platform branch resolves to a folder named "OpenMS" with no trailing separator
+  TEST_EQUAL(StringUtils::hasSuffix(config_dir, "OpenMS"), true)
+  TEST_EQUAL(StringUtils::hasSuffix(config_dir, "/"), false)
+#ifdef __unix__
+  // on unix-like systems, XDG_CONFIG_HOME takes precedence when set
+  const char* xdg_backup = getenv("XDG_CONFIG_HOME");
+  setenv("XDG_CONFIG_HOME", "/tmp/openms_xdg_test", 1);
+  TEST_EQUAL(SystemSettings::getOpenMSConfigDir(), "/tmp/openms_xdg_test/OpenMS")
+  // restore previous environment to avoid side effects on later tests
+  if (xdg_backup) { setenv("XDG_CONFIG_HOME", xdg_backup, 1); }
+  else { unsetenv("XDG_CONFIG_HOME"); }
+#endif
+END_SECTION
+
+START_SECTION(static Param getSystemParameters())
+  Param p = SystemSettings::getSystemParameters();
+  TEST_EQUAL(!p.empty(), true)
+  TEST_EQUAL(p.getValue("version"), VersionInfo::getVersion())
+  // the defaults always carry the directory policy entries, even without an OpenMS.ini
+  TEST_TRUE(p.exists("home_dir"))
+  TEST_TRUE(p.exists("temp_dir"))
+  TEST_TRUE(p.exists("id_db_dir"))
+END_SECTION
+
+START_SECTION(static std::string findDatabase(const std::string& db_name))
+  // findDatabase() logs the miss before rethrowing; the exception is what this asserts on.
+  {
+    Logger::LogSinkGuard quiet(getThreadLocalLogError(), std::cerr);
+    TEST_EXCEPTION(Exception::FileNotFound, SystemSettings::findDatabase("filedoesnotexists"))
+  }
+  // The success path is chatty too -- it announces the resolved path on the info log (which goes
+  // to stdout, so the stderr check above does not cover it), and since nothing flushes it until
+  // teardown it surfaces *after* the test's PASSED banner. Same packaging-log noise as the errors.
+  std::string db;
+  {
+    Logger::LogSinkGuard quiet(getThreadLocalLogInfo(), std::cout);
+    db = SystemSettings::findDatabase("./CV/unimod.obo");
+  }
+  TEST_EQUAL(StringUtils::hasSubstring(db, "share/OpenMS"), true)
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST

--- a/src/tests/class_tests/openms/source/SystemSettings_test.cpp
+++ b/src/tests/class_tests/openms/source/SystemSettings_test.cpp
@@ -22,11 +22,48 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <optional>
+#include <string>
 
 using namespace OpenMS;
 using namespace std;
 
+namespace
+{
+  // getenv() pointers may be invalidated by later setenv() calls, so copy the value
+  std::optional<std::string> readEnv(const char* name)
+  {
+    const char* value = getenv(name);
+    if (value == nullptr) return std::nullopt;
+    return std::string(value);
+  }
+
+  void setEnv(const char* name, const std::string& value)
+  {
+#ifdef OPENMS_WINDOWSPLATFORM
+    _putenv_s(name, value.c_str());
+#else
+    setenv(name, value.c_str(), 1);
+#endif
+  }
+
+  void restoreEnv(const char* name, const std::optional<std::string>& previous)
+  {
+#ifdef OPENMS_WINDOWSPLATFORM
+    _putenv_s(name, previous ? previous->c_str() : "");
+#else
+    if (previous) setenv(name, previous->c_str(), 1);
+    else unsetenv(name);
+#endif
+  }
+}
+
 START_TEST(SystemSettings, "$Id$")
+
+// remembered before any section changes it; restored in the getOpenMSHomePath() section
+const std::optional<std::string> home_backup = readEnv("OPENMS_HOME_PATH");
+// the directory OPENMS_HOME_PATH is pointed at by the getUserDirectory() section
+std::string home_dirname;
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
@@ -40,16 +77,13 @@ START_SECTION(static std::string getUserDirectory())
   TEST_NOT_EQUAL(SystemSettings::getUserDirectory(), std::string())
   TEST_EQUAL(File::exists(SystemSettings::getUserDirectory()), true)
 
-  // set user directory to a path set by environmental variable and test that
-  // it is correctly set (no changes on the file system occur)
-  std::string dirname = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "/";
-  TEST_EQUAL(File::makeDir(dirname), true);
-#ifdef OPENMS_WINDOWSPLATFORM
-  _putenv_s("OPENMS_HOME_PATH", dirname.c_str());
-#else
-  setenv("OPENMS_HOME_PATH", dirname.c_str(), 0);
-#endif
-  TEST_EQUAL(SystemSettings::getUserDirectory(), dirname)
+  // Point OPENMS_HOME_PATH at a fresh directory and check that it takes precedence
+  // (no changes on the file system occur). The previous value is restored at the
+  // end of the getOpenMSHomePath() section below.
+  home_dirname = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "/";
+  TEST_EQUAL(File::makeDir(home_dirname), true);
+  setEnv("OPENMS_HOME_PATH", home_dirname);
+  TEST_EQUAL(SystemSettings::getUserDirectory(), home_dirname)
   // Note: this does not guarantee any more that the user directory or an
   // OpenMS.ini file exists at the new location.
 END_SECTION
@@ -57,7 +91,8 @@ END_SECTION
 START_SECTION(static std::string getOpenMSHomePath())
   // OPENMS_HOME_PATH was set in the section above and takes precedence
   TEST_NOT_EQUAL(SystemSettings::getOpenMSHomePath(), std::string())
-  TEST_EQUAL(SystemSettings::getOpenMSHomePath(), std::string(getenv("OPENMS_HOME_PATH")))
+  TEST_EQUAL(SystemSettings::getOpenMSHomePath(), home_dirname)
+  restoreEnv("OPENMS_HOME_PATH", home_backup);
 END_SECTION
 
 START_SECTION(static std::string getOpenMSConfigDir())
@@ -68,12 +103,11 @@ START_SECTION(static std::string getOpenMSConfigDir())
   TEST_EQUAL(StringUtils::hasSuffix(config_dir, "/"), false)
 #ifdef __unix__
   // on unix-like systems, XDG_CONFIG_HOME takes precedence when set
-  const char* xdg_backup = getenv("XDG_CONFIG_HOME");
-  setenv("XDG_CONFIG_HOME", "/tmp/openms_xdg_test", 1);
+  const std::optional<std::string> xdg_backup = readEnv("XDG_CONFIG_HOME");
+  setEnv("XDG_CONFIG_HOME", "/tmp/openms_xdg_test");
   TEST_EQUAL(SystemSettings::getOpenMSConfigDir(), "/tmp/openms_xdg_test/OpenMS")
   // restore previous environment to avoid side effects on later tests
-  if (xdg_backup) { setenv("XDG_CONFIG_HOME", xdg_backup, 1); }
-  else { unsetenv("XDG_CONFIG_HOME"); }
+  restoreEnv("XDG_CONFIG_HOME", xdg_backup);
 #endif
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/TempFiles_test.cpp
+++ b/src/tests/class_tests/openms/source/TempFiles_test.cpp
@@ -1,0 +1,95 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Andreas Bertsch, Chris Bielow, Marc Sturm $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+#include <OpenMS/SYSTEM/TempFiles.h>
+///////////////////////////
+
+#include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
+
+#include <string>
+
+using namespace OpenMS;
+using namespace std;
+
+START_TEST(TempFiles, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+START_SECTION(TempDir::TempDir(bool keep_dir = false))
+{
+  TempDir* dir = new TempDir();
+  TempDir* nullPointer = nullptr;
+  TEST_NOT_EQUAL(dir, nullPointer)
+  TEST_TRUE(File::isDirectory(dir->getPath()))
+  // created below the configured temp directory
+  TEST_EQUAL(File::absolutePath(dir->getPath()).find(File::absolutePath(SystemSettings::getTempDirectory())), 0)
+  delete dir;
+}
+END_SECTION
+
+START_SECTION(TempDir::TempDir(const std::string& base_dir, bool keep_dir = false))
+{
+  TempDir parent;
+  std::string child_path;
+  {
+    TempDir child(parent.getPath(), false);
+    child_path = child.getPath();
+    TEST_TRUE(File::isDirectory(child_path))
+    TEST_EQUAL(child_path.find(parent.getPath()), 0)
+  }
+  TEST_FALSE(File::exists(child_path))
+  TEST_TRUE(File::exists(parent.getPath()))
+}
+END_SECTION
+
+START_SECTION(TempDir::~TempDir())
+{
+  std::string path;
+  {
+    TempDir dir;
+    path = dir.getPath();
+    TEST_EQUAL(File::exists(path), 1)
+  }
+  TEST_EQUAL(File::exists(path), 0)
+  if (File::exists(path)) File::removeDir(path);
+  {
+    TempDir dir2(true);
+    path = dir2.getPath();
+    TEST_EQUAL(File::exists(path), 1)
+  }
+  TEST_EQUAL(File::exists(path), 1)
+  if (File::exists(path)) File::removeDir(path);
+}
+END_SECTION
+
+START_SECTION(const std::string& TempDir::getPath() const)
+  NOT_TESTABLE // tested above
+END_SECTION
+
+START_SECTION(static std::string TempFiles::getTemporaryFile(const std::string& alternative_file = ""))
+{
+  const std::string first = TempFiles::getTemporaryFile();
+  const std::string second = TempFiles::getTemporaryFile();
+  TEST_FALSE(first.empty())
+  TEST_NOT_EQUAL(first, second)
+  // names are allocated below the configured temp directory; the file itself is not created
+  TEST_EQUAL(File::absolutePath(first).find(File::absolutePath(SystemSettings::getTempDirectory())), 0)
+  TEST_FALSE(File::exists(first))
+  TEST_EQUAL(TempFiles::getTemporaryFile("retain-this-filename"), "retain-this-filename")
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST

--- a/src/tests/class_tests/openms/source/ThermoRawFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ThermoRawFile_test.cpp
@@ -15,6 +15,7 @@
 #include <OpenMS/METADATA/MassAnalyzer.h>
 #include <OpenMS/METADATA/Precursor.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 
 #include <cmath>
 #include <set>
@@ -72,7 +73,7 @@ START_SECTION(round-trip load raw -> mzML -> reload MSExperiment)
   }
   TEST_EQUAL(found_positive, true)
 
-  std::string tmp_mzml = File::getTempDirectory() + "/" + File::getUniqueName() + "_thermo_roundtrip.mzML";
+  std::string tmp_mzml = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "_thermo_roundtrip.mzML";
   MzMLFile().store(tmp_mzml, original);
 
   MSExperiment reloaded;
@@ -268,7 +269,7 @@ START_SECTION(real Thermo FAIMS-DIA RAW -> FAIMS-aware SWATH maps)
 
   std::shared_ptr<ExperimentalSettings> exp_meta;
   auto groups = SwathFile().loadFromMSExperimentByFAIMSCV(
-    std::move(exp), File::getTempDirectory() + "/", exp_meta, "normal");
+    std::move(exp), SystemSettings::getTempDirectory() + "/", exp_meta, "normal");
 
   TEST_EQUAL(groups.size(), 1)
   TEST_EQUAL(exp_meta != nullptr, true)

--- a/src/tests/class_tests/openms/source/TransitionParquetFile_test.cpp
+++ b/src/tests/class_tests/openms/source/TransitionParquetFile_test.cpp
@@ -15,6 +15,7 @@
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/FORMAT/TraMLFile.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 #include <arrow/api.h>
 #include <arrow/io/api.h>
@@ -123,7 +124,7 @@ START_SECTION(void convertParquetToTargetedExperiment(const std::string& oswpq_d
   }
   TEST_EQUAL(transitions.size() > 0, true)
 
-  File::TempDir tmp_dir;
+  TempDir tmp_dir;
   const std::string base_dir = tmp_dir.getPath() + "/test.oswpq";
   const std::string library_dir = base_dir + "/library";
   File::makeDir(base_dir);
@@ -372,7 +373,7 @@ START_SECTION(void convertLightTargetedExperimentToParquet(const std::string& os
   TEST_EQUAL(light_exp.transitions.size() > 0, true)
 
   // --- Write to a temporary .oswpq directory ---
-  File::TempDir tmp_dir;
+  TempDir tmp_dir;
   const std::string out_dir = tmp_dir.getPath() + "/roundtrip.oswpq";
   File::makeDir(out_dir);
 

--- a/src/tests/class_tests/openms/source/UpdateCheck_test.cpp
+++ b/src/tests/class_tests/openms/source/UpdateCheck_test.cpp
@@ -14,6 +14,8 @@
 #include <OpenMS/SYSTEM/UpdateCheck.h>
 
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 
 #include <fstream>
@@ -31,7 +33,7 @@ START_TEST(UpdateCheck, "$Id$")
 
 START_SECTION((static void run(const std::string& tool_name, const std::string& version, int debug_level)))
 {
-  // UpdateCheck stamps a per-tool ".ver" file into File::getOpenMSConfigDir(). When that directory
+  // UpdateCheck stamps a per-tool ".ver" file into SystemSettings::getOpenMSConfigDir(). When that directory
   // cannot be created (a read-only / unwritable config location), run() must log a warning and return
   // *before* issuing any network request: it must not throw or crash, and the tool must continue.
   //
@@ -42,7 +44,7 @@ START_SECTION((static void run(const std::string& tool_name, const std::string& 
   const char* xdg_backup = getenv("XDG_CONFIG_HOME");
 
   // create a real temporary *file* and use it as the (bogus) config-home directory
-  std::string blocker = File::getTemporaryFile();
+  std::string blocker = TempFiles::getTemporaryFile();
   {
     std::ofstream f(blocker.c_str());
     f << "not a directory";

--- a/src/tests/class_tests/openms/source/ZipArchiveFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ZipArchiveFile_test.cpp
@@ -9,6 +9,7 @@
 #include <OpenMS/CONCEPT/ClassTest.h>
 #include <OpenMS/FORMAT/ZipArchiveFile.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <fstream>
 
 using namespace OpenMS;
@@ -18,7 +19,7 @@ START_TEST(ZipArchiveFile, "$Id$")
 START_SECTION(void addOrReplaceFromFile(const std::string&, const std::string&, const std::string&))
 {
   // prepare temporary workspace
-  File::TempDir tmp;
+  TempDir tmp;
   const std::string base = tmp.getPath() + "/workspace";
   File::makeDir(base);
   File::makeDir(base + "/library");
@@ -45,7 +46,7 @@ START_SECTION(void addOrReplaceFromFile(const std::string&, const std::string&, 
   TEST_EQUAL(found, true)
 
   // extract and verify content
-  std::unique_ptr<File::TempDir> unpack_tmp;
+  std::unique_ptr<TempDir> unpack_tmp;
   const std::string unpack_dir = ZipArchiveFile::unzipDirectory(archive, unpack_tmp);
   const std::string extracted = unpack_dir + "/library/precursors.parquet";
   TEST_EQUAL(File::exists(extracted), true)
@@ -68,7 +69,7 @@ START_SECTION(void addOrReplaceFromFile(const std::string&, const std::string&, 
   ZipArchiveFile::addOrReplaceFromFile(archive, "library/precursors.parquet", file1);
 
   // extract to new temp dir and verify replaced content
-  std::unique_ptr<File::TempDir> unpack_tmp2;
+  std::unique_ptr<TempDir> unpack_tmp2;
   const std::string unpack_dir2 = ZipArchiveFile::unzipDirectory(archive, unpack_tmp2);
   const std::string extracted2 = unpack_dir2 + "/library/precursors.parquet";
   TEST_EQUAL(File::exists(extracted2), true)
@@ -84,7 +85,7 @@ END_SECTION
 
 START_SECTION([EXTRA] unzipDirectory error paths)
 {
-  File::TempDir tmp;
+  TempDir tmp;
 
   // Corrupt archive: an existing, readable file that is not a valid ZIP (garbage
   // bytes, no central directory). libzip's zip_open() fails and unzipDirectory
@@ -98,13 +99,13 @@ START_SECTION([EXTRA] unzipDirectory error paths)
   }
   TEST_EQUAL(File::exists(corrupt), true)
   {
-    std::unique_ptr<File::TempDir> td;
+    std::unique_ptr<TempDir> td;
     TEST_EXCEPTION(Exception::InvalidValue, ZipArchiveFile::unzipDirectory(corrupt, td))
   }
 
   // Missing / unreadable input: a clear FileNotFound.
   {
-    std::unique_ptr<File::TempDir> td;
+    std::unique_ptr<TempDir> td;
     TEST_EXCEPTION(Exception::FileNotFound, ZipArchiveFile::unzipDirectory("/nonexistent/path/to/archive.oswpq", td))
   }
 
@@ -113,7 +114,7 @@ START_SECTION([EXTRA] unzipDirectory error paths)
   {
     const std::string adir = tmp.getPath() + "/already_a_dir";
     File::makeDir(adir);
-    std::unique_ptr<File::TempDir> td;
+    std::unique_ptr<TempDir> td;
     TEST_STRING_EQUAL(ZipArchiveFile::unzipDirectory(adir, td), adir)
   }
 }

--- a/src/tests/class_tests/openms/source/ZipRandomAccessFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ZipRandomAccessFile_test.cpp
@@ -8,6 +8,7 @@
 #include <OpenMS/FORMAT/ZipRandomAccessFile.h>
 #include <OpenMS/FORMAT/ZipArchiveFile.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <fstream>
 #include <vector>
 #include <cstring>
@@ -21,10 +22,10 @@ using namespace OpenMS;
 
 START_TEST(ZipRandomAccessFile, "$Id$")
 
-START_SECTION(static arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> Open(const std::string&, const std::string&, std::unique_ptr<File::TempDir>&))
+START_SECTION(static arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> Open(const std::string&, const std::string&, std::unique_ptr<TempDir>&))
 {
   // create temporary directory
-  std::unique_ptr<File::TempDir> tmpdir(new File::TempDir(false));
+  std::unique_ptr<TempDir> tmpdir(new TempDir(false));
   std::string tmp_path = tmpdir->getPath();
 
 #if __has_include(<zip.h>)

--- a/src/topp/CometAdapter.cpp
+++ b/src/topp/CometAdapter.cpp
@@ -30,6 +30,7 @@
 #include <OpenMS/CHEMISTRY/ResidueDB.h>
 #include <OpenMS/CHEMISTRY/ResidueModification.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 #include <OpenMS/ANALYSIS/ID/CometModification.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
@@ -646,7 +647,7 @@ protected:
 
     // do this early, to see if comet is installed
     std::string comet_executable = getStringOption_("comet_executable");
-    File::TempDir tmp_dir(debug_level_ >= 2);
+    TempDir tmp_dir(debug_level_ >= 2);
 
     writeDebug_("Comet is writing the default parameter file...", 1);
     
@@ -723,7 +724,7 @@ protected:
       // Thermo native IDs are "scan=N" with monotonic N — mzParser handles
       // them correctly, so no native ID rewriting is needed (unlike the
       // Bruker path below where "frame=F scan=S" triggers a sort UB).
-      auto tmp_mzml = File::getTemporaryFile() + ".mzML";
+      auto tmp_mzml = TempFiles::getTemporaryFile() + ".mzML";
       MzMLFile().store(tmp_mzml, exp);
       input_file_with_index = tmp_mzml;
 
@@ -773,7 +774,7 @@ protected:
       CometNativeIDRemapper::rewriteToIndex(exp);
 
       // Write to temporary indexed mzML for Comet
-      auto tmp_mzml = File::getTemporaryFile() + ".mzML";
+      auto tmp_mzml = TempFiles::getTemporaryFile() + ".mzML";
       MzMLFile().store(tmp_mzml, exp);
       input_file_with_index = tmp_mzml;
 
@@ -816,7 +817,7 @@ protected:
 
         CometNativeIDRemapper::rewriteToIndex(exp);
 
-        auto tmp_mzml = File::getTemporaryFile() + ".mzML";
+        auto tmp_mzml = TempFiles::getTemporaryFile() + ".mzML";
         MzMLFile().store(tmp_mzml, exp);
         input_file_with_index = tmp_mzml;
 
@@ -833,7 +834,7 @@ protected:
         {
           OPENMS_LOG_WARN << "The mzML file provided to CometAdapter is not indexed, but comet requires one. "
                           << "We will add an index by writing a temporary file. If you run this analysis more often, consider indexing your mzML in advance!" << std::endl;
-          auto tmp_file_mzml = File::getTemporaryFile() + ".mzML";
+          auto tmp_file_mzml = TempFiles::getTemporaryFile() + ".mzML";
           PlainMSDataWritingConsumer consumer(tmp_file_mzml);
           consumer.getOptions().addMSLevel(ms_level);
           bool skip_full_count = true;

--- a/src/topp/DecoyDatabase.cpp
+++ b/src/topp/DecoyDatabase.cpp
@@ -11,6 +11,7 @@
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/CHEMISTRY/ProteaseDigestion.h>
 #include <OpenMS/CHEMISTRY/ResidueDB.h>
 #include <OpenMS/DATASTRUCTURES/FASTAContainer.h>
@@ -275,7 +276,7 @@ protected:
       
       if (out_neighbor.empty())
       { // make it a temp file, since we need to append its content to the final 'out' DB
-        out_neighbor = File::getTemporaryFile(out_neighbor);
+        out_neighbor = TempFiles::getTemporaryFile(out_neighbor);
       }
 
       //-------------------------------------------------------------

--- a/src/topp/FuzzyDiff.cpp
+++ b/src/topp/FuzzyDiff.cpp
@@ -11,6 +11,7 @@
 #include <OpenMS/CONCEPT/FuzzyStringComparator.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 
 #include <algorithm>
 #include <fstream>
@@ -167,7 +168,7 @@ protected:
         std::sort(lines.begin(), lines.end());
 
         // Write to temp file
-        output_file = File::getTempDirectory() + "/" + File::basename(input_file) + ".sorted." + File::getUniqueName() + ".tmp";
+        output_file = SystemSettings::getTempDirectory() + "/" + File::basename(input_file) + ".sorted." + File::getUniqueName() + ".tmp";
         std::ofstream outfile(output_file);
         if (!outfile)
         {

--- a/src/topp/INIUpdater.cpp
+++ b/src/topp/INIUpdater.cpp
@@ -13,6 +13,7 @@
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/SYSTEM/ExternalProcess.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/ParamXMLFile.h>
 
@@ -124,7 +125,7 @@ protected:
   {
     Int this_instance = getIntOption_("instance");
     INIUpdater updater;
-    std::string tmp_ini_file = File::getTempDirectory() + "/" + File::getUniqueName() + "_INIUpdater.ini";
+    std::string tmp_ini_file = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "_INIUpdater.ini";
     tmp_files_.push_back(tmp_ini_file);
 
     ParamXMLFile paramFile;
@@ -238,7 +239,7 @@ protected:
   {
     Int this_instance = getIntOption_("instance");
     INIUpdater updater;
-    std::string tmp_ini_file = File::getTempDirectory() + "/" + File::getUniqueName() + "_INIUpdater.ini";
+    std::string tmp_ini_file = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "_INIUpdater.ini";
     tmp_files_.push_back(tmp_ini_file);
 
     Param p;

--- a/src/topp/LuciphorAdapter.cpp
+++ b/src/topp/LuciphorAdapter.cpp
@@ -21,6 +21,7 @@
 #include <OpenMS/FORMAT/PepXMLFile.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/SYSTEM/JavaInfo.h>
 #include <OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
@@ -466,7 +467,7 @@ protected:
     }
 
     //tmp_dir
-    File::TempDir tmp_dir(debug_level_ >= 2);
+    TempDir tmp_dir(debug_level_ >= 2);
 
     // create a temporary config file for LuciPHOr2 parameters
     std::string conf_file = tmp_dir.getPath() + "luciphor2_input_template.txt";

--- a/src/topp/MSFraggerAdapter.cpp
+++ b/src/topp/MSFraggerAdapter.cpp
@@ -18,6 +18,7 @@
 #include <OpenMS/FORMAT/PepXMLFile.h>
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/SYSTEM/JavaInfo.h>
@@ -396,7 +397,7 @@ protected:
       _fatalError("MSFragger may only be used upon acceptance of license terms.");
     }
 
-    File::TempDir working_directory(debug_level_ >= 2);
+    TempDir working_directory(debug_level_ >= 2);
     try
     {
       // java executable
@@ -548,7 +549,7 @@ protected:
       std::vector<std::string> arg_fixmod_unimod = this->getStringList_(TOPPMSFraggerAdapter::fixed_modifications_unimod);
 
       // parameters have been read in and verified, they are now going to be written into the fragger.params file in a temporary directory
-      this->parameter_file_path = File::getTemporaryFile();
+      this->parameter_file_path = TempFiles::getTemporaryFile();
 
       writeDebug_("Parameter file for MSFragger: '" + this->parameter_file_path + "'", TOPPMSFraggerAdapter::LOG_LEVEL_VERBOSE);
       writeDebug_("Working Directory: '" + working_directory.getPath() + "'", TOPPMSFraggerAdapter::LOG_LEVEL_VERBOSE);

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -24,6 +24,7 @@
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/SpectrumMetaDataLookup.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/SYSTEM/JavaInfo.h>
 
 #include <boost/interprocess/sync/file_lock.hpp>
@@ -546,7 +547,7 @@ protected:
     }
 
     // create temporary directory (and modifications file, if necessary):
-    File::TempDir tmp_dir(debug_level_ >= 2);
+    TempDir tmp_dir(debug_level_ >= 2);
     std::string mzid_temp, mod_file;
     // always create a temporary mzid file first, even if mzid output is requested via "mzid_out"
     // (reason: TOPPAS may pass a filename with wrong extension to "mzid_out", which would cause an error in MzIDToTSVConverter below,

--- a/src/topp/MaRaClusterAdapter.cpp
+++ b/src/topp/MaRaClusterAdapter.cpp
@@ -20,6 +20,7 @@
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 #include <iostream>
 #include <cmath>
@@ -298,7 +299,7 @@ protected:
     //-------------------------------------------------------------
 
     // create temp directory to store maracluster temporary files
-    File::TempDir tmp_dir(debug_level_ >= 2);
+    TempDir tmp_dir(debug_level_ >= 2);
 
     double pcut = getDoubleOption_("pcut");
 

--- a/src/topp/MascotAdapterOnline.cpp
+++ b/src/topp/MascotAdapterOnline.cpp
@@ -19,6 +19,7 @@
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 
 #include <OpenMS/APPLICATIONS/SearchEngineBase.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
@@ -138,7 +139,7 @@ protected:
 
   void parseMascotResponse_(const PeakMap& exp, bool decoy, MascotRemoteQuery* mascot_query, ProteinIdentification& prot_id, PeptideIdentificationList& pep_ids)
   {
-    std::string mascot_tmp_file_name = decoy ? (File::getTempDirectory() + "/" + File::getUniqueName() + "_Mascot_decoy_response") : (File::getTempDirectory() + "/" + File::getUniqueName() + "_Mascot_response");
+    std::string mascot_tmp_file_name = decoy ? (SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "_Mascot_decoy_response") : (SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + "_Mascot_response");
 
     {
       const std::string& data = decoy ? mascot_query->getMascotXMLDecoyResponse() : mascot_query->getMascotXMLResponse();

--- a/src/topp/MetaProSIP.cpp
+++ b/src/topp/MetaProSIP.cpp
@@ -34,6 +34,7 @@
 #include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 
 
 #include <boost/math/distributions/normal.hpp>
@@ -2983,7 +2984,7 @@ protected:
     Size n_heatmap_bins = getIntOption_("heatmap_bins");
     double score_plot_y_axis_min = getDoubleOption_("score_plot_yaxis_min");
 
-    std::string tmp_path = File::getTempDirectory();
+    std::string tmp_path = SystemSettings::getTempDirectory();
     StringUtils::substitute(tmp_path, '\\', '/');
 
     // Do we want to create a qc report?

--- a/src/topp/NovorAdapter.cpp
+++ b/src/topp/NovorAdapter.cpp
@@ -9,6 +9,7 @@
 #include <OpenMS/APPLICATIONS/TOPPExternalToolBase.h>
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
 
@@ -211,7 +212,7 @@ protected:
     //-------------------------------------------------------------
     
     // tmp_dir
-    File::TempDir tmp_dir(debug_level_ >= 2);
+    TempDir tmp_dir(debug_level_ >= 2);
 
     // parameter file
     std::string tmp_param = tmp_dir.getPath() + "param.txt";    

--- a/src/topp/OpenMSInfo.cpp
+++ b/src/topp/OpenMSInfo.cpp
@@ -13,6 +13,7 @@
 #include <OpenMS/FORMAT/IndentedStream.h>
 #include <OpenMS/SYSTEM/BuildInfo.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 #include <OpenMS/config.h>
 #include <OpenMS/openms_data_path.h>
 
@@ -124,8 +125,8 @@ protected:
        << green("<< Installation information >>\n")
        << "Data path    : " << File::getOpenMSDataPath()
        << " (via " << File::getOpenMSDataPathSource() << ")" << '\n'
-       << "Temp path    : " << File::getTempDirectory() << '\n'
-       << "Userdata path: " << File::getUserDirectory() << '\n'
+       << "Temp path    : " << SystemSettings::getTempDirectory() << '\n'
+       << "Userdata path: " << SystemSettings::getUserDirectory() << '\n'
        << '\n'
        << green("<< Build information >>\n") 
        << "Source path  : " << OPENMS_SOURCE_PATH << '\n'

--- a/src/topp/OpenSwathPeakMapExtractor.cpp
+++ b/src/topp/OpenSwathPeakMapExtractor.cpp
@@ -20,6 +20,8 @@
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 #include <algorithm>
 #include <cmath>
@@ -127,7 +129,7 @@ protected:
     registerFlag_("split_file_input", "The input files each contain one single SWATH window (alternatively: all SWATHs are in separate files)", true);
     registerStringOption_("readOptions", "<name>", "normal", "Whether to run directly on the input data, cache data to disk first, or load working sets into memory", false, true);
     setValidStrings_("readOptions", ListUtils::create<std::string>("normal,cache,cacheWorkingInMemory,workingInMemory"));
-    registerStringOption_("tempDirectory", "<tmp>", File::getTempDirectory(), "Temporary directory used for cached files", false, true);
+    registerStringOption_("tempDirectory", "<tmp>", SystemSettings::getTempDirectory(), "Temporary directory used for cached files", false, true);
     registerFlag_("keep_cached_files", "Do not remove cached files created in tempDirectory", false);
 
     registerStringOption_("extraction_function", "<name>", "tophat", "Function used to extract the signal", false, true);
@@ -631,11 +633,11 @@ protected:
       const StringList& current_run_files = run_groups[run_index];
       OPENMS_LOG_INFO << "Processing run " << (run_index + 1) << "/" << run_groups.size() << '\n';
 
-      std::unique_ptr<File::TempDir> per_run_temp_dir;
+      std::unique_ptr<TempDir> per_run_temp_dir;
       std::string per_run_tmp = tmp_dir;
       if (readoptions == "cache")
       {
-        per_run_temp_dir = std::make_unique<File::TempDir>(tmp_dir, keep_cached_files);
+        per_run_temp_dir = std::make_unique<TempDir>(tmp_dir, keep_cached_files);
         per_run_tmp = per_run_temp_dir->getPath();
       }
 

--- a/src/topp/OpenSwathWorkflow.cpp
+++ b/src/topp/OpenSwathWorkflow.cpp
@@ -29,6 +29,8 @@
 #include <filesystem>
 #include <system_error>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 // Kernel and implementations
 #include <OpenMS/KERNEL/MSExperiment.h>
@@ -332,7 +334,7 @@ protected:
     registerStringOption_("readOptions", "<name>", "normal", "Whether to run OpenSWATH directly on the input data, cache data to disk first or to perform a datareduction step first. If you choose cache, make sure to also set tempDirectory", false, true);
     setValidStrings_("readOptions", ListUtils::create<std::string>("normal,cache,cacheWorkingInMemory,workingInMemory"));
 
-    registerStringOption_("tempDirectory", "<tmp>", File::getTempDirectory(), "Temporary directory to store cached files for example", false, true);
+    registerStringOption_("tempDirectory", "<tmp>", SystemSettings::getTempDirectory(), "Temporary directory to store cached files for example", false, true);
     registerFlag_("keep_cached_files", "If set, do not remove cached files created in tempDirectory (disable automated cleanup)", false);
 
     registerStringOption_("extraction_function", "<name>", "tophat", "Function used to extract the signal", false, true);
@@ -771,10 +773,10 @@ protected:
                       << ": " << ListUtils::concatenate(current_run_files, ", ") << "\n";
 
       std::string per_run_tmp = tmp_dir;
-      std::unique_ptr<File::TempDir> per_run_temp_dir;
+      std::unique_ptr<TempDir> per_run_temp_dir;
       if (readoptions == "cache")
       {
-        per_run_temp_dir = std::make_unique<File::TempDir>(tmp_dir, keep_cached_files);
+        per_run_temp_dir = std::make_unique<TempDir>(tmp_dir, keep_cached_files);
         per_run_tmp = per_run_temp_dir->getPath();
       }
 
@@ -1282,7 +1284,7 @@ protected:
 
     std::string parquet_dir = out_features;
     bool parquet_zip_output = false;
-    std::unique_ptr<File::TempDir> parquet_temp_dir;
+    std::unique_ptr<TempDir> parquet_temp_dir;
     OpenSwathOSWParquetWriter parquet_writer;
     // Configure writer append behavior from CLI flag
     parquet_writer.setPreserveExisting(getFlag_("append_oswpq"));
@@ -1298,7 +1300,7 @@ protected:
         }
         else
         {
-          parquet_temp_dir = std::make_unique<File::TempDir>();
+          parquet_temp_dir = std::make_unique<TempDir>();
           parquet_dir = parquet_temp_dir->getPath() + "/oswpq_output";
           File::makeDir(parquet_dir);
         }
@@ -1325,12 +1327,12 @@ protected:
       
       ///////////////////////////////////
       // Per-run temporary cache directory (created only when using cache readOptions)
-      // Use File::TempDir for RAII-based cleanup: destructor removes dir (unless keep_cached_files is true)
+      // Use TempDir for RAII-based cleanup: destructor removes dir (unless keep_cached_files is true)
       std::string per_run_tmp = tmp_dir;
-      std::unique_ptr<File::TempDir> per_run_temp_dir;
+      std::unique_ptr<TempDir> per_run_temp_dir;
       if (readoptions == "cache")
       {
-        per_run_temp_dir = std::make_unique<File::TempDir>(tmp_dir, keep_cached_files);
+        per_run_temp_dir = std::make_unique<TempDir>(tmp_dir, keep_cached_files);
         per_run_tmp = per_run_temp_dir->getPath();
       }
 

--- a/src/topp/PeptideIndexer.cpp
+++ b/src/topp/PeptideIndexer.cpp
@@ -16,6 +16,7 @@
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 
 using namespace OpenMS;
 
@@ -141,7 +142,7 @@ protected:
       std::string full_db_name;
       try
       {
-        full_db_name = File::findDatabase(db_name);
+        full_db_name = SystemSettings::findDatabase(db_name);
       }
       catch (...)
       {

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -27,6 +27,7 @@
 #include <boost/regex.hpp>
 #include <OpenMS/FORMAT/OSWFile.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 
 #include <iostream>
@@ -854,7 +855,7 @@ protected:
     string enz_str = getStringOption_("enzyme");
     
     // create temp directory to store percolator in file pin.tab temporarily
-    File::TempDir tmp_dir(debug_level_ >= 2);
+    TempDir tmp_dir(debug_level_ >= 2);
     
     std::string txt_designator = File::getUniqueName();
     std::string pin_file;

--- a/src/topp/ProSE.cpp
+++ b/src/topp/ProSE.cpp
@@ -26,6 +26,7 @@
 #include <OpenMS/DATASTRUCTURES/DateTime.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 #include <OpenMS/SYSTEM/StopWatch.h>
 #include <OpenMS/METADATA/PeptideIdentificationList.h>
 #include <OpenMS/FORMAT/PercolatorInfile.h>
@@ -374,9 +375,9 @@ class ProSE :
           }
 
           // Write intermediate idXML for PercolatorAdapter input
-          std::string tmp_in = File::getTempDirectory() + "/" + File::stemName(in_list[i]) + "_perc_in.idXML";
-          std::string tmp_out = File::getTempDirectory() + "/" + File::stemName(in_list[i]) + "_perc_out.idXML";
-          std::string tmp_weights = File::getTempDirectory() + "/" + File::stemName(in_list[i]) + "_perc.weights";
+          std::string tmp_in = SystemSettings::getTempDirectory() + "/" + File::stemName(in_list[i]) + "_perc_in.idXML";
+          std::string tmp_out = SystemSettings::getTempDirectory() + "/" + File::stemName(in_list[i]) + "_perc_out.idXML";
+          std::string tmp_weights = SystemSettings::getTempDirectory() + "/" + File::stemName(in_list[i]) + "_perc.weights";
           FileHandler().storeIdentifications(tmp_in, result.protein_ids, result.peptide_ids, {FileTypes::IDXML});
 
           std::vector<std::string> perc_params = {

--- a/src/topp/SageAdapter.cpp
+++ b/src/topp/SageAdapter.cpp
@@ -28,6 +28,8 @@
 #include <OpenMS/PROCESSING/ID/IDFilter.h>
 
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 #include <fstream>
 #include <regex>
@@ -589,7 +591,7 @@ protected:
         MSExperiment exp_raw;
         FileHandler fh_raw;
         fh_raw.loadExperiment(f, exp_raw, {FileTypes::RAW}, log_type_);
-        auto tmp_mzml = File::getTemporaryFile() + ".mzML";
+        auto tmp_mzml = TempFiles::getTemporaryFile() + ".mzML";
         MzMLFile().store(tmp_mzml, exp_raw);
         sage_tmp_basename_to_original[File::basename(tmp_mzml)] = f;
         f = tmp_mzml;
@@ -609,7 +611,7 @@ protected:
 
     // store config in config_file
     OPENMS_LOG_INFO << "Creating temp file name..." << std::endl;
-    std::string config_file = File::getTempDirectory() + "/" + File::getUniqueName() + ".json";
+    std::string config_file = SystemSettings::getTempDirectory() + "/" + File::getUniqueName() + ".json";
     OPENMS_LOG_INFO << "Creating Sage config file..." << config_file << std::endl;
     ofstream config_stream(config_file.c_str());
     config_stream << config;

--- a/src/topp/SpectraSTSearchAdapter.cpp
+++ b/src/topp/SpectraSTSearchAdapter.cpp
@@ -11,6 +11,7 @@
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
 
 #include <filesystem>
 #include <sstream>
@@ -233,7 +234,7 @@ protected:
          }
      }
 
-     std::string temp_dir = File::getTempDirectory();
+     std::string temp_dir = SystemSettings::getTempDirectory();
      arguments.push_back("-sE" + outputFormat);
      arguments.push_back("-sO" + temp_dir);
 

--- a/src/topp/TransitionListEvidenceFilter.cpp
+++ b/src/topp/TransitionListEvidenceFilter.cpp
@@ -17,6 +17,8 @@
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/SystemSettings.h>
+#include <OpenMS/SYSTEM/TempFiles.h>
 
 #include <algorithm>
 #include <cmath>
@@ -116,7 +118,7 @@ protected:
                           "Whether to run directly on input data or cache data to disk first. If 'cache', set tempDirectory as needed.",
                           false, true);
     setValidStrings_("readOptions", {"normal", "cache"});
-    registerStringOption_("tempDirectory", "<tmp>", File::getTempDirectory(), "Temporary directory for cached data.", false, true);
+    registerStringOption_("tempDirectory", "<tmp>", SystemSettings::getTempDirectory(), "Temporary directory for cached data.", false, true);
     registerFlag_("keep_cached_files", "If set, do not remove cached files created in tempDirectory.", false);
     registerIntOption_("outer_loop_threads", "<number>", -1,
                        "How many threads the evidence filter should use (-1 uses the OpenMP maximum).",
@@ -262,10 +264,10 @@ protected:
                       << ": " << ListUtils::concatenate(run_files, ", ") << "\n";
 
       std::string per_run_tmp = tmp_dir;
-      std::unique_ptr<File::TempDir> per_run_temp_dir;
+      std::unique_ptr<TempDir> per_run_temp_dir;
       if (readoptions == "cache")
       {
-        per_run_temp_dir = std::make_unique<File::TempDir>(tmp_dir, keep_cached_files);
+        per_run_temp_dir = std::make_unique<TempDir>(tmp_dir, keep_cached_files);
         per_run_tmp = per_run_temp_dir->getPath();
       }
 


### PR DESCRIPTION
## Description

Implements step 6 of #10083. Follows #10098 (step 5), which is merged; this branch is rebased onto `develop`.

Step 5 split File's implementation across three source files while keeping every member on File. This step finishes the separation by giving the moved members their own classes, so File.h no longer carries the settings-dependent API and the split source files stop existing:

- `SystemSettings` (OpenMS/SYSTEM/SystemSettings.h) holds getOpenMSHomePath(), getOpenMSConfigDir(), getTempDirectory(), getUserDirectory(), getSystemParameters() and findDatabase(). It depends on File and Param; File does not depend on it.
- `TempDir` becomes a top-level class and `TempFiles::getTemporaryFile()` replaces File::getTemporaryFile(), both in OpenMS/SYSTEM/TempFiles.h. The private registry moves with them.
- BREAKING: the former File entry points and the nested File::TempDir are removed rather than kept as deprecated forwarders (second commit). File.h no longer forward-declares Param or includes TempFiles.h. FileConfig.cpp and FileTemp.cpp are gone.
- All in-tree callers are migrated (83 files: library, TOPP tools, GUI, tests, doc examples).
- The moved File_test sections become SystemSettings_test and TempFiles_test. TempFiles_test also checks that names land below the configured temp directory and that getTemporaryFile() does not create the file.
- pyOpenMS binds SystemSettings, TempDir and TempFiles. The Python-level File static methods (getTempDirectory, getUserDirectory, getSystemParameters, findDatabase, getOpenMSHomePath, getTemporaryFile) keep working and now call the new classes directly, with tests for both.

Method bodies are unchanged apart from a range-for in the registry destructor.

Validation: the OpenMS library, the 39 affected class tests and the 20 touched TOPP tools were built locally with GCC on Ubuntu 24.04 (system Boost 1.83, Xerces-C 3.2, Arrow 23), and all 39 tests pass, including the new SystemSettings_test and TempFiles_test. bind_misc.cpp and the two doc tutorials were syntax-checked against the library's compile flags. GUI sources and TOPPDocumenter.cpp need Qt and are left to CI. `git diff --check` passes. The first commit passed the full CI matrix on the identical diff before the rebase; the forwarder removal is verified locally by the same build and left to CI for the other platforms.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKpQTR4f8sxMUJer1j5YD2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated utilities for system settings, temporary files, and temporary directories.
  * Exposed the new utilities through pyOpenMS, including optional temporary-file naming.
* **Breaking Changes**
  * Removed legacy system-settings and temporary-file methods from the File API, including the nested temporary-directory type.
  * Updated ZIP and related interfaces to use the standalone temporary-directory type.
* **Documentation**
  * Updated tutorials, API documentation, and the changelog to reflect the new APIs and migration requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->