### PR TITLE
[ARCHITECTURE] Extract ion-mobility array metadata interpretation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1514,6 +1514,8 @@ Build System:
     FeatureMap instantiation coverage now lives in the class test (#10083, step 2).
   - Narrowed selected public headers and moved ToolInfo to DATASTRUCTURES/ToolInfo.h (#10083, step 3).
     Consumers relying on incidental transitive includes must include the used types directly.
+  - Separated ion-mobility array metadata from frame conversion, with IMDataConverter compatibility
+    entry points and unchanged CV lookup, unit handling, and vendor-name fallbacks (#10083, step 6).
   - pyOpenMS wheel workflow: Thermo RAW support is built into the Linux x86_64, macOS arm64 and Windows
     wheels. The managed half of openms-thermo-bridge comes from the bridge's pre-built release zip via
     tools/ci/fetch_thermo_assets.sh (curl with retries, pinned SHA-256, cached with actions/cache,

--- a/src/openms/include/OpenMS/IONMOBILITY/IMDataArrayUtils.h
+++ b/src/openms/include/OpenMS/IONMOBILITY/IMDataArrayUtils.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Eugen Netz, Chris Bielow, Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/IONMOBILITY/IMTypes.h>
+#include <OpenMS/METADATA/DataArrays.h>
+
+namespace OpenMS
+{
+  /**
+    @brief Interpret ion-mobility array metadata independently of frame conversion.
+
+    Uses the existing PSI-MS vocabulary and vendor-name fallbacks. The shared CV
+    files remain a runtime requirement. IMDataConverter retains compatibility
+    entry points for both operations.
+  */
+  class OPENMS_DLLAPI IMDataArrayUtils
+  {
+  public:
+    /**
+      @brief Set the array name corresponding to a supported ion-mobility unit.
+      @param[in,out] fda Array whose name is updated.
+      @param[in] unit MILLISECOND or VSSC.
+      @throws Exception::InvalidValue for other units.
+    */
+    static void setIMUnit(DataArrays::FloatDataArray& fda, const DriftTimeUnit unit);
+
+    /**
+      @brief Recognize an ion-mobility array and determine its unit.
+      @param[in] fda Array whose name is interpreted.
+      @param[out] unit Recognized unit, or NONE for a CV term without usable units.
+      Unchanged if the array is not recognized as ion-mobility data.
+      @return True if the array describes ion-mobility data.
+    */
+    static bool getIMUnit(const DataArrays::FloatDataArray& fda, DriftTimeUnit& unit);
+  };
+}

--- a/src/openms/include/OpenMS/IONMOBILITY/sources.cmake
+++ b/src/openms/include/OpenMS/IONMOBILITY/sources.cmake
@@ -5,6 +5,7 @@ set(directory include/OpenMS/IONMOBILITY)
 set(sources_list_h
 IMTypes.h
 IMDataConverter.h
+IMDataArrayUtils.h
 FAIMSHelper.h
 )
 

--- a/src/openms/source/IONMOBILITY/IMDataArrayUtils.cpp
+++ b/src/openms/source/IONMOBILITY/IMDataArrayUtils.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Eugen Netz $
+// $Authors: Eugen Netz, Chris Bielow $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/IONMOBILITY/IMDataArrayUtils.h>
+#include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/DATASTRUCTURES/StringUtils.h>
+#include <OpenMS/FORMAT/ControlledVocabulary.h>
+#include <ostream>
+
+namespace OpenMS
+{
+  void IMDataArrayUtils::setIMUnit(DataArrays::FloatDataArray& fda, const DriftTimeUnit unit)
+  {
+    const auto& cv = ControlledVocabulary::getPSIMSCV();
+    switch (unit)
+    {
+      case DriftTimeUnit::MILLISECOND: 
+        fda.setName(cv.getTerm("MS:1002816").name); // MS:1002816 ! mean ion mobility array
+        return;
+      case DriftTimeUnit::VSSC:
+        fda.setName(cv.getTerm("MS:1003008").name); // MS:1003008 ! raw inverse reduced ion mobility array
+        return;
+      default:
+        // invalid enum ...
+        // There is no CV term which can be used to describe the FDA
+        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Unit is not a valid IM unit for float data arrays", driftTimeUnitToString(unit));
+    }
+  }
+
+  bool IMDataArrayUtils::getIMUnit(const DataArrays::FloatDataArray& fda, DriftTimeUnit& unit)
+  {
+    const auto& cv = ControlledVocabulary::getPSIMSCV();
+
+    // Prefer PSI-MS ontology lookup so official names (e.g. MS:1003006
+    // "mean inverse reduced ion mobility array") get the CV unit (1/K0 = VSSC),
+    // not the UserParam fallback that defaulted them to milliseconds.
+    // Unknown names yield nullptr, so non-CV arrays cost no exception here —
+    // this runs for every float array of every spectrum/pixel.
+    const ControlledVocabulary::CVTerm* cv_term = cv.checkAndGetTermByName(fda.getName());
+    if (cv_term != nullptr && cv.isChildOf(cv_term->id, "MS:1002893")) // child of generic 'ion mobility array'?
+    {
+      if (cv_term->units.contains("MS:1002814"))
+      { // MS:1002814 ! volt-second per square centimeter
+        unit = DriftTimeUnit::VSSC;
+      }
+      else if (cv_term->units.contains("UO:0000028"))
+      { // UO:0000028 ! millisecond
+        unit = DriftTimeUnit::MILLISECOND;
+      }
+      else if (cv_term->units.contains("UO:0000324"))
+      { // UO:0000324 ! square angstrom (CCS)
+        unit = DriftTimeUnit::CCS;
+      }
+      else
+      { // fallback
+        OPENMS_LOG_WARN << "Warning: FloatDataArray for IonMobility data '" << cv_term->id << " " << cv_term->name << "' does not contain proper units!" << std::endl;
+        unit = DriftTimeUnit::NONE;
+      }
+      return true;
+    }
+
+    // Fallbacks for non-standard / vendor UserParam names
+    // (Mobi-DIK "Ion Mobility", MSConvert "inverse reduced ion mobility", …).
+    if (StringUtils::hasPrefix(fda.getName(), Constants::UserParam::MEAN_INVERSE_REDUCED_ION_MOBILITY_ARRAY) ||
+        StringUtils::hasPrefix(fda.getName(), Constants::UserParam::INVERSE_REDUCED_ION_MOBILITY))
+    {
+      // These names denote 1/K0 (Vs/cm^2), not drift time in ms.
+      unit = DriftTimeUnit::VSSC;
+      return true;
+    }
+    if (StringUtils::hasPrefix(fda.getName(), Constants::UserParam::ION_MOBILITY))
+    {
+      if (StringUtils::hasSubstring(fda.getName(), "MS:1002815") || StringUtils::hasSubstring(fda.getName(), "MS:1003006"))
+      {
+        unit = DriftTimeUnit::VSSC;
+      }
+      else if (StringUtils::hasSubstring(fda.getName(), "MS:1002954"))
+      {
+        unit = DriftTimeUnit::CCS;
+      }
+      else
+      {
+        unit = DriftTimeUnit::MILLISECOND;
+      }
+      return true;
+    }
+    return false;
+  }
+
+} // namespace OpenMS

--- a/src/openms/source/IONMOBILITY/IMDataArrayUtils.cpp
+++ b/src/openms/source/IONMOBILITY/IMDataArrayUtils.cpp
@@ -21,7 +21,7 @@ namespace OpenMS
     const auto& cv = ControlledVocabulary::getPSIMSCV();
     switch (unit)
     {
-      case DriftTimeUnit::MILLISECOND: 
+      case DriftTimeUnit::MILLISECOND:
         fda.setName(cv.getTerm("MS:1002816").name); // MS:1002816 ! mean ion mobility array
         return;
       case DriftTimeUnit::VSSC:

--- a/src/openms/source/IONMOBILITY/IMDataConverter.cpp
+++ b/src/openms/source/IONMOBILITY/IMDataConverter.cpp
@@ -13,7 +13,7 @@
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/IONMOBILITY/FAIMSHelper.h>
-#include <OpenMS/FORMAT/ControlledVocabulary.h>
+#include <OpenMS/IONMOBILITY/IMDataArrayUtils.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 
 
@@ -323,80 +323,12 @@ namespace OpenMS
 
   void IMDataConverter::setIMUnit(DataArrays::FloatDataArray& fda, const DriftTimeUnit unit)
   {
-    const auto& cv = ControlledVocabulary::getPSIMSCV();
-    switch (unit)
-    {
-      case DriftTimeUnit::MILLISECOND: 
-        fda.setName(cv.getTerm("MS:1002816").name); // MS:1002816 ! mean ion mobility array
-        return;
-      case DriftTimeUnit::VSSC:
-        fda.setName(cv.getTerm("MS:1003008").name); // MS:1003008 ! raw inverse reduced ion mobility array
-        return;
-      default:
-        // invalid enum ...
-        // There is no CV term which can be used to describe the FDA
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Unit is not a valid IM unit for float data arrays", driftTimeUnitToString(unit));
-    }
+    IMDataArrayUtils::setIMUnit(fda, unit);
   }
 
   bool IMDataConverter::getIMUnit(const DataArrays::FloatDataArray& fda, DriftTimeUnit& unit)
   {
-    const auto& cv = ControlledVocabulary::getPSIMSCV();
-
-    // Prefer PSI-MS ontology lookup so official names (e.g. MS:1003006
-    // "mean inverse reduced ion mobility array") get the CV unit (1/K0 = VSSC),
-    // not the UserParam fallback that defaulted them to milliseconds.
-    // Unknown names yield nullptr, so non-CV arrays cost no exception here —
-    // this runs for every float array of every spectrum/pixel.
-    const ControlledVocabulary::CVTerm* cv_term = cv.checkAndGetTermByName(fda.getName());
-    if (cv_term != nullptr && cv.isChildOf(cv_term->id, "MS:1002893")) // child of generic 'ion mobility array'?
-    {
-      if (cv_term->units.contains("MS:1002814"))
-      { // MS:1002814 ! volt-second per square centimeter
-        unit = DriftTimeUnit::VSSC;
-      }
-      else if (cv_term->units.contains("UO:0000028"))
-      { // UO:0000028 ! millisecond
-        unit = DriftTimeUnit::MILLISECOND;
-      }
-      else if (cv_term->units.contains("UO:0000324"))
-      { // UO:0000324 ! square angstrom (CCS)
-        unit = DriftTimeUnit::CCS;
-      }
-      else
-      { // fallback
-        OPENMS_LOG_WARN << "Warning: FloatDataArray for IonMobility data '" << cv_term->id << " " << cv_term->name << "' does not contain proper units!" << std::endl;
-        unit = DriftTimeUnit::NONE;
-      }
-      return true;
-    }
-
-    // Fallbacks for non-standard / vendor UserParam names
-    // (Mobi-DIK "Ion Mobility", MSConvert "inverse reduced ion mobility", …).
-    if (StringUtils::hasPrefix(fda.getName(), Constants::UserParam::MEAN_INVERSE_REDUCED_ION_MOBILITY_ARRAY) ||
-        StringUtils::hasPrefix(fda.getName(), Constants::UserParam::INVERSE_REDUCED_ION_MOBILITY))
-    {
-      // These names denote 1/K0 (Vs/cm^2), not drift time in ms.
-      unit = DriftTimeUnit::VSSC;
-      return true;
-    }
-    if (StringUtils::hasPrefix(fda.getName(), Constants::UserParam::ION_MOBILITY))
-    {
-      if (StringUtils::hasSubstring(fda.getName(), "MS:1002815") || StringUtils::hasSubstring(fda.getName(), "MS:1003006"))
-      {
-        unit = DriftTimeUnit::VSSC;
-      }
-      else if (StringUtils::hasSubstring(fda.getName(), "MS:1002954"))
-      {
-        unit = DriftTimeUnit::CCS;
-      }
-      else
-      {
-        unit = DriftTimeUnit::MILLISECOND;
-      }
-      return true;
-    }
-    return false;
+    return IMDataArrayUtils::getIMUnit(fda, unit);
   }
 
 }  //end namespace OpenMS

--- a/src/openms/source/IONMOBILITY/IMDataConverter.cpp
+++ b/src/openms/source/IONMOBILITY/IMDataConverter.cpp
@@ -14,6 +14,7 @@
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/IONMOBILITY/FAIMSHelper.h>
 #include <OpenMS/IONMOBILITY/IMDataArrayUtils.h>
+#include <OpenMS/FORMAT/ControlledVocabulary.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 
 

--- a/src/openms/source/IONMOBILITY/IMTypes.cpp
+++ b/src/openms/source/IONMOBILITY/IMTypes.cpp
@@ -9,8 +9,10 @@
 #include <OpenMS/IONMOBILITY/IMTypes.h>
 
 #include <OpenMS/CONCEPT/Exception.h>
-#include <OpenMS/CONCEPT/LogStream.h>
-#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/DATASTRUCTURES/StringUtils.h>
+
+#include <algorithm>
+#include <iterator>
 
 #include <cmath>
 #include <cstdlib>
@@ -83,70 +85,6 @@ namespace OpenMS
       throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Invalid IMPeakType index", std::to_string((int)im_peak_type));
     }
     return NamesOfIMPeakType[(int)im_peak_type];
-  }
-
-  IMFormat IMTypes::determineIMFormat(const MSExperiment& exp, int ms_level)
-  {
-    std::set<IMFormat> occs;
-    for (const auto& spec : exp.getSpectra())
-    {
-      if (spec.getMSLevel() != ms_level) continue;
-      occs.insert(determineIMFormat(spec));
-    }
-    occs.erase(IMFormat::NONE);
-
-    if (occs.empty())
-    {
-      return IMFormat::NONE;
-    }
-
-    if (occs.size() == 1)
-    {
-      auto format = *occs.begin();
-      if (format != IMFormat::IM_PEAK && format != IMFormat::IM_SPECTRUM)
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "subfunction returned invalid value(s)", "Number of different values: " + StringUtils::toStr(occs.size()));
-      }
-      return format;
-    }
-    else
-    {
-      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-        "MSExperiment contains MS" + StringUtils::toStr(ms_level) + " spectra with different IM formats. "
-        "Handle per-spectrum.", "Number of different formats: " + StringUtils::toStr(occs.size()));
-    }
-  }
-
-  IMFormat IMTypes::determineIMFormat(const MSSpectrum& spec)
-  {
-    // First check if format is already set and not UNKNOWN
-    IMFormat current_format = spec.getIMFormat();
-    if (current_format != IMFormat::UNKNOWN)
-    {
-      return current_format;
-    }
-    
-    // If format is UNKNOWN, determine it
-    bool has_float_data = spec.containsIMData(); // cache value; query is 'expensive'
-    bool has_drift_time = spec.getDriftTime() != DRIFTTIME_NOT_SET;
-
-    if (has_float_data)
-    {
-      if (has_drift_time)
-      {
-        OPENMS_LOG_DEBUG << "both drift time and IM data array found in spectrum " << spec.getNativeID() << "\n. Support for both is experimental." << std::endl;
-      }
-      return IMFormat::IM_PEAK;
-    }
-    else if (has_drift_time)
-    {
-      if (spec.getDriftTimeUnit() == DriftTimeUnit::NONE)
-      {
-        OPENMS_LOG_WARN << "Warning: no drift time unit set for spectrum " << spec.getNativeID() << "\n";
-      }
-      return IMFormat::IM_SPECTRUM;
-    }
-    return IMFormat::NONE;
   }
 
   DIM_UNIT IMTypes::fromIMUnit(const DriftTimeUnit from)

--- a/src/openms/source/IONMOBILITY/IMTypesExperiment.cpp
+++ b/src/openms/source/IONMOBILITY/IMTypesExperiment.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Chris Bielow $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/IONMOBILITY/IMTypes.h>
+#include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/DATASTRUCTURES/StringUtils.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <set>
+
+namespace OpenMS
+{
+  IMFormat IMTypes::determineIMFormat(const MSExperiment& exp, int ms_level)
+  {
+    std::set<IMFormat> occs;
+    for (const auto& spec : exp.getSpectra())
+    {
+      if (spec.getMSLevel() != ms_level) continue;
+      occs.insert(determineIMFormat(spec));
+    }
+    occs.erase(IMFormat::NONE);
+
+    if (occs.empty())
+    {
+      return IMFormat::NONE;
+    }
+
+    if (occs.size() == 1)
+    {
+      auto format = *occs.begin();
+      if (format != IMFormat::IM_PEAK && format != IMFormat::IM_SPECTRUM)
+      {
+        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "subfunction returned invalid value(s)", "Number of different values: " + StringUtils::toStr(occs.size()));
+      }
+      return format;
+    }
+    else
+    {
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "MSExperiment contains MS" + StringUtils::toStr(ms_level) + " spectra with different IM formats. "
+        "Handle per-spectrum.", "Number of different formats: " + StringUtils::toStr(occs.size()));
+    }
+  }
+
+  IMFormat IMTypes::determineIMFormat(const MSSpectrum& spec)
+  {
+    // First check if format is already set and not UNKNOWN
+    IMFormat current_format = spec.getIMFormat();
+    if (current_format != IMFormat::UNKNOWN)
+    {
+      return current_format;
+    }
+    
+    // If format is UNKNOWN, determine it
+    bool has_float_data = spec.containsIMData(); // cache value; query is 'expensive'
+    bool has_drift_time = spec.getDriftTime() != DRIFTTIME_NOT_SET;
+
+    if (has_float_data)
+    {
+      if (has_drift_time)
+      {
+        OPENMS_LOG_DEBUG << "both drift time and IM data array found in spectrum " << spec.getNativeID() << "\n. Support for both is experimental." << std::endl;
+      }
+      return IMFormat::IM_PEAK;
+    }
+    else if (has_drift_time)
+    {
+      if (spec.getDriftTimeUnit() == DriftTimeUnit::NONE)
+      {
+        OPENMS_LOG_WARN << "Warning: no drift time unit set for spectrum " << spec.getNativeID() << "\n";
+      }
+      return IMFormat::IM_SPECTRUM;
+    }
+    return IMFormat::NONE;
+  }
+
+} // namespace OpenMS

--- a/src/openms/source/IONMOBILITY/IMTypesExperiment.cpp
+++ b/src/openms/source/IONMOBILITY/IMTypesExperiment.cpp
@@ -57,7 +57,7 @@ namespace OpenMS
     {
       return current_format;
     }
-    
+
     // If format is UNKNOWN, determine it
     bool has_float_data = spec.containsIMData(); // cache value; query is 'expensive'
     bool has_drift_time = spec.getDriftTime() != DRIFTTIME_NOT_SET;

--- a/src/openms/source/IONMOBILITY/sources.cmake
+++ b/src/openms/source/IONMOBILITY/sources.cmake
@@ -4,7 +4,9 @@ set(directory source/IONMOBILITY)
 ### list all filenames of the directory here
 set(sources_list
 IMTypes.cpp
+IMTypesExperiment.cpp
 IMDataConverter.cpp
+IMDataArrayUtils.cpp
 FAIMSHelper.cpp
 )
 

--- a/src/openms/source/KERNEL/MSSpectrum.cpp
+++ b/src/openms/source/KERNEL/MSSpectrum.cpp
@@ -13,7 +13,7 @@
 #include <OpenMS/KERNEL/MSSpectrum.h>
 
 #include <OpenMS/FORMAT/PeakTypeEstimator.h>
-#include <OpenMS/IONMOBILITY/IMDataConverter.h>
+#include <OpenMS/IONMOBILITY/IMDataArrayUtils.h>
 
 namespace OpenMS
 {
@@ -809,7 +809,7 @@ namespace OpenMS
   {
     for (index = 0; index < fdas.size(); ++index)
     {
-      if (IMDataConverter::getIMUnit(fdas[index], unit))
+      if (IMDataArrayUtils::getIMUnit(fdas[index], unit))
       {
         return true;
       }

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -715,6 +715,7 @@ endif(NOT DISABLE_OPENSWATH)
 set(ionmobility_executables_list
   FAIMSHelper_test
   IMDataConverter_test
+  IMDataArrayUtils_test
   IMTypes_test
 )
 

--- a/src/tests/class_tests/openms/source/IMDataArrayUtils_test.cpp
+++ b/src/tests/class_tests/openms/source/IMDataArrayUtils_test.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/IONMOBILITY/IMDataArrayUtils.h>
+#include <OpenMS/IONMOBILITY/IMDataConverter.h>
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/CONCEPT/Exception.h>
+
+using namespace OpenMS;
+
+START_TEST(IMDataArrayUtils, "$Id$")
+
+START_SECTION((unit round trips and compatibility entry points))
+  for (const auto expected : {DriftTimeUnit::MILLISECOND, DriftTimeUnit::VSSC})
+  {
+    DataArrays::FloatDataArray direct, legacy;
+    direct.push_back(1.25f);
+    IMDataArrayUtils::setIMUnit(direct, expected);
+    IMDataConverter::setIMUnit(legacy, expected);
+    TEST_EQUAL(direct.getName(), legacy.getName())
+    TEST_REAL_SIMILAR(direct[0], 1.25f)
+    DriftTimeUnit actual = DriftTimeUnit::NONE;
+    TEST_TRUE(IMDataArrayUtils::getIMUnit(direct, actual))
+    TEST_TRUE(actual == expected)
+    actual = DriftTimeUnit::NONE;
+    TEST_TRUE(IMDataConverter::getIMUnit(direct, actual))
+    TEST_TRUE(actual == expected)
+  }
+  DataArrays::FloatDataArray array;
+  TEST_EXCEPTION(Exception::InvalidValue, IMDataArrayUtils::setIMUnit(array, DriftTimeUnit::NONE))
+  TEST_EXCEPTION(Exception::InvalidValue, IMDataArrayUtils::setIMUnit(array, DriftTimeUnit::FAIMS_COMPENSATION_VOLTAGE))
+  TEST_EXCEPTION(Exception::InvalidValue, IMDataArrayUtils::setIMUnit(array, DriftTimeUnit::CCS))
+END_SECTION
+
+START_SECTION((ontology and vendor names retain their units))
+  DataArrays::FloatDataArray array;
+  DriftTimeUnit unit = DriftTimeUnit::NONE;
+  array.setName("mean inverse reduced ion mobility array");
+  TEST_TRUE(IMDataArrayUtils::getIMUnit(array, unit))
+  TEST_TRUE(unit == DriftTimeUnit::VSSC)
+  array.setName(Constants::UserParam::ION_MOBILITY);
+  TEST_TRUE(IMDataArrayUtils::getIMUnit(array, unit))
+  TEST_TRUE(unit == DriftTimeUnit::MILLISECOND)
+  array.setName(Constants::UserParam::INVERSE_REDUCED_ION_MOBILITY);
+  TEST_TRUE(IMDataArrayUtils::getIMUnit(array, unit))
+  TEST_TRUE(unit == DriftTimeUnit::VSSC)
+  array.setName(std::string(Constants::UserParam::ION_MOBILITY) + " MS:1002954");
+  TEST_TRUE(IMDataArrayUtils::getIMUnit(array, unit))
+  TEST_TRUE(unit == DriftTimeUnit::CCS)
+  array.setName("unrelated auxiliary data");
+  TEST_FALSE(IMDataArrayUtils::getIMUnit(array, unit))
+  TEST_TRUE(unit == DriftTimeUnit::CCS)
+END_SECTION
+
+END_TEST


### PR DESCRIPTION
## Description

Part 6 of #10083. Supersedes #10090: the same three implementation commits rebased onto current `develop` on an OpenMS-hosted branch. The CHANGELOG entry was the only conflict, and the commit that removed the `tools/ci/core_dependencies` baseline files was dropped because `develop` already deleted them.

MSSpectrum currently includes the full IMDataConverter to interpret auxiliary-array names. Extract that interpretation into IMDataArrayUtils and keep the existing converter entry points as forwarding wrappers. Move the two experiment-format predicates out of IMTypes.cpp so numerical unit conversions no longer include MSExperiment.

The moved implementations preserve PSI-MS vocabulary lookup, unit recognition, vendor fallbacks, warnings and exceptions. The vocabulary service remains an explicit dependency; this does not make IM interpretation independent of runtime data.

Register the installed header, implementation files and focused regression tests. In the #10083 baseline, the MSSpectrum.cpp -> IMDataConverter.h edge is replaced by IMDataArrayUtils.cpp -> ControlledVocabulary.h, the retained vocabulary-service dependency.

Validation: moved method bodies match the originals apart from their class qualifiers. New C++ class tests cover unit round trips, compatibility entry points, ontology/vendor names, invalid units and unchanged output on unknown names. Locally, the OpenMS library plus IMDataArrayUtils_test, IMTypes_test, IMDataConverter_test and MSSpectrum_test were built with GCC on Ubuntu 24.04 (system Boost 1.83, Xerces-C 3.2, Arrow 23) and all four pass. The one compiler warning in the moved code, a signed/unsigned comparison of the MS level in determineIMFormat, is inherited verbatim from IMTypes.cpp on `develop`. `git diff --check` passes. Platform builds are left to CI.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKpQTR4f8sxMUJer1j5YD2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKpQTR4f8sxMUJer1j5YD2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added shared ion-mobility utilities for assigning and detecting supported units.
  - Improved ion-mobility format detection across experiments and spectra, including clearer handling of mixed or missing formats.
  - Preserved compatibility with existing ion-mobility conversion entry points.
  - Continued support for ontology-based unit recognition and vendor-specific naming fallbacks.

- **Bug Fixes**
  - Improved consistency when reading ion-mobility array units and identifying their formats.

- **Tests**
  - Added coverage for unit conversion, format detection, compatibility behavior, and unsupported or unrecognized values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->