### PR TITLE
docs(CHANGELOG): add missing PR references for recent merges

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,7 +30,7 @@ General:
   - Keep CURL and OpenSwathAlgo's Boost headers private in CMake usage requirements, and stop
     requiring CURL/Xerces development packages for shared-library consumers. CI now installs
     OpenMS and builds/runs the external consumer with discovery of those packages disabled
-    (CTest test `TestExternalCode_installed`, enabled by `OPENMS_TEST_INSTALLED_CONSUMER`).
+    (CTest test `TestExternalCode_installed`, enabled by `OPENMS_TEST_INSTALLED_CONSUMER`) (#10103)
   - Fix: XML metadata decoding now preserves UTF-8, including Latin-1 characters that previously
     entered the ASCII fast path. mzML sample comments and attribute whitespace survive round trips (#10077)
   - Thermo RAW imports preserve sample/method/trailer metadata, SHA-1 provenance, per-scan instrument
@@ -283,6 +283,11 @@ PyOpenMS:
     temporary directories/files; the Python-level File.getSystemParameters(), File.getTempDirectory(),
     File.getUserDirectory(), File.findDatabase(), File.getOpenMSHomePath() and File.getTemporaryFile()
     keep working and now call the new classes (#10083, step 6)
+  - BREAKING: removed the pure-Python pyopenms.String Cython-era shim class, which only survived to
+    emulate String& output parameters. MzMLFile.storeBuffer(), MSNumpressCoder.encodeNP() and
+    MSNumpressCoder.encodeNPRaw() now return their result (str/str/bytes) directly instead of writing
+    it into a pyopenms.String output argument; every other API already accepted/returned plain str
+    for OpenMS::String (#10109)
 
 TOPP tools:
   Changes:


### PR DESCRIPTION
## Description

Routine changelog maintenance: checked recently merged PRs against the `CHANGELOG` entries they added.

- **#10103** ("Test installed CMake consumers and narrow dependency exports") added a `General:` entry about keeping CURL/OpenSwathAlgo's Boost headers private and the new `TestExternalCode_installed` CTest, but the entry had no PR reference at all. Added `(#10103)`.
- **#10109** ("Remove OpenMS::String wrapper and simplify string handling in pyOpenMS") is a BREAKING pyOpenMS API change with no CHANGELOG entry: the pure-Python `pyopenms.String` Cython-era shim was removed, and `MzMLFile.storeBuffer()` / `MSNumpressCoder.encodeNP()` / `MSNumpressCoder.encodeNPRaw()` now return their result directly instead of writing into a `String` output argument. Added a new `PyOpenMS:` entry citing `(#10109)`.

The other recently merged PRs in this window (#10100, #10107, and the earlier #10092/#10099/#10101/#10077/#10070) already carry correct CHANGELOG entries citing either their own PR number or the `#10083` step-tracking convention used for that multi-step refactor, so no changes were needed there.

## Checklist
- [x] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A, docs-only change)
- [ ] New and existing unit tests pass locally with my changes (N/A, docs-only change)
- [ ] Updated or added python bindings for changed or new classes (N/A, docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFgizZqhnZCKHFyA1XjLjW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFgizZqhnZCKHFyA1XjLjW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the OpenMS 3.6.0 changelog with a reference for the private Boost header usage requirement.
  * Documented the removal of the `pyopenms.String` compatibility class.
  * Clarified that affected PyOpenMS methods now return results directly instead of using an output argument.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->