### PR TITLE
Fix string column truncation in DataFrame exports (#8583)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -286,6 +286,14 @@ PyOpenMS:
     temporary directories/files; the Python-level File.getSystemParameters(), File.getTempDirectory(),
     File.getUserDirectory(), File.findDatabase(), File.getOpenMSHomePath() and File.getTemporaryFile()
     keep working and now call the new classes (#10083, step 6)
+  - DataFrame exports no longer build string columns from fixed-width numpy unicode fields
+    ('U50' .. 'U1000') but from object-dtype fields. This removes the silent truncation of long
+    values (e.g. protein accession lists over 1000 characters or native IDs over 100 characters)
+    and the up to 4 KB per row that each such field preallocated regardless of content. Affects
+    PeptideIdentificationList.to_df(), ConsensusMap.get_intensity_df()/get_metadata_df(),
+    MRMTransitionGroupCP.to_feature_df() and the MSSpectrum, MSChromatogram and Mobilogram
+    exports. The pandas column dtypes are unchanged; missing string values are now null instead
+    of the strings 'None'/'nan' (#8583)
 
 TOPP tools:
   Changes:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -293,10 +293,14 @@ PyOpenMS:
     PeptideIdentificationList.to_df(), ConsensusMap.get_intensity_df()/get_metadata_df(),
     MRMTransitionGroupCP.to_feature_df() and the MSSpectrum, MSChromatogram and Mobilogram
     exports. The pandas column dtypes are unchanged (empty exports keep a string-typed column).
-    Two missing-value cases change: a consensus feature without peptide identification now gets a
-    null sequence in ConsensusMap.get_metadata_df() instead of the string 'None', and a missing
-    string meta value in MRMTransitionGroupCP.to_feature_df() is null instead of the string 'nan'.
-    FeatureMap.to_df() keeps its explicit 'None'/'unknown' sentinels (#8583)
+    Missing string values are now null throughout instead of placeholder strings: the sequence
+    of a consensus feature without peptide identification in ConsensusMap.get_metadata_df()
+    (was 'None'), a missing string meta value in MRMTransitionGroupCP.to_feature_df() (was 'nan'),
+    and ID_native_id / ID_filename in FeatureMap.to_df() (were 'None' / 'unknown').
+    MRMTransitionGroupCP.to_feature_df() also matches its known meta value names whether given
+    as str or bytes (FWHM etc. were exported as strings when discovered via meta_values='all'),
+    and an integer meta value missing on some feature now yields a float column with NaN instead
+    of raising (#8583)
 
 TOPP tools:
   Changes:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -292,8 +292,11 @@ PyOpenMS:
     and the up to 4 KB per row that each such field preallocated regardless of content. Affects
     PeptideIdentificationList.to_df(), ConsensusMap.get_intensity_df()/get_metadata_df(),
     MRMTransitionGroupCP.to_feature_df() and the MSSpectrum, MSChromatogram and Mobilogram
-    exports. The pandas column dtypes are unchanged; missing string values are now null instead
-    of the strings 'None'/'nan' (#8583)
+    exports. The pandas column dtypes are unchanged (empty exports keep a string-typed column).
+    Two missing-value cases change: a consensus feature without peptide identification now gets a
+    null sequence in ConsensusMap.get_metadata_df() instead of the string 'None', and a missing
+    string meta value in MRMTransitionGroupCP.to_feature_df() is null instead of the string 'nan'.
+    FeatureMap.to_df() keeps its explicit 'None'/'unknown' sentinels (#8583)
 
 TOPP tools:
   Changes:

--- a/src/pyOpenMS/pyopenms/addons/__init__.py
+++ b/src/pyOpenMS/pyopenms/addons/__init__.py
@@ -19,6 +19,17 @@ from typing import Any, Callable, Dict, Type
 _addon_registry: Dict[str, Dict[str, Callable]] = {}
 
 
+def string_dtype(count: int):
+    """numpy dtype for a string column with ``count`` rows in a DataFrame export.
+
+    Object arrays store one pointer per row and impose no length limit, unlike the
+    fixed-width ``'U<n>'`` fields that preallocated 4*n bytes per row and silently
+    truncated longer values (#8583). An empty column gets a zero-cost ``'U1'`` instead,
+    so pandas and Arrow still infer a string type rather than object/null.
+    """
+    return object if count else 'U1'
+
+
 def addon(class_name: str, method_name: str | None = None):
     """
     Decorator to register an addon method for a class.

--- a/src/pyOpenMS/pyopenms/addons/consensusmap.py
+++ b/src/pyOpenMS/pyopenms/addons/consensusmap.py
@@ -65,7 +65,7 @@ def get_intensity_df(self):
             labels[0] = "intensity"
 
         dtypes = [('id', np.dtype('uint64'))] + list(zip(labels, ['f'] * len(labels)))
-        dtypes.append(('file', 'U300'))
+        dtypes.append(('file', 'O'))
 
         total_rows = sum(len(extract_row_blocks_channel_wide_file_long(f)[1]) for f in self.iter_consensus_feature_views())
         intyarr = np.fromiter(iter=gen(self, extract_rows_channel_wide_file_long), dtype=dtypes, count=total_rows)
@@ -111,7 +111,7 @@ def get_metadata_df(self):
             yield f.getUniqueId(), None, f.getCharge(), f.getRT(), f.getMZ(), f.getQuality()
 
     cnt = self.size()
-    mddtypes = [('id', np.dtype('uint64')), ('sequence', 'U200'), ('charge', 'i4'),
+    mddtypes = [('id', np.dtype('uint64')), ('sequence', 'O'), ('charge', 'i4'),
                 ('rt', np.dtype('double')), ('mz', np.dtype('double')), ('quality', 'f')]
     mdarr = np.fromiter(iter=gen(self, extract_meta_data), dtype=mddtypes, count=cnt)
 

--- a/src/pyOpenMS/pyopenms/addons/consensusmap.py
+++ b/src/pyOpenMS/pyopenms/addons/consensusmap.py
@@ -1,7 +1,7 @@
 """ConsensusMap addon methods for DataFrame support."""
 import numpy as np
 from collections import defaultdict as _defaultdict
-from . import addon, register_element_views
+from . import addon, register_element_views, string_dtype
 
 
 @addon("ConsensusMap")
@@ -64,10 +64,10 @@ def get_intensity_df(self):
         if len(labels) == 1:
             labels[0] = "intensity"
 
-        dtypes = [('id', np.dtype('uint64'))] + list(zip(labels, ['f'] * len(labels)))
-        dtypes.append(('file', 'O'))
-
         total_rows = sum(len(extract_row_blocks_channel_wide_file_long(f)[1]) for f in self.iter_consensus_feature_views())
+        dtypes = [('id', np.dtype('uint64'))] + list(zip(labels, ['f'] * len(labels)))
+        dtypes.append(('file', string_dtype(total_rows)))
+
         intyarr = np.fromiter(iter=gen(self, extract_rows_channel_wide_file_long), dtype=dtypes, count=total_rows)
 
         return pd.DataFrame(intyarr).set_index('id')
@@ -111,7 +111,7 @@ def get_metadata_df(self):
             yield f.getUniqueId(), None, f.getCharge(), f.getRT(), f.getMZ(), f.getQuality()
 
     cnt = self.size()
-    mddtypes = [('id', np.dtype('uint64')), ('sequence', 'O'), ('charge', 'i4'),
+    mddtypes = [('id', np.dtype('uint64')), ('sequence', string_dtype(cnt)), ('charge', 'i4'),
                 ('rt', np.dtype('double')), ('mz', np.dtype('double')), ('quality', 'f')]
     mdarr = np.fromiter(iter=gen(self, extract_meta_data), dtype=mddtypes, count=cnt)
 

--- a/src/pyOpenMS/pyopenms/addons/featuremap.py
+++ b/src/pyOpenMS/pyopenms/addons/featuremap.py
@@ -33,7 +33,7 @@ def _get_prot_id_filename_from_pep_id(self, pep_id):
             filenames = prot.getPrimaryMSRunPath()
             if filenames and filenames[0] != '':
                 return filenames[0]
-    return 'unknown'
+    return None
 
 
 @addon("FeatureMap")
@@ -82,7 +82,7 @@ def to_df(self, columns=None, meta_values=None, export_peptide_identifications=T
             pep = f.getPeptideIdentifications()
             if len(pep) > 0:
                 ID_filename = self._get_prot_id_filename_from_pep_id(pep[0])
-                spec_id = 'None'
+                spec_id = None
                 if f.metaValueExists('spectrum_native_id'):
                     spec_id = str(f.getMetaValue('spectrum_native_id'))
                 hits = pep[0].getHits()

--- a/src/pyOpenMS/pyopenms/addons/mobilogram.py
+++ b/src/pyOpenMS/pyopenms/addons/mobilogram.py
@@ -34,7 +34,7 @@ def get_data_dict(self, columns=None):
     if want('drift_time_unit'):
         unit_str = self.getDriftTimeUnitAsString()
         unit_decoded = unit_str.decode('utf-8') if isinstance(unit_str, bytes) else str(unit_str)
-        data_dict['drift_time_unit'] = np.full(cnt, unit_decoded, dtype='U50')
+        data_dict['drift_time_unit'] = np.full(cnt, unit_decoded, dtype=object)
 
     return data_dict
 

--- a/src/pyOpenMS/pyopenms/addons/mobilogram.py
+++ b/src/pyOpenMS/pyopenms/addons/mobilogram.py
@@ -1,6 +1,6 @@
 """Mobilogram addon methods for DataFrame support."""
 import numpy as np
-from . import addon
+from . import addon, string_dtype
 
 
 @addon("Mobilogram")
@@ -34,7 +34,7 @@ def get_data_dict(self, columns=None):
     if want('drift_time_unit'):
         unit_str = self.getDriftTimeUnitAsString()
         unit_decoded = unit_str.decode('utf-8') if isinstance(unit_str, bytes) else str(unit_str)
-        data_dict['drift_time_unit'] = np.full(cnt, unit_decoded, dtype=object)
+        data_dict['drift_time_unit'] = np.full(cnt, unit_decoded, dtype=string_dtype(cnt))
 
     return data_dict
 

--- a/src/pyOpenMS/pyopenms/addons/mrmtransitiongroupcp.py
+++ b/src/pyOpenMS/pyopenms/addons/mrmtransitiongroupcp.py
@@ -1,6 +1,6 @@
 """MRMTransitionGroupCP addon methods for DataFrame support."""
 import numpy as np
-from . import addon, register_element_views
+from . import addon, register_element_views, string_dtype
 
 
 @addon("MRMTransitionGroupCP")
@@ -50,13 +50,16 @@ def to_feature_df(self, columns=None, meta_values=None):
     except ImportError:
         raise ImportError("pandas is required for to_feature_df(). Install with: pip install pandas")
 
+    features = self.feature_views()  # zero-copy read; the generators below only read
+    str_dtype = string_dtype(len(features))
+    # keyed by the decoded (str) name: getKeys() and user-supplied meta_values may be str or bytes
     common_meta_value_types = {
-        b'label': 'O', b'spectrum_index': 'i', b'score_fit': 'f',
-        b'score_correlation': 'f', b'FWHM': 'f', b'spectrum_native_id': 'O',
-        b'max_height': 'f', b'num_of_masstraces': 'i', b'masstrace_intensity': 'f',
-        b'Group': 'O', b'is_ungrouped_monoisotopic': 'i', b'leftWidth': 'f',
-        b'rightWidth': 'f', b'total_xic': 'f', b'PeptideRef': 'O',
-        b'peak_apices_sum': 'f'
+        'label': str_dtype, 'spectrum_index': 'i', 'score_fit': 'f',
+        'score_correlation': 'f', 'FWHM': 'f', 'spectrum_native_id': str_dtype,
+        'max_height': 'f', 'num_of_masstraces': 'i', 'masstrace_intensity': 'f',
+        'Group': str_dtype, 'is_ungrouped_monoisotopic': 'i', 'leftWidth': 'f',
+        'rightWidth': 'f', 'total_xic': 'f', 'PeptideRef': str_dtype,
+        'peak_apices_sum': 'f'
     }
 
     def gen(features, fun):
@@ -67,7 +70,6 @@ def to_feature_df(self, columns=None, meta_values=None):
         vals = [f.getMetaValue(m) if f.metaValueExists(m) else np.nan for m in meta_values_list]
         yield tuple((f.getUniqueId(), f.getRT(), f.getIntensity(), f.getOverallQuality(), *vals))
 
-    features = self.feature_views()  # zero-copy read; the generators below only read
     mddtypes = [('feature_id', np.dtype('uint64')), ('rt', 'f'), ('intensity', 'f'), ('quality', 'f')]
 
     if meta_values is not None:
@@ -83,11 +85,8 @@ def to_feature_df(self, columns=None, meta_values=None):
             meta_values_list = list(meta_values)
 
         for meta_value in meta_values_list:
-            if meta_value in common_meta_value_types:
-                mddtypes.append((meta_value.decode() if isinstance(meta_value, bytes) else meta_value,
-                                common_meta_value_types.get(meta_value, 'O')))
-            else:
-                mddtypes.append((meta_value.decode() if isinstance(meta_value, bytes) else meta_value, 'O'))
+            name = meta_value.decode() if isinstance(meta_value, bytes) else meta_value
+            mddtypes.append((name, common_meta_value_types.get(name, str_dtype)))
     else:
         meta_values_list = []
 

--- a/src/pyOpenMS/pyopenms/addons/mrmtransitiongroupcp.py
+++ b/src/pyOpenMS/pyopenms/addons/mrmtransitiongroupcp.py
@@ -86,7 +86,12 @@ def to_feature_df(self, columns=None, meta_values=None):
 
         for meta_value in meta_values_list:
             name = meta_value.decode() if isinstance(meta_value, bytes) else meta_value
-            mddtypes.append((name, common_meta_value_types.get(name, str_dtype)))
+            dtype = common_meta_value_types.get(name, str_dtype)
+            if dtype == 'i' and not all(f.metaValueExists(meta_value) for f in features):
+                # an integer field cannot hold NaN for the missing values; promote to float64
+                # (what pandas does for an integer column with missing entries)
+                dtype = 'd'
+            mddtypes.append((name, dtype))
     else:
         meta_values_list = []
 

--- a/src/pyOpenMS/pyopenms/addons/mrmtransitiongroupcp.py
+++ b/src/pyOpenMS/pyopenms/addons/mrmtransitiongroupcp.py
@@ -51,11 +51,11 @@ def to_feature_df(self, columns=None, meta_values=None):
         raise ImportError("pandas is required for to_feature_df(). Install with: pip install pandas")
 
     common_meta_value_types = {
-        b'label': 'U50', b'spectrum_index': 'i', b'score_fit': 'f',
-        b'score_correlation': 'f', b'FWHM': 'f', b'spectrum_native_id': 'U100',
+        b'label': 'O', b'spectrum_index': 'i', b'score_fit': 'f',
+        b'score_correlation': 'f', b'FWHM': 'f', b'spectrum_native_id': 'O',
         b'max_height': 'f', b'num_of_masstraces': 'i', b'masstrace_intensity': 'f',
-        b'Group': 'U50', b'is_ungrouped_monoisotopic': 'i', b'leftWidth': 'f',
-        b'rightWidth': 'f', b'total_xic': 'f', b'PeptideRef': 'U100',
+        b'Group': 'O', b'is_ungrouped_monoisotopic': 'i', b'leftWidth': 'f',
+        b'rightWidth': 'f', b'total_xic': 'f', b'PeptideRef': 'O',
         b'peak_apices_sum': 'f'
     }
 
@@ -85,9 +85,9 @@ def to_feature_df(self, columns=None, meta_values=None):
         for meta_value in meta_values_list:
             if meta_value in common_meta_value_types:
                 mddtypes.append((meta_value.decode() if isinstance(meta_value, bytes) else meta_value,
-                                common_meta_value_types.get(meta_value, 'U50')))
+                                common_meta_value_types.get(meta_value, 'O')))
             else:
-                mddtypes.append((meta_value.decode() if isinstance(meta_value, bytes) else meta_value, 'U50'))
+                mddtypes.append((meta_value.decode() if isinstance(meta_value, bytes) else meta_value, 'O'))
     else:
         meta_values_list = []
 

--- a/src/pyOpenMS/pyopenms/addons/mschromatogram.py
+++ b/src/pyOpenMS/pyopenms/addons/mschromatogram.py
@@ -52,7 +52,7 @@ def get_data_dict(self, columns=None, export_meta_values=True):
     if want('product_mz'):
         data_dict['product_mz'] = np.full(cnt, self.getProduct().getMZ(), dtype=np.float64)
     if want('native_id'):
-        data_dict['native_id'] = np.full(cnt, self.getNativeID(), dtype='U100')
+        data_dict['native_id'] = np.full(cnt, self.getNativeID(), dtype=object)
 
     if want_explicit('chromatogram_type'):
         chrom_type = self.getChromatogramType()
@@ -65,10 +65,10 @@ def get_data_dict(self, columns=None, export_meta_values=True):
             7: 'ABSORPTION_CHROMATOGRAM', 8: 'EMISSION_CHROMATOGRAM'
         }
         type_name = type_names.get(int(chrom_type), f'UNKNOWN_{chrom_type}')
-        data_dict['chromatogram_type'] = np.full(cnt, type_name, dtype='U100')
+        data_dict['chromatogram_type'] = np.full(cnt, type_name, dtype=object)
 
     if want_explicit('comment'):
-        data_dict['comment'] = np.full(cnt, self.getComment(), dtype='U100')
+        data_dict['comment'] = np.full(cnt, self.getComment(), dtype=object)
 
     # Meta values
     if requested is None and export_meta_values:
@@ -87,7 +87,7 @@ def get_data_dict(self, columns=None, export_meta_values=True):
                 elif isinstance(v, float):
                     data_dict[k_str] = np.full(cnt, v, dtype=np.float64)
                 elif isinstance(v, str):
-                    data_dict[k_str] = np.full(cnt, v, dtype=f"U{max(len(v), 1)}")
+                    data_dict[k_str] = np.full(cnt, v, dtype=object)
                 else:
                     data_dict[k_str] = np.full(cnt, str(v), dtype='object')
             except Exception:
@@ -109,7 +109,7 @@ def get_data_dict(self, columns=None, export_meta_values=True):
                         elif isinstance(v, float):
                             data_dict[col] = np.full(cnt, v, dtype=np.float64)
                         elif isinstance(v, str):
-                            data_dict[col] = np.full(cnt, v, dtype=f"U{max(len(v), 1)}")
+                            data_dict[col] = np.full(cnt, v, dtype=object)
                         else:
                             data_dict[col] = np.full(cnt, str(v), dtype='object')
                     except Exception:

--- a/src/pyOpenMS/pyopenms/addons/mschromatogram.py
+++ b/src/pyOpenMS/pyopenms/addons/mschromatogram.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 import warnings
 import numpy as np
-from . import addon, register_element_views
+from . import addon, register_element_views, string_dtype
 
 
 @addon("MSChromatogram")
@@ -52,7 +52,7 @@ def get_data_dict(self, columns=None, export_meta_values=True):
     if want('product_mz'):
         data_dict['product_mz'] = np.full(cnt, self.getProduct().getMZ(), dtype=np.float64)
     if want('native_id'):
-        data_dict['native_id'] = np.full(cnt, self.getNativeID(), dtype=object)
+        data_dict['native_id'] = np.full(cnt, self.getNativeID(), dtype=string_dtype(cnt))
 
     if want_explicit('chromatogram_type'):
         chrom_type = self.getChromatogramType()
@@ -65,10 +65,10 @@ def get_data_dict(self, columns=None, export_meta_values=True):
             7: 'ABSORPTION_CHROMATOGRAM', 8: 'EMISSION_CHROMATOGRAM'
         }
         type_name = type_names.get(int(chrom_type), f'UNKNOWN_{chrom_type}')
-        data_dict['chromatogram_type'] = np.full(cnt, type_name, dtype=object)
+        data_dict['chromatogram_type'] = np.full(cnt, type_name, dtype=string_dtype(cnt))
 
     if want_explicit('comment'):
-        data_dict['comment'] = np.full(cnt, self.getComment(), dtype=object)
+        data_dict['comment'] = np.full(cnt, self.getComment(), dtype=string_dtype(cnt))
 
     # Meta values
     if requested is None and export_meta_values:
@@ -86,10 +86,8 @@ def get_data_dict(self, columns=None, export_meta_values=True):
                     data_dict[k_str] = np.full(cnt, v, dtype=np.int64)
                 elif isinstance(v, float):
                     data_dict[k_str] = np.full(cnt, v, dtype=np.float64)
-                elif isinstance(v, str):
-                    data_dict[k_str] = np.full(cnt, v, dtype=object)
                 else:
-                    data_dict[k_str] = np.full(cnt, str(v), dtype='object')
+                    data_dict[k_str] = np.full(cnt, v if isinstance(v, str) else str(v), dtype=string_dtype(cnt))
             except Exception:
                 data_dict[k_str] = np.full(cnt, str(v), dtype='object')
     elif requested is not None:
@@ -108,10 +106,8 @@ def get_data_dict(self, columns=None, export_meta_values=True):
                             data_dict[col] = np.full(cnt, v, dtype=np.int64)
                         elif isinstance(v, float):
                             data_dict[col] = np.full(cnt, v, dtype=np.float64)
-                        elif isinstance(v, str):
-                            data_dict[col] = np.full(cnt, v, dtype=object)
                         else:
-                            data_dict[col] = np.full(cnt, str(v), dtype='object')
+                            data_dict[col] = np.full(cnt, v if isinstance(v, str) else str(v), dtype=string_dtype(cnt))
                     except Exception:
                         data_dict[col] = np.full(cnt, str(v), dtype='object')
 

--- a/src/pyOpenMS/pyopenms/addons/msspectrum.py
+++ b/src/pyOpenMS/pyopenms/addons/msspectrum.py
@@ -82,7 +82,7 @@ def get_data_dict(self, columns=None, export_meta_values=True):
     if want('ms_level'):
         data_dict['ms_level'] = np.full(cnt, self.getMSLevel(), dtype=np.uint16)
     if want('native_id'):
-        data_dict['native_id'] = np.full(cnt, self.getNativeID(), dtype='U100')
+        data_dict['native_id'] = np.full(cnt, self.getNativeID(), dtype=object)
 
     if want('ion_mobility') or want('ion_mobility_unit'):
         if self.containsIMData():
@@ -104,14 +104,14 @@ def get_data_dict(self, columns=None, export_meta_values=True):
                 # exactly the spectra this column exists to describe
                 from pyopenms import IMTypes
                 data_dict['ion_mobility_unit'] = np.full(
-                    cnt, IMTypes.driftTimeUnitToString(drift_time_unit), dtype='U50'
+                    cnt, IMTypes.driftTimeUnitToString(drift_time_unit), dtype=object
                 )
         else:
             if requested is not None:
                 if want('ion_mobility'):
                     data_dict['ion_mobility'] = np.full(cnt, np.nan, dtype=np.float64)
                 if want('ion_mobility_unit'):
-                    data_dict['ion_mobility_unit'] = np.full(cnt, '', dtype='U1')
+                    data_dict['ion_mobility_unit'] = np.full(cnt, '', dtype=object)
 
     if want('precursor_mz') or want('precursor_charge'):
         precursors = self.getPrecursors()
@@ -129,13 +129,11 @@ def get_data_dict(self, columns=None, export_meta_values=True):
                     data_dict['precursor_charge'] = np.full(cnt, 0, dtype=np.int16)
 
     if want('ion_annotation'):
-        ion_annotations = np.full(cnt, '', dtype='U1')
+        ion_annotations = np.full(cnt, '', dtype=object)
         for sda in self.getStringDataArrays():
             if sda.getName() == 'IonNames':
                 if len(sda) == cnt:
-                    annotations = sda.get_data()
-                    max_len = max((len(s) for s in annotations), default=1)
-                    ion_annotations = np.array(annotations, dtype=f'U{max_len}')
+                    ion_annotations = np.array(sda.get_data(), dtype=object)
                 break
         if requested is not None or any(ion_annotations != ''):
             data_dict['ion_annotation'] = ion_annotations
@@ -157,7 +155,7 @@ def get_data_dict(self, columns=None, export_meta_values=True):
                 elif isinstance(v, float):
                     data_dict[k_str] = np.full(cnt, v, dtype=np.float64)
                 elif isinstance(v, str):
-                    data_dict[k_str] = np.full(cnt, v, dtype=f"U{max(len(v), 1)}")
+                    data_dict[k_str] = np.full(cnt, v, dtype=object)
                 else:
                     data_dict[k_str] = np.full(cnt, str(v), dtype='object')
             except Exception:
@@ -179,7 +177,7 @@ def get_data_dict(self, columns=None, export_meta_values=True):
                         elif isinstance(v, float):
                             data_dict[col] = np.full(cnt, v, dtype=np.float64)
                         elif isinstance(v, str):
-                            data_dict[col] = np.full(cnt, v, dtype=f"U{max(len(v), 1)}")
+                            data_dict[col] = np.full(cnt, v, dtype=object)
                         else:
                             data_dict[col] = np.full(cnt, str(v), dtype='object')
                     except Exception:
@@ -207,11 +205,9 @@ def get_data_dict(self, columns=None, export_meta_values=True):
             col_name = f'string_array:{sda.getName()}'
             if col_name in requested:
                 if len(sda) == cnt:
-                    strings = sda.get_data()
-                    max_len = max((len(s) for s in strings), default=1)
-                    data_dict[col_name] = np.array(strings, dtype=f'U{max_len}')
+                    data_dict[col_name] = np.array(sda.get_data(), dtype=object)
                 else:
-                    data_dict[col_name] = np.full(cnt, '', dtype='U1')
+                    data_dict[col_name] = np.full(cnt, '', dtype=object)
 
     return data_dict
 

--- a/src/pyOpenMS/pyopenms/addons/msspectrum.py
+++ b/src/pyOpenMS/pyopenms/addons/msspectrum.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Tuple
 
 import numpy as np
 
-from . import addon, register_element_views
+from . import addon, register_element_views, string_dtype
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -82,7 +82,7 @@ def get_data_dict(self, columns=None, export_meta_values=True):
     if want('ms_level'):
         data_dict['ms_level'] = np.full(cnt, self.getMSLevel(), dtype=np.uint16)
     if want('native_id'):
-        data_dict['native_id'] = np.full(cnt, self.getNativeID(), dtype=object)
+        data_dict['native_id'] = np.full(cnt, self.getNativeID(), dtype=string_dtype(cnt))
 
     if want('ion_mobility') or want('ion_mobility_unit'):
         if self.containsIMData():
@@ -104,14 +104,14 @@ def get_data_dict(self, columns=None, export_meta_values=True):
                 # exactly the spectra this column exists to describe
                 from pyopenms import IMTypes
                 data_dict['ion_mobility_unit'] = np.full(
-                    cnt, IMTypes.driftTimeUnitToString(drift_time_unit), dtype=object
+                    cnt, IMTypes.driftTimeUnitToString(drift_time_unit), dtype=string_dtype(cnt)
                 )
         else:
             if requested is not None:
                 if want('ion_mobility'):
                     data_dict['ion_mobility'] = np.full(cnt, np.nan, dtype=np.float64)
                 if want('ion_mobility_unit'):
-                    data_dict['ion_mobility_unit'] = np.full(cnt, '', dtype=object)
+                    data_dict['ion_mobility_unit'] = np.full(cnt, '', dtype=string_dtype(cnt))
 
     if want('precursor_mz') or want('precursor_charge'):
         precursors = self.getPrecursors()
@@ -129,11 +129,11 @@ def get_data_dict(self, columns=None, export_meta_values=True):
                     data_dict['precursor_charge'] = np.full(cnt, 0, dtype=np.int16)
 
     if want('ion_annotation'):
-        ion_annotations = np.full(cnt, '', dtype=object)
+        ion_annotations = np.full(cnt, '', dtype=string_dtype(cnt))
         for sda in self.getStringDataArrays():
             if sda.getName() == 'IonNames':
                 if len(sda) == cnt:
-                    ion_annotations = np.array(sda.get_data(), dtype=object)
+                    ion_annotations = np.array(sda.get_data(), dtype=string_dtype(cnt))
                 break
         if requested is not None or any(ion_annotations != ''):
             data_dict['ion_annotation'] = ion_annotations
@@ -154,10 +154,8 @@ def get_data_dict(self, columns=None, export_meta_values=True):
                     data_dict[k_str] = np.full(cnt, v, dtype=np.int64)
                 elif isinstance(v, float):
                     data_dict[k_str] = np.full(cnt, v, dtype=np.float64)
-                elif isinstance(v, str):
-                    data_dict[k_str] = np.full(cnt, v, dtype=object)
                 else:
-                    data_dict[k_str] = np.full(cnt, str(v), dtype='object')
+                    data_dict[k_str] = np.full(cnt, v if isinstance(v, str) else str(v), dtype=string_dtype(cnt))
             except Exception:
                 data_dict[k_str] = np.full(cnt, str(v), dtype='object')
     elif requested is not None:
@@ -176,10 +174,8 @@ def get_data_dict(self, columns=None, export_meta_values=True):
                             data_dict[col] = np.full(cnt, v, dtype=np.int64)
                         elif isinstance(v, float):
                             data_dict[col] = np.full(cnt, v, dtype=np.float64)
-                        elif isinstance(v, str):
-                            data_dict[col] = np.full(cnt, v, dtype=object)
                         else:
-                            data_dict[col] = np.full(cnt, str(v), dtype='object')
+                            data_dict[col] = np.full(cnt, v if isinstance(v, str) else str(v), dtype=string_dtype(cnt))
                     except Exception:
                         data_dict[col] = np.full(cnt, str(v), dtype='object')
 
@@ -205,9 +201,9 @@ def get_data_dict(self, columns=None, export_meta_values=True):
             col_name = f'string_array:{sda.getName()}'
             if col_name in requested:
                 if len(sda) == cnt:
-                    data_dict[col_name] = np.array(sda.get_data(), dtype=object)
+                    data_dict[col_name] = np.array(sda.get_data(), dtype=string_dtype(cnt))
                 else:
-                    data_dict[col_name] = np.full(cnt, '', dtype=object)
+                    data_dict[col_name] = np.full(cnt, '', dtype=string_dtype(cnt))
 
     return data_dict
 

--- a/src/pyOpenMS/pyopenms/addons/peptideidentificationlist.py
+++ b/src/pyOpenMS/pyopenms/addons/peptideidentificationlist.py
@@ -22,7 +22,10 @@ def to_df(self, decode_ontology=True, default_missing_values=None, export_uniden
     if default_missing_values is None:
         default_missing_values = {bool: False, int: -9999, float: np.nan, str: ''}
 
-    switchDict = {bool: '?', int: 'i', float: 'f', str: 'U100'}
+    # String columns use the object dtype: fixed-width unicode fields ('U100', 'U1000')
+    # preallocate 4 bytes per character per row regardless of content and silently
+    # truncate longer values; object fields hold a pointer to the Python str instead.
+    switchDict = {bool: '?', int: 'i', float: 'f', str: 'O'}
 
     count = len(self)
     if not export_unidentified:
@@ -58,7 +61,7 @@ def to_df(self, decode_ontology=True, default_missing_values=None, export_uniden
                         found = True
                         break
             if not found:
-                types.append('U100')
+                types.append('O')
 
     # get default value for each type
     def get_key(val):
@@ -80,7 +83,7 @@ def to_df(self, decode_ontology=True, default_missing_values=None, export_uniden
         clearMVs = decodedMVs
 
     clearcols = ["id", "rt", "mz", mainscorename, "charge", "protein_accession", "start", "end", "P_ID", "PSM_ID"] + clearMVs
-    coltypes = ['U100', 'f', 'f', 'f', 'i', 'U1000', 'U1000', 'U1000', 'i', 'i'] + types
+    coltypes = ['O', 'f', 'f', 'f', 'i', 'O', 'O', 'O', 'i', 'i'] + types
     dt = list(zip(clearcols, coltypes))
 
     def extract(pep, pep_idx):

--- a/src/pyOpenMS/pyopenms/addons/peptideidentificationlist.py
+++ b/src/pyOpenMS/pyopenms/addons/peptideidentificationlist.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 import numpy as np
 import warnings
-from . import addon, register_element_views
+from . import addon, register_element_views, string_dtype
 
 
 @addon("PeptideIdentificationList")
@@ -22,14 +22,14 @@ def to_df(self, decode_ontology=True, default_missing_values=None, export_uniden
     if default_missing_values is None:
         default_missing_values = {bool: False, int: -9999, float: np.nan, str: ''}
 
-    # String columns use the object dtype: fixed-width unicode fields ('U100', 'U1000')
-    # preallocate 4 bytes per character per row regardless of content and silently
-    # truncate longer values; object fields hold a pointer to the Python str instead.
-    switchDict = {bool: '?', int: 'i', float: 'f', str: 'O'}
-
     count = len(self)
     if not export_unidentified:
         count = sum(len(pep.getHits()) > 0 for pep in self.iter_peptide_identification_views())
+
+    # String columns use the object dtype (see string_dtype): fixed-width unicode fields
+    # ('U100', 'U1000') preallocated 4 bytes per character per row and silently truncated.
+    str_dtype = string_dtype(count)
+    switchDict = {bool: '?', int: 'i', float: 'f', str: str_dtype}
 
     # get all possible metavalues
     metavals = []
@@ -61,7 +61,7 @@ def to_df(self, decode_ontology=True, default_missing_values=None, export_uniden
                         found = True
                         break
             if not found:
-                types.append('O')
+                types.append(str_dtype)
 
     # get default value for each type
     def get_key(val):
@@ -83,7 +83,10 @@ def to_df(self, decode_ontology=True, default_missing_values=None, export_uniden
         clearMVs = decodedMVs
 
     clearcols = ["id", "rt", "mz", mainscorename, "charge", "protein_accession", "start", "end", "P_ID", "PSM_ID"] + clearMVs
-    coltypes = ['O', 'f', 'f', 'f', 'i', 'O', 'O', 'O', 'i', 'i'] + types
+    coltypes = [str_dtype, 'f', 'f', 'f', 'i', str_dtype, str_dtype, str_dtype, 'i', 'i'] + types
+    # the fixed-width fields used to coerce every value to str; keep that for string columns
+    # so a meta value whose type differs between hits cannot produce a mixed-type column
+    is_str_col = [t == str_dtype for t in types]
     dt = list(zip(clearcols, coltypes))
 
     def extract(pep, pep_idx):
@@ -109,6 +112,8 @@ def to_df(self, decode_ontology=True, default_missing_values=None, export_uniden
                         ret.append(True)
                     else:
                         ret.append(False)
+                elif is_str_col[idx] and not isinstance(val, str):
+                    ret.append(str(val))
                 else:
                     ret.append(val)
             else:

--- a/src/pyOpenMS/tests/unittests/test_dataframe_columns.py
+++ b/src/pyOpenMS/tests/unittests/test_dataframe_columns.py
@@ -1150,8 +1150,9 @@ class TestBugFixes:
         assert len(df) == 2
         # First feature should have the native_id
         assert df.iloc[0]['ID_native_id'] == 'scan=100'
-        # Second feature should have 'None' string (numpy converts None to string due to U100 dtype)
-        assert df.iloc[1]['ID_native_id'] == 'None'
+        # Second feature has no spectrum_native_id meta value: exported as null
+        import pandas as pd
+        assert pd.isna(df.iloc[1]['ID_native_id'])
 
 
 class TestFeatureMapColumnSelection:
@@ -1531,3 +1532,62 @@ class TestStringColumnsNotTruncated:
             assert df['FWHM'].dtype == np.float32, meta_values
             assert df.loc[3, 'FWHM'] == pytest.approx(3.5)
             assert df.loc[3, 'PeptideRef'] == 'PEP_1'
+
+    def test_feature_map_missing_id_columns_are_null(self):
+        """A feature whose peptide identification has no matching ProteinIdentification and no
+        spectrum_native_id meta value gets null ID_filename / ID_native_id, not 'unknown' / 'None'."""
+        import pandas as pd
+        fmap = pyopenms.FeatureMap()
+        f = pyopenms.Feature()
+        f.setRT(1.0)
+        f.setMZ(2.0)
+        f.setUniqueId(11)
+        pep = pyopenms.PeptideIdentification()
+        pep.setIdentifier('run_without_protein_id')
+        hit = pyopenms.PeptideHit()
+        hit.setSequence(pyopenms.AASequence.fromString('PEPTIDE'))
+        hit.setScore(0.5)
+        pep.setHits([hit])
+        pep_list = pyopenms.PeptideIdentificationList()
+        pep_list.push_back(pep)
+        f.setPeptideIdentifications(pep_list)
+        fmap.push_back(f)
+
+        df = fmap.to_df()
+        assert df.loc[11, 'peptide_sequence'] == 'PEPTIDE'
+        assert pd.isna(df.loc[11, 'ID_filename'])
+        assert pd.isna(df.loc[11, 'ID_native_id'])
+
+    def test_mrm_feature_df_missing_int_meta_value_promotes_to_float(self):
+        """An integer meta value missing on one feature yields a float column with NaN
+        instead of raising when the NaN is written into an integer field."""
+        import pandas as pd
+        tg = pyopenms.MRMTransitionGroupCP()
+        f1 = pyopenms.MRMFeature()
+        f1.setRT(1.0)
+        f1.setIntensity(1.0)
+        f1.setOverallQuality(0.5)
+        f1.setUniqueId(1)
+        f1.setMetaValue('spectrum_index', 42)
+        tg.addFeature(f1)
+        f2 = pyopenms.MRMFeature()
+        f2.setRT(2.0)
+        f2.setIntensity(2.0)
+        f2.setOverallQuality(0.6)
+        f2.setUniqueId(2)
+        tg.addFeature(f2)
+
+        for meta_values in ('all', ['spectrum_index']):
+            df = tg.to_feature_df(meta_values=meta_values)
+            assert df['spectrum_index'].dtype == np.float64
+            assert df.loc[1, 'spectrum_index'] == 42
+            assert pd.isna(df.loc[2, 'spectrum_index'])
+
+        # present on every feature: stays integer
+        f2.setMetaValue('spectrum_index', 43)
+        tg2 = pyopenms.MRMTransitionGroupCP()
+        tg2.addFeature(f1)
+        tg2.addFeature(f2)
+        df = tg2.to_feature_df(meta_values=['spectrum_index'])
+        assert df['spectrum_index'].dtype == np.int32
+        assert list(df['spectrum_index']) == [42, 43]

--- a/src/pyOpenMS/tests/unittests/test_dataframe_columns.py
+++ b/src/pyOpenMS/tests/unittests/test_dataframe_columns.py
@@ -1307,3 +1307,98 @@ class TestMSExperimentDFColumnSelection:
         assert 'ms_level' in cols
         assert 'mz_array' in cols
         assert 'intensity_array' in cols
+
+
+class TestStringColumnsNotTruncated:
+    """String columns are exported with the object dtype instead of fixed-width unicode
+    fields ('U100', 'U1000', ...), so long values are no longer silently truncated (#8583)."""
+
+    def test_peptide_identification_list_long_strings(self):
+        """Identifier > 100 chars, accession list > 1000 chars and a long string meta value survive."""
+        pep_list = pyopenms.PeptideIdentificationList()
+        pep = pyopenms.PeptideIdentification()
+        pep.setRT(1.0)
+        pep.setMZ(2.0)
+        pep.setScoreType('Mascot')
+        long_id = 'identifier_' + 'x' * 200
+        pep.setIdentifier(long_id)
+
+        hit = pyopenms.PeptideHit()
+        hit.setScore(1.0)
+        hit.setCharge(2)
+        hit.setSequence(pyopenms.AASequence.fromString('PEPTIDE'))
+        hit.setMetaValue('long_meta', 'm' * 300)
+        evidences = []
+        accessions = []
+        for i in range(60):
+            ev = pyopenms.PeptideEvidence()
+            acc = f'sp|P{i:05d}|PROTEIN_HUMAN'
+            ev.setProteinAccession(acc)
+            ev.setStart(i)
+            ev.setEnd(i + 7)
+            evidences.append(ev)
+            accessions.append(acc)
+        hit.setPeptideEvidences(evidences)
+        pep.setHits([hit])
+        pep_list.append(pep)
+
+        df = pep_list.to_df()
+
+        expected_accessions = ','.join(accessions)
+        assert len(expected_accessions) > 1000
+        assert df.loc[0, 'id'] == long_id
+        assert df.loc[0, 'protein_accession'] == expected_accessions
+        assert df.loc[0, 'start'] == ','.join(str(i) for i in range(60))
+        assert df.loc[0, 'end'] == ','.join(str(i + 7) for i in range(60))
+        assert df.loc[0, 'long_meta'] == 'm' * 300
+
+    def test_spectrum_long_strings(self):
+        """native_id, string meta values and string data arrays keep their full length."""
+        spec = pyopenms.MSSpectrum()
+        long_native_id = 'controllerType=0 controllerNumber=1 scan=' + '9' * 200
+        spec.setNativeID(long_native_id)
+        spec.setMetaValue('long_meta', 'm' * 300)
+        spec.set_peaks([np.array([100.0, 200.0]), np.array([1.0, 2.0], dtype=np.float32)])
+        sda = pyopenms.StringDataArray()
+        sda.setName('IonNames')
+        sda.push_back('b' * 150)
+        sda.push_back('y2+')
+        spec.setStringDataArrays([sda])
+
+        df = spec.to_df()
+        assert df.loc[0, 'native_id'] == long_native_id
+        assert df.loc[0, 'long_meta'] == 'm' * 300
+        assert df.loc[0, 'ion_annotation'] == 'b' * 150
+        assert df.loc[1, 'ion_annotation'] == 'y2+'
+
+        df = spec.to_df(columns=['mz', 'string_array:IonNames'])
+        assert df.loc[0, 'string_array:IonNames'] == 'b' * 150
+
+    def test_chromatogram_long_strings(self):
+        """native_id and comment keep their full length."""
+        chrom = pyopenms.MSChromatogram()
+        long_native_id = 'chrom_' + 'c' * 200
+        chrom.setNativeID(long_native_id)
+        chrom.setComment('comment ' * 50)
+        chrom.setMetaValue('long_meta', 'm' * 300)
+        chrom.set_peaks([np.array([1.0, 2.0]), np.array([1.0, 2.0], dtype=np.float32)])
+
+        df = chrom.to_df(columns=['rt', 'native_id', 'comment', 'long_meta'])
+        assert df.loc[0, 'native_id'] == long_native_id
+        assert df.loc[0, 'comment'] == 'comment ' * 50
+        assert df.loc[0, 'long_meta'] == 'm' * 300
+
+    def test_consensus_map_missing_sequence_is_null(self):
+        """A consensus feature without peptide identification exports a null sequence,
+        not the string 'None' that the fixed-width dtype used to produce."""
+        import pandas as pd
+        cmap = pyopenms.ConsensusMap()
+        cf = pyopenms.ConsensusFeature()
+        cf.setRT(1.0)
+        cf.setMZ(2.0)
+        cf.setCharge(2)
+        cmap.push_back(cf)
+
+        df = cmap.get_metadata_df()
+        assert len(df) == 1
+        assert pd.isna(df['sequence'].iloc[0])

--- a/src/pyOpenMS/tests/unittests/test_dataframe_columns.py
+++ b/src/pyOpenMS/tests/unittests/test_dataframe_columns.py
@@ -1402,3 +1402,132 @@ class TestStringColumnsNotTruncated:
         df = cmap.get_metadata_df()
         assert len(df) == 1
         assert pd.isna(df['sequence'].iloc[0])
+
+    def test_mrm_feature_df_long_strings_and_missing_meta_value(self):
+        """to_feature_df keeps long string meta values and exports a missing one as null."""
+        import pandas as pd
+        tg = pyopenms.MRMTransitionGroupCP()
+        f1 = pyopenms.MRMFeature()
+        f1.setRT(10.0)
+        f1.setIntensity(5.0)
+        f1.setOverallQuality(0.9)
+        f1.setUniqueId(7)
+        f1.setMetaValue('PeptideRef', 'PEP_' + 'x' * 150)
+        f1.setMetaValue('custom', 'c' * 80)
+        tg.addFeature(f1)
+        f2 = pyopenms.MRMFeature()
+        f2.setRT(11.0)
+        f2.setIntensity(6.0)
+        f2.setOverallQuality(0.8)
+        f2.setUniqueId(8)
+        tg.addFeature(f2)
+
+        df = tg.to_feature_df(meta_values=[b'PeptideRef', 'custom'])
+        assert df.loc[7, 'PeptideRef'] == 'PEP_' + 'x' * 150
+        assert df.loc[7, 'custom'] == 'c' * 80
+        assert pd.isna(df.loc[8, 'PeptideRef'])
+        assert pd.isna(df.loc[8, 'custom'])
+
+    def test_consensus_intensity_df_long_file_name(self):
+        """The 'file' column of the labelled long-format export is not cut at 300 characters."""
+        cmap = pyopenms.ConsensusMap()
+        cmap.setExperimentType('labeled_MS1')
+        long_file = '/data/' + 'f' * 350 + '.mzML'
+        headers = cmap.getColumnHeaders()
+        for i, label in enumerate(['light', 'heavy']):
+            h = pyopenms.ColumnHeader()
+            h.filename = long_file
+            h.label = label
+            h.size = 1
+            headers[i] = h
+        cmap.setColumnHeaders(headers)
+        cf = pyopenms.ConsensusFeature()
+        cf.setUniqueId(1)
+        for i, intensity in enumerate([10.0, 20.0]):
+            fh = pyopenms.FeatureHandle()
+            fh.setMapIndex(i)
+            fh.setIntensity(intensity)
+            cf.insert(fh)
+        cmap.push_back(cf)
+
+        df = cmap.get_intensity_df()
+        assert df['file'].iloc[0] == long_file
+
+    def test_mobilogram_drift_time_unit(self):
+        """drift_time_unit is exported as a plain string column."""
+        mob = pyopenms.Mobilogram()
+        mob.setRT(5.0)
+        p = pyopenms.MobilityPeak1D()
+        p.setMobility(1.0)
+        p.setIntensity(2.0)
+        mob.push_back(p)
+        df = mob.to_df()
+        assert isinstance(df['drift_time_unit'].iloc[0], str)
+
+    def test_empty_exports_keep_string_type(self):
+        """Empty spectra/chromatograms still produce string-typed columns, so they concatenate
+        with non-empty ones in pandas and Arrow instead of collapsing to object/null."""
+        import pandas as pd
+        empty = pyopenms.MSSpectrum()
+        empty.setNativeID('scan=1')
+        full = pyopenms.MSSpectrum()
+        full.setNativeID('scan=2')
+        full.set_peaks([np.array([100.0]), np.array([1.0], dtype=np.float32)])
+
+        both = pd.concat([empty.to_df(), full.to_df()])
+        assert both['native_id'].dtype == full.to_df()['native_id'].dtype
+        assert list(both['native_id']) == ['scan=2']
+
+        empty_chrom = pyopenms.MSChromatogram()
+        empty_chrom.setNativeID('c1')
+        assert empty_chrom.to_df(columns=['rt', 'native_id', 'comment']).shape == (0, 3)
+
+        pa = pytest.importorskip('pyarrow')
+        assert empty.to_arrow().schema.field('native_id').type == pa.string()
+        table = pa.concat_tables([empty.to_arrow(), full.to_arrow()])
+        assert table.column('native_id').to_pylist() == ['scan=2']
+
+    def test_mixed_type_meta_value_is_exported_as_str(self):
+        """A meta value that is a str in one hit and an int in another gives a plain string
+        column (as the fixed-width dtype used to), so Arrow export still works."""
+        pep_list = pyopenms.PeptideIdentificationList()
+        for value in ['abc', 7]:
+            pep = pyopenms.PeptideIdentification()
+            pep.setRT(1.0)
+            pep.setMZ(2.0)
+            pep.setScoreType('Mascot')
+            pep.setIdentifier('id')
+            hit = pyopenms.PeptideHit()
+            hit.setScore(1.0)
+            hit.setCharge(2)
+            hit.setSequence(pyopenms.AASequence.fromString('PEPTIDE'))
+            hit.setMetaValue('mixed', value)
+            pep.setHits([hit])
+            pep_list.append(pep)
+
+        df = pep_list.to_df()
+        assert list(df['mixed']) == ['abc', '7']
+
+        pa = pytest.importorskip('pyarrow')
+        # pandas 2 (object) maps to string, pandas 3 (str dtype) to large_string
+        mixed_type = pep_list.to_arrow().schema.field('mixed').type
+        assert pa.types.is_string(mixed_type) or pa.types.is_large_string(mixed_type)
+
+    def test_mrm_feature_df_typed_meta_values_by_str_and_bytes_name(self):
+        """Known numeric meta values get their numeric dtype whether requested as str, as bytes
+        or discovered via meta_values='all' (the type table used to match bytes names only)."""
+        tg = pyopenms.MRMTransitionGroupCP()
+        f = pyopenms.MRMFeature()
+        f.setRT(10.0)
+        f.setIntensity(5.0)
+        f.setOverallQuality(0.9)
+        f.setUniqueId(3)
+        f.setMetaValue('FWHM', 3.5)
+        f.setMetaValue('PeptideRef', 'PEP_1')
+        tg.addFeature(f)
+
+        for meta_values in ('all', ['FWHM', 'PeptideRef'], [b'FWHM', b'PeptideRef']):
+            df = tg.to_feature_df(meta_values=meta_values)
+            assert df['FWHM'].dtype == np.float32, meta_values
+            assert df.loc[3, 'FWHM'] == pytest.approx(3.5)
+            assert df.loc[3, 'PeptideRef'] == 'PEP_1'


### PR DESCRIPTION
## Description

This PR fixes silent truncation of long string values in DataFrame exports across multiple pyOpenMS classes. Previously, string columns were built using fixed-width numpy unicode fields (`'U50'`, `'U100'`, `'U1000'`) that preallocated 4 bytes per character per row and silently truncated values exceeding the field width. This affected:

- `PeptideIdentificationList.to_df()` - protein accession lists over 1000 chars, identifiers over 100 chars
- `ConsensusMap.get_intensity_df()/get_metadata_df()` - file paths over 300 chars
- `MRMTransitionGroupCP.to_feature_df()` - string meta values
- `MSSpectrum.to_df()` - native IDs, string meta values, string data arrays
- `MSChromatogram.to_df()` - native IDs, comments, string meta values
- `Mobilogram.to_df()` - drift time unit strings
- `FeatureMap.to_df()` - ID columns

### Key Changes

1. **New `string_dtype()` helper** in `addons/__init__.py`: Returns `object` dtype for non-empty columns (no length limit) and `'U1'` for empty columns (preserves string type inference in pandas/Arrow).

2. **Updated all DataFrame export methods** to use `string_dtype()` instead of fixed-width fields:
   - `PeptideIdentificationList.to_df()`
   - `ConsensusMap.get_intensity_df()/get_metadata_df()`
   - `MRMTransitionGroupCP.to_feature_df()`
   - `MSSpectrum.to_df()`
   - `MSChromatogram.to_df()`
   - `Mobilogram.to_df()`
   - `FeatureMap.to_df()`

3. **Fixed missing value handling**: Missing string values now export as `null`/`NaN` instead of placeholder strings:
   - `ConsensusMap.get_metadata_df()`: sequence without peptide ID (was `'None'`)
   - `MRMTransitionGroupCP.to_feature_df()`: missing string meta value (was `'nan'`)
   - `FeatureMap.to_df()`: ID_native_id/ID_filename (were `'None'`/`'unknown'`)

4. **Fixed meta value type handling in `MRMTransitionGroupCP.to_feature_df()`**:
   - Now matches known meta value names whether given as `str` or `bytes`
   - Integer meta values missing on some features promote to `float64` with `NaN` instead of raising
   - Mixed-type meta values coerce to string (preserving previous behavior)

5. **Updated CHANGELOG** with comprehensive description of changes and impact.

### Behavior Changes

- **No truncation**: Long strings now preserved in full
- **Memory efficiency**: Object arrays use one pointer per row vs. 4*n bytes for fixed-width fields
- **Type consistency**: Empty exports maintain string-typed columns for proper pandas/Arrow concatenation
- **Null handling**: Missing values are proper nulls, not placeholder strings

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (N/A - addon methods only)

## Testing

Comprehensive test coverage added in `test_dataframe_columns.py`:
- `TestStringColumnsNotTruncated` class with 11 new test methods covering:
  - Long identifiers, accession lists, and meta values in `PeptideIdentificationList`
  - Long native IDs and string data arrays in `MSSpectrum`
  - Long native IDs and comments in `MSChromatogram`
  - Missing sequence in `ConsensusMap`
  - Missing and long string meta values in `MRM

https://claude.ai/code/session_014mkzLeWj2ThZofKTJoWhgo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - DataFrame exports no longer truncate long strings such as protein accessions, native IDs, comments, and file names.
  - Missing string values are consistently exported as null rather than placeholder text.
  - Metadata names provided as bytes are handled consistently with string names.
  - Integer metadata with missing values now exports correctly with `NaN` instead of raising an error.
  - Mixed-type metadata values are converted consistently for DataFrame output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->