### PR TITLE
[API] Add Param::ParamEntry::isBool() as the single definition of a boolean parameter (#10116, step 1)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,9 @@ PR - Pull Request (on GitHub), i.e. integration of a new feature or bugfix
 ------------------------------------------------------------------------------------------
 
 General:
+  - Param::ParamEntry::isBool(): single definition of a boolean parameter (scalar string restricted to
+    exactly "true" and "false", in either order, independent of the current value). First step of #10116;
+    the flag/CTD/INI/CWL writers will be switched to it in follow-ups.
   - Move spectrum-type estimation into KERNEL and share the linear resampling implementation
     between MSExperiment::calculateTIC and LinearResamplerAlign, removing three dependencies
     from core code to FORMAT, PROCESSING and APPLICATIONS. Existing APIs, the old estimator

--- a/src/openms/include/OpenMS/DATASTRUCTURES/Param.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/Param.h
@@ -67,6 +67,20 @@ public:
 
       /// Check if 'value' fulfills restrictions
       bool isValid(std::string& message) const;
+      /**
+        @brief Is this entry a boolean parameter?
+
+        OpenMS has no boolean value type. A boolean parameter is a scalar string parameter whose
+        valid strings are exactly the two values "true" and "false", in either order.
+        The current value is not considered: a boolean parameter stays boolean after it was set to "true".
+
+        Not boolean are: string lists, unrestricted "true"/"false" strings, single-value restrictions
+        and restrictions that allow further values (e.g. "auto,true,false").
+
+        @note Whether a boolean parameter is a command-line flag (given without a value) or an option
+              taking a value is decided by TOPPBase at registration time, not by this function.
+      */
+      bool isBool() const;
       /// Equality operator (only name and value are compared)
       bool operator==(const ParamEntry& rhs) const;
 

--- a/src/openms/source/DATASTRUCTURES/Param.cpp
+++ b/src/openms/source/DATASTRUCTURES/Param.cpp
@@ -165,6 +165,16 @@ namespace OpenMS
     return true;
   }
 
+  bool Param::ParamEntry::isBool() const
+  {
+    if (value.valueType() != ParamValue::STRING_VALUE || valid_strings.size() != 2)
+    {
+      return false;
+    }
+    return (valid_strings[0] == "true" && valid_strings[1] == "false") ||
+           (valid_strings[0] == "false" && valid_strings[1] == "true");
+  }
+
   bool Param::ParamEntry::operator==(const ParamEntry& rhs) const
   {
     return name == rhs.name && value == rhs.value;

--- a/src/pyOpenMS/bindings/bind_datastructures.cpp
+++ b/src/pyOpenMS/bindings/bind_datastructures.cpp
@@ -1017,6 +1017,7 @@ Validates types, string restrictions, and numeric ranges. Raises exception on in
             bool valid = self.isValid(msg);
             return nb::make_tuple(valid, msg);
         }, "Check if value fulfills restrictions. Returns (valid, message)")
+        .def("isBool", &OpenMS::Param::ParamEntry::isBool, "True if this is a boolean parameter: a scalar string restricted to exactly 'true' and 'false' (either order), independent of the current value")
         .def("__eq__", &OpenMS::Param::ParamEntry::operator==, nb::is_operator())
         .def("__repr__", [](const OpenMS::Param::ParamEntry& self) {
             std::string tags = "[";

--- a/src/pyOpenMS/tests/unittests/test_ParamEntry_isBool.py
+++ b/src/pyOpenMS/tests/unittests/test_ParamEntry_isBool.py
@@ -1,0 +1,28 @@
+"""Tests for Param.ParamEntry.isBool()."""
+import pyopenms
+
+
+def test_param_entry_isBool():
+    p = pyopenms.Param()
+
+    p.setValue("flag", "false")
+    p.setValidStrings("flag", ["true", "false"])
+    assert p.getEntry("flag").isBool()
+
+    # reversed order and current value do not matter
+    p.setValue("flag", "true")
+    p.setValidStrings("flag", ["false", "true"])
+    assert p.getEntry("flag").isBool()
+
+    # unrestricted true/false strings are not boolean
+    p.setValue("unrestricted", "true")
+    assert not p.getEntry("unrestricted").isBool()
+
+    # additional allowed values are not boolean
+    p.setValue("tristate", "auto")
+    p.setValidStrings("tristate", ["auto", "true", "false"])
+    assert not p.getEntry("tristate").isBool()
+
+    # other types are not boolean
+    p.setValue("int", 1)
+    assert not p.getEntry("int").isBool()

--- a/src/pyOpenMS/tests/unittests/test_ParamEntry_isBool.py
+++ b/src/pyOpenMS/tests/unittests/test_ParamEntry_isBool.py
@@ -1,4 +1,11 @@
-"""Tests for Param.ParamEntry.isBool()."""
+"""
+## ----------------------------------------------------------------------------
+## $Maintainer: $
+## $Authors: $
+## ----------------------------------------------------------------------------
+
+Tests for Param.ParamEntry.isBool().
+"""
 import pyopenms
 
 
@@ -13,6 +20,11 @@ def test_param_entry_isBool():
     p.setValue("flag", "true")
     p.setValidStrings("flag", ["false", "true"])
     assert p.getEntry("flag").isBool()
+
+    # a value outside the restrictions does not change the type (isValid() reports that separately)
+    p.setValue("flag", "auto")
+    assert p.getEntry("flag").isBool()
+    assert not p.getEntry("flag").isValid()[0]
 
     # unrestricted true/false strings are not boolean
     p.setValue("unrestricted", "true")

--- a/src/tests/class_tests/openms/source/Param_test.cpp
+++ b/src/tests/class_tests/openms/source/Param_test.cpp
@@ -107,6 +107,65 @@ START_SECTION(([Param::ParamEntry] bool isValid(std::string& message) const))
 
 END_SECTION
 
+START_SECTION(([Param::ParamEntry] bool isBool() const))
+	Param p;
+
+	// canonical flag declaration
+	p.setValue("flag", "false");
+	p.setValidStrings("flag", {"true", "false"});
+	TEST_EQUAL(p.getEntry("flag").isBool(), true)
+
+	// reversed order is boolean as well
+	p.setValue("reversed", "false");
+	p.setValidStrings("reversed", {"false", "true"});
+	TEST_EQUAL(p.getEntry("reversed").isBool(), true)
+
+	// the current value does not matter
+	p.setValue("flag", "true");
+	TEST_EQUAL(p.getEntry("flag").isBool(), true)
+	p.setValue("reversed", "true");
+	TEST_EQUAL(p.getEntry("reversed").isBool(), true)
+
+	// unrestricted "true"/"false" strings are not boolean
+	p.setValue("unrestricted", "true");
+	TEST_EQUAL(p.getEntry("unrestricted").isBool(), false)
+
+	// restrictions with additional values are not boolean
+	p.setValue("tristate", "auto");
+	p.setValidStrings("tristate", {"auto", "true", "false"});
+	TEST_EQUAL(p.getEntry("tristate").isBool(), false)
+
+	// single-value and duplicate restrictions are not boolean
+	p.setValue("single", "true");
+	p.setValidStrings("single", {"true"});
+	TEST_EQUAL(p.getEntry("single").isBool(), false)
+	p.setValue("duplicate", "true");
+	p.setValidStrings("duplicate", {"true", "true"});
+	TEST_EQUAL(p.getEntry("duplicate").isBool(), false)
+
+	// other two-value restrictions are not boolean
+	p.setValue("unit", "ppm");
+	p.setValidStrings("unit", {"ppm", "Da"});
+	TEST_EQUAL(p.getEntry("unit").isBool(), false)
+
+	// string lists are not boolean, even with true/false restrictions
+	p.setValue("list", std::vector<std::string>{"true", "false"});
+	p.setValidStrings("list", {"true", "false"});
+	TEST_EQUAL(p.getEntry("list").isBool(), false)
+
+	// non-string types are not boolean
+	p.setValue("int", 1);
+	TEST_EQUAL(p.getEntry("int").isBool(), false)
+	p.setValue("double", 1.0);
+	TEST_EQUAL(p.getEntry("double").isBool(), false)
+
+	// a freshly constructed entry without restrictions is not boolean
+	Param::ParamEntry pe("n", "false", "d");
+	TEST_EQUAL(pe.isBool(), false)
+	pe.valid_strings = {"true", "false"};
+	TEST_EQUAL(pe.isBool(), true)
+END_SECTION
+
 START_SECTION(([Param::ParamEntry] bool operator==(const ParamEntry& rhs) const))
 	Param::ParamEntry n1("n","d","v",{"advanced"});
 	Param::ParamEntry n2("n","d","v",{"advanced"});

--- a/src/tests/class_tests/openms/source/Param_test.cpp
+++ b/src/tests/class_tests/openms/source/Param_test.cpp
@@ -126,6 +126,12 @@ START_SECTION(([Param::ParamEntry] bool isBool() const))
 	p.setValue("reversed", "true");
 	TEST_EQUAL(p.getEntry("reversed").isBool(), true)
 
+	// a value outside the restrictions does not change the type (isValid() reports that separately)
+	std::string msg;
+	p.setValue("flag", "auto");
+	TEST_EQUAL(p.getEntry("flag").isBool(), true)
+	TEST_EQUAL(p.getEntry("flag").isValid(msg), false)
+
 	// unrestricted "true"/"false" strings are not boolean
 	p.setValue("unrestricted", "true");
 	TEST_EQUAL(p.getEntry("unrestricted").isBool(), false)


### PR DESCRIPTION
## Description

First, purely additive step of #10116.

OpenMS has no boolean value type; a boolean parameter is a string parameter restricted to `true`/`false`. Today four code paths (`TOPPBase`, `ParamXMLFile`, `ParamCTDFile`, `ParamCWLFile`) re-derive "is this a boolean" from the **order** of those two restrictions plus the **current value**, and `ParamJSONFile` uses yet another rule. This PR introduces the one definition they will be switched to in follow-ups:

- `Param::ParamEntry::isBool()`: scalar `STRING_VALUE` whose `valid_strings` are exactly the two distinct values `"true"` and `"false"`, in either order, independent of the current value. String lists, unrestricted `"true"`/`"false"` strings, single-value/duplicate restrictions and tri-state restrictions (`auto,true,false`) are not boolean.
- The doc comment states explicitly that flag-vs-value-option is a `TOPPBase` registration decision, not a property of the entry (review point 1 on #10116).
- pyOpenMS: `ParamEntry.isBool()` binding + small test, so #10108 can build on the same definition instead of content sniffing.
- Class test covering both orders, both values, lists, tri-state, singleton, duplicate, other two-value restrictions, non-string types.
- CHANGELOG entry.

No caller is changed; behaviour of every tool and file format is identical to `develop`.

Note: this session has no build environment, so the new tests were written against the existing `Param_test.cpp` conventions but not executed locally. CI is the first run.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes (not run locally, see note above)
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UEHgs71nDGJrkfYTs8uRa

---
_Generated by [Claude Code](https://claude.ai/code/session_019UEHgs71nDGJrkfYTs8uRa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added boolean parameter detection for scalar string parameters restricted exclusively to `"true"` and `"false"`, regardless of value or ordering.
  * Exposed boolean parameter detection through the Python API.

* **Tests**
  * Added coverage for valid boolean restrictions, reversed value ordering, current values outside restrictions, and invalid parameter configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->