### PR TITLE
[FIX] AssayGeneratorMetabo: apply the registered SiriusExportAlgorithm parameters (fixes #10120)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -302,6 +302,10 @@ PyOpenMS:
 
 TOPP tools:
   Changes:
+    AssayGeneratorMetabo:
+      - The SiriusExportAlgorithm options (-feature_only, -filter_by_num_masstraces, -precursor_mz_tolerance,
+        -precursor_mz_tolerance_unit, -precursor_rt_tolerance) were registered but never applied to the
+        algorithm and therefore silently ignored; they are now effective (#10120)
     all:
       - BREAKING: when a parameter is given several times on the command line, the LAST occurrence now
         wins (previously the first); a warning is issued when duplicates are detected. This enables the

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -3633,6 +3633,13 @@ add_test("TOPP_AssayGeneratorMetabo_6" ${TOPP_BIN_PATH}/TargetedFileConverter -t
 add_test("TOPP_AssayGeneratorMetabo_6_out1" ${DIFF} -in1 ${TESTS_TEMP_DIR}/AssayGeneratorMetabo_ams_uku_output_consensus_traml.tmp.TraML -in2 ${DATA_DIR_TOPP}/AssayGeneratorMetabo_ams_uku_output_consensus_traml.TraML)
 set_tests_properties("TOPP_AssayGeneratorMetabo_6_out1" PROPERTIES DEPENDS "TOPP_AssayGeneratorMetabo_6")
 
+# SiriusExportAlgorithm parameters must reach the algorithm (#10120): with -feature_only true and
+# -filter_by_num_masstraces 2, 15 of the 24 features (all with a single mass trace) are dropped, so the
+# output must differ from the default-parameter output of TOPP_AssayGeneratorMetabo_1.
+add_test("TOPP_AssayGeneratorMetabo_7" ${TOPP_BIN_PATH}/AssayGeneratorMetabo -test -in ${DATA_DIR_TOPP}/AssayGeneratorMetabo_input.mzML -in_featureinfo ${DATA_DIR_TOPP}/AssayGeneratorMetabo_ffm_input.featureXML -out ${TESTS_TEMP_DIR}/AssayGeneratorMetabo_ffm_output_filtered.tmp.tsv -min_transitions 1 -max_transitions 3 -feature_only true -filter_by_num_masstraces 2)
+add_test("TOPP_AssayGeneratorMetabo_7_out1" ${DIFF} -in1 ${TESTS_TEMP_DIR}/AssayGeneratorMetabo_ffm_output_filtered.tmp.tsv -in2 ${DATA_DIR_TOPP}/AssayGeneratorMetabo_ffm_output.tsv)
+set_tests_properties("TOPP_AssayGeneratorMetabo_7_out1" PROPERTIES DEPENDS "TOPP_AssayGeneratorMetabo_7" WILL_FAIL TRUE)
+
 # ImageCreator:
 if(WITH_GUI)
   add_test("TOPP_ImageCreator_1" ${TOPP_BIN_PATH}/ImageCreator -test -in ${DATA_DIR_TOPP}/ImageCreator_1_input.mzML -out ${TESTS_TEMP_DIR}/ImageCreator1.bmp -width 20 -height 15)

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -3633,12 +3633,18 @@ add_test("TOPP_AssayGeneratorMetabo_6" ${TOPP_BIN_PATH}/TargetedFileConverter -t
 add_test("TOPP_AssayGeneratorMetabo_6_out1" ${DIFF} -in1 ${TESTS_TEMP_DIR}/AssayGeneratorMetabo_ams_uku_output_consensus_traml.tmp.TraML -in2 ${DATA_DIR_TOPP}/AssayGeneratorMetabo_ams_uku_output_consensus_traml.TraML)
 set_tests_properties("TOPP_AssayGeneratorMetabo_6_out1" PROPERTIES DEPENDS "TOPP_AssayGeneratorMetabo_6")
 
-# SiriusExportAlgorithm parameters must reach the algorithm (#10120): with -feature_only true and
-# -filter_by_num_masstraces 2, 15 of the 24 features (all with a single mass trace) are dropped, so the
-# output must differ from the default-parameter output of TOPP_AssayGeneratorMetabo_1.
+# SiriusExportAlgorithm parameters must reach the algorithm (#10120). -feature_only true enables the
+# mass-trace filter (otherwise filter_by_num_masstraces is reset to 1) and -filter_by_num_masstraces 2
+# drops the 15 of 24 input features that have a single mass trace. Compared to the default output of
+# TOPP_AssayGeneratorMetabo_1: the compounds at RT 437.423 and 438.351 (single-trace features only) must
+# be gone, the compounds of the 2-, 4- and 7-trace features at RT 446.172, 448.028 and 461.815 must remain.
 add_test("TOPP_AssayGeneratorMetabo_7" ${TOPP_BIN_PATH}/AssayGeneratorMetabo -test -in ${DATA_DIR_TOPP}/AssayGeneratorMetabo_input.mzML -in_featureinfo ${DATA_DIR_TOPP}/AssayGeneratorMetabo_ffm_input.featureXML -out ${TESTS_TEMP_DIR}/AssayGeneratorMetabo_ffm_output_filtered.tmp.tsv -min_transitions 1 -max_transitions 3 -feature_only true -filter_by_num_masstraces 2)
-add_test("TOPP_AssayGeneratorMetabo_7_out1" ${DIFF} -in1 ${TESTS_TEMP_DIR}/AssayGeneratorMetabo_ffm_output_filtered.tmp.tsv -in2 ${DATA_DIR_TOPP}/AssayGeneratorMetabo_ffm_output.tsv)
-set_tests_properties("TOPP_AssayGeneratorMetabo_7_out1" PROPERTIES DEPENDS "TOPP_AssayGeneratorMetabo_7" WILL_FAIL TRUE)
+add_test("TOPP_AssayGeneratorMetabo_7_out1" ${CMAKE_COMMAND}
+  -DINPUT_FILE=${TESTS_TEMP_DIR}/AssayGeneratorMetabo_ffm_output_filtered.tmp.tsv
+  "-DEXPECTED=446.172000000000025;448.027999999980011;461.815000000020007"
+  "-DFORBIDDEN=437.422999999979993;438.350999999999999"
+  -P ${DATA_DIR_TOPP}/check_file_contains.cmake)
+set_tests_properties("TOPP_AssayGeneratorMetabo_7_out1" PROPERTIES DEPENDS "TOPP_AssayGeneratorMetabo_7")
 
 # ImageCreator:
 if(WITH_GUI)

--- a/src/topp/AssayGeneratorMetabo.cpp
+++ b/src/topp/AssayGeneratorMetabo.cpp
@@ -148,11 +148,16 @@ protected:
     registerFlag_("deisotoping_annotate_charge", "Annotate the charge to the peaks", false);
 
     addEmptyLine_();
-    auto defaults = sirius_export_algorithm.getDefaults();
-    defaults.remove("isotope_pattern_iterations"); 
-    defaults.remove("no_masstrace_info_isotope_pattern"); 
+    registerFullParam_(siriusExportParamSubset_());
+  }
 
-    registerFullParam_(defaults);
+  /// SiriusExportAlgorithm parameters exposed by this tool (the isotope pattern options are not used here)
+  Param siriusExportParamSubset_() const
+  {
+    Param defaults = sirius_export_algorithm.getDefaults();
+    defaults.remove("isotope_pattern_iterations");
+    defaults.remove("no_masstrace_info_isotope_pattern");
+    return defaults;
   }
 
   ExitCodes main_(int, const char **) override
@@ -197,6 +202,8 @@ protected:
     bool keep_only_deisotoped = getFlag_("deisotoping_keep_only_deisotoped");
     bool annotate_charge = getFlag_("deisotoping_annotate_charge");
 
+    // apply the SiriusExportAlgorithm options registered via registerFullParam_() (they were silently ignored before, see #10120)
+    sirius_export_algorithm.setParameters(getParam_().copySubset(siriusExportParamSubset_()));
     writeDebug_("Parameters passed to SiriusExportAlgorithm", sirius_export_algorithm.getParameters(), 3);
 
     //-------------------------------------------------------------


### PR DESCRIPTION
## Description

Fixes #10120.

`AssayGeneratorMetabo` registered the `SiriusExportAlgorithm` defaults on its command line (`registerFullParam_`) but never called `setParameters()` on its `sirius_export_algorithm` member. `-feature_only`, `-filter_by_num_masstraces`, `-precursor_mz_tolerance`, `-precursor_mz_tolerance_unit` and `-precursor_rt_tolerance` were therefore silently ignored; the tool even logged "Parameters passed to SiriusExportAlgorithm" with the untouched defaults.

Changes:
- One helper `siriusExportParamSubset_()` builds the exposed subset (the two isotope-pattern options stay excluded, as before) and is used both for registration and for `setParameters(getParam_().copySubset(...))` right before the algorithm is used, mirroring what `SiriusExport.cpp` does.
- New TOPP test `TOPP_AssayGeneratorMetabo_7`: runs with `-feature_only true -filter_by_num_masstraces 2`. `-feature_only true` enables the mass-trace filter (otherwise the algorithm resets `filter_by_num_masstraces` to 1), and the filter drops the 15 of 24 input features that have a single mass trace. `check_file_contains.cmake` then asserts on the output that the compounds at RT 437.423 and 438.351 (produced only by single-trace features in the default output) are gone and that the compounds of the 2-, 4- and 7-trace features at RT 446.172, 448.028 and 461.815 are still present. Retained features can only gain MS2 assignments when neighbours are removed (closest-m/z assignment in `FeatureMapping`), so their rows cannot vanish. This needs no new fixture and catches both "parameters not wired through" and a header-only output. The existing tests do not pass any of the affected options, so their fixtures are unchanged.
- CHANGELOG entry.

Note: this session has no build environment, so the change was written against the code but not executed locally. CI is the first run.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes (not run locally, see note above)
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UEHgs71nDGJrkfYTs8uRa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `AssayGeneratorMetabo` so Sirius export settings now take effect when configured.
  * The feature-only, mass-trace filtering, precursor m/z tolerance, tolerance unit, and precursor RT tolerance options are no longer silently ignored.

* **Tests**
  * Added coverage verifying feature-only processing and mass-trace filtering behavior, including retained and excluded features.

* **Documentation**
  * Updated the changelog to document the corrected Sirius export option behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->