### PR TITLE
[TOPP] Accept an explicit true/false after a flag and a bare boolean string option (#10116, step 2)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -318,6 +318,11 @@ PyOpenMS:
 TOPP tools:
   Changes:
     all:
+      - Boolean command-line parameters accept both syntaxes (#10116): a flag may be followed by an explicit
+        'true' or 'false' (e.g. '-flag false' to override a flag enabled in an INI file or by an earlier
+        '-flag' in appended workflow arguments), and a string option restricted to 'true'/'false' may be
+        given without a value, meaning 'true'. Any other token after a flag is still an error, and
+        '--help false' no longer prints the help.
       - BREAKING: when a parameter is given several times on the command line, the LAST occurrence now
         wins (previously the first); a warning is issued when duplicates are detected. This enables the
         nextflow pattern of appending ${ext.args} to override hardcoded defaults. Error messages for

--- a/src/openms/include/OpenMS/APPLICATIONS/TOPPBase.h
+++ b/src/openms/include/OpenMS/APPLICATIONS/TOPPBase.h
@@ -353,6 +353,10 @@ protected:
       @brief Sets the valid command line options (with argument) and flags (without argument).
 
       The options '-ini' '-log' '-instance' '-debug' and the flag '--help' are automatically registered.
+
+      A string option whose valid strings are exactly 'true' and 'false' (see setValidStrings_()) may be given
+      without a value on the command line, which means 'true'; a flag may be followed by an explicit 'true' or
+      'false' (see registerFlag_()).
     */
     virtual void registerOptionsAndFlags_() = 0;
 
@@ -616,7 +620,13 @@ protected:
      */
     void registerOutputFileList_(const std::string& name, const std::string& argument, const StringList& default_value, const std::string& description, bool required = true, bool advanced = false);
 
-    /// Registers a flag
+    /**
+      @brief Registers a flag
+
+      On the command line a flag is given without a value ('-flag'). It may be followed by exactly one explicit
+      'true' or 'false' ('-flag false'), e.g. to override a flag enabled in an INI file or by an earlier '-flag';
+      any other token after a flag is an error.
+    */
     void registerFlag_(const std::string& name, const std::string& description, bool advanced = false);
 
     /**

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -336,6 +336,8 @@ namespace OpenMS
 
 
         finalParam.remove("ini"); // not contained in default params; remove to avoid "unknown param" in update()
+        finalParam.remove("-help"); // dito; only present here when given with an explicit 'false'
+        finalParam.remove("-helphelp");
 
         // finally: augment default values with INI/CLI values
         // note the copy(getIniLocation_(),..) as we want the param tree without instance

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -235,8 +235,9 @@ namespace OpenMS
       return ILLEGAL_PARAMETERS;
     }
 
-    // '--help' given
-    if (param_cmdline_.exists("-help") || param_cmdline_.exists("-helphelp"))
+    // '--help' given (a flag may carry an explicit value, so '--help false' must not print the help)
+    auto flag_given = [this](const std::string& name) { return param_cmdline_.exists(name) && param_cmdline_.getValue(name) == "true"; };
+    if (flag_given("-help") || flag_given("-helphelp"))
     {
       printUsage_();
       return EXECUTION_OK;
@@ -2279,6 +2280,18 @@ namespace OpenMS
     return p;
   }
 
+  namespace
+  {
+    /// True if the valid strings are exactly "true" and "false" (either order), i.e. the option is a boolean
+    /// given as a string. Mirrors Param::ParamEntry::isBool() for a registration's restrictions.
+    bool isBoolRestriction_(const StringList& valid_strings)
+    {
+      return valid_strings.size() == 2 &&
+             ((valid_strings[0] == "true" && valid_strings[1] == "false") ||
+              (valid_strings[0] == "false" && valid_strings[1] == "true"));
+    }
+  }
+
   Param TOPPBase::parseCommandLine_(const int argc, const char** argv, const std::string& misc, const std::string& unknown)
   {
     // current state:
@@ -2327,18 +2340,28 @@ namespace OpenMS
           if (pos->second->type == ParameterInformation::FLAG) // flag
           {
             value = "true";
-            // Check if there are trailing arguments after the flag - this is an error
             if (!queue.empty())
             {
-              // Collect the trailing arguments for the error message
-              std::string trailing_args;
-              for (list<std::string>::const_iterator it = queue.begin(); it != queue.end(); ++it)
+              // A flag may be followed by exactly one explicit boolean value: '-flag false' is the only way to
+              // override a flag enabled in an INI file or by an earlier '-flag' (e.g. in appended workflow
+              // arguments), see #10116. Anything else after a flag is a user error (see #5345).
+              if (queue.size() == 1 && (queue.front() == "true" || queue.front() == "false"))
               {
-                if (it != queue.begin()) trailing_args += " ";
-                trailing_args += *it;
+                value = queue.front();
+                queue.pop_front();
               }
-              throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                std::string("Command line error: Trailing arguments after flag '") + arg + "': " + trailing_args);
+              else
+              {
+                // Collect the trailing arguments for the error message
+                std::string trailing_args;
+                for (list<std::string>::const_iterator it = queue.begin(); it != queue.end(); ++it)
+                {
+                  if (it != queue.begin()) trailing_args += " ";
+                  trailing_args += *it;
+                }
+                throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                  std::string("Command line error: Trailing arguments after flag '") + arg + "': " + trailing_args);
+              }
             }
           }
           else // option with argument(s)
@@ -2351,7 +2374,15 @@ namespace OpenMS
             case ParameterInformation::OUTPUT_PREFIX:
             case ParameterInformation::OUTPUT_DIR:
               if (queue.empty())
-                value = std::string();
+              {
+                // A boolean string option (restricted to 'true'/'false') given without a value means 'true',
+                // like a flag (see #10116). Any other option keeps the empty string and is rejected later if
+                // its restrictions do not allow it.
+                if (pos->second->type == ParameterInformation::STRING && isBoolRestriction_(pos->second->valid_strings))
+                  value = std::string("true");
+                else
+                  value = std::string();
+              }
               else
                 value = queue.front();
               break;

--- a/src/tests/class_tests/openms/data/TOPPBase_flag_true.ini
+++ b/src/tests/class_tests/openms/data/TOPPBase_flag_true.ini
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<PARAMETERS>
+  <NODE name="TOPPBaseTest">
+    <NODE name="1">
+      <ITEM name="flag" value="true" type="bool" description="flag description"/>
+    </NODE>
+  </NODE>
+</PARAMETERS>

--- a/src/tests/class_tests/openms/source/TOPPBase_test.cpp
+++ b/src/tests/class_tests/openms/source/TOPPBase_test.cpp
@@ -312,6 +312,48 @@ public:
   }
 };
 
+//test class with boolean string options (restricted to true/false) next to a real flag
+class TOPPBaseBoolOptionTest
+  : public TOPPBase
+{
+public:
+  TOPPBaseBoolOptionTest()
+    : TOPPBase("TOPPBaseBoolOptionTest", "A test class for boolean string options", false, {}, false)
+  {}
+  void registerOptionsAndFlags_() override
+  {
+    registerStringOption_("boolopt", "<bool>", "false", "boolean string option", false);
+    setValidStrings_("boolopt", {"true", "false"});
+    registerStringOption_("boolopt_reversed", "<bool>", "true", "boolean string option with reversed restrictions", false);
+    setValidStrings_("boolopt_reversed", {"false", "true"});
+    registerStringOption_("tristate", "<mode>", "auto", "string option with a third allowed value", false);
+    setValidStrings_("tristate", {"auto", "true", "false"});
+    registerFlag_("flag", "flag description");
+  }
+  ExitCodes run(int argc, const char** argv)
+  {
+    static char* var = (char *)("OPENMS_DISABLE_UPDATE_CHECK=ON");
+#ifdef OPENMS_WINDOWSPLATFORM
+      _putenv(var);
+#else
+      putenv(var);
+#endif
+    return main(argc, argv);
+  }
+  std::string getStringOption(const std::string& name) const
+  {
+    return getStringOption_(name);
+  }
+  Param const& getParam() const
+  {
+    return getParam_();
+  }
+  ExitCodes main_(int /*argc*/, const char** /*argv*/) override
+  {
+    return EXECUTION_OK;
+  }
+};
+
 //test class with optional parameters
 class TOPPBaseCmdParseSubsectionsTest
 : public TOPPBase
@@ -864,6 +906,126 @@ START_SECTION(([EXTRA] test flag with trailing arguments))
   TOPPBaseTest tmp_flag2;
   TOPPBase::ExitCodes ec_flag2 = tmp_flag2.main(6, string_cl_flag2);
   TEST_EQUAL(ec_flag2, TOPPBase::ILLEGAL_PARAMETERS)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] flags accept an explicit true/false value))
+{
+  std::string temp_flag_ini(OPENMS_GET_TEST_DATA_PATH("TOPPBase_flag_true.ini"));
+  const char* flag_ini = temp_flag_ini.c_str();
+  const char* val_true = "true";
+  const char* val_false = "false";
+
+  // -flag true
+  const char* cl1[4] = {a1, a11, val_true, test}; //command line: "TOPPBaseTest -flag true -test"
+  TOPPBaseTest t1;
+  TEST_EQUAL(t1.main(4, cl1), TOPPBase::EXECUTION_OK)
+  TEST_EQUAL(t1.getFlag("flag"), true)
+
+  // -flag false
+  const char* cl2[4] = {a1, a11, val_false, test}; //command line: "TOPPBaseTest -flag false -test"
+  TOPPBaseTest t2;
+  TEST_EQUAL(t2.main(4, cl2), TOPPBase::EXECUTION_OK)
+  TEST_EQUAL(t2.getFlag("flag"), false)
+
+  // duplicates: the last occurrence wins in both directions
+  const char* cl3[5] = {a1, a11, val_false, a11, test}; //command line: "TOPPBaseTest -flag false -flag -test"
+  TOPPBaseTest t3;
+  TEST_EQUAL(t3.main(5, cl3), TOPPBase::EXECUTION_OK)
+  TEST_EQUAL(t3.getFlag("flag"), true)
+  const char* cl4[5] = {a1, a11, a11, val_false, test}; //command line: "TOPPBaseTest -flag -flag false -test"
+  TOPPBaseTest t4;
+  TEST_EQUAL(t4.main(5, cl4), TOPPBase::EXECUTION_OK)
+  TEST_EQUAL(t4.getFlag("flag"), false)
+
+  // a flag enabled in an INI file ...
+  const char* cl5[4] = {a1, a3, flag_ini, test}; //command line: "TOPPBaseTest -ini TOPPBase_flag_true.ini -test"
+  TOPPBaseTest t5;
+  TEST_EQUAL(t5.main(4, cl5), TOPPBase::EXECUTION_OK)
+  TEST_EQUAL(t5.getFlag("flag"), true)
+  // ... is overridden by '-flag false' on the command line
+  const char* cl6[6] = {a1, a3, flag_ini, a11, val_false, test}; //command line: "TOPPBaseTest -ini TOPPBase_flag_true.ini -flag false -test"
+  TOPPBaseTest t6;
+  TEST_EQUAL(t6.main(6, cl6), TOPPBase::EXECUTION_OK)
+  TEST_EQUAL(t6.getFlag("flag"), false)
+
+  // only the literal 'true'/'false' is accepted, and only a single token
+  const char* val_upper = "TRUE";
+  const char* cl7[4] = {a1, a11, val_upper, test}; //command line: "TOPPBaseTest -flag TRUE -test"
+  TOPPBaseTest t7;
+  TEST_EQUAL(t7.main(4, cl7), TOPPBase::ILLEGAL_PARAMETERS)
+  const char* cl8[5] = {a1, a11, val_true, a12, test}; //command line: "TOPPBaseTest -flag true commandline -test"
+  TOPPBaseTest t8;
+  TEST_EQUAL(t8.main(5, cl8), TOPPBase::ILLEGAL_PARAMETERS)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] boolean string options may be given without a value))
+{
+  const char* tool = "TOPPBaseBoolOptionTest";
+  const char* boolopt = "-boolopt";
+  const char* boolopt_reversed = "-boolopt_reversed";
+  const char* tristate = "-tristate";
+  const char* val_false = "false";
+
+  // not given: default
+  const char* cl0[2] = {tool, test};
+  TOPPBaseBoolOptionTest t0;
+  TEST_EQUAL(t0.run(2, cl0), TOPPBase::EXECUTION_OK)
+  TEST_EQUAL(t0.getStringOption("boolopt"), "false")
+
+  // bare option means 'true'
+  const char* cl1[3] = {tool, boolopt, test}; //command line: "TOPPBaseBoolOptionTest -boolopt -test"
+  TOPPBaseBoolOptionTest t1;
+  TEST_EQUAL(t1.run(3, cl1), TOPPBase::EXECUTION_OK)
+  TEST_EQUAL(t1.getStringOption("boolopt"), "true")
+
+  // ... also as the last argument
+  const char* cl2[3] = {tool, test, boolopt}; //command line: "TOPPBaseBoolOptionTest -test -boolopt"
+  TOPPBaseBoolOptionTest t2;
+  TEST_EQUAL(t2.run(3, cl2), TOPPBase::EXECUTION_OK)
+  TEST_EQUAL(t2.getStringOption("boolopt"), "true")
+
+  // an explicit value still works
+  const char* cl3[4] = {tool, boolopt, val_false, test}; //command line: "TOPPBaseBoolOptionTest -boolopt false -test"
+  TOPPBaseBoolOptionTest t3;
+  TEST_EQUAL(t3.run(4, cl3), TOPPBase::EXECUTION_OK)
+  TEST_EQUAL(t3.getStringOption("boolopt"), "false")
+
+  // reversed restriction order is boolean as well
+  const char* cl4[4] = {tool, boolopt_reversed, val_false, test}; //command line: "TOPPBaseBoolOptionTest -boolopt_reversed false -test"
+  TOPPBaseBoolOptionTest t4;
+  TEST_EQUAL(t4.run(4, cl4), TOPPBase::EXECUTION_OK)
+  TEST_EQUAL(t4.getStringOption("boolopt_reversed"), "false")
+  const char* cl5[3] = {tool, boolopt_reversed, test}; //command line: "TOPPBaseBoolOptionTest -boolopt_reversed -test"
+  TOPPBaseBoolOptionTest t5;
+  TEST_EQUAL(t5.run(3, cl5), TOPPBase::EXECUTION_OK)
+  TEST_EQUAL(t5.getStringOption("boolopt_reversed"), "true")
+
+  // an option with a third allowed value is not boolean: the bare form is still rejected
+  const char* cl6[3] = {tool, tristate, test}; //command line: "TOPPBaseBoolOptionTest -tristate -test"
+  TOPPBaseBoolOptionTest t6;
+  TEST_EQUAL(t6.run(3, cl6), TOPPBase::ILLEGAL_PARAMETERS)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] --help with an explicit false does not print the help))
+{
+  const char* tool = "TOPPBaseBoolOptionTest";
+  const char* help = "--help";
+  const char* val_false = "false";
+
+  // '--help' stops before the parameters are evaluated
+  const char* cl1[3] = {tool, help, test}; //command line: "TOPPBaseBoolOptionTest --help -test"
+  TOPPBaseBoolOptionTest t1;
+  TEST_EQUAL(t1.run(3, cl1), TOPPBase::EXECUTION_OK)
+  TEST_EQUAL(t1.getParam().exists("boolopt"), false)
+
+  // '--help false' runs the tool normally
+  const char* cl2[4] = {tool, help, val_false, test}; //command line: "TOPPBaseBoolOptionTest --help false -test"
+  TOPPBaseBoolOptionTest t2;
+  TEST_EQUAL(t2.run(4, cl2), TOPPBase::EXECUTION_OK)
+  TEST_EQUAL(t2.getParam().exists("boolopt"), true)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/TOPPBase_test.cpp
+++ b/src/tests/class_tests/openms/source/TOPPBase_test.cpp
@@ -957,6 +957,26 @@ START_SECTION(([EXTRA] flags accept an explicit true/false value))
   const char* cl8[5] = {a1, a11, val_true, a12, test}; //command line: "TOPPBaseTest -flag true commandline -test"
   TOPPBaseTest t8;
   TEST_EQUAL(t8.main(5, cl8), TOPPBase::ILLEGAL_PARAMETERS)
+
+  // a value meant for a different parameter is still caught (the mistake fixed in #9850, where a
+  // '-Search:decoys auto' was copied from a tool that registers 'decoys' with a third allowed value)
+  const char* val_auto = "auto";
+  const char* cl9[4] = {a1, a11, val_auto, test}; //command line: "TOPPBaseTest -flag auto -test"
+  TOPPBaseTest t9;
+  TEST_EQUAL(t9.main(4, cl9), TOPPBase::ILLEGAL_PARAMETERS)
+
+  // a negative number is not an option (no letter follows the '-'), so it reaches the flag as a
+  // trailing argument; it must not be mistaken for an explicit boolean
+  const char* val_negative = "-5.5";
+  const char* cl10[4] = {a1, a11, val_negative, test}; //command line: "TOPPBaseTest -flag -5.5 -test"
+  TOPPBaseTest t10;
+  TEST_EQUAL(t10.main(4, cl10), TOPPBase::ILLEGAL_PARAMETERS)
+
+  // two flags in a row: the value belongs to the flag it follows, the preceding one stays bare
+  const char* cl11[4] = {a1, a11, test, val_true}; //command line: "TOPPBaseTest -flag -test true"
+  TOPPBaseTest t11;
+  TEST_EQUAL(t11.main(4, cl11), TOPPBase::EXECUTION_OK)
+  TEST_EQUAL(t11.getFlag("flag"), true)
 }
 END_SECTION
 
@@ -1006,6 +1026,12 @@ START_SECTION(([EXTRA] boolean string options may be given without a value))
   const char* cl6[3] = {tool, tristate, test}; //command line: "TOPPBaseBoolOptionTest -tristate -test"
   TOPPBaseBoolOptionTest t6;
   TEST_EQUAL(t6.run(3, cl6), TOPPBase::ILLEGAL_PARAMETERS)
+
+  // an explicitly empty value is not the bare form and stays invalid
+  const char* val_empty = "";
+  const char* cl7[4] = {tool, boolopt, val_empty, test}; //command line: "TOPPBaseBoolOptionTest -boolopt '' -test"
+  TOPPBaseBoolOptionTest t7;
+  TEST_EQUAL(t7.run(4, cl7), TOPPBase::ILLEGAL_PARAMETERS)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/TOPPBase_test.cpp
+++ b/src/tests/class_tests/openms/source/TOPPBase_test.cpp
@@ -972,11 +972,15 @@ START_SECTION(([EXTRA] flags accept an explicit true/false value))
   TOPPBaseTest t10;
   TEST_EQUAL(t10.main(4, cl10), TOPPBase::ILLEGAL_PARAMETERS)
 
-  // two flags in a row: the value belongs to the flag it follows, the preceding one stays bare
-  const char* cl11[4] = {a1, a11, test, val_true}; //command line: "TOPPBaseTest -flag -test true"
+  // two flags in a row: the value belongs to the flag it follows, the preceding one stays bare.
+  // The two flags must end up with different values, otherwise the assertion would also hold for a
+  // parser that wrongly gave the value to '-flag'.
+  const char* no_progress = "-no_progress";
+  const char* cl11[5] = {a1, a11, no_progress, val_false, test}; //command line: "TOPPBaseTest -flag -no_progress false -test"
   TOPPBaseTest t11;
-  TEST_EQUAL(t11.main(4, cl11), TOPPBase::EXECUTION_OK)
+  TEST_EQUAL(t11.main(5, cl11), TOPPBase::EXECUTION_OK)
   TEST_EQUAL(t11.getFlag("flag"), true)
+  TEST_EQUAL(t11.getFlag("no_progress"), false)
 }
 END_SECTION
 


### PR DESCRIPTION
## Description

Step 2 of #10116 (tolerant command line), implemented as the **narrow rule** discussed in [this comment](https://github.com/OpenMS/OpenMS/issues/10116#issuecomment-5635181093), which reconciles it with the decision in #5345 / #8670 that tokens after a flag are an error.

`TOPPBase::parseCommandLine_`:
- **Flag followed by exactly one literal `true` or `false`** → the token is consumed as the flag's value. `-flag false` is the only way to override a flag enabled in an INI file or by an earlier `-flag` in appended Nextflow `ext.args`; the last occurrence wins as for every other parameter. Any other trailing token (`-flag auto`, `-flag TRUE`, `-flag true extra`) still aborts with `Command line error: Trailing arguments after flag`, so the mistake class fixed in #9850 is still caught. No deprecation note for either form.
- **Boolean string option given without a value** (a `STRING` registration whose valid strings are exactly `true` and `false`, either order) → `"true"`, like a flag. Fixes "Invalid string parameter value ''" for e.g. `FeatureFinderMetabo -algorithm:ffm:remove_single_traces` (the 2019 report on #2350) and bare `CometAdapter -clip_nterm_methionine`. Options with further allowed values (`auto,true,false`) keep the empty value and are still rejected. STRING registrations stay STRING, so `getStringOption_()` callers are untouched (review point 1).
- **`--help` / `--helphelp` are now value-aware**: `--help false` runs the tool instead of printing the help (the old `exists()` check ran before the unknown-option check, so it would have exited 0).

The boolean-restriction predicate is a small file-local helper on the registration's `valid_strings`; it mirrors `Param::ParamEntry::isBool()` from #10122 and will be unified in step 3 when the flag tag lands (this PR is independent of #10122).

Docs: `registerFlag_()` and `registerOptionsAndFlags_()` describe both syntaxes. CHANGELOG entry under "TOPP tools: all".

**Tests** (`TOPPBase_test.cpp`):
- flags: `-flag true`, `-flag false`, duplicates in both directions, INI-enabled flag (new fixture `TOPPBase_flag_true.ini`) with and without `-flag false` override, `-flag TRUE` and `-flag true commandline` still `ILLEGAL_PARAMETERS`. The two existing `[EXTRA] test flag with trailing arguments` cases are unchanged and keep asserting the abort for non-boolean tokens.
- new `TOPPBaseBoolOptionTest` tool: bare boolean option (first and last position), explicit value, reversed restriction order, tri-state option bare still `ILLEGAL_PARAMETERS`, default untouched.
- `--help` stops before parameter evaluation, `--help false` does not.

Note: this session has no build environment, so the change was written against the code but not executed locally. CI is the first run.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes (not run locally, see note above)
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UEHgs71nDGJrkfYTs8uRa

---
_Generated by [Claude Code](https://claude.ai/code/session_019UEHgs71nDGJrkfYTs8uRa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Boolean command-line flags now accept explicit `true` or `false` values.
  - Boolean-restricted string options can be provided without a value, defaulting to `true`.
  - Explicitly setting `--help false` no longer displays help.
  - Invalid values and trailing arguments continue to produce validation errors.

- **Documentation**
  - Updated command-line option documentation to describe supported boolean syntaxes and validation rules.

- **Tests**
  - Added coverage for boolean flags, overrides, validation, valueless options, and help behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->