### PR TITLE
docs(CHANGELOG): document pyOpenMS String wrapper removal (#10109)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -191,6 +191,11 @@ PyOpenMS:
     - PEP 561 type stubs (.pyi), smaller binaries, faster builds and better error messages
     - along the way: ~50 mutable-reference output parameter bugs fixed and ~100 missing default
       arguments restored
+  - BREAKING: the pure Python pyopenms.String wrapper class (addons/string_class.py), a Cython-era
+    shim kept only to emulate String& output parameters, was removed; OpenMS::String parameters are
+    plain Python str in the nanobind bindings and no longer need wrapping. The three bindings that
+    wrote their result into its _value attribute now return it directly instead: MzMLFile.storeBuffer()
+    returns str, MSNumpressCoder.encodeNP() returns str and encodeNPRaw() returns bytes (#10109)
   - BREAKING: getters return owned copies again, restoring the 3.5 (Cython) semantics that the initial
     nanobind port had turned into live aliases (#9792, #9794)
     - element access (spec[i], for peak in spec, exp.getSpectrum(i)), vector getters (getSpectra(),


### PR DESCRIPTION
## Description

Scanned recently merged PRs against develop for changes missing from the CHANGELOG.

PR #10109 ("Remove OpenMS::String wrapper and simplify string handling in pyOpenMS") removed the legacy `pyopenms.String` shim class and changed three bindings (`MzMLFile.storeBuffer()`, `MSNumpressCoder.encodeNP()`/`encodeNPRaw()`) to return values directly instead of writing into a `String&` output parameter. This is a breaking API change for pyOpenMS users but its CHANGELOG checklist item was left unchecked and no entry was added.

This PR adds a BREAKING entry under the PyOpenMS section documenting the removal and the affected bindings.

All other recently merged PRs I checked (#10123, #10122, #10117, #10113, #10112, #10107, #10103, #10101, #10100, #10098, #10099, etc.) already included their own CHANGELOG updates in the merge commit, so no further additions were needed there. PRs #10079 (thermo-bridge version bump, already referenced from the Thermo entry) and #10074 (test-only change) did not need entries.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas (N/A, CHANGELOG only)
- [x] New and existing unit tests pass locally with my changes (N/A, CHANGELOG only)
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BA4gTubWVwKSgYT1ti1YCo

---
_Generated by [Claude Code](https://claude.ai/code/session_01BA4gTubWVwKSgYT1ti1YCo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Removed the `pyopenms.String` wrapper class.
  - `OpenMS::String` parameters now use standard Python `str` values.
  - `MzMLFile.storeBuffer()` and `MSNumpressCoder.encodeNP()` now return `str` directly.
  - `MSNumpressCoder.encodeNPRaw()` now returns `bytes` directly.
  - Update integrations that access the wrapper’s `_value` attribute or expect output-parameter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->