### PR TITLE
[FIX] Limit FragmentIndex fragment sort to the tool's thread budget

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -140,6 +140,12 @@ General:
     codebase calls) now throws NotImplemented rather than a file-not-found error, i.e. semantic
     schema validation stays unavailable for these two formats. Normal file reading/writing is
     unaffected (#9757)
+  - Fix: FragmentIndex fragment sorting now honors the tool's -threads option (and
+    OMP_NUM_THREADS). boost::sort::block_indirect_sort defaulted to
+    std::thread::hardware_concurrency() threads, so the sort spawned one thread per logical
+    core -- 384 threads on a 384-core node -- even for the default single-threaded run,
+    ignoring omp_set_num_threads() and the process CPU affinity. The sort now uses the same
+    OpenMP thread budget as the rest of the index build (#10129)
 
 Dependencies:
   - PyOpenMS: Autowrap/Cython replaced with nanobind; nanobind 2.10.0+ fetched automatically (#8699)

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -1262,11 +1262,15 @@ namespace OpenMS
 
       OPENMS_LOG_INFO << "Sorting fragments..." << std::endl;
 
-      /// 1.) First all Fragments are sorted by their own mass (parallel via Boost.Sort)
+      /// 1.) First all Fragments are sorted by their own mass (parallel via Boost.Sort).
+      /// Boost defaults to std::thread::hardware_concurrency() threads, which ignores both
+      /// the tool's -threads option and the process CPU affinity: on a 384-core node a
+      /// single-threaded run spawned 384 sort threads. Use the same budget as the OpenMP
+      /// regions around it.
       boost::sort::block_indirect_sort(fi_fragments_.begin(), fi_fragments_.end(), [](const Fragment& a, const Fragment& b)
       {
         return std::tie(a.fragment_mz_, a.peptide_idx_) < std::tie(b.fragment_mz_, b.peptide_idx_);
-      });
+      }, static_cast<uint32_t>(num_threads));
 
       // Empty database (no peptide passed length / mass / motif filters): nothing to bucket.
       // Mark as built and return — guards against the OMP loop below dividing by zero


### PR DESCRIPTION
## Description

`FragmentIndex::build()` sorts all generated fragments with `boost::sort::block_indirect_sort()` without passing a thread count. Per the [Boost.Sort implementation](https://github.com/boostorg/sort/blob/develop/include/boost/sort/block_indirect_sort/block_indirect_sort.hpp), that overload forwards to `std::thread::hardware_concurrency()` — so the sort spawns one `std::async` thread **per logical core of the machine**, regardless of the tool's thread budget.

This bypasses two mechanisms:

1. **The `-threads` option of TOPP tools**, which is applied via `omp_set_num_threads()` (`TOPPBase::setMaxNumberOfThreads`). With the default `-threads 1`, every OpenMP region in `FragmentIndex::build()` (fragment generation, per-bucket re-sort) runs single-threaded — while the fragment sort in between still launches `std::thread::hardware_concurrency()` threads. On a 384-core node, a nominally single-threaded run spawned 384 sort threads (plus a `Block_size * nthreads * sizeof(Fragment)` scratch buffer sized for them).
2. **The process CPU affinity / cgroup limits** on common standard library implementations, where `hardware_concurrency()` reports online cores, not the cores the process is actually allowed to run on.

The fix passes the same `num_threads` budget (`omp_get_max_threads()`, already computed for the surrounding OpenMP regions and per-thread buffers) to the sort, so it honors `-threads` and `OMP_NUM_THREADS` like the rest of the index build. `num_threads` is always >= 1, and Boost treats values < 2 as single-threaded, so the non-OpenMP fallback (`num_threads = 1`) sorts serially.

Sorted output is unchanged; only the number of worker threads differs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fragment index sorting now respects the configured thread count, including tool settings, OpenMP configuration, and process CPU affinity.
  - Improved consistency between fragment sorting and the rest of the index-building process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->