### PR TITLE
docs(CHANGELOG): fix wrong PR reference for CMake 3.24 / compiler version centralization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -147,7 +147,7 @@ Dependencies:
   - Boost minimum version requirement raised from 1.78 to 1.81 (#9042, #9095)
   - Minimum CMake version raised from 3.21 to 3.24; the minimum compiler versions (GCC, Clang,
     AppleClang, MSVC toolset) are now defined centrally in cmake/min_compiler_versions.cmake and
-    checked at configure time before vcpkg runs (#10063)
+    checked at configure time before vcpkg runs (#10112)
   - Qt6::Network replaced with libcurl for all HTTP operations in the core library (#8841)
   - minizip-ng replaced with libzip for ZIP64 archive support (#8808)
   - Qt6 removed from the core library and from all non-GUI TOPP tools (incremental steps, Qt is now


### PR DESCRIPTION
## Summary
- Audited PRs merged into `develop` over the last week (from #10055 through #10128) against the CHANGELOG for missing or incorrect entries.
- Found that the CHANGELOG entry documenting the CMake 3.24 minimum-version bump and the centralization of minimum compiler versions in `cmake/min_compiler_versions.cmake` cites `#10063` instead of `#10112`.
  - `#10112` ("Consolidate vcpkg documentation and build system improvements") is the PR that actually introduced this change and added the CHANGELOG entry.
  - `#10063` ("Pjones/vcpkg cleanup") is a different, still-open PR by a different author with no relation to this change.
- All other recently merged PRs I checked (architecture/dependency-narrowing steps of #10083, the `#10109` String-wrapper removal, the `#10097`/`#10106` `print(Param)` improvement, the `#8583`/`#10117` DataFrame truncation fix, the `#10120`/`#10123` AssayGeneratorMetabo fix, `#10113`'s RPATH/CTest-fixture follow-up, etc.) already have accurate CHANGELOG coverage, so no further entries were needed.

## Test plan
- N/A (documentation-only change): visually diffed the corrected line against the PR history to confirm `#10112` is the correct reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjxByk53SBNmuTu3bTeoqC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjxByk53SBNmuTu3bTeoqC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog reference for the CMake/compiler-version requirement to point to issue `#10112`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->